### PR TITLE
feature: Close blocks during fatal ISS

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -593,7 +593,11 @@ public final class Hedera implements SwirldMain<MerkleNodeState>, PlatformStatus
         logger.info("HederaNode#{} is {}", platform.getSelfId(), platformStatus.name());
         switch (platformStatus) {
             case ACTIVE -> startGrpcServer();
-            case CATASTROPHIC_FAILURE -> shutdownGrpcServer();
+            case CATASTROPHIC_FAILURE -> {
+                shutdownGrpcServer();
+                // Wait for the block stream to close any pending or current blocks–-we may need them for triage
+                blockStreamManager().awaitFatalShutdown(java.time.Duration.ofSeconds(30));
+            }
             case FREEZE_COMPLETE -> {
                 closeRecordStreams();
                 shutdownGrpcServer();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamManager.java
@@ -23,6 +23,8 @@ import com.swirlds.platform.system.Round;
 import com.swirlds.platform.system.state.notifications.StateHashedListener;
 import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Duration;
 import java.time.Instant;
 
 /**
@@ -139,4 +141,17 @@ public interface BlockStreamManager extends BlockRecordInfo, StateHashedListener
      * @throws IllegalStateException if the stream is closed
      */
     void writeItem(@NonNull BlockItem item);
+
+    /**
+     * Notifies the block stream manager that a fatal event has occurred, e.g. an ISS. This event should
+     * trigger any essential fatal shutdown logic.
+     */
+    void notifyFatalEvent();
+
+    /**
+     * Synchronous method that, when invoked, blocks until the block stream manager signals a successful
+     * completion of its fatal shutdown logic.
+     * @param maybeTimeout the maximum time to wait for block stream shutdown
+     */
+    void awaitFatalShutdown(@Nullable Duration maybeTimeout);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/FatalIssListenerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/listeners/FatalIssListenerImpl.java
@@ -16,6 +16,9 @@
 
 package com.hedera.node.app.state.listeners;
 
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.node.app.blocks.BlockStreamManager;
 import com.swirlds.platform.system.state.notifications.AsyncFatalIssListener;
 import com.swirlds.platform.system.state.notifications.IssNotification;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -29,13 +32,16 @@ public class FatalIssListenerImpl implements AsyncFatalIssListener {
 
     private static final Logger log = LogManager.getLogger(FatalIssListenerImpl.class);
 
+    private final BlockStreamManager blockStreamManager;
+
     @Inject
-    public FatalIssListenerImpl() {
-        // no-op
+    public FatalIssListenerImpl(@NonNull final BlockStreamManager blockStreamManager) {
+        this.blockStreamManager = requireNonNull(blockStreamManager);
     }
 
     @Override
     public void notify(@NonNull final IssNotification data) {
         log.warn("ISS detected (type={}, round={})", data.getIssType(), data.getRound());
+        blockStreamManager.notifyFatalEvent();
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/IssHapiTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/IssHapiTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.junit;
+
+import com.hedera.services.bdd.junit.extensions.NetworkTargetingExtension;
+import com.hedera.services.bdd.junit.extensions.SpecNamingExtension;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.parallel.Isolated;
+
+/**
+ * A subprocess-only variant of {@link HapiTest} that intentionally starts node 0 with a different
+ * configuration. For now, any test class annotated with {@link IssHapiTest} should expect node 0
+ * to allow for one extra transaction to be submitted in a crypto transfer body in its test(s). A test
+ * should then submit a crypto transfer <b>to node 0</b> that will result in successfully processing
+ * an illegal number of transfers on node 0, but which transfer will be (correctly) rejected by the rest
+ * of the nodes in the network. An ISS event will then occur on node 0, after which the test can then
+ * verify particulars of the ISS node's diverging block stream, the block stream of the rest of the
+ * network, or both.
+ * <p>
+ * This annotation is not designed for maximum flexibility at present, especially in being limited to
+ * use as a class-level annotation; however, if this type of test is found to be useful in simulating
+ * other ISS scenarios, the annotation's functionality may be enhanced later. For example, it may prove
+ * useful to set any desired config value to a different property on a single node.
+ */
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith({NetworkTargetingExtension.class, SpecNamingExtension.class})
+@Isolated
+public @interface IssHapiTest {}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
@@ -173,13 +173,14 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
      * Creates a shared network of sub-process nodes with the given size.
      *
      * @param size the number of nodes in the network
+     * @param simulateIss true if we want to simulate an ISS event in the network
      * @return the shared network
      */
-    public static synchronized HederaNetwork newSharedNetwork(final int size) {
+    public static synchronized HederaNetwork newSharedNetwork(final int size, final boolean simulateIss) {
         if (NetworkTargetingExtension.SHARED_NETWORK.get() != null) {
             throw new UnsupportedOperationException("Only one shared network allowed per launcher session");
         }
-        final var sharedNetwork = liveNetwork(SHARED_NETWORK_NAME, size);
+        final var sharedNetwork = liveNetwork(SHARED_NETWORK_NAME, size, simulateIss);
         NetworkTargetingExtension.SHARED_NETWORK.set(sharedNetwork);
         return sharedNetwork;
     }
@@ -333,7 +334,8 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
                         nextExternalGossipPort + (int) nodeId * 2,
                         nextPrometheusPort + (int) nodeId),
                 GRPC_PINGER,
-                PROMETHEUS_CLIENT);
+                PROMETHEUS_CLIENT,
+                false);
         final var accountId = pendingNodeAccounts.remove(nodeId);
         if (accountId != null) {
             node.reassignNodeAccountIdFrom(accountId);
@@ -380,9 +382,11 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
      *
      * @param name the name of the network
      * @param size the number of nodes in the network
+     * @param simulateIss true to simulate an ISS event
      * @return the network
      */
-    private static synchronized HederaNetwork liveNetwork(@NonNull final String name, final int size) {
+    private static synchronized HederaNetwork liveNetwork(
+            @NonNull final String name, final int size, final boolean simulateIss) {
         if (!nextPortsInitialized) {
             initializeNextPortsForNetwork(size);
         }
@@ -402,7 +406,9 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
                                         nextExternalGossipPort,
                                         nextPrometheusPort),
                                 GRPC_PINGER,
-                                PROMETHEUS_CLIENT))
+                                PROMETHEUS_CLIENT,
+                                // For consistency, only simulate an ISS on node 0
+                                (simulateIss && nodeId == 0)))
                         .toList());
         Runtime.getRuntime().addShutdownHook(new Thread(network::terminate));
         return network;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -242,10 +242,10 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
                         throw new HapiTxnCheckStateException("Unable to resolve txn status");
                     }
                 }
+            } finally {
+                /* Used by superclass to perform standard housekeeping. */
+                txnSubmitted = txn;
             }
-
-            /* Used by superclass to perform standard housekeeping. */
-            txnSubmitted = txn;
 
             actualPrecheck = response.getNodeTransactionPrecheckCode();
             if (retryPrechecks.isPresent()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -554,7 +554,12 @@ public class UtilVerbs {
     }
 
     public static WaitForStatusOp waitForFrozenNetwork(@NonNull final Duration timeout) {
-        return new WaitForStatusOp(NodeSelector.allNodes(), FREEZE_COMPLETE, timeout);
+        return waitForFrozenNetwork(timeout, NodeSelector.allNodes());
+    }
+
+    public static WaitForStatusOp waitForFrozenNetwork(
+            @NonNull final Duration timeout, @NonNull final NodeSelector selector) {
+        return new WaitForStatusOp(selector, FREEZE_COMPLETE, timeout);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/ParseableIssBlockStreamValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/ParseableIssBlockStreamValidationOp.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.suites.crypto;
+
+import static com.hedera.node.config.types.StreamMode.RECORDS;
+import static com.hedera.services.bdd.junit.hedera.ExternalPath.BLOCK_STREAMS_DIR;
+import static com.hedera.services.bdd.junit.support.BlockStreamAccess.BLOCK_STREAM_ACCESS;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.BlockProof;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.services.bdd.junit.support.translators.inputs.TransactionParts;
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.utilops.UtilOp;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * A {@link UtilOp} that validates the streams produced in an ISS scenario, where the ISS node
+ * block stream diverges from the block streams of the other nodes.
+ */
+// (FUTURE) Split up into more granular ops
+public class ParseableIssBlockStreamValidationOp extends UtilOp {
+    private static final Logger log = LogManager.getLogger(ParseableIssBlockStreamValidationOp.class);
+
+    public static void main(String[] args) {}
+
+    @Override
+    protected boolean submitOp(@NonNull final HapiSpec spec) throws Throwable {
+        // Skip if the network is in RECORDS stream mode (not applicable)
+        if (spec.startupProperties().getStreamMode("blockStream.streamMode") == RECORDS) {
+            log.warn("Skipping validation since the network is in record stream mode");
+            return false;
+        }
+
+        // Verify we can find the right number of streams
+        final var blockPaths = spec.getNetworkNodes().stream()
+                .map(node -> node.getExternalPath(BLOCK_STREAMS_DIR))
+                .map(Path::toAbsolutePath)
+                .map(Path::toString)
+                .toList();
+        final List<List<Block>> blocksPerNode = readBlockStreamsFor(blockPaths);
+        if (blocksPerNode.isEmpty()) {
+            Assertions.fail("Block stream validation failed: No blocks found");
+        }
+        if (blocksPerNode.size() != spec.getNetworkNodes().size()) {
+            log.warn(
+                    "Block streams found for {} nodes, but the network has {} nodes",
+                    blocksPerNode.size(),
+                    spec.getNetworkNodes().size());
+        }
+
+        // Node 0 should always be the stream with the ISS. Verify its stream first
+        final var deviatingBlockStream = blocksPerNode.getFirst();
+        verifyExpectedIssStream(deviatingBlockStream);
+
+        // Verify the non-ISS block streams
+        int freezeThreshold = deviatingBlockStream.size() - 1 - 3;
+        for (int i = 1; i < blocksPerNode.size(); i++) { // i = the node id
+            final List<Block> nodeBlocks = blocksPerNode.get(i);
+
+            // Assert the stream has a freeze transaction
+            Assertions.assertTrue(
+                    hasFreezeWithProof(nodeBlocks, freezeThreshold),
+                    "No freeze transaction found in stream for node " + i);
+
+            // Assert the last block has a non-empty block proof
+            final Block last = nodeBlocks.getLast();
+            final Bytes actualSig = last.items().getLast().blockProofOrThrow().blockSignature();
+            Assertions.assertNotEquals(Bytes.EMPTY, actualSig);
+            Assertions.assertTrue(actualSig.length() > 0);
+
+            // Assert that this node has more blocks than the ISS node, since it should have continued processing
+            // transactions
+            Assertions.assertTrue(
+                    nodeBlocks.size() > deviatingBlockStream.size(),
+                    "Non-ISS node " + i + " should have more blocks than ISS node 0");
+        }
+
+        return false;
+    }
+
+    private boolean hasFreezeWithProof(final List<Block> blocks, int startIndex) {
+        boolean foundFreeze = false;
+        for (int i = startIndex; i < blocks.size(); i++) {
+            final List<BlockItem> items = blocks.get(i).items();
+            for (final BlockItem item : items) {
+                if (!foundFreeze && item.hasEventTransaction()) {
+                    final var appTxn = item.eventTransactionOrThrow().applicationTransactionOrThrow();
+                    final var txnBody = TransactionParts.from(appTxn).body();
+                    if (txnBody.hasFreeze()) {
+                        foundFreeze = true;
+                    }
+                }
+                if (foundFreeze && item.hasBlockProof()) {
+                    return item.blockProofOrThrow().blockSignature().length() > 0;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    private void verifyExpectedIssStream(final List<Block> deviatingBlockStream) {
+        // Node 0 should always be the stream with the ISS. Verify its stream first
+        final Block issLast = deviatingBlockStream.getLast();
+        final BlockProof lastIssProof = issLast.items().getLast().blockProof();
+        // It doesn't matter if the block proof item is empty, just that it's parseable/exists
+        // (FUTURE) parse the processed round numbers from the log and assert corresponding blocks can be parsed
+        Assertions.assertNotNull(lastIssProof);
+        Assertions.assertNotEquals(BlockProof.DEFAULT, lastIssProof);
+        Assertions.assertTrue(lastIssProof.siblingHashes().isEmpty());
+    }
+
+    /**
+     * Reads the block streams for the given paths and returns them as an ordered collection of blocks
+     * @param blockPaths the paths to search for block streams
+     * @return the blocks found for each node. The index of the outer list corresponds to the node ids as
+     * returned by {@link HapiSpec#getNetworkNodes()}
+     */
+    private static List<List<Block>> readBlockStreamsFor(List<String> blockPaths) {
+        final List<List<Block>> blocksByNode = new ArrayList<>();
+        final StringBuilder errors = new StringBuilder();
+        for (final var path : blockPaths) {
+            List<Block> singleNodeBlocks = null;
+            try {
+                log.info("Trying to read blocks from {}", path);
+                singleNodeBlocks = BLOCK_STREAM_ACCESS.readBlocks(Path.of(path));
+                log.info("Read {} blocks from {}", singleNodeBlocks.size(), path);
+            } catch (Exception e) {
+                final String message = "Failed to read blocks from '" + path + "' due to '" + e.getMessage() + "'";
+                log.error(message, path, e);
+
+                errors.append(message).append("\n");
+            }
+            if (singleNodeBlocks != null && !singleNodeBlocks.isEmpty()) {
+                blocksByNode.add(singleNodeBlocks);
+            } else {
+                errors.append("Failed to read blocks from '").append(path).append("'\n");
+            }
+        }
+        if (!errors.isEmpty()) {
+            Assertions.fail(errors.toString());
+        }
+
+        return blocksByNode;
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingSuite.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.services.bdd.suites.misc;
+
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeOnly;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForFrozenNetwork;
+import static com.hedera.services.bdd.suites.regression.system.LifecycleTest.FREEZE_TIMEOUT;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.IssHapiTest;
+import com.hedera.services.bdd.junit.hedera.NodeSelector;
+import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
+import com.hedera.services.bdd.spec.utilops.UtilVerbs;
+import com.hedera.services.bdd.suites.crypto.ParseableIssBlockStreamValidationOp;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+@IssHapiTest
+class IssHandlingSuite implements BeforeAllCallback {
+    private static final long NODE_0_ACCT_ID = 3; // The ISS node
+    private static final long NODE_1_ACCT_ID = 4; // One of the Non-ISS nodes
+    private static final String NODE_1_FULL_ACCT_ID = "0.0." + NODE_1_ACCT_ID;
+
+    @HapiTest
+    final Stream<DynamicTest> simulateIss() {
+        final var node0Selector = NodeSelector.byOperatorAccountId(
+                AccountID.newBuilder().accountNum(NODE_0_ACCT_ID).build());
+        return hapiTest(
+                newKeyNamed("key1"),
+                newKeyNamed("key2"),
+                newKeyNamed("key3"),
+                newKeyNamed("key4"),
+                // Create accounts with one of the non-ISS nodes to ensure we don't get an ISS before we expect it
+                cryptoCreate("civilian1").balance(1000000L).key("key1").setNode(NODE_1_FULL_ACCT_ID),
+                cryptoCreate("civilian2").balance(100L).key("key2").setNode(NODE_1_FULL_ACCT_ID),
+                cryptoCreate("civilian3").balance(100L).key("key3").setNode(NODE_1_FULL_ACCT_ID),
+                cryptoCreate("civilian4").balance(100L).key("key4").setNode(NODE_1_FULL_ACCT_ID),
+                // The explicit transfers are specified here, but others will be calculated and included by the
+                // node, thus putting the total number of transfers over the _network's_ configured limit, but not
+                // over the ISS node's configured limit
+                cryptoTransfer(
+                                TokenMovement.movingHbar(1).between("civilian1", "civilian4"),
+                                TokenMovement.movingHbar(1).between("civilian2", "civilian4"),
+                                TokenMovement.movingHbar(1).between("civilian3", "civilian4"))
+                        .signedBy("key1", "key2", "key3")
+                        .payingWith("civilian1")
+                        // Intentionally submit this transfer to the modified node
+                        .setNode("0.0." + NODE_0_ACCT_ID)
+                        // The ISS node will shut down its GRPC server after detecting the ISS, so we need to allow for
+                        // any status type
+                        .hasAnyStatusAtAll(),
+                // Verify we actually got an ISS
+                UtilVerbs.assertHgcaaLogContains(node0Selector, "ISS detected", Duration.ofSeconds(60)),
+                // Verify the block stream manager completed its fatal shutdown process
+                UtilVerbs.assertHgcaaLogContains(
+                        node0Selector, "Block stream fatal shutdown complete", Duration.ofSeconds(30)),
+                // Submit the freeze to one of the non-ISS nodes
+                freezeOnly().startingIn(2).seconds().setNode(NODE_1_FULL_ACCT_ID),
+                waitForFrozenNetwork(FREEZE_TIMEOUT, NodeSelector.exceptNodeIds(0)),
+                // Wait for any block stream files to close
+                sleepFor(2000),
+                new ParseableIssBlockStreamValidationOp());
+    }
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        // no-op
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingTestSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingTestSuite.java
@@ -35,11 +35,9 @@ import com.hedera.services.bdd.suites.crypto.ParseableIssBlockStreamValidationOp
 import java.time.Duration;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
 
 @IssHapiTest
-class IssHandlingSuite implements BeforeAllCallback {
+class IssHandlingTestSuite {
     private static final long NODE_0_ACCT_ID = 3; // The ISS node
     private static final long NODE_1_ACCT_ID = 4; // One of the Non-ISS nodes
     private static final String NODE_1_FULL_ACCT_ID = "0.0." + NODE_1_ACCT_ID;
@@ -83,10 +81,5 @@ class IssHandlingSuite implements BeforeAllCallback {
                 // Wait for any block stream files to close
                 sleepFor(2000),
                 new ParseableIssBlockStreamValidationOp());
-    }
-
-    @Override
-    public void beforeAll(ExtensionContext context) throws Exception {
-        // no-op
     }
 }


### PR DESCRIPTION
This PR adds handling to 'safely' terminate the block stream in the event of an ISS. In this context, 'safely' means that the block stream manager will identify all block files that were in progress, and fill the remaining data with default block items (e.g. the block proof). 

A Hapi test is included to assert that the ISS behavior of a node is correct, which is accomplished by simulating an actual ISS on node 0. An ISS can now be simulated on a node by annotating the test _suite_ with `@IssHapiTest`, which under the hood modifies the `ledger.transfers.maxLen` property in the disk `application.properties` file. A crypto transfer transaction with an increased number of transfers can then be submitted to node 0 during the test; node 0 will accept it, but it should be rejected by the other nodes, thus causing an ISS. 

Note: in order to ensure the differing property is loaded by node 0, we must inject the property earlier in the test's lifecycle than the current network extension supports. `SharedNetworkLauncherSessionListener#isIssScenario` is a good starting point for evaluating how the `@IssHapiTest` annotation works.

Closes #17742 