### PR TITLE
chore: Refactor hapi tests to use hapiTest(...) instead of defaultHapiSpec(...) (Part 4) 

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm46ValidationSuite.java
@@ -22,7 +22,6 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asContract;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asContractIdWithEvmAddress;
 import static com.hedera.services.bdd.spec.HapiPropertySource.idAsHeadlongAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
@@ -752,51 +751,40 @@ public class Evm46ValidationSuite {
     @HapiTest
     final Stream<DynamicTest>
             internalCallWithValueToNonExistingNonMirrorAddressWithoutEnoughGasForLazyCreationResultsInSuccessNoAccountCreated() {
-        return defaultHapiSpec(
-                        "internalCallWithValueToNonExistingNonMirrorAddressWithoutEnoughGasForLazyCreationResultsInSuccessNoAccountCreated")
-                .given(
-                        cryptoCreate(CUSTOM_PAYER),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("contractBalance", INTERNAL_CALLER_CONTRACT),
-                        contractCall(
-                                        INTERNAL_CALLER_CONTRACT,
-                                        CALL_WITH_VALUE_TO_FUNCTION,
-                                        nonMirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 7))
-                                .payingWith(CUSTOM_PAYER)
-                                .gas(NOT_ENOUGH_GAS_LIMIT_FOR_CREATION)
-                                .via("transferWithLowGasLimit"))
-                .then(
-                        getTxnRecord("transferWithLowGasLimit")
-                                .hasPriority(recordWith().status(SUCCESS)),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("contractBalance", 0)));
+        return hapiTest(
+                cryptoCreate(CUSTOM_PAYER),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("contractBalance", INTERNAL_CALLER_CONTRACT),
+                contractCall(
+                                INTERNAL_CALLER_CONTRACT,
+                                CALL_WITH_VALUE_TO_FUNCTION,
+                                nonMirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 7))
+                        .payingWith(CUSTOM_PAYER)
+                        .gas(NOT_ENOUGH_GAS_LIMIT_FOR_CREATION)
+                        .via("transferWithLowGasLimit"),
+                getTxnRecord("transferWithLowGasLimit").hasPriority(recordWith().status(SUCCESS)),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("contractBalance", 0)));
     }
 
     @HapiTest
     final Stream<DynamicTest>
             internalCallWithValueToNonExistingNonMirrorAddressWithEnoughGasForLazyCreationResultsInSuccessAccountCreated() {
-        return defaultHapiSpec(
-                        "internalCallWithValueToNonExistingNonMirrorAddressWithEnoughGasForLazyCreationResultsInSuccessAccountCreated")
-                .given(
-                        cryptoCreate(CUSTOM_PAYER),
-                        uploadInitCode(INTERNAL_CALLER_CONTRACT),
-                        contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR))
-                .when(
-                        balanceSnapshot("contractBalance", INTERNAL_CALLER_CONTRACT),
-                        contractCall(
-                                        INTERNAL_CALLER_CONTRACT,
-                                        CALL_WITH_VALUE_TO_FUNCTION,
-                                        nonMirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 8))
-                                .payingWith(CUSTOM_PAYER)
-                                .gas(ENOUGH_GAS_LIMIT_FOR_CREATION)
-                                .via("transferWithEnoughGasLimit"))
-                .then(
-                        getTxnRecord("transferWithEnoughGasLimit")
-                                .hasPriority(recordWith().status(SUCCESS)),
-                        getAccountBalance(INTERNAL_CALLER_CONTRACT)
-                                .hasTinyBars(changeFromSnapshot("contractBalance", -1)));
+        return hapiTest(
+                cryptoCreate(CUSTOM_PAYER),
+                uploadInitCode(INTERNAL_CALLER_CONTRACT),
+                contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
+                balanceSnapshot("contractBalance", INTERNAL_CALLER_CONTRACT),
+                contractCall(
+                                INTERNAL_CALLER_CONTRACT,
+                                CALL_WITH_VALUE_TO_FUNCTION,
+                                nonMirrorAddrWith(FIRST_NONEXISTENT_CONTRACT_NUM + 8))
+                        .payingWith(CUSTOM_PAYER)
+                        .gas(ENOUGH_GAS_LIMIT_FOR_CREATION)
+                        .via("transferWithEnoughGasLimit"),
+                getTxnRecord("transferWithEnoughGasLimit")
+                        .hasPriority(recordWith().status(SUCCESS)),
+                getAccountBalance(INTERNAL_CALLER_CONTRACT).hasTinyBars(changeFromSnapshot("contractBalance", -1)));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/traceability/TraceabilitySuite.java
@@ -20,7 +20,6 @@ import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubK
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asContract;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
@@ -3821,33 +3820,30 @@ public class TraceabilitySuite {
     @Order(12)
     final Stream<DynamicTest> traceabilityE2EScenario12() {
         final var contract = "CreateTrivial";
-        final var scenario12 = "traceabilityE2EScenario12";
-        return defaultHapiSpec(scenario12)
-                .given(uploadInitCode(contract))
-                .when(contractCreate(contract)
+        return hapiTest(
+                uploadInitCode(contract),
+                contractCreate(contract)
                         .via(TRACEABILITY_TXN)
-                        .inlineInitCode(extractBytecodeUnhexed(getResourcePath(contract, ".bin"))))
-                .then(
-                        withOpContext((spec, opLog) -> {
-                            final HapiGetTxnRecord txnRecord = getTxnRecord(TRACEABILITY_TXN);
-                            allRunFor(
-                                    spec,
-                                    txnRecord,
-                                    expectContractActionSidecarFor(
-                                            TRACEABILITY_TXN,
-                                            List.of(ContractAction.newBuilder()
-                                                    .setCallType(CREATE)
-                                                    .setCallOperationType(CallOperationType.OP_CREATE)
-                                                    .setCallingAccount(
-                                                            spec.registry().getAccountID(GENESIS))
-                                                    .setRecipientContract(
-                                                            spec.registry().getContractId(contract))
-                                                    .setGas(184672)
-                                                    .setGasUsed(214)
-                                                    .setOutput(EMPTY)
-                                                    .build())));
-                        }),
-                        expectContractBytecodeSansInitcodeFor(TRACEABILITY_TXN, contract));
+                        .inlineInitCode(extractBytecodeUnhexed(getResourcePath(contract, ".bin"))),
+                withOpContext((spec, opLog) -> {
+                    final HapiGetTxnRecord txnRecord = getTxnRecord(TRACEABILITY_TXN);
+                    allRunFor(
+                            spec,
+                            txnRecord,
+                            expectContractActionSidecarFor(
+                                    TRACEABILITY_TXN,
+                                    List.of(ContractAction.newBuilder()
+                                            .setCallType(CREATE)
+                                            .setCallOperationType(CallOperationType.OP_CREATE)
+                                            .setCallingAccount(spec.registry().getAccountID(GENESIS))
+                                            .setRecipientContract(
+                                                    spec.registry().getContractId(contract))
+                                            .setGas(184672)
+                                            .setGasUsed(214)
+                                            .setOutput(EMPTY)
+                                            .build())));
+                }),
+                expectContractBytecodeSansInitcodeFor(TRACEABILITY_TXN, contract));
     }
 
     @HapiTest
@@ -4416,33 +4412,30 @@ public class TraceabilitySuite {
         final var EMPTY_CONSTRUCTOR_CONTRACT = "EmptyConstructor";
         final var vanillaBytecodeSidecar = "vanillaBytecodeSidecar";
         final var firstTxn = "firstTxn";
-        return defaultHapiSpec(vanillaBytecodeSidecar)
-                .given(uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT))
-                .when(contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
+        return hapiTest(
+                uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),
+                contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
                         .hasKnownStatus(SUCCESS)
-                        .via(firstTxn))
-                .then(
-                        withOpContext((spec, opLog) -> {
-                            final HapiGetTxnRecord txnRecord = getTxnRecord(firstTxn);
-                            allRunFor(
-                                    spec,
-                                    txnRecord,
-                                    expectContractActionSidecarFor(
-                                            firstTxn,
-                                            List.of(ContractAction.newBuilder()
-                                                    .setCallType(CREATE)
-                                                    .setCallOperationType(CallOperationType.OP_CREATE)
-                                                    .setCallingAccount(
-                                                            spec.registry().getAccountID(GENESIS))
-                                                    .setRecipientContract(
-                                                            spec.registry().getContractId(EMPTY_CONSTRUCTOR_CONTRACT))
-                                                    .setGas(195600)
-                                                    .setGasUsed(66)
-                                                    .setOutput(EMPTY)
-                                                    .build())));
-                        }),
-                        expectContractBytecodeSidecarFor(
-                                firstTxn, EMPTY_CONSTRUCTOR_CONTRACT, EMPTY_CONSTRUCTOR_CONTRACT));
+                        .via(firstTxn),
+                withOpContext((spec, opLog) -> {
+                    final HapiGetTxnRecord txnRecord = getTxnRecord(firstTxn);
+                    allRunFor(
+                            spec,
+                            txnRecord,
+                            expectContractActionSidecarFor(
+                                    firstTxn,
+                                    List.of(ContractAction.newBuilder()
+                                            .setCallType(CREATE)
+                                            .setCallOperationType(CallOperationType.OP_CREATE)
+                                            .setCallingAccount(spec.registry().getAccountID(GENESIS))
+                                            .setRecipientContract(
+                                                    spec.registry().getContractId(EMPTY_CONSTRUCTOR_CONTRACT))
+                                            .setGas(195600)
+                                            .setGasUsed(66)
+                                            .setOutput(EMPTY)
+                                            .build())));
+                }),
+                expectContractBytecodeSidecarFor(firstTxn, EMPTY_CONSTRUCTOR_CONTRACT, EMPTY_CONSTRUCTOR_CONTRACT));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/NonceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/NonceSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/NonceSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/NonceSuite.java
@@ -18,7 +18,6 @@ package com.hedera.services.bdd.suites.ethereum;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
@@ -641,14 +640,12 @@ public class NonceSuite {
     @HapiTest
     final Stream<DynamicTest>
             nonceNotUpdatedWhenOfferedGasPriceIsLessThanCurrentAndSenderDoesNotHaveEnoughBalanceHandlerCheckFailedEthContractCreate() {
-        return defaultHapiSpec(
-                        "nonceNotUpdatedWhenOfferedGasPriceIsLessThanCurrentAndSenderDoesNotHaveEnoughBalanceHandlerCheckFailedEthContractCreate")
-                .given(
-                        newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoCreate(RELAYER).balance(ONE_MILLION_HBARS),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, 1L)),
-                        uploadInitCode(INTERNAL_CALLEE_CONTRACT))
-                .when(ethereumContractCreate(INTERNAL_CALLEE_CONTRACT)
+        return hapiTest(
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(ONE_MILLION_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, 1L)),
+                uploadInitCode(INTERNAL_CALLEE_CONTRACT),
+                ethereumContractCreate(INTERNAL_CALLEE_CONTRACT)
                         .type(EthTransactionType.EIP1559)
                         .signingWith(SECP_256K1_SOURCE_KEY)
                         .payingWith(RELAYER)
@@ -656,14 +653,12 @@ public class NonceSuite {
                         .gasLimit(ENOUGH_GAS_LIMIT)
                         .maxFeePerGas(LOW_GAS_PRICE)
                         .hasKnownStatus(INSUFFICIENT_PAYER_BALANCE)
-                        .via(TX))
-                .then(
-                        getAliasedAccountInfo(SECP_256K1_SOURCE_KEY)
-                                .has(accountWith().nonce(0L)),
-                        getTxnRecord(TX)
-                                .hasPriority(recordWith()
-                                        .status(INSUFFICIENT_PAYER_BALANCE)
-                                        .contractCallResult(resultWith().signerNonce(0L))));
+                        .via(TX),
+                getAliasedAccountInfo(SECP_256K1_SOURCE_KEY).has(accountWith().nonce(0L)),
+                getTxnRecord(TX)
+                        .hasPriority(recordWith()
+                                .status(INSUFFICIENT_PAYER_BALANCE)
+                                .contractCallResult(resultWith().signerNonce(0L))));
     }
 
     @HapiTest
@@ -694,14 +689,12 @@ public class NonceSuite {
     @HapiTest
     final Stream<DynamicTest>
             nonceNotUpdatedWhenOfferedGasPriceIsBiggerThanCurrentAndSenderDoesNotHaveEnoughBalanceHandlerCheckFailedEthContractCreate() {
-        return defaultHapiSpec(
-                        "nonceNotUpdatedWhenOfferedGasPriceIsBiggerThanCurrentAndSenderDoesNotHaveEnoughBalanceHandlerCheckFailedEthContractCreate")
-                .given(
-                        newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
-                        cryptoCreate(RELAYER).balance(ONE_MILLION_HBARS),
-                        cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, 1L)),
-                        uploadInitCode(INTERNAL_CALLEE_CONTRACT))
-                .when(ethereumContractCreate(INTERNAL_CALLEE_CONTRACT)
+        return hapiTest(
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(ONE_MILLION_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, 1L)),
+                uploadInitCode(INTERNAL_CALLEE_CONTRACT),
+                ethereumContractCreate(INTERNAL_CALLEE_CONTRACT)
                         .type(EthTransactionType.EIP1559)
                         .signingWith(SECP_256K1_SOURCE_KEY)
                         .payingWith(RELAYER)
@@ -709,14 +702,12 @@ public class NonceSuite {
                         .gasLimit(ENOUGH_GAS_LIMIT)
                         .maxFeePerGas(ENOUGH_GAS_PRICE)
                         .hasKnownStatus(INSUFFICIENT_PAYER_BALANCE)
-                        .via(TX))
-                .then(
-                        getAliasedAccountInfo(SECP_256K1_SOURCE_KEY)
-                                .has(accountWith().nonce(0L)),
-                        getTxnRecord(TX)
-                                .hasPriority(recordWith()
-                                        .status(INSUFFICIENT_PAYER_BALANCE)
-                                        .contractCallResult(resultWith().signerNonce(0L))));
+                        .via(TX),
+                getAliasedAccountInfo(SECP_256K1_SOURCE_KEY).has(accountWith().nonce(0L)),
+                getTxnRecord(TX)
+                        .hasPriority(recordWith()
+                                .status(INSUFFICIENT_PAYER_BALANCE)
+                                .contractCallResult(resultWith().signerNonce(0L))));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ProtectedFilesUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ProtectedFilesUpdateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -20,7 +20,6 @@ import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubK
 import static com.hedera.services.bdd.junit.ContextRequirement.PROPERTY_OVERRIDES;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asHexedSolidityAddress;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.includingFungibleMovement;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.includingFungiblePendingAirdrop;
@@ -421,40 +420,32 @@ public class TokenAirdropTest extends TokenAirdropBase {
             final Stream<DynamicTest>
                     transferOneFTTwiceFromEOAWithOneFTInBalanceToAccountWithNoFreeAutoAssociationsResultsInPendingAggregated() {
                 var sender = "sender";
-                return defaultHapiSpec(
-                                "Send one FT from EOA with only One FT in balance twice to Account without free Auto-Associations")
-                        .given(
-                                cryptoCreate(sender).maxAutomaticTokenAssociations(-1),
-                                cryptoTransfer(moving(1, FUNGIBLE_TOKEN).between(OWNER, sender))
-                                        .payingWith(OWNER))
-                        .when(
-                                tokenAirdrop(moving(1, FUNGIBLE_TOKEN)
-                                                .between(sender, RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS))
-                                        .payingWith(sender)
-                                        .signedBy(sender)
-                                        .via("first airdrop"),
-                                tokenAirdrop(moving(1, FUNGIBLE_TOKEN)
-                                                .between(sender, RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS))
-                                        .payingWith(sender)
-                                        .signedBy(sender)
-                                        .via("second airdrop"))
-                        .then(
-                                getTxnRecord("first airdrop")
-                                        .hasPriority(recordWith()
-                                                .pendingAirdrops(includingFungiblePendingAirdrop(moving(
-                                                                1, FUNGIBLE_TOKEN)
-                                                        .between(sender, RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS)))),
-                                getTxnRecord("second airdrop")
-                                        .hasPriority(recordWith()
-                                                .pendingAirdrops(includingFungiblePendingAirdrop(moving(
-                                                                2, FUNGIBLE_TOKEN)
-                                                        .between(sender, RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS)))),
-                                // assert account balances
-                                getAccountBalance(RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS)
-                                        .hasTokenBalance(FUNGIBLE_TOKEN, 0),
-                                getAccountBalance(sender).hasTokenBalance(FUNGIBLE_TOKEN, 1),
-                                validateChargedUsd("first airdrop", 0.1, 10),
-                                validateChargedUsd("second airdrop", 0.05, 10));
+                return hapiTest(
+                        cryptoCreate(sender).maxAutomaticTokenAssociations(-1),
+                        cryptoTransfer(moving(1, FUNGIBLE_TOKEN).between(OWNER, sender))
+                                .payingWith(OWNER),
+                        tokenAirdrop(moving(1, FUNGIBLE_TOKEN).between(sender, RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS))
+                                .payingWith(sender)
+                                .signedBy(sender)
+                                .via("first airdrop"),
+                        tokenAirdrop(moving(1, FUNGIBLE_TOKEN).between(sender, RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS))
+                                .payingWith(sender)
+                                .signedBy(sender)
+                                .via("second airdrop"),
+                        getTxnRecord("first airdrop")
+                                .hasPriority(recordWith()
+                                        .pendingAirdrops(includingFungiblePendingAirdrop(moving(1, FUNGIBLE_TOKEN)
+                                                .between(sender, RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS)))),
+                        getTxnRecord("second airdrop")
+                                .hasPriority(recordWith()
+                                        .pendingAirdrops(includingFungiblePendingAirdrop(moving(2, FUNGIBLE_TOKEN)
+                                                .between(sender, RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS)))),
+                        // assert account balances
+                        getAccountBalance(RECEIVER_WITHOUT_FREE_AUTO_ASSOCIATIONS)
+                                .hasTokenBalance(FUNGIBLE_TOKEN, 0),
+                        getAccountBalance(sender).hasTokenBalance(FUNGIBLE_TOKEN, 1),
+                        validateChargedUsd("first airdrop", 0.1, 10),
+                        validateChargedUsd("second airdrop", 0.05, 10));
             }
 
             @HapiTest
@@ -1287,26 +1278,22 @@ public class TokenAirdropTest extends TokenAirdropBase {
         final Stream<DynamicTest>
                 airdropNFTToNonExistingEvmAddressWithoutAutoAssociationsResultingInPendingAirdropToHollowAccount() {
             final var validAliasForAirdrop = "validAliasForAirdrop";
-            return defaultHapiSpec(
-                            "Send one NFT from EOA to EVM address without auto-associations resulting in the creation of Hollow account and pending airdrop")
-                    .given()
-                    .when(tokenAirdrop(movingUnique(NON_FUNGIBLE_TOKEN, 7L).between(OWNER, validAliasForAirdrop))
+            return hapiTest(
+                    tokenAirdrop(movingUnique(NON_FUNGIBLE_TOKEN, 7L).between(OWNER, validAliasForAirdrop))
                             .payingWith(OWNER)
                             .signedBy(OWNER)
-                            .via("EVM address NFT airdrop"))
-                    .then(
-                            getTxnRecord("EVM address NFT airdrop")
-                                    .hasPriority(recordWith()
-                                            .pendingAirdrops(
-                                                    includingNftPendingAirdrop(movingUnique(NON_FUNGIBLE_TOKEN, 7L)
-                                                            .between(OWNER, validAliasForAirdrop)))),
-                            // assert hollow account
-                            getAliasedAccountInfo(validAliasForAirdrop)
-                                    .isHollow()
-                                    .hasAlreadyUsedAutomaticAssociations(0)
-                                    .hasMaxAutomaticAssociations(0)
-                                    .hasNoTokenRelationship(NON_FUNGIBLE_TOKEN),
-                            validateChargedUsd("EVM address NFT airdrop", 0.1, 10));
+                            .via("EVM address NFT airdrop"),
+                    getTxnRecord("EVM address NFT airdrop")
+                            .hasPriority(recordWith()
+                                    .pendingAirdrops(includingNftPendingAirdrop(movingUnique(NON_FUNGIBLE_TOKEN, 7L)
+                                            .between(OWNER, validAliasForAirdrop)))),
+                    // assert hollow account
+                    getAliasedAccountInfo(validAliasForAirdrop)
+                            .isHollow()
+                            .hasAlreadyUsedAutomaticAssociations(0)
+                            .hasMaxAutomaticAssociations(0)
+                            .hasNoTokenRelationship(NON_FUNGIBLE_TOKEN),
+                    validateChargedUsd("EVM address NFT airdrop", 0.1, 10));
         }
 
         @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
@@ -17,12 +17,11 @@
 package com.hedera.services.bdd.suites.regression.system;
 
 import static com.hedera.services.bdd.junit.TestTags.ND_RECONNECT;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForActive;
-import static com.hedera.services.bdd.suites.regression.system.LifecycleTest.RESTART_TO_ACTIVE_TIMEOUT;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.burstOfTps;
 
 import com.hedera.services.bdd.junit.HapiTest;
@@ -40,27 +39,24 @@ import org.junit.jupiter.api.Tag;
 public class MixedOpsNodeDeathReconnectTest implements LifecycleTest {
     @HapiTest
     final Stream<DynamicTest> reconnectMixedOps() {
-        return defaultHapiSpec("RestartMixedOps")
-                .given(
-                        // Validate we can initially submit transactions to node2
-                        cryptoCreate("nobody").setNode("0.0.5"),
-                        // Run some mixed transactions
-                        burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
-                        // Stop node 2
-                        FakeNmt.shutdownWithin("Carol", SHUTDOWN_TIMEOUT),
-                        logIt("Node 2 is supposedly down"),
-                        sleepFor(PORT_UNBINDING_WAIT_PERIOD.toMillis()))
-                .when(
-                        // Submit operations when node 2 is down
-                        burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
-                        // Restart node2
-                        FakeNmt.restartNode("Carol"),
-                        // Wait for node2 ACTIVE (BUSY and RECONNECT_COMPLETE are too transient to reliably poll for)
-                        waitForActive("Carol", RESTART_TO_ACTIVE_TIMEOUT))
-                .then(
-                        // Run some more transactions
-                        burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
-                        // And validate we can still submit transactions to node2
-                        cryptoCreate("somebody").setNode("0.0.5"));
+        return hapiTest(
+                // Validate we can initially submit transactions to node2
+                cryptoCreate("nobody").setNode("0.0.5"),
+                // Run some mixed transactions
+                burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
+                // Stop node 2
+                FakeNmt.shutdownWithin("Carol", SHUTDOWN_TIMEOUT),
+                logIt("Node 2 is supposedly down"),
+                sleepFor(PORT_UNBINDING_WAIT_PERIOD.toMillis()),
+                // Submit operations when node 2 is down
+                burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
+                // Restart node2
+                FakeNmt.restartNode("Carol"),
+                // Wait for node2 ACTIVE (BUSY and RECONNECT_COMPLETE are too transient to reliably poll for)
+                waitForActive("Carol", RESTART_TO_ACTIVE_TIMEOUT),
+                // Run some more transactions
+                burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
+                // And validate we can still submit transactions to node2
+                cryptoCreate("somebody").setNode("0.0.5"));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StakingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StakingSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/ThrottleDefValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/ThrottleDefValidationSuite.java
@@ -16,7 +16,6 @@
 
 package com.hedera.services.bdd.suites.throttling;
 
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
@@ -74,20 +73,17 @@ public class ThrottleDefValidationSuite {
     @HapiTest
     @Order(5)
     final Stream<DynamicTest> throttleDefsRejectUnauthorizedPayers() {
-        return defaultHapiSpec("ThrottleDefsRejectUnauthorizedPayers")
-                .given(
-                        cryptoCreate("civilian"),
-                        cryptoTransfer(movingHbar(ONE_HUNDRED_HBARS).between(GENESIS, FEE_SCHEDULE_CONTROL)))
-                .when()
-                .then(
-                        fileUpdate(THROTTLE_DEFS)
-                                .contents("BOOM")
-                                .payingWith("civilian")
-                                .hasPrecheck(AUTHORIZATION_FAILED),
-                        fileUpdate(THROTTLE_DEFS)
-                                .contents("BOOM")
-                                .payingWith(FEE_SCHEDULE_CONTROL)
-                                .hasPrecheck(AUTHORIZATION_FAILED));
+        return hapiTest(
+                cryptoCreate("civilian"),
+                cryptoTransfer(movingHbar(ONE_HUNDRED_HBARS).between(GENESIS, FEE_SCHEDULE_CONTROL)),
+                fileUpdate(THROTTLE_DEFS)
+                        .contents("BOOM")
+                        .payingWith("civilian")
+                        .hasPrecheck(AUTHORIZATION_FAILED),
+                fileUpdate(THROTTLE_DEFS)
+                        .contents("BOOM")
+                        .payingWith(FEE_SCHEDULE_CONTROL)
+                        .hasPrecheck(AUTHORIZATION_FAILED));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyAccountsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/Hip17UnhappyAccountsSuite.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
@@ -60,140 +60,120 @@ public class Hip17UnhappyAccountsSuite {
 
     @HapiTest
     final Stream<DynamicTest> uniqueTokenOperationsFailForDeletedAccount() {
-        return defaultHapiSpec("UniqueTokenOperationsFailForDeletedAccount")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(KYC_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        cryptoCreate(CLIENT_1),
-                        cryptoCreate(TREASURY))
-                .when(
-                        tokenCreate(UNIQUE_TOKEN_A)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .freezeKey(FREEZE_KEY)
-                                .kycKey(KYC_KEY)
-                                .wipeKey(WIPE_KEY)
-                                .treasury(TREASURY),
-                        mintToken(
-                                UNIQUE_TOKEN_A,
-                                List.of(ByteString.copyFromUtf8(MEMO_1), ByteString.copyFromUtf8(MEMO_2))),
-                        tokenAssociate(CLIENT_1, UNIQUE_TOKEN_A),
-                        cryptoDelete(CLIENT_1))
-                .then(
-                        cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 2L).between(TREASURY, CLIENT_1))
-                                .hasKnownStatus(ACCOUNT_DELETED),
-                        revokeTokenKyc(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(ACCOUNT_DELETED),
-                        grantTokenKyc(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(ACCOUNT_DELETED),
-                        tokenFreeze(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(ACCOUNT_DELETED),
-                        tokenUnfreeze(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(ACCOUNT_DELETED),
-                        wipeTokenAccount(UNIQUE_TOKEN_A, CLIENT_1, List.of(1L)).hasKnownStatus(ACCOUNT_DELETED));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(FREEZE_KEY),
+                newKeyNamed(KYC_KEY),
+                newKeyNamed(WIPE_KEY),
+                cryptoCreate(CLIENT_1),
+                cryptoCreate(TREASURY),
+                tokenCreate(UNIQUE_TOKEN_A)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .freezeKey(FREEZE_KEY)
+                        .kycKey(KYC_KEY)
+                        .wipeKey(WIPE_KEY)
+                        .treasury(TREASURY),
+                mintToken(UNIQUE_TOKEN_A, List.of(ByteString.copyFromUtf8(MEMO_1), ByteString.copyFromUtf8(MEMO_2))),
+                tokenAssociate(CLIENT_1, UNIQUE_TOKEN_A),
+                cryptoDelete(CLIENT_1),
+                cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 2L).between(TREASURY, CLIENT_1))
+                        .hasKnownStatus(ACCOUNT_DELETED),
+                revokeTokenKyc(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(ACCOUNT_DELETED),
+                grantTokenKyc(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(ACCOUNT_DELETED),
+                tokenFreeze(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(ACCOUNT_DELETED),
+                tokenUnfreeze(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(ACCOUNT_DELETED),
+                wipeTokenAccount(UNIQUE_TOKEN_A, CLIENT_1, List.of(1L)).hasKnownStatus(ACCOUNT_DELETED));
     }
 
     @HapiTest
     final Stream<DynamicTest> uniqueTokenOperationsFailForKycRevokedAccount() {
-        return defaultHapiSpec("UniqueTokenOperationsFailForKycRevokedAccount")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(KYC_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        cryptoCreate(CLIENT_1),
-                        cryptoCreate(CLIENT_2),
-                        cryptoCreate(TREASURY))
-                .when(
-                        tokenCreate(UNIQUE_TOKEN_A)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .freezeKey(FREEZE_KEY)
-                                .kycKey(KYC_KEY)
-                                .wipeKey(WIPE_KEY)
-                                .treasury(TREASURY),
-                        mintToken(
-                                UNIQUE_TOKEN_A,
-                                List.of(ByteString.copyFromUtf8(MEMO_1), ByteString.copyFromUtf8(MEMO_2))),
-                        tokenAssociate(CLIENT_1, UNIQUE_TOKEN_A),
-                        grantTokenKyc(UNIQUE_TOKEN_A, CLIENT_1),
-                        cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(TREASURY, CLIENT_1)),
-                        tokenAssociate(CLIENT_2, UNIQUE_TOKEN_A),
-                        revokeTokenKyc(UNIQUE_TOKEN_A, CLIENT_1))
-                .then(
-                        cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 2L).between(TREASURY, CLIENT_1))
-                                .hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
-                        cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(CLIENT_1, CLIENT_2))
-                                .hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
-                        wipeTokenAccount(UNIQUE_TOKEN_A, CLIENT_1, List.of(1L))
-                                .hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(FREEZE_KEY),
+                newKeyNamed(KYC_KEY),
+                newKeyNamed(WIPE_KEY),
+                cryptoCreate(CLIENT_1),
+                cryptoCreate(CLIENT_2),
+                cryptoCreate(TREASURY),
+                tokenCreate(UNIQUE_TOKEN_A)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .freezeKey(FREEZE_KEY)
+                        .kycKey(KYC_KEY)
+                        .wipeKey(WIPE_KEY)
+                        .treasury(TREASURY),
+                mintToken(UNIQUE_TOKEN_A, List.of(ByteString.copyFromUtf8(MEMO_1), ByteString.copyFromUtf8(MEMO_2))),
+                tokenAssociate(CLIENT_1, UNIQUE_TOKEN_A),
+                grantTokenKyc(UNIQUE_TOKEN_A, CLIENT_1),
+                cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(TREASURY, CLIENT_1)),
+                tokenAssociate(CLIENT_2, UNIQUE_TOKEN_A),
+                revokeTokenKyc(UNIQUE_TOKEN_A, CLIENT_1),
+                cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 2L).between(TREASURY, CLIENT_1))
+                        .hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
+                cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(CLIENT_1, CLIENT_2))
+                        .hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
+                wipeTokenAccount(UNIQUE_TOKEN_A, CLIENT_1, List.of(1L))
+                        .hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN));
     }
 
     @HapiTest
     final Stream<DynamicTest> uniqueTokenOperationsFailForFrozenAccount() {
-        return defaultHapiSpec("UniqueTokenOperationsFailForFrozenAccount")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(KYC_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        cryptoCreate(CLIENT_1),
-                        cryptoCreate(CLIENT_2),
-                        cryptoCreate(TREASURY))
-                .when(
-                        tokenCreate(UNIQUE_TOKEN_A)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .freezeKey(FREEZE_KEY)
-                                .kycKey(KYC_KEY)
-                                .wipeKey(WIPE_KEY)
-                                .treasury(TREASURY),
-                        mintToken(
-                                UNIQUE_TOKEN_A,
-                                List.of(ByteString.copyFromUtf8(MEMO_1), ByteString.copyFromUtf8(MEMO_2))),
-                        tokenAssociate(CLIENT_1, UNIQUE_TOKEN_A),
-                        grantTokenKyc(UNIQUE_TOKEN_A, CLIENT_1),
-                        cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(TREASURY, CLIENT_1)),
-                        tokenAssociate(CLIENT_2, UNIQUE_TOKEN_A),
-                        tokenFreeze(UNIQUE_TOKEN_A, CLIENT_1))
-                .then(
-                        cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 2L).between(TREASURY, CLIENT_1))
-                                .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
-                        cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(CLIENT_1, CLIENT_2))
-                                .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
-                        wipeTokenAccount(UNIQUE_TOKEN_A, CLIENT_1, List.of(1L))
-                                .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(FREEZE_KEY),
+                newKeyNamed(KYC_KEY),
+                newKeyNamed(WIPE_KEY),
+                cryptoCreate(CLIENT_1),
+                cryptoCreate(CLIENT_2),
+                cryptoCreate(TREASURY),
+                tokenCreate(UNIQUE_TOKEN_A)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .freezeKey(FREEZE_KEY)
+                        .kycKey(KYC_KEY)
+                        .wipeKey(WIPE_KEY)
+                        .treasury(TREASURY),
+                mintToken(UNIQUE_TOKEN_A, List.of(ByteString.copyFromUtf8(MEMO_1), ByteString.copyFromUtf8(MEMO_2))),
+                tokenAssociate(CLIENT_1, UNIQUE_TOKEN_A),
+                grantTokenKyc(UNIQUE_TOKEN_A, CLIENT_1),
+                cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(TREASURY, CLIENT_1)),
+                tokenAssociate(CLIENT_2, UNIQUE_TOKEN_A),
+                tokenFreeze(UNIQUE_TOKEN_A, CLIENT_1),
+                cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 2L).between(TREASURY, CLIENT_1))
+                        .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
+                cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(CLIENT_1, CLIENT_2))
+                        .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
+                wipeTokenAccount(UNIQUE_TOKEN_A, CLIENT_1, List.of(1L)).hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN));
     }
 
     @HapiTest
     final Stream<DynamicTest> uniqueTokenOperationsFailForDissociatedAccount() {
-        return defaultHapiSpec("UniqueTokenOperationsFailForDissociatedAccount")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(FREEZE_KEY),
-                        newKeyNamed(KYC_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        cryptoCreate(CLIENT_1),
-                        cryptoCreate(TREASURY))
-                .when(
-                        tokenCreate(UNIQUE_TOKEN_A)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .freezeKey(FREEZE_KEY)
-                                .kycKey(KYC_KEY)
-                                .wipeKey(WIPE_KEY)
-                                .treasury(TREASURY),
-                        mintToken(UNIQUE_TOKEN_A, List.of(ByteString.copyFromUtf8("memo"))))
-                .then(
-                        tokenFreeze(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-                        tokenUnfreeze(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-                        grantTokenKyc(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-                        revokeTokenKyc(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-                        wipeTokenAccount(UNIQUE_TOKEN_A, CLIENT_1, List.of(1L))
-                                .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-                        cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(TREASURY, CLIENT_1))
-                                .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(FREEZE_KEY),
+                newKeyNamed(KYC_KEY),
+                newKeyNamed(WIPE_KEY),
+                cryptoCreate(CLIENT_1),
+                cryptoCreate(TREASURY),
+                tokenCreate(UNIQUE_TOKEN_A)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .freezeKey(FREEZE_KEY)
+                        .kycKey(KYC_KEY)
+                        .wipeKey(WIPE_KEY)
+                        .treasury(TREASURY),
+                mintToken(UNIQUE_TOKEN_A, List.of(ByteString.copyFromUtf8("memo"))),
+                tokenFreeze(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+                tokenUnfreeze(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+                grantTokenKyc(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+                revokeTokenKyc(UNIQUE_TOKEN_A, CLIENT_1).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+                wipeTokenAccount(UNIQUE_TOKEN_A, CLIENT_1, List.of(1L)).hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+                cryptoTransfer(movingUnique(UNIQUE_TOKEN_A, 1L).between(TREASURY, CLIENT_1))
+                        .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.HapiSpecOperation.UnknownFieldLocation.OP_BODY;
 import static com.hedera.services.bdd.spec.HapiSpecOperation.UnknownFieldLocation.SIGNED_TRANSACTION;
@@ -135,7 +134,7 @@ public class TokenCreateSpecs {
     private static final String CREATE_TXN = "createTxn";
     private static final String PAYER = "payer";
 
-    private static String TOKEN_TREASURY = "treasury";
+    private static final String TOKEN_TREASURY = "treasury";
 
     private static final String A_TOKEN = "TokenA";
     private static final String B_TOKEN = "TokenB";
@@ -144,58 +143,49 @@ public class TokenCreateSpecs {
 
     @HapiTest
     final Stream<DynamicTest> getInfoIdVariantsTreatedAsExpected() {
-        return defaultHapiSpec("getInfoIdVariantsTreatedAsExpected")
-                .given(tokenCreate("something"))
-                .when()
-                .then(sendModified(withSuccessivelyVariedQueryIds(), () -> getTokenInfo("something")));
+        return hapiTest(
+                tokenCreate("something"),
+                sendModified(withSuccessivelyVariedQueryIds(), () -> getTokenInfo("something")));
     }
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
-        return defaultHapiSpec("idVariantsTreatedAsExpected")
-                .given(
-                        newKeyNamed("supplyKey"),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate("autoRenewAccount"),
-                        cryptoCreate("feeCollector"),
-                        tokenCreate("feeToken"),
-                        tokenAssociate("feeCollector", "feeToken"))
-                .when()
-                .then(
-                        submitModified(withSuccessivelyVariedBodyIds(), () -> tokenCreate("fungibleToken")
-                                .treasury(TOKEN_TREASURY)
-                                .autoRenewAccount("autoRenewAccount")
-                                .withCustom(fixedHbarFee(1L, "feeCollector"))
-                                .withCustom(fixedHtsFee(1L, "feeToken", "feeCollector"))
-                                .withCustom(fractionalFee(1L, 100L, 1L, OptionalLong.of(5L), "feeCollector"))
-                                .signedBy(DEFAULT_PAYER, TOKEN_TREASURY, "feeCollector", "autoRenewAccount")),
-                        submitModified(withSuccessivelyVariedBodyIds(), () -> tokenCreate("nonFungibleToken")
-                                .treasury(TOKEN_TREASURY)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0L)
-                                .supplyKey("supplyKey")
-                                .autoRenewAccount("autoRenewAccount")
-                                .withCustom(royaltyFeeWithFallback(
-                                        1L, 10L, fixedHbarFeeInheritingRoyaltyCollector(123L), "feeCollector"))
-                                .signedBy(DEFAULT_PAYER, TOKEN_TREASURY, "autoRenewAccount")));
+        return hapiTest(
+                newKeyNamed("supplyKey"),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate("autoRenewAccount"),
+                cryptoCreate("feeCollector"),
+                tokenCreate("feeToken"),
+                tokenAssociate("feeCollector", "feeToken"),
+                submitModified(withSuccessivelyVariedBodyIds(), () -> tokenCreate("fungibleToken")
+                        .treasury(TOKEN_TREASURY)
+                        .autoRenewAccount("autoRenewAccount")
+                        .withCustom(fixedHbarFee(1L, "feeCollector"))
+                        .withCustom(fixedHtsFee(1L, "feeToken", "feeCollector"))
+                        .withCustom(fractionalFee(1L, 100L, 1L, OptionalLong.of(5L), "feeCollector"))
+                        .signedBy(DEFAULT_PAYER, TOKEN_TREASURY, "feeCollector", "autoRenewAccount")),
+                submitModified(withSuccessivelyVariedBodyIds(), () -> tokenCreate("nonFungibleToken")
+                        .treasury(TOKEN_TREASURY)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0L)
+                        .supplyKey("supplyKey")
+                        .autoRenewAccount("autoRenewAccount")
+                        .withCustom(royaltyFeeWithFallback(
+                                1L, 10L, fixedHbarFeeInheritingRoyaltyCollector(123L), "feeCollector"))
+                        .signedBy(DEFAULT_PAYER, TOKEN_TREASURY, "autoRenewAccount")));
     }
 
     @HapiTest
     final Stream<DynamicTest> canHandleInvalidTokenCreateTransactions() {
         final String alice = "ALICE";
-        return defaultHapiSpec("canHandleInvalidTokenCreateTransactions")
-                .given(cryptoCreate(alice))
-                .when()
-                .then(
-                        tokenCreate(null).hasKnownStatus(MISSING_TOKEN_NAME),
-                        tokenCreate(A_TOKEN)
-                                .treasury(alice)
-                                .signedBy(DEFAULT_PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        tokenCreate(A_TOKEN)
-                                .treasury(alice)
-                                .signedBy(DEFAULT_PAYER, alice)
-                                .hasKnownStatus(SUCCESS));
+        return hapiTest(
+                cryptoCreate(alice),
+                tokenCreate(null).hasKnownStatus(MISSING_TOKEN_NAME),
+                tokenCreate(A_TOKEN).treasury(alice).signedBy(DEFAULT_PAYER).hasKnownStatus(INVALID_SIGNATURE),
+                tokenCreate(A_TOKEN)
+                        .treasury(alice)
+                        .signedBy(DEFAULT_PAYER, alice)
+                        .hasKnownStatus(SUCCESS));
     }
 
     /**
@@ -207,7 +197,7 @@ public class TokenCreateSpecs {
      *     <li>Any self-denominated fixed fee collector.</li>
      * </ul>
      * It also verifies that these auto-associations don't "count" against the max
-     * automatic associations limit defined by https://hips.hedera.com/hip/hip-23.
+     * automatic associations limit defined by <a href="https://hips.hedera.com/hip/hip-23">...</a>.
      */
     @HapiTest
     final Stream<DynamicTest> validateNewTokenAssociations() {
@@ -287,20 +277,16 @@ public class TokenCreateSpecs {
      */
     @HapiTest
     final Stream<DynamicTest> createsFungibleInfiniteByDefault() {
-        return defaultHapiSpec("CreatesFungibleInfiniteByDefault")
-                .given()
-                .when(tokenCreate("DefaultFungible"))
-                .then(getTokenInfo("DefaultFungible")
+        return hapiTest(
+                tokenCreate("DefaultFungible"),
+                getTokenInfo("DefaultFungible")
                         .hasTokenType(TokenType.FUNGIBLE_COMMON)
                         .hasSupplyType(TokenSupplyType.INFINITE));
     }
 
     @HapiTest
     final Stream<DynamicTest> worksAsExpectedWithDefaultTokenId() {
-        return defaultHapiSpec("WorksAsExpectedWithDefaultTokenId")
-                .given()
-                .when()
-                .then(getTokenInfo(SENTINEL_VALUE).hasCostAnswerPrecheck(INVALID_TOKEN_ID));
+        return hapiTest(getTokenInfo(SENTINEL_VALUE).hasCostAnswerPrecheck(INVALID_TOKEN_ID));
     }
 
     @HapiTest
@@ -318,42 +304,39 @@ public class TokenCreateSpecs {
     @HapiTest
     final Stream<DynamicTest> autoRenewValidationWorks() {
         final var deletingAccount = "deletingAccount";
-        return defaultHapiSpec("AutoRenewValidationWorks")
-                .given(
-                        cryptoCreate(AUTO_RENEW).balance(0L),
-                        cryptoCreate(deletingAccount).balance(0L))
-                .when(
-                        cryptoDelete(deletingAccount),
-                        tokenCreate(PRIMARY)
-                                .autoRenewAccount(deletingAccount)
-                                .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
-                        tokenCreate(PRIMARY)
-                                .signedBy(GENESIS)
-                                .autoRenewAccount("1.2.3")
-                                .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
-                        tokenCreate(PRIMARY)
-                                .autoRenewAccount(AUTO_RENEW)
-                                .autoRenewPeriod(Long.MAX_VALUE)
-                                .hasPrecheck(INVALID_RENEWAL_PERIOD),
-                        tokenCreate(PRIMARY)
-                                .signedBy(GENESIS)
-                                .autoRenewAccount(AUTO_RENEW)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        tokenCreate(PRIMARY).autoRenewAccount(AUTO_RENEW))
-                .then(getTokenInfo(PRIMARY).logged());
+        return hapiTest(
+                cryptoCreate(AUTO_RENEW).balance(0L),
+                cryptoCreate(deletingAccount).balance(0L),
+                cryptoDelete(deletingAccount),
+                tokenCreate(PRIMARY).autoRenewAccount(deletingAccount).hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
+                tokenCreate(PRIMARY)
+                        .signedBy(GENESIS)
+                        .autoRenewAccount("1.2.3")
+                        .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
+                tokenCreate(PRIMARY)
+                        .autoRenewAccount(AUTO_RENEW)
+                        .autoRenewPeriod(Long.MAX_VALUE)
+                        .hasPrecheck(INVALID_RENEWAL_PERIOD),
+                tokenCreate(PRIMARY)
+                        .signedBy(GENESIS)
+                        .autoRenewAccount(AUTO_RENEW)
+                        .hasKnownStatus(INVALID_SIGNATURE),
+                tokenCreate(PRIMARY).autoRenewAccount(AUTO_RENEW),
+                getTokenInfo(PRIMARY).logged());
     }
 
     @HapiTest
     final Stream<DynamicTest> creationYieldsExpectedToken() {
-        return defaultHapiSpec("CreationYieldsExpectedToken")
-                .given(cryptoCreate(TOKEN_TREASURY).balance(0L), newKeyNamed("freeze"))
-                .when(tokenCreate(PRIMARY)
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                newKeyNamed("freeze"),
+                tokenCreate(PRIMARY)
                         .initialSupply(123)
                         .decimals(4)
                         .freezeDefault(true)
                         .freezeKey("freeze")
-                        .treasury(TOKEN_TREASURY))
-                .then(getTokenInfo(PRIMARY).logged().hasRegisteredId(PRIMARY));
+                        .treasury(TOKEN_TREASURY),
+                getTokenInfo(PRIMARY).logged().hasRegisteredId(PRIMARY));
     }
 
     @HapiTest
@@ -562,260 +545,237 @@ public class TokenCreateSpecs {
 
     @HapiTest
     final Stream<DynamicTest> creationSetsCorrectExpiry() {
-        return defaultHapiSpec("CreationSetsCorrectExpiry")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY).balance(0L),
-                        cryptoCreate(AUTO_RENEW).balance(0L))
-                .when(tokenCreate(PRIMARY)
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                cryptoCreate(AUTO_RENEW).balance(0L),
+                tokenCreate(PRIMARY)
                         .autoRenewAccount(AUTO_RENEW)
                         .autoRenewPeriod(THREE_MONTHS_IN_SECONDS)
                         .treasury(TOKEN_TREASURY)
-                        .via(CREATE_TXN))
-                .then(
-                        withOpContext((spec, opLog) -> {
-                            var createTxn = getTxnRecord(CREATE_TXN);
-                            allRunFor(spec, createTxn);
-                            var timestamp = createTxn
-                                    .getResponseRecord()
-                                    .getConsensusTimestamp()
-                                    .getSeconds();
-                            spec.registry().saveExpiry(PRIMARY, timestamp + THREE_MONTHS_IN_SECONDS);
-                        }),
-                        getTokenInfo(PRIMARY).logged().hasRegisteredId(PRIMARY).hasValidExpiry());
+                        .via(CREATE_TXN),
+                withOpContext((spec, opLog) -> {
+                    var createTxn = getTxnRecord(CREATE_TXN);
+                    allRunFor(spec, createTxn);
+                    var timestamp = createTxn
+                            .getResponseRecord()
+                            .getConsensusTimestamp()
+                            .getSeconds();
+                    spec.registry().saveExpiry(PRIMARY, timestamp + THREE_MONTHS_IN_SECONDS);
+                }),
+                getTokenInfo(PRIMARY).logged().hasRegisteredId(PRIMARY).hasValidExpiry());
     }
 
     @HapiTest
     final Stream<DynamicTest> creationValidatesExpiry() {
-        return defaultHapiSpec("CreationValidatesExpiry")
-                .given()
-                .when()
-                .then(tokenCreate(PRIMARY).expiry(1000).hasPrecheck(INVALID_EXPIRATION_TIME));
+        return hapiTest(tokenCreate(PRIMARY).expiry(1000).hasPrecheck(INVALID_EXPIRATION_TIME));
     }
 
     @HapiTest
     final Stream<DynamicTest> creationValidatesFreezeDefaultWithNoFreezeKey() {
-        return defaultHapiSpec("CreationValidatesFreezeDefaultWithNoFreezeKey")
-                .given()
-                .when()
-                .then(tokenCreate(PRIMARY).freezeDefault(true).hasPrecheck(TOKEN_HAS_NO_FREEZE_KEY));
+        return hapiTest(tokenCreate(PRIMARY).freezeDefault(true).hasPrecheck(TOKEN_HAS_NO_FREEZE_KEY));
     }
 
     @HapiTest
     final Stream<DynamicTest> creationValidatesMemo() {
-        return defaultHapiSpec("CreationValidatesMemo")
-                .given()
-                .when()
-                .then(tokenCreate(PRIMARY).entityMemo("N\u0000!!!").hasPrecheck(INVALID_ZERO_BYTE_IN_STRING));
+        return hapiTest(tokenCreate(PRIMARY).entityMemo("N\u0000!!!").hasPrecheck(INVALID_ZERO_BYTE_IN_STRING));
     }
 
     @HapiTest
     final Stream<DynamicTest> creationValidatesNonFungiblePrechecks() {
-        return defaultHapiSpec("CreationValidatesNonFungiblePrechecks")
-                .given()
-                .when()
-                .then(
-                        tokenCreate(PRIMARY)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .decimals(0)
-                                .hasPrecheck(TOKEN_HAS_NO_SUPPLY_KEY),
-                        tokenCreate(PRIMARY)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(1)
-                                .decimals(0)
-                                .hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY),
-                        tokenCreate(PRIMARY)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .decimals(1)
-                                .hasPrecheck(INVALID_TOKEN_DECIMALS));
+        return hapiTest(
+                tokenCreate(PRIMARY)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .decimals(0)
+                        .hasPrecheck(TOKEN_HAS_NO_SUPPLY_KEY),
+                tokenCreate(PRIMARY)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(1)
+                        .decimals(0)
+                        .hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY),
+                tokenCreate(PRIMARY)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .decimals(1)
+                        .hasPrecheck(INVALID_TOKEN_DECIMALS));
     }
 
     @HapiTest
     final Stream<DynamicTest> creationValidatesMaxSupply() {
-        return defaultHapiSpec("CreationValidatesMaxSupply")
-                .given()
-                .when()
-                .then(
-                        tokenCreate(PRIMARY).maxSupply(-1).hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
-                        tokenCreate(PRIMARY).maxSupply(1).hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
-                        tokenCreate(PRIMARY)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .maxSupply(0)
-                                .hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
-                        tokenCreate(PRIMARY)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .maxSupply(-1)
-                                .hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
-                        tokenCreate(PRIMARY)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .initialSupply(2)
-                                .maxSupply(1)
-                                .hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY));
+        return hapiTest(
+                tokenCreate(PRIMARY).maxSupply(-1).hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
+                tokenCreate(PRIMARY).maxSupply(1).hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
+                tokenCreate(PRIMARY)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .maxSupply(0)
+                        .hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
+                tokenCreate(PRIMARY)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .maxSupply(-1)
+                        .hasPrecheck(INVALID_TOKEN_MAX_SUPPLY),
+                tokenCreate(PRIMARY)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .initialSupply(2)
+                        .maxSupply(1)
+                        .hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY));
     }
 
     @HapiTest
     final Stream<DynamicTest> onlyValidCustomFeeScheduleCanBeCreated() {
-        return defaultHapiSpec("OnlyValidCustomFeeScheduleCanBeCreated")
-                .given(
-                        newKeyNamed(customFeesKey),
-                        cryptoCreate(htsCollector),
-                        cryptoCreate(hbarCollector),
-                        cryptoCreate(tokenCollector),
-                        tokenCreate(feeDenom).treasury(htsCollector))
-                .when(
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fractionalFee(
-                                        numerator,
-                                        0,
-                                        minimumToCollect,
-                                        OptionalLong.of(maximumToCollect),
-                                        tokenCollector))
-                                .hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fixedHbarFee(hbarAmount, invalidEntityId))
-                                .hasKnownStatus(INVALID_CUSTOM_FEE_COLLECTOR),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fixedHtsFee(htsAmount, invalidEntityId, htsCollector))
-                                .hasKnownStatus(INVALID_TOKEN_ID_IN_CUSTOM_FEES),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fixedHtsFee(htsAmount, feeDenom, hbarCollector))
-                                .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(incompleteCustomFee(hbarCollector))
-                                .signedBy(DEFAULT_PAYER, tokenCollector, hbarCollector)
-                                .hasKnownStatus(CUSTOM_FEE_NOT_FULLY_SPECIFIED),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fixedHtsFee(negativeHtsFee, feeDenom, hbarCollector))
-                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fractionalFee(
-                                        numerator,
-                                        -denominator,
-                                        minimumToCollect,
-                                        OptionalLong.of(maximumToCollect),
-                                        tokenCollector))
-                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fractionalFee(
-                                        numerator,
-                                        denominator,
-                                        -minimumToCollect,
-                                        OptionalLong.of(maximumToCollect),
-                                        tokenCollector))
-                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fractionalFee(
-                                        numerator,
-                                        denominator,
-                                        minimumToCollect,
-                                        OptionalLong.of(-maximumToCollect),
-                                        tokenCollector))
-                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fractionalFee(
-                                        -numerator,
-                                        -denominator,
-                                        minimumToCollect,
-                                        OptionalLong.of(maximumToCollect),
-                                        tokenCollector))
-                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fractionalFee(
-                                        numerator,
-                                        denominator,
-                                        minimumToCollect,
-                                        OptionalLong.of(minimumToCollect - 1),
-                                        tokenCollector))
-                                .hasKnownStatus(FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fractionalFee(
-                                        numerator,
-                                        denominator,
-                                        minimumToCollect,
-                                        OptionalLong.of(minimumToCollect),
-                                        tokenCollector))
-                                .hasKnownStatus(SUCCESS),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(royaltyFeeNoFallback(1, 2, tokenCollector))
-                                .hasKnownStatus(CUSTOM_ROYALTY_FEE_ONLY_ALLOWED_FOR_NON_FUNGIBLE_UNIQUE),
-                        tokenCreate(token)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(GENESIS)
-                                .initialSupply(0L)
-                                .treasury(tokenCollector)
-                                .withCustom(royaltyFeeNoFallback(-1, 2, tokenCollector))
-                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-                        tokenCreate(token)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(GENESIS)
-                                .initialSupply(0L)
-                                .treasury(tokenCollector)
-                                .withCustom(royaltyFeeNoFallback(1, -2, tokenCollector))
-                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-                        tokenCreate(token)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(GENESIS)
-                                .initialSupply(0L)
-                                .treasury(tokenCollector)
-                                .withCustom(royaltyFeeNoFallback(1, 0, tokenCollector))
-                                .hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
-                        tokenCreate(token)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(GENESIS)
-                                .initialSupply(0L)
-                                .treasury(tokenCollector)
-                                .withCustom(royaltyFeeNoFallback(2, 1, tokenCollector))
-                                .hasKnownStatus(ROYALTY_FRACTION_CANNOT_EXCEED_ONE),
-                        tokenCreate(token)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(GENESIS)
-                                .initialSupply(0L)
-                                .treasury(tokenCollector)
-                                .withCustom(royaltyFeeWithFallback(
-                                        1, 2, fixedHbarFeeInheritingRoyaltyCollector(-100), tokenCollector))
-                                .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
-                        tokenCreate(token)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(GENESIS)
-                                .initialSupply(0L)
-                                .treasury(tokenCollector)
-                                .withCustom(royaltyFeeWithFallback(
-                                        1, 2, fixedHtsFeeInheritingRoyaltyCollector(100, "1.2.3"), tokenCollector))
-                                .hasKnownStatus(INVALID_TOKEN_ID_IN_CUSTOM_FEES),
-                        tokenCreate(token)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(GENESIS)
-                                .initialSupply(0L)
-                                .treasury(htsCollector)
-                                .withCustom(royaltyFeeWithFallback(
-                                        1, 2, fixedHtsFeeInheritingRoyaltyCollector(100, feeDenom), htsCollector)),
-                        tokenCreate(token)
-                                .treasury(tokenCollector)
-                                .withCustom(fixedHbarFee(hbarAmount, hbarCollector))
-                                .withCustom(fixedHtsFee(htsAmount, feeDenom, htsCollector))
-                                .withCustom(fixedHtsFee(htsAmount, SENTINEL_VALUE, htsCollector))
-                                .withCustom(fractionalFee(
-                                        numerator,
-                                        denominator,
-                                        minimumToCollect,
-                                        OptionalLong.of(maximumToCollect),
-                                        tokenCollector))
-                                .signedBy(DEFAULT_PAYER, tokenCollector, htsCollector))
-                .then(getTokenInfo(token)
+        return hapiTest(
+                newKeyNamed(customFeesKey),
+                cryptoCreate(htsCollector),
+                cryptoCreate(hbarCollector),
+                cryptoCreate(tokenCollector),
+                tokenCreate(feeDenom).treasury(htsCollector),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fractionalFee(
+                                numerator, 0, minimumToCollect, OptionalLong.of(maximumToCollect), tokenCollector))
+                        .hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fixedHbarFee(hbarAmount, invalidEntityId))
+                        .hasKnownStatus(INVALID_CUSTOM_FEE_COLLECTOR),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fixedHtsFee(htsAmount, invalidEntityId, htsCollector))
+                        .hasKnownStatus(INVALID_TOKEN_ID_IN_CUSTOM_FEES),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fixedHtsFee(htsAmount, feeDenom, hbarCollector))
+                        .hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_FEE_COLLECTOR),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(incompleteCustomFee(hbarCollector))
+                        .signedBy(DEFAULT_PAYER, tokenCollector, hbarCollector)
+                        .hasKnownStatus(CUSTOM_FEE_NOT_FULLY_SPECIFIED),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fixedHtsFee(negativeHtsFee, feeDenom, hbarCollector))
+                        .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fractionalFee(
+                                numerator,
+                                -denominator,
+                                minimumToCollect,
+                                OptionalLong.of(maximumToCollect),
+                                tokenCollector))
+                        .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fractionalFee(
+                                numerator,
+                                denominator,
+                                -minimumToCollect,
+                                OptionalLong.of(maximumToCollect),
+                                tokenCollector))
+                        .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fractionalFee(
+                                numerator,
+                                denominator,
+                                minimumToCollect,
+                                OptionalLong.of(-maximumToCollect),
+                                tokenCollector))
+                        .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fractionalFee(
+                                -numerator,
+                                -denominator,
+                                minimumToCollect,
+                                OptionalLong.of(maximumToCollect),
+                                tokenCollector))
+                        .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fractionalFee(
+                                numerator,
+                                denominator,
+                                minimumToCollect,
+                                OptionalLong.of(minimumToCollect - 1),
+                                tokenCollector))
+                        .hasKnownStatus(FRACTIONAL_FEE_MAX_AMOUNT_LESS_THAN_MIN_AMOUNT),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fractionalFee(
+                                numerator,
+                                denominator,
+                                minimumToCollect,
+                                OptionalLong.of(minimumToCollect),
+                                tokenCollector))
+                        .hasKnownStatus(SUCCESS),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(royaltyFeeNoFallback(1, 2, tokenCollector))
+                        .hasKnownStatus(CUSTOM_ROYALTY_FEE_ONLY_ALLOWED_FOR_NON_FUNGIBLE_UNIQUE),
+                tokenCreate(token)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(GENESIS)
+                        .initialSupply(0L)
+                        .treasury(tokenCollector)
+                        .withCustom(royaltyFeeNoFallback(-1, 2, tokenCollector))
+                        .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                tokenCreate(token)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(GENESIS)
+                        .initialSupply(0L)
+                        .treasury(tokenCollector)
+                        .withCustom(royaltyFeeNoFallback(1, -2, tokenCollector))
+                        .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                tokenCreate(token)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(GENESIS)
+                        .initialSupply(0L)
+                        .treasury(tokenCollector)
+                        .withCustom(royaltyFeeNoFallback(1, 0, tokenCollector))
+                        .hasKnownStatus(FRACTION_DIVIDES_BY_ZERO),
+                tokenCreate(token)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(GENESIS)
+                        .initialSupply(0L)
+                        .treasury(tokenCollector)
+                        .withCustom(royaltyFeeNoFallback(2, 1, tokenCollector))
+                        .hasKnownStatus(ROYALTY_FRACTION_CANNOT_EXCEED_ONE),
+                tokenCreate(token)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(GENESIS)
+                        .initialSupply(0L)
+                        .treasury(tokenCollector)
+                        .withCustom(royaltyFeeWithFallback(
+                                1, 2, fixedHbarFeeInheritingRoyaltyCollector(-100), tokenCollector))
+                        .hasKnownStatus(CUSTOM_FEE_MUST_BE_POSITIVE),
+                tokenCreate(token)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(GENESIS)
+                        .initialSupply(0L)
+                        .treasury(tokenCollector)
+                        .withCustom(royaltyFeeWithFallback(
+                                1, 2, fixedHtsFeeInheritingRoyaltyCollector(100, "1.2.3"), tokenCollector))
+                        .hasKnownStatus(INVALID_TOKEN_ID_IN_CUSTOM_FEES),
+                tokenCreate(token)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(GENESIS)
+                        .initialSupply(0L)
+                        .treasury(htsCollector)
+                        .withCustom(royaltyFeeWithFallback(
+                                1, 2, fixedHtsFeeInheritingRoyaltyCollector(100, feeDenom), htsCollector)),
+                tokenCreate(token)
+                        .treasury(tokenCollector)
+                        .withCustom(fixedHbarFee(hbarAmount, hbarCollector))
+                        .withCustom(fixedHtsFee(htsAmount, feeDenom, htsCollector))
+                        .withCustom(fixedHtsFee(htsAmount, SENTINEL_VALUE, htsCollector))
+                        .withCustom(fractionalFee(
+                                numerator,
+                                denominator,
+                                minimumToCollect,
+                                OptionalLong.of(maximumToCollect),
+                                tokenCollector))
+                        .signedBy(DEFAULT_PAYER, tokenCollector, htsCollector),
+                getTokenInfo(token)
                         .hasCustom(fixedHbarFeeInSchedule(hbarAmount, hbarCollector))
                         .hasCustom(fixedHtsFeeInSchedule(htsAmount, feeDenom, htsCollector))
                         .hasCustom(fixedHtsFeeInSchedule(htsAmount, token, htsCollector))
@@ -923,26 +883,23 @@ public class TokenCreateSpecs {
 
     @HapiTest
     final Stream<DynamicTest> creationRequiresAppropriateSigs() {
-        return defaultHapiSpec("CreationRequiresAppropriateSigs")
-                .given(
-                        cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L),
-                        newKeyNamed(ADMIN_KEY))
-                .when()
-                .then(
-                        tokenCreate("shouldntWork")
-                                .treasury(TOKEN_TREASURY)
-                                .payingWith(PAYER)
-                                .adminKey(ADMIN_KEY)
-                                .signedBy(PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        /* treasury must sign */
-                        tokenCreate("shouldntWorkEither")
-                                .treasury(TOKEN_TREASURY)
-                                .payingWith(PAYER)
-                                .adminKey(ADMIN_KEY)
-                                .signedBy(PAYER, ADMIN_KEY)
-                                .hasKnownStatus(INVALID_SIGNATURE));
+        return hapiTest(
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                newKeyNamed(ADMIN_KEY),
+                tokenCreate("shouldntWork")
+                        .treasury(TOKEN_TREASURY)
+                        .payingWith(PAYER)
+                        .adminKey(ADMIN_KEY)
+                        .signedBy(PAYER)
+                        .hasKnownStatus(INVALID_SIGNATURE),
+                /* treasury must sign */
+                tokenCreate("shouldntWorkEither")
+                        .treasury(TOKEN_TREASURY)
+                        .payingWith(PAYER)
+                        .adminKey(ADMIN_KEY)
+                        .signedBy(PAYER, ADMIN_KEY)
+                        .hasKnownStatus(INVALID_SIGNATURE));
     }
 
     @HapiTest
@@ -960,26 +917,21 @@ public class TokenCreateSpecs {
 
     @HapiTest
     final Stream<DynamicTest> creationValidatesTreasuryAccount() {
-        return defaultHapiSpec("CreationValidatesTreasuryAccount")
-                .given(cryptoCreate(TOKEN_TREASURY).balance(0L))
-                .when(cryptoDelete(TOKEN_TREASURY))
-                .then(tokenCreate("shouldntWork")
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                cryptoDelete(TOKEN_TREASURY),
+                tokenCreate("shouldntWork")
                         .treasury(TOKEN_TREASURY)
                         .hasKnownStatus(INVALID_TREASURY_ACCOUNT_FOR_TOKEN));
     }
 
     @HapiTest
     final Stream<DynamicTest> initialSupplyMustBeSane() {
-        return defaultHapiSpec("InitialSupplyMustBeSane")
-                .given()
-                .when()
-                .then(
-                        tokenCreate("sinking").initialSupply(-1L).hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY),
-                        tokenCreate("bad decimals").decimals(-1).hasPrecheck(INVALID_TOKEN_DECIMALS),
-                        tokenCreate("bad decimals").decimals(1 << 31).hasPrecheck(INVALID_TOKEN_DECIMALS),
-                        tokenCreate("bad initial supply")
-                                .initialSupply(1L << 63)
-                                .hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY));
+        return hapiTest(
+                tokenCreate("sinking").initialSupply(-1L).hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY),
+                tokenCreate("bad decimals").decimals(-1).hasPrecheck(INVALID_TOKEN_DECIMALS),
+                tokenCreate("bad decimals").decimals(1 << 31).hasPrecheck(INVALID_TOKEN_DECIMALS),
+                tokenCreate("bad initial supply").initialSupply(1L << 63).hasPrecheck(INVALID_TOKEN_INITIAL_SUPPLY));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
@@ -60,55 +59,47 @@ public class TokenDeleteSpecs {
 
     @HapiTest
     final Stream<DynamicTest> treasuryBecomesDeletableAfterTokenDelete() {
-        return defaultHapiSpec("TreasuryBecomesDeletableAfterTokenDelete")
-                .given(
-                        newKeyNamed(TOKEN_ADMIN),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L),
-                        tokenCreate(FIRST_TBD).adminKey(TOKEN_ADMIN).treasury(TOKEN_TREASURY),
-                        tokenCreate(SECOND_TBD).adminKey(TOKEN_ADMIN).treasury(TOKEN_TREASURY),
-                        cryptoDelete(TOKEN_TREASURY).hasKnownStatus(ACCOUNT_IS_TREASURY),
-                        tokenDissociate(TOKEN_TREASURY, FIRST_TBD).hasKnownStatus(ACCOUNT_IS_TREASURY))
-                .when(
-                        tokenDelete(FIRST_TBD),
-                        tokenDissociate(TOKEN_TREASURY, FIRST_TBD),
-                        cryptoDelete(TOKEN_TREASURY).hasKnownStatus(ACCOUNT_IS_TREASURY),
-                        tokenDelete(SECOND_TBD))
-                .then(tokenDissociate(TOKEN_TREASURY, SECOND_TBD), cryptoDelete(TOKEN_TREASURY));
+        return hapiTest(
+                newKeyNamed(TOKEN_ADMIN),
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                tokenCreate(FIRST_TBD).adminKey(TOKEN_ADMIN).treasury(TOKEN_TREASURY),
+                tokenCreate(SECOND_TBD).adminKey(TOKEN_ADMIN).treasury(TOKEN_TREASURY),
+                cryptoDelete(TOKEN_TREASURY).hasKnownStatus(ACCOUNT_IS_TREASURY),
+                tokenDissociate(TOKEN_TREASURY, FIRST_TBD).hasKnownStatus(ACCOUNT_IS_TREASURY),
+                tokenDelete(FIRST_TBD),
+                tokenDissociate(TOKEN_TREASURY, FIRST_TBD),
+                cryptoDelete(TOKEN_TREASURY).hasKnownStatus(ACCOUNT_IS_TREASURY),
+                tokenDelete(SECOND_TBD),
+                tokenDissociate(TOKEN_TREASURY, SECOND_TBD),
+                cryptoDelete(TOKEN_TREASURY));
     }
 
     @HapiTest
     final Stream<DynamicTest> deletionValidatesAlreadyDeletedToken() {
-        return defaultHapiSpec("DeletionValidatesAlreadyDeletedToken")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L),
-                        tokenCreate("tbd").adminKey(MULTI_KEY).treasury(TOKEN_TREASURY),
-                        tokenDelete("tbd"))
-                .when()
-                .then(tokenDelete("tbd").hasKnownStatus(TOKEN_WAS_DELETED));
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                tokenCreate("tbd").adminKey(MULTI_KEY).treasury(TOKEN_TREASURY),
+                tokenDelete("tbd"),
+                tokenDelete("tbd").hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
-        return defaultHapiSpec("idVariantsTreatedAsExpected")
-                .given(newKeyNamed("adminKey"), tokenCreate("t").adminKey("adminKey"))
-                .when()
-                .then(submitModified(withSuccessivelyVariedBodyIds(), () -> tokenDelete("t")));
+        return hapiTest(
+                newKeyNamed("adminKey"),
+                tokenCreate("t").adminKey("adminKey"),
+                submitModified(withSuccessivelyVariedBodyIds(), () -> tokenDelete("t")));
     }
 
     @HapiTest
     final Stream<DynamicTest> deletionValidatesMissingAdminKey() {
-        return defaultHapiSpec("DeletionValidatesMissingAdminKey")
-                .given(
-                        newKeyNamed(MULTI_KEY),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L),
-                        cryptoCreate(PAYER),
-                        tokenCreate("tbd")
-                                .freezeDefault(false)
-                                .treasury(TOKEN_TREASURY)
-                                .payingWith(PAYER))
-                .when()
-                .then(tokenDelete("tbd").payingWith(PAYER).signedBy(PAYER).hasKnownStatus(TOKEN_IS_IMMUTABLE));
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                cryptoCreate(PAYER),
+                tokenCreate("tbd").freezeDefault(false).treasury(TOKEN_TREASURY).payingWith(PAYER),
+                tokenDelete("tbd").payingWith(PAYER).signedBy(PAYER).hasKnownStatus(TOKEN_IS_IMMUTABLE));
     }
 
     @HapiTest
@@ -150,11 +141,9 @@ public class TokenDeleteSpecs {
 
     @HapiTest
     final Stream<DynamicTest> deletionValidatesRef() {
-        return defaultHapiSpec("DeletionValidatesRef")
-                .given(cryptoCreate(PAYER))
-                .when()
-                .then(
-                        tokenDelete("0.0.0").payingWith(PAYER).signedBy(PAYER).hasKnownStatus(INVALID_TOKEN_ID),
-                        tokenDelete("1.2.3").payingWith(PAYER).signedBy(PAYER).hasKnownStatus(INVALID_TOKEN_ID));
+        return hapiTest(
+                cryptoCreate(PAYER),
+                tokenDelete("0.0.0").payingWith(PAYER).signedBy(PAYER).hasKnownStatus(INVALID_TOKEN_ID),
+                tokenDelete("1.2.3").payingWith(PAYER).signedBy(PAYER).hasKnownStatus(INVALID_TOKEN_ID));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecsStateful.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecsStateful.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
@@ -59,39 +58,29 @@ public class TokenManagementSpecsStateful {
         var unfreezableToken = "without";
         var freezableToken = "withPlusDefaultTrue";
 
-        return defaultHapiSpec("FreezeMgmtFailureCasesWork")
-                .given(
-                        fileUpdate(APP_PROPERTIES)
-                                .payingWith(ADDRESS_BOOK_CONTROL)
-                                .overridingProps(Map.of("tokens.maxPerAccount", "" + 1000)),
-                        newKeyNamed("oneFreeze"),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L),
-                        cryptoCreate("go").balance(0L),
-                        tokenCreate(unfreezableToken).treasury(TOKEN_TREASURY),
-                        tokenCreate(freezableToken)
-                                .freezeDefault(true)
-                                .freezeKey("oneFreeze")
-                                .treasury(TOKEN_TREASURY))
-                .when(
-                        tokenFreeze(unfreezableToken, TOKEN_TREASURY)
-                                .signedBy(GENESIS)
-                                .hasKnownStatus(TOKEN_HAS_NO_FREEZE_KEY),
-                        tokenFreeze(freezableToken, "1.2.3").hasKnownStatus(INVALID_ACCOUNT_ID),
-                        tokenFreeze(freezableToken, TOKEN_TREASURY)
-                                .signedBy(GENESIS)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        tokenFreeze(freezableToken, "go").hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-                        tokenUnfreeze(freezableToken, "go").hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
-                        tokenUnfreeze(unfreezableToken, TOKEN_TREASURY)
-                                .signedBy(GENESIS)
-                                .hasKnownStatus(TOKEN_HAS_NO_FREEZE_KEY),
-                        tokenUnfreeze(freezableToken, "1.2.3").hasKnownStatus(INVALID_ACCOUNT_ID),
-                        tokenUnfreeze(freezableToken, TOKEN_TREASURY)
-                                .signedBy(GENESIS)
-                                .hasKnownStatus(INVALID_SIGNATURE))
-                .then(getTokenInfo(unfreezableToken)
-                        .hasRegisteredId(unfreezableToken)
-                        .logged());
+        return hapiTest(
+                fileUpdate(APP_PROPERTIES)
+                        .payingWith(ADDRESS_BOOK_CONTROL)
+                        .overridingProps(Map.of("tokens.maxPerAccount", "" + 1000)),
+                newKeyNamed("oneFreeze"),
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                cryptoCreate("go").balance(0L),
+                tokenCreate(unfreezableToken).treasury(TOKEN_TREASURY),
+                tokenCreate(freezableToken)
+                        .freezeDefault(true)
+                        .freezeKey("oneFreeze")
+                        .treasury(TOKEN_TREASURY),
+                tokenFreeze(unfreezableToken, TOKEN_TREASURY).signedBy(GENESIS).hasKnownStatus(TOKEN_HAS_NO_FREEZE_KEY),
+                tokenFreeze(freezableToken, "1.2.3").hasKnownStatus(INVALID_ACCOUNT_ID),
+                tokenFreeze(freezableToken, TOKEN_TREASURY).signedBy(GENESIS).hasKnownStatus(INVALID_SIGNATURE),
+                tokenFreeze(freezableToken, "go").hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+                tokenUnfreeze(freezableToken, "go").hasKnownStatus(TOKEN_NOT_ASSOCIATED_TO_ACCOUNT),
+                tokenUnfreeze(unfreezableToken, TOKEN_TREASURY)
+                        .signedBy(GENESIS)
+                        .hasKnownStatus(TOKEN_HAS_NO_FREEZE_KEY),
+                tokenUnfreeze(freezableToken, "1.2.3").hasKnownStatus(INVALID_ACCOUNT_ID),
+                tokenUnfreeze(freezableToken, TOKEN_TREASURY).signedBy(GENESIS).hasKnownStatus(INVALID_SIGNATURE),
+                getTokenInfo(unfreezableToken).hasRegisteredId(unfreezableToken).logged());
     }
 
     @LeakyHapiTest(overrides = {"tokens.nfts.maxAllowedMints"})

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMetadataSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenMetadataSpecs.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairsInAnyOrder;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -72,39 +71,33 @@ public class TokenMetadataSpecs {
     private static final String METADATA_KEY = "metadataKey";
     private static final String FREEZE_KEY = "freezeKey";
     private static final String KYC_KEY = "kycKey";
-    private static String TOKEN_TREASURY = "treasury";
+    private static final String TOKEN_TREASURY = "treasury";
 
     @HapiTest
     final Stream<DynamicTest> rejectsMetadataTooLong() {
         String metadataStringTooLong = TxnUtils.nAscii(101);
-        return defaultHapiSpec("validatesMetadataLength")
-                .given()
-                .when()
-                .then(tokenCreate(PRIMARY).metaData(metadataStringTooLong).hasPrecheck(METADATA_TOO_LONG));
+        return hapiTest(tokenCreate(PRIMARY).metaData(metadataStringTooLong).hasPrecheck(METADATA_TOO_LONG));
     }
 
     @HapiTest
     final Stream<DynamicTest> creationDoesNotHaveRequiredSigs() {
-        return defaultHapiSpec("CreationRequiresAppropriateSigs")
-                .given(
-                        cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L),
-                        newKeyNamed(ADMIN_KEY))
-                .when()
-                .then(
-                        tokenCreate("shouldntWork")
-                                .treasury(TOKEN_TREASURY)
-                                .payingWith(PAYER)
-                                .adminKey(ADMIN_KEY)
-                                .signedBy(PAYER)
-                                .hasKnownStatus(INVALID_SIGNATURE),
-                        /* treasury must sign */
-                        tokenCreate("shouldntWorkEither")
-                                .treasury(TOKEN_TREASURY)
-                                .payingWith(PAYER)
-                                .adminKey(ADMIN_KEY)
-                                .signedBy(PAYER, ADMIN_KEY)
-                                .hasKnownStatus(INVALID_SIGNATURE));
+        return hapiTest(
+                cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                newKeyNamed(ADMIN_KEY),
+                tokenCreate("shouldntWork")
+                        .treasury(TOKEN_TREASURY)
+                        .payingWith(PAYER)
+                        .adminKey(ADMIN_KEY)
+                        .signedBy(PAYER)
+                        .hasKnownStatus(INVALID_SIGNATURE),
+                /* treasury must sign */
+                tokenCreate("shouldntWorkEither")
+                        .treasury(TOKEN_TREASURY)
+                        .payingWith(PAYER)
+                        .adminKey(ADMIN_KEY)
+                        .signedBy(PAYER, ADMIN_KEY)
+                        .hasKnownStatus(INVALID_SIGNATURE));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTotalSupplyAfterMintBurnWipeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenTotalSupplyAfterMintBurnWipeSuite.java
@@ -17,7 +17,6 @@
 package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
@@ -41,7 +40,7 @@ import org.junit.jupiter.api.Tag;
 
 @Tag(TOKEN)
 public class TokenTotalSupplyAfterMintBurnWipeSuite {
-    private static String TOKEN_TREASURY = "treasury";
+    private static final String TOKEN_TREASURY = "treasury";
 
     @HapiTest
     final Stream<DynamicTest> checkTokenTotalSupplyAfterMintAndBurn() {
@@ -71,37 +70,30 @@ public class TokenTotalSupplyAfterMintBurnWipeSuite {
     final Stream<DynamicTest> totalSupplyAfterWipe() {
         var tokenToWipe = "tokenToWipe";
 
-        return defaultHapiSpec("totalSupplyAfterWipe")
-                .given(
-                        newKeyNamed("wipeKey"),
-                        cryptoCreate("assoc1").balance(0L),
-                        cryptoCreate("assoc2").balance(0L),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L))
-                .when(
-                        tokenCreate(tokenToWipe)
-                                .name(tokenToWipe)
-                                .treasury(TOKEN_TREASURY)
-                                .initialSupply(1_000)
-                                .wipeKey("wipeKey"),
-                        tokenAssociate("assoc1", tokenToWipe),
-                        tokenAssociate("assoc2", tokenToWipe),
-                        cryptoTransfer(moving(500, tokenToWipe).between(TOKEN_TREASURY, "assoc1")),
-                        cryptoTransfer(moving(200, tokenToWipe).between(TOKEN_TREASURY, "assoc2")),
-                        getAccountBalance("assoc1").hasTokenBalance(tokenToWipe, 500),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(tokenToWipe, 300),
-                        getAccountInfo("assoc1").logged(),
-                        wipeTokenAccount(tokenToWipe, "assoc1", 200)
-                                .via("wipeTxn1")
-                                .logged(),
-                        wipeTokenAccount(tokenToWipe, "assoc2", 200)
-                                .via("wipeTxn2")
-                                .logged())
-                .then(
-                        getAccountBalance("assoc2").hasTokenBalance(tokenToWipe, 0),
-                        getTokenInfo(tokenToWipe)
-                                .hasTotalSupply(600)
-                                .hasName(tokenToWipe)
-                                .logged(),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(tokenToWipe, 300));
+        return hapiTest(
+                newKeyNamed("wipeKey"),
+                cryptoCreate("assoc1").balance(0L),
+                cryptoCreate("assoc2").balance(0L),
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                tokenCreate(tokenToWipe)
+                        .name(tokenToWipe)
+                        .treasury(TOKEN_TREASURY)
+                        .initialSupply(1_000)
+                        .wipeKey("wipeKey"),
+                tokenAssociate("assoc1", tokenToWipe),
+                tokenAssociate("assoc2", tokenToWipe),
+                cryptoTransfer(moving(500, tokenToWipe).between(TOKEN_TREASURY, "assoc1")),
+                cryptoTransfer(moving(200, tokenToWipe).between(TOKEN_TREASURY, "assoc2")),
+                getAccountBalance("assoc1").hasTokenBalance(tokenToWipe, 500),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(tokenToWipe, 300),
+                getAccountInfo("assoc1").logged(),
+                wipeTokenAccount(tokenToWipe, "assoc1", 200).via("wipeTxn1").logged(),
+                wipeTokenAccount(tokenToWipe, "assoc2", 200).via("wipeTxn2").logged(),
+                getAccountBalance("assoc2").hasTokenBalance(tokenToWipe, 0),
+                getTokenInfo(tokenToWipe)
+                        .hasTotalSupply(600)
+                        .hasName(tokenToWipe)
+                        .logged(),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(tokenToWipe, 300));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/UniqueTokenManagementSpecs.java
@@ -17,7 +17,7 @@
 package com.hedera.services.bdd.suites.token;
 
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
-import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
@@ -48,7 +48,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NFT_ID
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_BURN_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_MINT_METADATA;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIAL_NUMBER;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_WIPING_AMOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_MAX_SUPPLY_REACHED;
@@ -100,76 +99,69 @@ public class UniqueTokenManagementSpecs {
 
     @HapiTest // here
     final Stream<DynamicTest> populatingMetadataForFungibleDoesNotWork() {
-        return defaultHapiSpec("PopulatingMetadataForFungibleDoesNotWork")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .initialSupply(0)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(mintToken(
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .initialSupply(0)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(
                                 FUNGIBLE_TOKEN,
                                 List.of(
                                         metadata("some-data"),
                                         metadata("some-data2"),
                                         metadata("some-data3"),
                                         metadata("some-data4")))
-                        .via(SHOULD_NOT_WORK))
-                .then(
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 0),
-                        getTxnRecord(SHOULD_NOT_WORK).showsNoTransfers(),
-                        UtilVerbs.withOpContext((spec, opLog) -> {
-                            var mintNFT = getTxnRecord(SHOULD_NOT_WORK);
-                            allRunFor(spec, mintNFT);
-                            var receipt = mintNFT.getResponseRecord().getReceipt();
-                            Assertions.assertEquals(0, receipt.getNewTotalSupply());
-                        }));
+                        .via(SHOULD_NOT_WORK),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 0),
+                getTxnRecord(SHOULD_NOT_WORK).showsNoTransfers(),
+                UtilVerbs.withOpContext((spec, opLog) -> {
+                    var mintNFT = getTxnRecord(SHOULD_NOT_WORK);
+                    allRunFor(spec, mintNFT);
+                    var receipt = mintNFT.getResponseRecord().getReceipt();
+                    Assertions.assertEquals(0, receipt.getNewTotalSupply());
+                }));
     }
 
     @HapiTest
     final Stream<DynamicTest> populatingAmountForNonFungibleDoesNotWork() {
-        return defaultHapiSpec("PopulatingAmountForNonFungibleDoesNotWork")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .initialSupply(0)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(mintToken(NFT, 300)
-                        .hasKnownStatus(INVALID_TOKEN_MINT_METADATA)
-                        .via(SHOULD_NOT_WORK))
-                .then(
-                        getTxnRecord(SHOULD_NOT_WORK).showsNoTransfers(),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 0),
-                        UtilVerbs.withOpContext((spec, opLog) -> {
-                            var mintNFT = getTxnRecord(SHOULD_NOT_WORK);
-                            allRunFor(spec, mintNFT);
-                            var receipt = mintNFT.getResponseRecord().getReceipt();
-                            Assertions.assertEquals(0, receipt.getNewTotalSupply());
-                            Assertions.assertEquals(0, receipt.getSerialNumbersCount());
-                        }));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .initialSupply(0)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, 300).hasKnownStatus(INVALID_TOKEN_MINT_METADATA).via(SHOULD_NOT_WORK),
+                getTxnRecord(SHOULD_NOT_WORK).showsNoTransfers(),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 0),
+                UtilVerbs.withOpContext((spec, opLog) -> {
+                    var mintNFT = getTxnRecord(SHOULD_NOT_WORK);
+                    allRunFor(spec, mintNFT);
+                    var receipt = mintNFT.getResponseRecord().getReceipt();
+                    Assertions.assertEquals(0, receipt.getNewTotalSupply());
+                    Assertions.assertEquals(0, receipt.getSerialNumbersCount());
+                }));
     }
 
     @HapiTest
     final Stream<DynamicTest> finiteNftReachesMaxSupplyProperly() {
-        return defaultHapiSpec("FiniteNftReachesMaxSupplyProperly")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .initialSupply(0)
-                                .maxSupply(3)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(mintToken(
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .initialSupply(0)
+                        .maxSupply(3)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(
                                 NFT,
                                 List.of(
                                         metadata("some-data"),
@@ -177,244 +169,213 @@ public class UniqueTokenManagementSpecs {
                                         metadata("some-data3"),
                                         metadata("some-data4")))
                         .hasKnownStatus(TOKEN_MAX_SUPPLY_REACHED)
-                        .via(SHOULD_NOT_APPEAR))
-                .then(
-                        getTxnRecord(SHOULD_NOT_APPEAR).showsNoTransfers(),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 0),
-                        UtilVerbs.withOpContext((spec, opLog) -> {
-                            var mintNFT = getTxnRecord(SHOULD_NOT_APPEAR);
-                            allRunFor(spec, mintNFT);
-                            var receipt = mintNFT.getResponseRecord().getReceipt();
-                            Assertions.assertEquals(0, receipt.getNewTotalSupply());
-                            Assertions.assertEquals(0, receipt.getSerialNumbersCount());
-                        }));
+                        .via(SHOULD_NOT_APPEAR),
+                getTxnRecord(SHOULD_NOT_APPEAR).showsNoTransfers(),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 0),
+                UtilVerbs.withOpContext((spec, opLog) -> {
+                    var mintNFT = getTxnRecord(SHOULD_NOT_APPEAR);
+                    allRunFor(spec, mintNFT);
+                    var receipt = mintNFT.getResponseRecord().getReceipt();
+                    Assertions.assertEquals(0, receipt.getNewTotalSupply());
+                    Assertions.assertEquals(0, receipt.getSerialNumbersCount());
+                }));
     }
 
     @HapiTest
     final Stream<DynamicTest> serialNumbersOnlyOnFungibleBurnFails() {
-        return defaultHapiSpec("SerialNumbersOnlyOnFungibleBurnFails")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .initialSupply(0)
-                                .tokenType(FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(mintToken(FUNGIBLE_TOKEN, 300))
-                .then(
-                        burnToken(FUNGIBLE_TOKEN, List.of(1L, 2L, 3L))
-                                .via(BURN_FAILURE)
-                                .logged(),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 300),
-                        getTxnRecord(BURN_FAILURE).showsNoTransfers().logged(),
-                        UtilVerbs.withOpContext((spec, opLog) -> {
-                            var burnTxn = getTxnRecord(BURN_FAILURE);
-                            allRunFor(spec, burnTxn);
-                            Assertions.assertEquals(
-                                    300,
-                                    burnTxn.getResponseRecord().getReceipt().getNewTotalSupply());
-                        }));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .initialSupply(0)
+                        .tokenType(FUNGIBLE_COMMON)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(FUNGIBLE_TOKEN, 300),
+                burnToken(FUNGIBLE_TOKEN, List.of(1L, 2L, 3L)).via(BURN_FAILURE).logged(),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(FUNGIBLE_TOKEN, 300),
+                getTxnRecord(BURN_FAILURE).showsNoTransfers().logged(),
+                UtilVerbs.withOpContext((spec, opLog) -> {
+                    var burnTxn = getTxnRecord(BURN_FAILURE);
+                    allRunFor(spec, burnTxn);
+                    Assertions.assertEquals(
+                            300, burnTxn.getResponseRecord().getReceipt().getNewTotalSupply());
+                }));
     }
 
     @HapiTest
     final Stream<DynamicTest> amountOnlyOnNonFungibleBurnFails() {
-        return defaultHapiSpec("AmountOnlyOnNonFungibleBurnFails")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .initialSupply(0)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(mintToken(NFT, List.of(metadata("some-random-data"), metadata("some-other-random-data"))))
-                .then(
-                        burnToken(NFT, 300)
-                                .hasKnownStatus(INVALID_TOKEN_BURN_METADATA)
-                                .via(BURN_FAILURE),
-                        getTxnRecord(BURN_FAILURE).showsNoTransfers(),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2),
-                        UtilVerbs.withOpContext((spec, opLog) -> {
-                            var burnTxn = getTxnRecord(BURN_FAILURE);
-                            allRunFor(spec, burnTxn);
-                            Assertions.assertEquals(
-                                    0, burnTxn.getResponseRecord().getReceipt().getNewTotalSupply());
-                        }));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .initialSupply(0)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("some-random-data"), metadata("some-other-random-data"))),
+                burnToken(NFT, 300).hasKnownStatus(INVALID_TOKEN_BURN_METADATA).via(BURN_FAILURE),
+                getTxnRecord(BURN_FAILURE).showsNoTransfers(),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2),
+                UtilVerbs.withOpContext((spec, opLog) -> {
+                    var burnTxn = getTxnRecord(BURN_FAILURE);
+                    allRunFor(spec, burnTxn);
+                    Assertions.assertEquals(
+                            0, burnTxn.getResponseRecord().getReceipt().getNewTotalSupply());
+                }));
     }
 
     @HapiTest
     final Stream<DynamicTest> burnWorksWhenAccountsAreFrozenByDefault() {
-        return defaultHapiSpec("BurnWorksWhenAccountsAreFrozenByDefault")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(NFT, List.of(metadata("memo"))))
-                .when(burnToken(NFT, List.of(1L)).via(BURN_TXN).logged())
-                .then(
-                        getTxnRecord(BURN_TXN).hasCostAnswerPrecheck(OK),
-                        getTokenNftInfo(NFT, 1).hasCostAnswerPrecheck(INVALID_NFT_ID),
-                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(0));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo"))),
+                burnToken(NFT, List.of(1L)).via(BURN_TXN).logged(),
+                getTxnRecord(BURN_TXN).hasCostAnswerPrecheck(OK),
+                getTokenNftInfo(NFT, 1).hasCostAnswerPrecheck(INVALID_NFT_ID),
+                getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(0));
     }
 
     @HapiTest
     final Stream<DynamicTest> burnFailsOnInvalidSerialNumber() {
-        return defaultHapiSpec("BurnFailsOnInvalidSerialNumber")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(NFT, List.of(metadata("memo"))))
-                .when()
-                .then(
-                        burnToken(NFT, List.of(0L, 1L, 2L)).via(BURN_TXN).hasPrecheck(INVALID_NFT_ID),
-                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo"))),
+                burnToken(NFT, List.of(0L, 1L, 2L)).via(BURN_TXN).hasPrecheck(INVALID_NFT_ID),
+                getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1));
     }
 
     @HapiTest
     final Stream<DynamicTest> burnRespectsBurnBatchConstraints() {
-        return defaultHapiSpec("BurnRespectsBurnBatchConstraints")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(NFT, List.of(metadata("memo"))))
-                .when()
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo"))),
                 // This ID range needs to be exclusively positive (i.e. not zero)
-                .then(burnToken(NFT, LongStream.range(1, 1001).boxed().collect(Collectors.toList()))
+                burnToken(NFT, LongStream.range(1, 1001).boxed().collect(Collectors.toList()))
                         .via(BURN_TXN)
                         .hasPrecheck(BATCH_SIZE_LIMIT_EXCEEDED));
     }
 
     @HapiTest
     final Stream<DynamicTest> burnHappyPath() {
-        return defaultHapiSpec("BurnHappyPath")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(NFT, List.of(metadata("memo"))))
-                .when(burnToken(NFT, List.of(1L)).via(BURN_TXN))
-                .then(
-                        getTokenNftInfo(NFT, 1).hasCostAnswerPrecheck(INVALID_NFT_ID),
-                        getTokenInfo(NFT).hasTotalSupply(0),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 0),
-                        getAccountInfo(TOKEN_TREASURY)
-                                .hasToken(relationshipWith(NFT))
-                                .hasOwnedNfts(0));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo"))),
+                burnToken(NFT, List.of(1L)).via(BURN_TXN),
+                getTokenNftInfo(NFT, 1).hasCostAnswerPrecheck(INVALID_NFT_ID),
+                getTokenInfo(NFT).hasTotalSupply(0),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 0),
+                getAccountInfo(TOKEN_TREASURY).hasToken(relationshipWith(NFT)).hasOwnedNfts(0));
     }
 
     @HapiTest
     final Stream<DynamicTest> canOnlyBurnFromTreasury() {
         final var nonTreasury = "anybodyElse";
 
-        return defaultHapiSpec("CanOnlyBurnFromTreasury")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(nonTreasury),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(NFT, List.of(metadata("1"), metadata("2"))),
-                        tokenAssociate(nonTreasury, NFT),
-                        cryptoTransfer(movingUnique(NFT, 2L).between(TOKEN_TREASURY, nonTreasury)))
-                .when(burnToken(NFT, List.of(1L, 2L)).via(BURN_TXN).hasKnownStatus(TREASURY_MUST_OWN_BURNED_NFT))
-                .then(
-                        getTokenNftInfo(NFT, 1).hasSerialNum(1),
-                        getTokenNftInfo(NFT, 2).hasSerialNum(2),
-                        getTokenInfo(NFT).hasTotalSupply(2),
-                        getAccountBalance(nonTreasury).hasTokenBalance(NFT, 1),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 1),
-                        getAccountInfo(nonTreasury).hasOwnedNfts(1),
-                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(nonTreasury),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("1"), metadata("2"))),
+                tokenAssociate(nonTreasury, NFT),
+                cryptoTransfer(movingUnique(NFT, 2L).between(TOKEN_TREASURY, nonTreasury)),
+                burnToken(NFT, List.of(1L, 2L)).via(BURN_TXN).hasKnownStatus(TREASURY_MUST_OWN_BURNED_NFT),
+                getTokenNftInfo(NFT, 1).hasSerialNum(1),
+                getTokenNftInfo(NFT, 2).hasSerialNum(2),
+                getTokenInfo(NFT).hasTotalSupply(2),
+                getAccountBalance(nonTreasury).hasTokenBalance(NFT, 1),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 1),
+                getAccountInfo(nonTreasury).hasOwnedNfts(1),
+                getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1));
     }
 
     @HapiTest
     final Stream<DynamicTest> treasuryBalanceCorrectAfterBurn() {
-        return defaultHapiSpec("TreasuryBalanceCorrectAfterBurn")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(
-                                NFT,
-                                List.of(metadata("1"), metadata("2"), metadata("3"), metadata("4"), metadata("5"))))
-                .when(burnToken(NFT, List.of(3L, 4L, 5L))
-                        .payingWith(TOKEN_TREASURY)
-                        .via(BURN_TXN))
-                .then(
-                        getTokenNftInfo(NFT, 1).hasSerialNum(1).hasCostAnswerPrecheck(OK),
-                        getTokenNftInfo(NFT, 2).hasSerialNum(2).hasCostAnswerPrecheck(OK),
-                        getTokenNftInfo(NFT, 3).hasCostAnswerPrecheck(INVALID_NFT_ID),
-                        getTokenNftInfo(NFT, 4).hasCostAnswerPrecheck(INVALID_NFT_ID),
-                        getTokenNftInfo(NFT, 5).hasCostAnswerPrecheck(INVALID_NFT_ID),
-                        getTokenInfo(NFT).hasTotalSupply(2),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2),
-                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(2));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("1"), metadata("2"), metadata("3"), metadata("4"), metadata("5"))),
+                burnToken(NFT, List.of(3L, 4L, 5L)).payingWith(TOKEN_TREASURY).via(BURN_TXN),
+                getTokenNftInfo(NFT, 1).hasSerialNum(1).hasCostAnswerPrecheck(OK),
+                getTokenNftInfo(NFT, 2).hasSerialNum(2).hasCostAnswerPrecheck(OK),
+                getTokenNftInfo(NFT, 3).hasCostAnswerPrecheck(INVALID_NFT_ID),
+                getTokenNftInfo(NFT, 4).hasCostAnswerPrecheck(INVALID_NFT_ID),
+                getTokenNftInfo(NFT, 5).hasCostAnswerPrecheck(INVALID_NFT_ID),
+                getTokenInfo(NFT).hasTotalSupply(2),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2),
+                getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(2));
     }
 
     @HapiTest
     final Stream<DynamicTest> mintDistinguishesFeeSubTypes() {
-        return defaultHapiSpec("MintDistinguishesFeeSubTypes")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(CUSTOM_PAYER),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY),
-                        tokenCreate(FUNGIBLE_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .supplyType(TokenSupplyType.FINITE)
-                                .initialSupply(10)
-                                .maxSupply(1100)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(
-                        mintToken(NFT, List.of(metadata("memo")))
-                                .payingWith(CUSTOM_PAYER)
-                                .signedBy(CUSTOM_PAYER, SUPPLY_KEY)
-                                .via("mintNFT"),
-                        mintToken(FUNGIBLE_TOKEN, 100L)
-                                .payingWith(CUSTOM_PAYER)
-                                .signedBy(CUSTOM_PAYER, SUPPLY_KEY)
-                                .via("mintFungible"))
-                .then(UtilVerbs.withOpContext((spec, opLog) -> {
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(CUSTOM_PAYER),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .supplyType(TokenSupplyType.FINITE)
+                        .initialSupply(10)
+                        .maxSupply(1100)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo")))
+                        .payingWith(CUSTOM_PAYER)
+                        .signedBy(CUSTOM_PAYER, SUPPLY_KEY)
+                        .via("mintNFT"),
+                mintToken(FUNGIBLE_TOKEN, 100L)
+                        .payingWith(CUSTOM_PAYER)
+                        .signedBy(CUSTOM_PAYER, SUPPLY_KEY)
+                        .via("mintFungible"),
+                UtilVerbs.withOpContext((spec, opLog) -> {
                     var mintNFT = getTxnRecord("mintNFT");
                     var mintFungible = getTxnRecord("mintFungible");
                     allRunFor(spec, mintNFT, mintFungible);
@@ -426,257 +387,229 @@ public class UniqueTokenManagementSpecs {
 
     @HapiTest
     final Stream<DynamicTest> mintFailsWithTooLongMetadata() {
-        return defaultHapiSpec("MintFailsWithTooLongMetadata")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when()
-                .then(mintToken(NFT, List.of(metadataOfLength(101))).hasPrecheck(ResponseCodeEnum.METADATA_TOO_LONG));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadataOfLength(101))).hasPrecheck(ResponseCodeEnum.METADATA_TOO_LONG));
     }
 
     @HapiTest
     final Stream<DynamicTest> mintFailsWithInvalidMetadataFromBatch() {
-        return defaultHapiSpec("MintFailsWithInvalidMetadataFromBatch")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when()
-                .then(mintToken(NFT, List.of(metadataOfLength(101), metadataOfLength(1)))
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadataOfLength(101), metadataOfLength(1)))
                         .hasPrecheck(ResponseCodeEnum.METADATA_TOO_LONG));
     }
 
     @HapiTest
     final Stream<DynamicTest> mintFailsWithLargeBatchSize() {
-        return defaultHapiSpec("MintFailsWithLargeBatchSize")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when()
-                .then(mintToken(NFT, batchOfSize(BIGGER_THAN_LIMIT)).hasPrecheck(BATCH_SIZE_LIMIT_EXCEEDED));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, batchOfSize(BIGGER_THAN_LIMIT)).hasPrecheck(BATCH_SIZE_LIMIT_EXCEEDED));
     }
 
     @HapiTest
     final Stream<DynamicTest> mintUniqueTokenHappyPath() {
-        return defaultHapiSpec("MintUniqueTokenHappyPath")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(SUPPLY_KEY)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(mintToken(NFT, List.of(metadata("memo"), metadata(MEMO_1)))
-                        .via(MINT_TXN))
-                .then(
-                        getReceipt(MINT_TXN).logged(),
-                        getTokenNftInfo(NFT, 1)
-                                .hasSerialNum(1)
-                                .hasMetadata(metadata("memo"))
-                                .hasTokenID(NFT)
-                                .hasAccountID(TOKEN_TREASURY)
-                                .hasValidCreationTime(),
-                        getTokenNftInfo(NFT, 2)
-                                .hasSerialNum(2)
-                                .hasMetadata(metadata(MEMO_1))
-                                .hasTokenID(NFT)
-                                .hasAccountID(TOKEN_TREASURY)
-                                .hasValidCreationTime(),
-                        getTokenNftInfo(NFT, 3).hasCostAnswerPrecheck(INVALID_NFT_ID),
-                        getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2),
-                        getTokenInfo(NFT).hasTreasury(TOKEN_TREASURY).hasTotalSupply(2),
-                        getAccountInfo(TOKEN_TREASURY)
-                                .hasToken(relationshipWith(NFT))
-                                .hasOwnedNfts(2));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(SUPPLY_KEY)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo"), metadata(MEMO_1))).via(MINT_TXN),
+                getReceipt(MINT_TXN).logged(),
+                getTokenNftInfo(NFT, 1)
+                        .hasSerialNum(1)
+                        .hasMetadata(metadata("memo"))
+                        .hasTokenID(NFT)
+                        .hasAccountID(TOKEN_TREASURY)
+                        .hasValidCreationTime(),
+                getTokenNftInfo(NFT, 2)
+                        .hasSerialNum(2)
+                        .hasMetadata(metadata(MEMO_1))
+                        .hasTokenID(NFT)
+                        .hasAccountID(TOKEN_TREASURY)
+                        .hasValidCreationTime(),
+                getTokenNftInfo(NFT, 3).hasCostAnswerPrecheck(INVALID_NFT_ID),
+                getAccountBalance(TOKEN_TREASURY).hasTokenBalance(NFT, 2),
+                getTokenInfo(NFT).hasTreasury(TOKEN_TREASURY).hasTotalSupply(2),
+                getAccountInfo(TOKEN_TREASURY).hasToken(relationshipWith(NFT)).hasOwnedNfts(2));
     }
 
     @HapiTest
     final Stream<DynamicTest> mintTokenWorksWhenAccountsAreFrozenByDefault() {
-        return defaultHapiSpec("MintTokenWorksWhenAccountsAreFrozenByDefault")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed("tokenFreezeKey"),
-                        cryptoCreate(TOKEN_TREASURY).balance(0L),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyKey(SUPPLY_KEY)
-                                .freezeKey("tokenFreezeKey")
-                                .freezeDefault(true)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY))
-                .when(mintToken(NFT, List.of(metadata("memo"))).via(MINT_TXN))
-                .then(
-                        getTokenNftInfo(NFT, 1)
-                                .hasTokenID(NFT)
-                                .hasAccountID(TOKEN_TREASURY)
-                                .hasMetadata(metadata("memo"))
-                                .hasValidCreationTime(),
-                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed("tokenFreezeKey"),
+                cryptoCreate(TOKEN_TREASURY).balance(0L),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyKey(SUPPLY_KEY)
+                        .freezeKey("tokenFreezeKey")
+                        .freezeDefault(true)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo"))).via(MINT_TXN),
+                getTokenNftInfo(NFT, 1)
+                        .hasTokenID(NFT)
+                        .hasAccountID(TOKEN_TREASURY)
+                        .hasMetadata(metadata("memo"))
+                        .hasValidCreationTime(),
+                getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1));
     }
 
     @HapiTest
     final Stream<DynamicTest> mintFailsWithDeletedToken() {
-        return defaultHapiSpec("MintFailsWithDeletedToken")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed("adminKey"),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .supplyKey(SUPPLY_KEY)
-                                .adminKey("adminKey")
-                                .treasury(TOKEN_TREASURY))
-                .when(tokenDelete(NFT))
-                .then(
-                        mintToken(NFT, List.of(metadata("memo"))).via(MINT_TXN).hasKnownStatus(TOKEN_WAS_DELETED),
-                        getTokenNftInfo(NFT, 1).hasCostAnswerPrecheck(INVALID_NFT_ID),
-                        getTokenInfo(NFT).isDeleted());
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed("adminKey"),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT).supplyKey(SUPPLY_KEY).adminKey("adminKey").treasury(TOKEN_TREASURY),
+                tokenDelete(NFT),
+                mintToken(NFT, List.of(metadata("memo"))).via(MINT_TXN).hasKnownStatus(TOKEN_WAS_DELETED),
+                getTokenNftInfo(NFT, 1).hasCostAnswerPrecheck(INVALID_NFT_ID),
+                getTokenInfo(NFT).isDeleted());
     }
 
     @HapiTest
     final Stream<DynamicTest> getTokenNftInfoFailsWithNoNft() {
-        return defaultHapiSpec("GetTokenNftInfoFailsWithNoNft")
-                .given(newKeyNamed(SUPPLY_KEY), cryptoCreate(TOKEN_TREASURY))
-                .when(
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(NFT, List.of(metadata("memo"))).via(MINT_TXN))
-                .then(
-                        getTokenNftInfo(NFT, 0).hasCostAnswerPrecheck(INVALID_TOKEN_NFT_SERIAL_NUMBER),
-                        getTokenNftInfo(NFT, -1).hasCostAnswerPrecheck(INVALID_TOKEN_NFT_SERIAL_NUMBER),
-                        getTokenNftInfo(NFT, 2).hasCostAnswerPrecheck(INVALID_NFT_ID));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo"))).via(MINT_TXN),
+                getTokenNftInfo(NFT, 0).hasCostAnswerPrecheck(INVALID_TOKEN_NFT_SERIAL_NUMBER),
+                getTokenNftInfo(NFT, -1).hasCostAnswerPrecheck(INVALID_TOKEN_NFT_SERIAL_NUMBER),
+                getTokenNftInfo(NFT, 2).hasCostAnswerPrecheck(INVALID_NFT_ID));
     }
 
     @HapiTest
     final Stream<DynamicTest> getTokenNftInfoWorks() {
-        return defaultHapiSpec("GetTokenNftInfoWorks")
-                .given(newKeyNamed(SUPPLY_KEY), cryptoCreate(TOKEN_TREASURY))
-                .when(
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY),
-                        mintToken(NFT, List.of(metadata("memo"))))
-                .then(
-                        getTokenNftInfo(NFT, 0).hasCostAnswerPrecheck(INVALID_TOKEN_NFT_SERIAL_NUMBER),
-                        getTokenNftInfo(NFT, -1).hasCostAnswerPrecheck(INVALID_TOKEN_NFT_SERIAL_NUMBER),
-                        getTokenNftInfo(NFT, 2).hasCostAnswerPrecheck(INVALID_NFT_ID),
-                        getTokenNftInfo(NFT, 1)
-                                .hasTokenID(NFT)
-                                .hasAccountID(TOKEN_TREASURY)
-                                .hasMetadata(metadata("memo"))
-                                .hasSerialNum(1)
-                                .hasValidCreationTime());
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo"))),
+                getTokenNftInfo(NFT, 0).hasCostAnswerPrecheck(INVALID_TOKEN_NFT_SERIAL_NUMBER),
+                getTokenNftInfo(NFT, -1).hasCostAnswerPrecheck(INVALID_TOKEN_NFT_SERIAL_NUMBER),
+                getTokenNftInfo(NFT, 2).hasCostAnswerPrecheck(INVALID_NFT_ID),
+                getTokenNftInfo(NFT, 1)
+                        .hasTokenID(NFT)
+                        .hasAccountID(TOKEN_TREASURY)
+                        .hasMetadata(metadata("memo"))
+                        .hasSerialNum(1)
+                        .hasValidCreationTime());
     }
 
     @HapiTest
     final Stream<DynamicTest> mintUniqueTokenWorksWithRepeatedMetadata() {
-        return defaultHapiSpec("MintUniqueTokenWorksWithRepeatedMetadata")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY))
-                .when(mintToken(NFT, List.of(metadata("memo"), metadata("memo")))
-                        .via(MINT_TXN))
-                .then(
-                        getTokenNftInfo(NFT, 1)
-                                .hasSerialNum(1)
-                                .hasMetadata(metadata("memo"))
-                                .hasAccountID(TOKEN_TREASURY)
-                                .hasTokenID(NFT)
-                                .hasValidCreationTime(),
-                        getTokenNftInfo(NFT, 2)
-                                .hasSerialNum(2)
-                                .hasMetadata(metadata("memo"))
-                                .hasAccountID(TOKEN_TREASURY)
-                                .hasTokenID(NFT)
-                                .hasValidCreationTime(),
-                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(2));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(NFT, List.of(metadata("memo"), metadata("memo"))).via(MINT_TXN),
+                getTokenNftInfo(NFT, 1)
+                        .hasSerialNum(1)
+                        .hasMetadata(metadata("memo"))
+                        .hasAccountID(TOKEN_TREASURY)
+                        .hasTokenID(NFT)
+                        .hasValidCreationTime(),
+                getTokenNftInfo(NFT, 2)
+                        .hasSerialNum(2)
+                        .hasMetadata(metadata("memo"))
+                        .hasAccountID(TOKEN_TREASURY)
+                        .hasTokenID(NFT)
+                        .hasValidCreationTime(),
+                getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(2));
     }
 
     @HapiTest
     final Stream<DynamicTest> wipeHappyPath() {
-        return defaultHapiSpec("WipeHappyPath")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        newKeyNamed("treasuryKey"),
-                        newKeyNamed("accKey"),
-                        cryptoCreate(TOKEN_TREASURY).key("treasuryKey"),
-                        cryptoCreate(ACCOUNT).key("accKey"),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .wipeKey(WIPE_KEY),
-                        tokenAssociate(ACCOUNT, NFT),
-                        getTokenInfo(NFT).logged(),
-                        mintToken(NFT, List.of(ByteString.copyFromUtf8("memo"), ByteString.copyFromUtf8(MEMO_2))),
-                        getTokenInfo(NFT).logged(),
-                        cryptoTransfer(movingUnique(NFT, 2L).between(TOKEN_TREASURY, ACCOUNT)))
-                .when(wipeTokenAccount(NFT, ACCOUNT, List.of(2L)).via(WIPE_TXN))
-                .then(
-                        getAccountInfo(ACCOUNT).hasOwnedNfts(0),
-                        getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
-                        getTokenInfo(NFT).hasTotalSupply(1).logged(),
-                        getTokenNftInfo(NFT, 2).hasCostAnswerPrecheck(INVALID_NFT_ID),
-                        getTokenNftInfo(NFT, 1).hasSerialNum(1),
-                        wipeTokenAccount(NFT, ACCOUNT, List.of(1L)).hasKnownStatus(ACCOUNT_DOES_NOT_OWN_WIPED_NFT));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(WIPE_KEY),
+                newKeyNamed("treasuryKey"),
+                newKeyNamed("accKey"),
+                cryptoCreate(TOKEN_TREASURY).key("treasuryKey"),
+                cryptoCreate(ACCOUNT).key("accKey"),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .wipeKey(WIPE_KEY),
+                tokenAssociate(ACCOUNT, NFT),
+                getTokenInfo(NFT).logged(),
+                mintToken(NFT, List.of(ByteString.copyFromUtf8("memo"), ByteString.copyFromUtf8(MEMO_2))),
+                getTokenInfo(NFT).logged(),
+                cryptoTransfer(movingUnique(NFT, 2L).between(TOKEN_TREASURY, ACCOUNT)),
+                wipeTokenAccount(NFT, ACCOUNT, List.of(2L)).via(WIPE_TXN),
+                getAccountInfo(ACCOUNT).hasOwnedNfts(0),
+                getAccountInfo(TOKEN_TREASURY).hasOwnedNfts(1),
+                getTokenInfo(NFT).hasTotalSupply(1).logged(),
+                getTokenNftInfo(NFT, 2).hasCostAnswerPrecheck(INVALID_NFT_ID),
+                getTokenNftInfo(NFT, 1).hasSerialNum(1),
+                wipeTokenAccount(NFT, ACCOUNT, List.of(1L)).hasKnownStatus(ACCOUNT_DOES_NOT_OWN_WIPED_NFT));
     }
 
     @HapiTest
     final Stream<DynamicTest> wipeRespectsConstraints() {
-        return defaultHapiSpec("WipeRespectsConstraints")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(ACCOUNT),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .wipeKey(WIPE_KEY),
-                        tokenAssociate(ACCOUNT, NFT),
-                        mintToken(NFT, List.of(metadata("memo"), metadata(MEMO_2)))
-                                .via(MINT_TXN),
-                        cryptoTransfer(movingUnique(NFT, 1, 2).between(TOKEN_TREASURY, ACCOUNT)))
-                .when()
-                .then(wipeTokenAccount(
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(WIPE_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(ACCOUNT),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .wipeKey(WIPE_KEY),
+                tokenAssociate(ACCOUNT, NFT),
+                mintToken(NFT, List.of(metadata("memo"), metadata(MEMO_2))).via(MINT_TXN),
+                cryptoTransfer(movingUnique(NFT, 1, 2).between(TOKEN_TREASURY, ACCOUNT)),
+                wipeTokenAccount(
                                 // This ID range needs to be exclusively positive (i.e. not zero)
                                 NFT, ACCOUNT, LongStream.range(1, 1001).boxed().collect(Collectors.toList()))
                         .hasPrecheck(BATCH_SIZE_LIMIT_EXCEEDED));
@@ -684,159 +617,136 @@ public class UniqueTokenManagementSpecs {
 
     @HapiTest // here
     final Stream<DynamicTest> commonWipeFailsWhenInvokedOnUniqueToken() {
-        return defaultHapiSpec("CommonWipeFailsWhenInvokedOnUniqueToken")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(ACCOUNT),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .wipeKey(WIPE_KEY),
-                        tokenAssociate(ACCOUNT, NFT),
-                        mintToken(NFT, List.of(metadata("memo"))),
-                        cryptoTransfer(movingUnique(NFT, 1).between(TOKEN_TREASURY, ACCOUNT)))
-                .when()
-                .then(
-                        wipeTokenAccount(NFT, ACCOUNT, 1L)
-                                .hasKnownStatus(INVALID_WIPING_AMOUNT)
-                                .via(WIPE_TXN),
-                        // no new totalSupply
-                        getTokenInfo(NFT).hasTotalSupply(1),
-                        // no tx record
-                        getTxnRecord(WIPE_TXN).showsNoTransfers(),
-                        // verify balance not decreased
-                        getAccountInfo(ACCOUNT).hasOwnedNfts(1),
-                        getAccountBalance(ACCOUNT).hasTokenBalance(NFT, 1));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(WIPE_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(ACCOUNT),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .wipeKey(WIPE_KEY),
+                tokenAssociate(ACCOUNT, NFT),
+                mintToken(NFT, List.of(metadata("memo"))),
+                cryptoTransfer(movingUnique(NFT, 1).between(TOKEN_TREASURY, ACCOUNT)),
+                // no tx record
+                getTxnRecord(WIPE_TXN).showsNoTransfers(),
+                // verify balance not decreased
+                getAccountInfo(ACCOUNT).hasOwnedNfts(1),
+                getAccountBalance(ACCOUNT).hasTokenBalance(NFT, 1));
     }
 
     @HapiTest // here
     final Stream<DynamicTest> uniqueWipeFailsWhenInvokedOnFungibleToken() { // invokes unique wipe on fungible tokens
-        return defaultHapiSpec("UniqueWipeFailsWhenInvokedOnFungibleToken")
-                .given(
-                        newKeyNamed(WIPE_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(ACCOUNT),
-                        tokenCreate(A_TOKEN)
-                                .tokenType(TokenType.FUNGIBLE_COMMON)
-                                .initialSupply(10)
-                                .treasury(TOKEN_TREASURY)
-                                .wipeKey(WIPE_KEY),
-                        tokenAssociate(ACCOUNT, A_TOKEN),
-                        cryptoTransfer(TokenMovement.moving(5, A_TOKEN).between(TOKEN_TREASURY, ACCOUNT)))
-                .when(
-                        wipeTokenAccount(A_TOKEN, ACCOUNT, List.of(1L, 2L)).via("wipeTx"),
-                        wipeTokenAccount(A_TOKEN, ACCOUNT, List.of())
-                                .hasKnownStatus(SUCCESS)
-                                .via("wipeEmptySerialTx"))
-                .then(
-                        getTokenInfo(A_TOKEN).hasTotalSupply(10),
-                        getTxnRecord("wipeTx").showsNoTransfers(),
-                        getAccountBalance(ACCOUNT).hasTokenBalance(A_TOKEN, 5));
+        return hapiTest(
+                newKeyNamed(WIPE_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(ACCOUNT),
+                tokenCreate(A_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(10)
+                        .treasury(TOKEN_TREASURY)
+                        .wipeKey(WIPE_KEY),
+                tokenAssociate(ACCOUNT, A_TOKEN),
+                cryptoTransfer(TokenMovement.moving(5, A_TOKEN).between(TOKEN_TREASURY, ACCOUNT)),
+                wipeTokenAccount(A_TOKEN, ACCOUNT, List.of(1L, 2L)).via("wipeTx"),
+                wipeTokenAccount(A_TOKEN, ACCOUNT, List.of())
+                        .hasKnownStatus(SUCCESS)
+                        .via("wipeEmptySerialTx"),
+                getTokenInfo(A_TOKEN).hasTotalSupply(10),
+                getTxnRecord("wipeTx").showsNoTransfers(),
+                getAccountBalance(ACCOUNT).hasTokenBalance(A_TOKEN, 5));
     }
 
     @HapiTest
     final Stream<DynamicTest> wipeFailsWithInvalidSerialNumber() {
-        return defaultHapiSpec("WipeFailsWithInvalidSerialNumber")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        newKeyNamed(WIPE_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(ACCOUNT),
-                        tokenCreate(NFT)
-                                .tokenType(NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .initialSupply(0)
-                                .treasury(TOKEN_TREASURY)
-                                .wipeKey(WIPE_KEY),
-                        tokenAssociate(ACCOUNT, NFT),
-                        mintToken(NFT, List.of(metadata("memo"), metadata("memo")))
-                                .via(MINT_TXN))
-                .when()
-                .then(wipeTokenAccount(NFT, ACCOUNT, List.of(-5L, -6L)).hasPrecheck(INVALID_NFT_ID));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                newKeyNamed(WIPE_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(ACCOUNT),
+                tokenCreate(NFT)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .wipeKey(WIPE_KEY),
+                tokenAssociate(ACCOUNT, NFT),
+                mintToken(NFT, List.of(metadata("memo"), metadata("memo"))).via(MINT_TXN),
+                wipeTokenAccount(NFT, ACCOUNT, List.of(-5L, -6L)).hasPrecheck(INVALID_NFT_ID));
     }
 
     @HapiTest
     final Stream<DynamicTest> mintUniqueTokenReceiptCheck() {
         final var mintTransferTxn = "mintTransferTxn";
-        return defaultHapiSpec("mintUniqueTokenReceiptCheck")
-                .given(
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate(FIRST_USER),
-                        newKeyNamed(SUPPLY_KEY),
-                        tokenCreate(A_TOKEN)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .initialSupply(0)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(mintToken(A_TOKEN, List.of(metadata("memo"))).via(mintTransferTxn))
-                .then(
-                        UtilVerbs.withOpContext((spec, opLog) -> {
-                            var mintNft = getTxnRecord(mintTransferTxn);
-                            allRunFor(spec, mintNft);
-                            var tokenTransferLists = mintNft.getResponseRecord().getTokenTransferListsList();
-                            Assertions.assertEquals(1, tokenTransferLists.size());
-                            tokenTransferLists.forEach(tokenTransferList -> {
-                                Assertions.assertEquals(
-                                        1,
-                                        tokenTransferList.getNftTransfersList().size());
-                                tokenTransferList.getNftTransfersList().forEach(nftTransfers -> {
-                                    Assertions.assertEquals(
-                                            AccountID.newBuilder()
-                                                    .setAccountNum(0)
-                                                    .build(),
-                                            nftTransfers.getSenderAccountID());
-                                    Assertions.assertEquals(
-                                            TxnUtils.asId(TOKEN_TREASURY, spec), nftTransfers.getReceiverAccountID());
-                                    Assertions.assertEquals(1L, nftTransfers.getSerialNumber());
-                                });
-                            });
-                        }),
-                        getTxnRecord(mintTransferTxn).logged(),
-                        getReceipt(mintTransferTxn).logged());
+        return hapiTest(
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate(FIRST_USER),
+                newKeyNamed(SUPPLY_KEY),
+                tokenCreate(A_TOKEN)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                mintToken(A_TOKEN, List.of(metadata("memo"))).via(mintTransferTxn),
+                UtilVerbs.withOpContext((spec, opLog) -> {
+                    var mintNft = getTxnRecord(mintTransferTxn);
+                    allRunFor(spec, mintNft);
+                    var tokenTransferLists = mintNft.getResponseRecord().getTokenTransferListsList();
+                    Assertions.assertEquals(1, tokenTransferLists.size());
+                    tokenTransferLists.forEach(tokenTransferList -> {
+                        Assertions.assertEquals(
+                                1, tokenTransferList.getNftTransfersList().size());
+                        tokenTransferList.getNftTransfersList().forEach(nftTransfers -> {
+                            Assertions.assertEquals(
+                                    AccountID.newBuilder().setAccountNum(0).build(), nftTransfers.getSenderAccountID());
+                            Assertions.assertEquals(
+                                    TxnUtils.asId(TOKEN_TREASURY, spec), nftTransfers.getReceiverAccountID());
+                            Assertions.assertEquals(1L, nftTransfers.getSerialNumber());
+                        });
+                    });
+                }),
+                getTxnRecord(mintTransferTxn).logged(),
+                getReceipt(mintTransferTxn).logged());
     }
 
     @HapiTest
     final Stream<DynamicTest> tokenDissociateHappyPath() {
-        return defaultHapiSpec("tokenDissociateHappyPath")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate("acc"),
-                        tokenCreate(NFT)
-                                .initialSupply(0)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(tokenAssociate("acc", NFT))
-                .then(
-                        tokenDissociate("acc", NFT).hasKnownStatus(SUCCESS),
-                        getAccountInfo("acc").hasNoTokenRelationship(NFT));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate("acc"),
+                tokenCreate(NFT)
+                        .initialSupply(0)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenAssociate("acc", NFT),
+                tokenDissociate("acc", NFT).hasKnownStatus(SUCCESS),
+                getAccountInfo("acc").hasNoTokenRelationship(NFT));
     }
 
     @HapiTest
     final Stream<DynamicTest> tokenDissociateFailsIfAccountOwnsUniqueTokens() {
-        return defaultHapiSpec("tokenDissociateFailsIfAccountOwnsUniqueTokens")
-                .given(
-                        newKeyNamed(SUPPLY_KEY),
-                        cryptoCreate(TOKEN_TREASURY),
-                        cryptoCreate("acc"),
-                        tokenCreate(NFT)
-                                .initialSupply(0)
-                                .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
-                                .supplyType(TokenSupplyType.INFINITE)
-                                .supplyKey(SUPPLY_KEY)
-                                .treasury(TOKEN_TREASURY))
-                .when(tokenAssociate("acc", NFT), mintToken(NFT, List.of(metadata(MEMO_1), metadata(MEMO_2))))
-                .then(
-                        cryptoTransfer(TokenMovement.movingUnique(NFT, 1, 2).between(TOKEN_TREASURY, "acc")),
-                        tokenDissociate("acc", NFT).hasKnownStatus(ACCOUNT_STILL_OWNS_NFTS));
+        return hapiTest(
+                newKeyNamed(SUPPLY_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate("acc"),
+                tokenCreate(NFT)
+                        .initialSupply(0)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .supplyKey(SUPPLY_KEY)
+                        .treasury(TOKEN_TREASURY),
+                tokenAssociate("acc", NFT),
+                mintToken(NFT, List.of(metadata(MEMO_1), metadata(MEMO_2))),
+                cryptoTransfer(TokenMovement.movingUnique(NFT, 1, 2).between(TOKEN_TREASURY, "acc")),
+                tokenDissociate("acc", NFT).hasKnownStatus(ACCOUNT_STILL_OWNS_NFTS));
     }
 
     protected Logger getResultsLogger() {


### PR DESCRIPTION
This PR continues the work for replacing defaultHapiSpec(...) with hapiTest(...). There should be no change to any of the current test conditions

Part of https://github.com/hashgraph/hedera-services/issues/16494