### PR TITLE
feat: HIP-1021 Allow `autoRenewAccountID` to be set without `adminKey` on Topics

### DIFF
--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusCreateTopicHandler.java
@@ -16,7 +16,6 @@
 
 package com.hedera.node.app.service.consensus.impl.handlers;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTORENEW_ACCOUNT_NOT_ALLOWED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BAD_ENCODING;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CUSTOM_FEES_LIST_TOO_LONG;
@@ -153,12 +152,6 @@ public class ConsensusCreateTopicHandler implements TransactionHandler {
             final var effectiveExpiryMeta = handleContext
                     .expiryValidator()
                     .resolveCreationAttempt(false, entityExpiryMeta, HederaFunctionality.CONSENSUS_CREATE_TOPIC);
-
-            // HapiTest, TopicCreateSuite.signingRequirementsEnforced() expects error code from resolveCreationAttempt()
-            // before the following check
-            if (op.hasAutoRenewAccount()) {
-                validateTrue(op.hasAdminKey(), AUTORENEW_ACCOUNT_NOT_ALLOWED);
-            }
 
             builder.autoRenewPeriod(effectiveExpiryMeta.autoRenewPeriod());
             builder.expirationSecond(effectiveExpiryMeta.expiry());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,6 @@ import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuc
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.NONSENSE_KEY;
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.PAY_RECEIVABLE_CONTRACT;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_ACCOUNT_NOT_ALLOWED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BAD_ENCODING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
@@ -82,16 +81,17 @@ public class TopicCreateSuite {
     }
 
     @HapiTest
-    final Stream<DynamicTest> autoRenewAccountIdNeedsAdminKeyToo() {
+    final Stream<DynamicTest> autoRenewAccountIdDoesntNeedAdminKey() {
         return hapiTest(
                 cryptoCreate("payer"),
                 cryptoCreate("autoRenewAccount"),
                 createTopic("noAdminKeyExplicitAutoRenewAccount")
                         .payingWith("payer")
                         .autoRenewAccountId("autoRenewAccount")
-                        .signedBy("payer", "autoRenewAccount")
-                        // In hedera-app, we will allow an immutable topic to have an auto-renew account
-                        .hasKnownStatusFrom(AUTORENEW_ACCOUNT_NOT_ALLOWED));
+                        .signedBy("payer", "autoRenewAccount"),
+                getTopicInfo("noAdminKeyExplicitAutoRenewAccount")
+                        .hasNoAdminKey()
+                        .hasAutoRenewAccount("autoRenewAccount"));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -85,6 +85,7 @@ public class TopicCreateSuite {
         return hapiTest(
                 cryptoCreate("payer"),
                 cryptoCreate("autoRenewAccount"),
+                // autoRenewAccount can be set on topic without adminKey
                 createTopic("noAdminKeyExplicitAutoRenewAccount")
                         .payingWith("payer")
                         .autoRenewAccountId("autoRenewAccount")
@@ -151,10 +152,10 @@ public class TopicCreateSuite {
                 createTopic("NotToBe")
                         .autoRenewAccountId(PAY_RECEIVABLE_CONTRACT)
                         .hasKnownStatusFrom(INVALID_SIGNATURE),
+                // Auto-renew account should sign if set on a topic
                 createTopic("testTopic")
                         .payingWith("payer")
                         .autoRenewAccountId("autoRenewAccount")
-                        /* SigMap missing signature from auto-renew account's key. */
                         .signedBy("payer")
                         .hasKnownStatus(INVALID_SIGNATURE),
                 createTopic("testTopic")
@@ -185,6 +186,7 @@ public class TopicCreateSuite {
                 getTopicInfo("explicitAdminKeyNoAutoRenewAccount")
                         .hasAdminKey("adminKey")
                         .logged(),
+                // Auto-renew account can be set along with admin key on topic
                 createTopic("explicitAdminKeyExplicitAutoRenewAccount")
                         .adminKeyName("adminKey")
                         .autoRenewAccountId("autoRenewAccount"),


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/17921

- Allow `autoRenewAccountID` to be set without `adminKey` on Topic creation

Testing:
- Added unit test
- Validated with a HapiTest