### PR TITLE
fix: Reset stateful variables in WritableQueueStateBase on `commit()`

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/WritableQueueStateBaseTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/WritableQueueStateBaseTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ package com.swirlds.platform.state;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.inOrder;
 
 import com.swirlds.state.spi.QueueChangeListener;
@@ -339,6 +340,23 @@ final class WritableQueueStateBaseTest<E> extends ReadableQueueStateBaseTest<E> 
             subject.peek();
             subject.commit();
             assertThat(backingList).containsExactly(CHEMISTRY);
+        }
+
+        @Test
+        void commitResetsIndex() {
+            final var backingList = new LinkedList<String>();
+            final var subject = new ListWritableQueueState<>(STEAM_STATE_KEY, backingList);
+            subject.add(ART);
+            subject.add(BIOLOGY);
+            subject.removeIf(s -> true);
+            assertEquals(BIOLOGY, subject.peek());
+            subject.removeIf(s -> true);
+            subject.commit();
+            assertThat(backingList).isEmpty();
+
+            subject.add(ART);
+            subject.add(ECOLOGY);
+            assertEquals(ART, subject.peek());
         }
 
         @Test

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/WritableQueueStateBase.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/WritableQueueStateBase.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -114,6 +114,7 @@ public abstract class WritableQueueStateBase<E> implements WritableQueueState<E>
         addedElements.clear();
         peekedElement = null;
         dsIterator = null;
+        currentAddedElementIndex = 0;
     }
 
     @NonNull


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/17904

- Fixes the missed variable `currentAddedElementIndex` that should be reset on `WritableSingletonSttaeBase.commit()`
- Resets all stateful variables on `WritableSingletonSttaeBase.commit()` call. 