### PR TITLE
feat: add fixes for Hapi test suites with non-zero shard or realm values

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockImplUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockImplUtils.java
@@ -144,31 +144,45 @@ public class BlockImplUtils {
                         case "MIDNIGHT_RATES" -> STATE_ID_MIDNIGHT_RATES.protoOrdinal();
                         default -> UNKNOWN_STATE_ID;
                     };
-                    case "FileService" -> switch (stateKey) {
-                        case "FILES" -> STATE_ID_FILES.protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=150]]" -> STATE_ID_UPGRADE_DATA_150
-                                .protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=151]]" -> STATE_ID_UPGRADE_DATA_151
-                                .protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=152]]" -> STATE_ID_UPGRADE_DATA_152
-                                .protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=153]]" -> STATE_ID_UPGRADE_DATA_153
-                                .protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=154]]" -> STATE_ID_UPGRADE_DATA_154
-                                .protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=155]]" -> STATE_ID_UPGRADE_DATA_155
-                                .protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=156]]" -> STATE_ID_UPGRADE_DATA_156
-                                .protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=157]]" -> STATE_ID_UPGRADE_DATA_157
-                                .protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=158]]" -> STATE_ID_UPGRADE_DATA_158
-                                .protoOrdinal();
-                        case "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=159]]" -> STATE_ID_UPGRADE_DATA_159
-                                .protoOrdinal();
-                        case "UPGRADE_FILE" -> STATE_ID_UPGRADE_FILE.protoOrdinal();
-                        default -> UNKNOWN_STATE_ID;
-                    };
+                    case "FileService" -> {
+                        if ("FILES".equals(stateKey)) {
+                            yield STATE_ID_FILES.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=150]]")) {
+                            yield STATE_ID_UPGRADE_DATA_150.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=151]]")) {
+                            yield STATE_ID_UPGRADE_DATA_151.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=152]]")) {
+                            yield STATE_ID_UPGRADE_DATA_152.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=153]]")) {
+                            yield STATE_ID_UPGRADE_DATA_153.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=154]]")) {
+                            yield STATE_ID_UPGRADE_DATA_154.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=155]]")) {
+                            yield STATE_ID_UPGRADE_DATA_155.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=156]]")) {
+                            yield STATE_ID_UPGRADE_DATA_156.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=157]]")) {
+                            yield STATE_ID_UPGRADE_DATA_157.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=158]]")) {
+                            yield STATE_ID_UPGRADE_DATA_158.protoOrdinal();
+                        } else if (stateKey.matches(
+                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=159]]")) {
+                            yield STATE_ID_UPGRADE_DATA_159.protoOrdinal();
+                        } else if ("UPGRADE_FILE".equals(stateKey)) {
+                            yield STATE_ID_UPGRADE_FILE.protoOrdinal();
+                        } else {
+                            yield UNKNOWN_STATE_ID;
+                        }
+                    }
                     case "FreezeService" -> switch (stateKey) {
                         case "FREEZE_TIME" -> STATE_ID_FREEZE_TIME.protoOrdinal();
                         case "UPGRADE_FILE_HASH" -> STATE_ID_UPGRADE_FILE_HASH.protoOrdinal();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockImplUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockImplUtils.java
@@ -84,12 +84,15 @@ import com.swirlds.common.crypto.DigestType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.function.IntFunction;
 
 /**
  * Utility methods for block implementation.
  */
 public class BlockImplUtils {
     private static final int UNKNOWN_STATE_ID = -1;
+    private static final IntFunction<String> UPGRADE_DATA_FILE_FORMAT =
+            n -> String.format("UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=%s]]", n);
 
     /**
      * Prevent instantiation
@@ -147,35 +150,25 @@ public class BlockImplUtils {
                     case "FileService" -> {
                         if ("FILES".equals(stateKey)) {
                             yield STATE_ID_FILES.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=150]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(150))) {
                             yield STATE_ID_UPGRADE_DATA_150.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=151]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(151))) {
                             yield STATE_ID_UPGRADE_DATA_151.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=152]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(152))) {
                             yield STATE_ID_UPGRADE_DATA_152.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=153]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(153))) {
                             yield STATE_ID_UPGRADE_DATA_153.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=154]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(154))) {
                             yield STATE_ID_UPGRADE_DATA_154.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=155]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(155))) {
                             yield STATE_ID_UPGRADE_DATA_155.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=156]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(156))) {
                             yield STATE_ID_UPGRADE_DATA_156.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=157]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(157))) {
                             yield STATE_ID_UPGRADE_DATA_157.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=158]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(158))) {
                             yield STATE_ID_UPGRADE_DATA_158.protoOrdinal();
-                        } else if (stateKey.matches(
-                                "UPGRADE_DATA\\[FileID\\[shardNum=\\d, realmNum=\\d, fileNum=159]]")) {
+                        } else if (stateKey.matches(UPGRADE_DATA_FILE_FORMAT.apply(159))) {
                             yield STATE_ID_UPGRADE_DATA_159.protoOrdinal();
                         } else if ("UPGRADE_FILE".equals(stateKey)) {
                             yield STATE_ID_UPGRADE_FILE.protoOrdinal();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/AbstractNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/AbstractNode.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -101,11 +101,19 @@ public abstract class AbstractNode implements HederaNode {
             case RECORD_STREAMS_DIR -> workingDir
                     .resolve(DATA_DIR)
                     .resolve(RECORD_STREAMS_DIR)
-                    .resolve("record0.0." + getAccountId().accountNumOrThrow());
+                    .resolve(String.format(
+                            "record%d.%d.%d",
+                            getAccountId().shardNum(),
+                            getAccountId().realmNum(),
+                            getAccountId().accountNumOrThrow()));
             case BLOCK_STREAMS_DIR -> workingDir
                     .resolve(DATA_DIR)
                     .resolve(BLOCK_STREAMS_DIR)
-                    .resolve("block-0.0." + getAccountId().accountNumOrThrow());
+                    .resolve(String.format(
+                            "block-%d.%d.%d",
+                            getAccountId().shardNum(),
+                            getAccountId().realmNum(),
+                            getAccountId().accountNumOrThrow()));
             case UPGRADE_ARTIFACTS_DIR -> workingDir
                     .resolve(DATA_DIR)
                     .resolve(UPGRADE_DIR)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/AddressBookUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/AddressBookUtils.java
@@ -49,9 +49,8 @@ public class AddressBookUtils {
     public static final long CLASSIC_FIRST_NODE_ACCOUNT_NUM = 3;
     public static final String[] CLASSIC_NODE_NAMES =
             new String[] {"node1", "node2", "node3", "node4", "node5", "node6", "node7", "node8"};
-
-    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
     private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
 
     private AddressBookUtils() {
         throw new UnsupportedOperationException("Utility Class");
@@ -185,6 +184,8 @@ public class AddressBookUtils {
                 nodeId,
                 CLASSIC_NODE_NAMES[nodeId],
                 AccountID.newBuilder()
+                        .shardNum(Long.parseLong(SHARD))
+                        .realmNum(Long.parseLong(REALM))
                         .accountNum(CLASSIC_FIRST_NODE_ACCOUNT_NUM + nodeId)
                         .build(),
                 host,
@@ -293,6 +294,8 @@ public class AddressBookUtils {
      */
     public static com.hederahashgraph.api.proto.java.AccountID classicFeeCollectorIdFor(final long nodeId) {
         return com.hederahashgraph.api.proto.java.AccountID.newBuilder()
+                .setShardNum(Long.parseLong(SHARD))
+                .setRealmNum(Long.parseLong(REALM))
                 .setAccountNum(nodeId + CLASSIC_FIRST_NODE_ACCOUNT_NUM)
                 .build();
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/entities/SpecAccount.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/entities/SpecAccount.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -43,6 +43,7 @@ import com.hedera.services.bdd.spec.dsl.operations.transactions.DeleteAccountOpe
 import com.hedera.services.bdd.spec.dsl.operations.transactions.DissociateTokensOperation;
 import com.hedera.services.bdd.spec.dsl.operations.transactions.TransferTokensOperation;
 import com.hedera.services.bdd.spec.dsl.utils.KeyMetadata;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoCreate;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
@@ -53,6 +54,8 @@ import java.util.List;
  */
 public class SpecAccount extends AbstractSpecEntity<HapiCryptoCreate, Account>
         implements OwningEntity, EvmAddressableEntity {
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
     private static final long UNSPECIFIED_CENT_BALANCE = -1;
 
     private final Account.Builder builder = Account.newBuilder();
@@ -374,6 +377,8 @@ public class SpecAccount extends AbstractSpecEntity<HapiCryptoCreate, Account>
                     .saveAccountId(
                             name,
                             com.hederahashgraph.api.proto.java.AccountID.newBuilder()
+                                    .setShardNum(Long.parseLong(SHARD))
+                                    .setRealmNum(Long.parseLong(REALM))
                                     .setAccountNum(model.accountIdOrThrow().accountNumOrThrow())
                                     .build());
             if (model.receiverSigRequired()) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CommonUpgradeResources.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/CommonUpgradeResources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 
 import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import com.hedera.services.bdd.suites.perf.PerfTestLoadSettings;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -30,7 +31,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 
 public final class CommonUpgradeResources {
-    public static final String DEFAULT_UPGRADE_FILE_ID = "0.0.150";
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
+    public static final String DEFAULT_UPGRADE_FILE_ID = String.format("%s.%s.150", SHARD, REALM);
     public static final String DEFAULT_UPGRADE_FILE_PATH = "testfiles/poeticUpgrade.zip";
     // This file is inside the pretend ZIP and PREPARE_UPGRADE should put it in the current artifacts directory
     public static final String FAKE_UPGRADE_FILE_NAME = "MrBleaney.txt";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpgradeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpgradeSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpgradeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/UpgradeSuite.java
@@ -40,6 +40,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UPDATE_FILE_HA
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UPDATE_FILE_ID_DOES_NOT_MATCH_PREPARED;
 
 import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.swirlds.common.utility.CommonUtils;
 import java.io.IOException;
@@ -57,6 +58,8 @@ import org.junit.jupiter.api.DynamicTest;
 public class UpgradeSuite extends HapiSuite {
     private static final Logger log = LogManager.getLogger(UpgradeSuite.class);
 
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
     public static final String pragmatism = "Think of the children!";
     public static final String poeticUpgradeLoc = "testfiles/poeticUpgrade.zip";
     public static final String heavyPoeticUpgradeLoc = "testfiles/heavyPoeticUpgrade.zip";
@@ -71,8 +74,8 @@ public class UpgradeSuite extends HapiSuite {
     private final byte[] heavyPoeticUpgradeHash;
     private final byte[] notEvenASha384Hash = "abcdefgh".getBytes(StandardCharsets.UTF_8);
 
-    public static final String standardUpdateFile = "0.0.150";
-    public static final String standardTelemetryFile = "0.0.159";
+    public static final String standardUpdateFile = String.format("%s.%s.150", SHARD, REALM);
+    public static final String standardTelemetryFile = String.format("%s.%s.159", SHARD, REALM);
 
     public UpgradeSuite() {
         try {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/BalanceValidation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/BalanceValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 import com.hedera.services.bdd.junit.support.validators.utils.AccountClassifier;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import com.hedera.services.bdd.spec.queries.QueryVerbs;
 import com.hedera.services.bdd.suites.HapiSuite;
 import java.util.List;
@@ -38,6 +39,8 @@ public class BalanceValidation extends HapiSuite {
 
     private final Map<Long, Long> expectedBalances;
     private final AccountClassifier accountClassifier;
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
 
     public BalanceValidation(final Map<Long, Long> expectedBalances, final AccountClassifier accountClassifier) {
         this.expectedBalances = expectedBalances;
@@ -71,7 +74,8 @@ public class BalanceValidation extends HapiSuite {
                                 .map(entry -> {
                                     final var accountNum = entry.getKey();
                                     return QueryVerbs.getAccountBalance(
-                                                    "0.0." + accountNum, accountClassifier.isContract(accountNum))
+                                                    String.format("%s.%s.%d", SHARD, REALM, accountNum),
+                                                    accountClassifier.isContract(accountNum))
                                             .hasAnswerOnlyPrecheckFrom(CONTRACT_DELETED, ACCOUNT_DELETED, OK)
                                             .hasTinyBars(entry.getValue());
                                 })

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/TargetNetworkPrep.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/TargetNetworkPrep.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,6 +40,7 @@ import com.hedera.node.app.hapi.utils.fee.FeeObject;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.assertions.AccountInfoAsserts;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import java.util.concurrent.atomic.AtomicReference;
@@ -48,6 +49,9 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 
 public class TargetNetworkPrep {
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
+
     @LeakyHapiTest(requirement = {SYSTEM_ACCOUNT_BALANCES})
     final Stream<DynamicTest> ensureSystemStateAsExpectedWithSystemDefaultFiles() {
         final var emptyKey =
@@ -90,7 +94,7 @@ public class TargetNetworkPrep {
                                 .noAlias()
                                 .noAllowances()),
                 withOpContext((spec, opLog) -> {
-                    final var genesisInfo = getAccountInfo("0.0.2");
+                    final var genesisInfo = getAccountInfo(String.format("%s.%s.2", SHARD, REALM));
                     allRunFor(spec, genesisInfo);
                     final var key = genesisInfo
                             .getResponse()
@@ -99,7 +103,7 @@ public class TargetNetworkPrep {
                             .getKey();
                     final var cloneConfirmations = inParallel(IntStream.rangeClosed(200, 750)
                             .filter(i -> i < 350 || i >= 400)
-                            .mapToObj(i -> getAccountInfo("0.0." + i)
+                            .mapToObj(i -> getAccountInfo(String.format("%s.%s.%d", SHARD, REALM, i))
                                     .noLogging()
                                     .payingWith(GENESIS)
                                     .has(AccountInfoAsserts.accountWith().key(key)))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/DabEnabledUpgradeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/DabEnabledUpgradeTest.java
@@ -63,6 +63,7 @@ import com.hedera.services.bdd.junit.hedera.NodeSelector;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.dsl.annotations.Account;
 import com.hedera.services.bdd.spec.dsl.entities.SpecAccount;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import com.hedera.services.bdd.spec.utilops.FakeNmt;
 import com.hederahashgraph.api.proto.java.SemanticVersion;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -105,6 +106,9 @@ import org.junit.jupiter.api.TestMethodOrder;
 @HapiTestLifecycle
 @OrderedInIsolation
 public class DabEnabledUpgradeTest implements LifecycleTest {
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
+
     // To test BirthRoundStateMigration, use,
     //    Map.of("event.useBirthRoundAncientThreshold", "true")
     private static final Map<String, String> ENV_OVERRIDES = Map.of();
@@ -300,6 +304,6 @@ public class DabEnabledUpgradeTest implements LifecycleTest {
     }
 
     private static String classicFeeCollectorIdLiteralFor(final long nodeId) {
-        return "0.0." + (nodeId + 3L);
+        return String.format("%s.%s.%d", SHARD, REALM, (nodeId + 3L));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import static com.hedera.services.bdd.suites.regression.system.LifecycleTest.RES
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.burstOfTps;
 
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import com.hedera.services.bdd.spec.utilops.FakeNmt;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
@@ -38,12 +39,15 @@ import org.junit.jupiter.api.Tag;
  */
 @Tag(ND_RECONNECT)
 public class MixedOpsNodeDeathReconnectTest implements LifecycleTest {
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
+
     @HapiTest
     final Stream<DynamicTest> reconnectMixedOps() {
         return defaultHapiSpec("RestartMixedOps")
                 .given(
                         // Validate we can initially submit transactions to node2
-                        cryptoCreate("nobody").setNode("0.0.5"),
+                        cryptoCreate("nobody").setNode(String.format("%s.%s.5", SHARD, REALM)),
                         // Run some mixed transactions
                         burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
                         // Stop node 2
@@ -61,6 +65,6 @@ public class MixedOpsNodeDeathReconnectTest implements LifecycleTest {
                         // Run some more transactions
                         burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
                         // And validate we can still submit transactions to node2
-                        cryptoCreate("somebody").setNode("0.0.5"));
+                        cryptoCreate("somebody").setNode(String.format("%s.%s.5", SHARD, REALM)));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/FutureSchedulableOpsTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/FutureSchedulableOpsTest.java
@@ -70,6 +70,7 @@ import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
@@ -82,6 +83,9 @@ import org.junit.jupiter.api.DynamicTest;
  */
 @HapiTestLifecycle
 public class FutureSchedulableOpsTest {
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
+
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         testLifecycle.overrideInClass(Map.of(
@@ -119,7 +123,7 @@ public class FutureSchedulableOpsTest {
         return hapiTest(
                 cryptoCreate(PAYING_ACCOUNT),
                 cryptoCreate(PAYING_ACCOUNT_2),
-                scheduleCreate(A_SCHEDULE, fileUpdate("0.0.150").contents("fooo!"))
+                scheduleCreate(A_SCHEDULE, fileUpdate(String.format("%s.%s.150", SHARD, REALM)).contents("fooo!"))
                         .withEntityMemo(randomUppercase(100))
                         .designatingPayer(PAYING_ACCOUNT_2)
                         .payingWith(PAYING_ACCOUNT)
@@ -175,7 +179,7 @@ public class FutureSchedulableOpsTest {
         return hapiTest(
                 doWithStartupConfig(
                         "accounts.lastThrottleExempt",
-                        value -> doAdhoc(() -> unprivilegedThrottleExemptPayerId.set("0.0." + value))),
+                        value -> doAdhoc(() -> unprivilegedThrottleExemptPayerId.set(String.format("%s.%s.%s", SHARD, REALM, value)))),
                 cryptoCreate(PAYING_ACCOUNT),
                 fileCreate("misc").lifetime(THREE_MONTHS_IN_SECONDS).contents(ORIG_FILE),
                 sourcing(() -> scheduleCreate(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/FutureSchedulableOpsTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/FutureSchedulableOpsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -123,7 +123,10 @@ public class FutureSchedulableOpsTest {
         return hapiTest(
                 cryptoCreate(PAYING_ACCOUNT),
                 cryptoCreate(PAYING_ACCOUNT_2),
-                scheduleCreate(A_SCHEDULE, fileUpdate(String.format("%s.%s.150", SHARD, REALM)).contents("fooo!"))
+                scheduleCreate(
+                                A_SCHEDULE,
+                                fileUpdate(String.format("%s.%s.150", SHARD, REALM))
+                                        .contents("fooo!"))
                         .withEntityMemo(randomUppercase(100))
                         .designatingPayer(PAYING_ACCOUNT_2)
                         .payingWith(PAYING_ACCOUNT)
@@ -179,7 +182,8 @@ public class FutureSchedulableOpsTest {
         return hapiTest(
                 doWithStartupConfig(
                         "accounts.lastThrottleExempt",
-                        value -> doAdhoc(() -> unprivilegedThrottleExemptPayerId.set(String.format("%s.%s.%s", SHARD, REALM, value)))),
+                        value -> doAdhoc(() ->
+                                unprivilegedThrottleExemptPayerId.set(String.format("%s.%s.%s", SHARD, REALM, value)))),
                 cryptoCreate(PAYING_ACCOUNT),
                 fileCreate("misc").lifetime(THREE_MONTHS_IN_SECONDS).contents(ORIG_FILE),
                 sourcing(() -> scheduleCreate(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleUtils.java
@@ -35,7 +35,7 @@ public final class ScheduleUtils {
     static final String CREATE_TXN = "createTx";
     static final String CREATION = "creation";
     static final String DEFERRED_XFER = "deferredXfer";
-    static final String DESIGNATING_PAYER = "1.2.3";
+    static final String DESIGNATING_PAYER = "111.222.333";
     static final String ENTITY_MEMO = "This was Mr. Bleaney's room. He stayed";
     static final String FAILED_XFER = "failedXfer";
     static final String FAILING_TXN = "failingTxn";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/PrivilegedOpsTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/PrivilegedOpsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,14 +50,17 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 
 public class PrivilegedOpsTest {
-    private static final String ACCOUNT_88 = "0.0.88";
-    private static final String ACCOUNT_2 = "0.0.2";
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
+    private static final String ACCOUNT_88 = String.format("%s.%s.88", SHARD, REALM);
+    private static final String ACCOUNT_2 = String.format("%s.%s.2", SHARD, REALM);
     private static final String CIVILIAN = "civilian";
     private static final String NEW_88 = "new88";
     private static final int BURST_SIZE = 10;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/SteadyStateThrottlingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/SteadyStateThrottlingTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.OpProvider;
+import com.hedera.services.bdd.spec.props.JutilPropertySource;
 import com.hedera.services.bdd.spec.queries.crypto.HapiGetAccountBalance;
 import com.hedera.services.bdd.spec.utilops.SysFileOverrideOp;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
@@ -97,6 +98,8 @@ public class SteadyStateThrottlingTest {
     private static final String SUPPLY = "supply";
     private static final String TOKEN = "token";
     private static final String CIVILIAN = "civilian";
+    private static final String SHARD = JutilPropertySource.getDefaultInstance().get("default.shard");
+    private static final String REALM = JutilPropertySource.getDefaultInstance().get("default.realm");
     /**
      * In general, only {@code BUSY} and {@code SUCCESS} will be returned by the network ({@code BUSY} if we exhaust
      * all retries for a particular transaction without ever submitting it); however, in CI with fewer CPUs available,
@@ -208,7 +211,7 @@ public class SteadyStateThrottlingTest {
                     int logScreen = 0;
                     while (watch.elapsed(SECONDS) < secsToRun) {
                         var subOps = IntStream.range(0, burstSize)
-                                .mapToObj(ignore -> getAccountBalance("0.0.2")
+                                .mapToObj(ignore -> getAccountBalance(String.format("%s.%s.2", SHARD, REALM))
                                         .noLogging()
                                         .payingWith("curious")
                                         .hasAnswerOnlyPrecheckFrom(BUSY, OK))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -134,6 +134,7 @@ public class TokenCreateSpecs {
     private static final String AUTO_RENEW = "autoRenew";
     private static final String CREATE_TXN = "createTxn";
     private static final String PAYER = "payer";
+    public static final String INVALID_ACCOUNT = "999.999.999";
 
     private static String TOKEN_TREASURY = "treasury";
 
@@ -329,7 +330,7 @@ public class TokenCreateSpecs {
                                 .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
                         tokenCreate(PRIMARY)
                                 .signedBy(GENESIS)
-                                .autoRenewAccount("1.2.3")
+                                .autoRenewAccount(INVALID_ACCOUNT)
                                 .hasKnownStatus(INVALID_AUTORENEW_ACCOUNT),
                         tokenCreate(PRIMARY)
                                 .autoRenewAccount(AUTO_RENEW)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,6 +120,7 @@ public class TokenManagementSpecs {
     private static final String WIPE_TXN = "wipeTxn";
     private static final String ONE_KYC = "oneKyc";
     private static final String RIGID = "rigid";
+    public static final String INVALID_ACCOUNT = "999.999.999";
 
     @HapiTest
     final Stream<DynamicTest> aliasFormFailsForAllTokenOps() {
@@ -561,10 +562,10 @@ public class TokenManagementSpecs {
                 tokenCreate(withoutKycKey).treasury(TOKEN_TREASURY),
                 tokenCreate(withKycKey).kycKey(ONE_KYC).treasury(TOKEN_TREASURY),
                 grantTokenKyc(withoutKycKey, TOKEN_TREASURY).signedBy(GENESIS).hasKnownStatus(TOKEN_HAS_NO_KYC_KEY),
-                grantTokenKyc(withKycKey, "1.2.3").hasKnownStatus(INVALID_ACCOUNT_ID),
+                grantTokenKyc(withKycKey, INVALID_ACCOUNT).hasKnownStatus(INVALID_ACCOUNT_ID),
                 grantTokenKyc(withKycKey, TOKEN_TREASURY).signedBy(GENESIS).hasKnownStatus(INVALID_SIGNATURE),
                 grantTokenKyc(withoutKycKey, TOKEN_TREASURY).signedBy(GENESIS).hasKnownStatus(TOKEN_HAS_NO_KYC_KEY),
-                revokeTokenKyc(withKycKey, "1.2.3").hasKnownStatus(INVALID_ACCOUNT_ID),
+                revokeTokenKyc(withKycKey, INVALID_ACCOUNT).hasKnownStatus(INVALID_ACCOUNT_ID),
                 revokeTokenKyc(withKycKey, TOKEN_TREASURY).signedBy(GENESIS).hasKnownStatus(INVALID_SIGNATURE),
                 getTokenInfo(withoutKycKey).hasRegisteredId(withoutKycKey).logged());
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecsStateful.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenManagementSpecsStateful.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,6 +53,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(TOKEN)
 public class TokenManagementSpecsStateful {
     private static final String FUNGIBLE_TOKEN = "fungibleToken";
+    public static final String INVALID_ACCOUNT = "999.999.999";
 
     @HapiTest
     final Stream<DynamicTest> freezeMgmtFailureCasesWork() {
@@ -76,7 +77,7 @@ public class TokenManagementSpecsStateful {
                         tokenFreeze(unfreezableToken, TOKEN_TREASURY)
                                 .signedBy(GENESIS)
                                 .hasKnownStatus(TOKEN_HAS_NO_FREEZE_KEY),
-                        tokenFreeze(freezableToken, "1.2.3").hasKnownStatus(INVALID_ACCOUNT_ID),
+                        tokenFreeze(freezableToken, INVALID_ACCOUNT).hasKnownStatus(INVALID_ACCOUNT_ID),
                         tokenFreeze(freezableToken, TOKEN_TREASURY)
                                 .signedBy(GENESIS)
                                 .hasKnownStatus(INVALID_SIGNATURE),
@@ -85,7 +86,7 @@ public class TokenManagementSpecsStateful {
                         tokenUnfreeze(unfreezableToken, TOKEN_TREASURY)
                                 .signedBy(GENESIS)
                                 .hasKnownStatus(TOKEN_HAS_NO_FREEZE_KEY),
-                        tokenUnfreeze(freezableToken, "1.2.3").hasKnownStatus(INVALID_ACCOUNT_ID),
+                        tokenUnfreeze(freezableToken, INVALID_ACCOUNT).hasKnownStatus(INVALID_ACCOUNT_ID),
                         tokenUnfreeze(freezableToken, TOKEN_TREASURY)
                                 .signedBy(GENESIS)
                                 .hasKnownStatus(INVALID_SIGNATURE))


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Fixed failing Hapi tests for non-zero shard/realm values in the following packages:
- [X] util
  - [X] UtilPrngSuite
- [X] validation
  - [X] StreamValidationTest (tested with SubmitMessageSuite)
  - [X] LogValidationTest (tested with SubmitMessageSuite)
- [X] regression
  - [X] TargetNetworkPrep
  - [X] MixedOpsNodeDeathReconnectTest
  - [X] DabEnabledUpgradeTest
- [X] schedule 
- [X] staking 
- [X] throttling 
  - [X] systemAccountUpdatePrivilegesAsExpected
  - [X] checkBalanceQps
- [X] token 
  - [X] TokenCreateSpecs 
  - [X] TokenManagementSpecs
  - [X] TokenManagementSpecsStateful

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-services/issues/17681

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

 - `utils` package doesn't contain Hapi tests, so nothing to fix there
 - There are some tests failing because they use ContractCreate transactions, those should be fixed as part of work done by HSCS team:
    - AddressAliasIdFuzzing
    - CompletedHollowAccountOperationsFuzzing
    - HollowAccountCompletionFuzzing
    - UmbrellaRedux
    - stakingMetadataUpdateIsRewardOpportunity
    - txOverGasLimitThrottled
    - precompileNftMintsAreLimitedByConsThrottle
    - contractInfoQueriesAsExpected
    - associatedContractsMustHaveAdminKeys
    - dissociateHasExpectedSemanticsForDissociatedContracts
    - expiredAndDeletedTokensStillAppearInContractInfo
    - cannotGiveNftsToDissociatedContractsOrAccounts
    - cannotSendFungibleToDissociatedContractsOrAccounts
    
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
