### PR TITLE
feat: Make base read and write state classes more customizable by constructor overload

### DIFF
--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
@@ -40,7 +40,9 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * changed before we got to handle transaction. If the value is "null", this means it was NOT
      * FOUND when we looked it up.
      */
-    private ConcurrentMap<K, V> readCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<K, V> readCache;
+
+    private final Set<K> unmodifiableReadKeys;
 
     private static final Object marker = new Object();
 
@@ -50,7 +52,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * @param stateKey The state key. Cannot be null.
      */
     protected ReadableKVStateBase(@NonNull String stateKey) {
-        this.stateKey = Objects.requireNonNull(stateKey);
+        this(stateKey, new ConcurrentHashMap<>());
     }
 
     /**
@@ -59,9 +61,11 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * @param stateKey The state key. Cannot be null.
      * @param readCache A map that is used to init the cache.
      */
+    // This constructor is used by some consumers of the API that are outside of this repository.
     protected ReadableKVStateBase(@NonNull String stateKey, @NonNull ConcurrentMap<K, V> readCache) {
         this.stateKey = Objects.requireNonNull(stateKey);
         this.readCache = Objects.requireNonNull(readCache);
+        this.unmodifiableReadKeys = Collections.unmodifiableSet(readCache.keySet());
     }
 
     /** {@inheritDoc} */
@@ -93,7 +97,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      */
     @NonNull
     public final Set<K> readKeys() {
-        return Collections.unmodifiableSet(readCache.keySet());
+        return unmodifiableReadKeys;
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
@@ -40,9 +40,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * changed before we got to handle transaction. If the value is "null", this means it was NOT
      * FOUND when we looked it up.
      */
-    private final ConcurrentMap<K, V> readCache = new ConcurrentHashMap<>();
-
-    private final Set<K> unmodifiableReadKeys = Collections.unmodifiableSet(readCache.keySet());
+    private ConcurrentMap<K, V> readCache = new ConcurrentHashMap<>();
 
     private static final Object marker = new Object();
 
@@ -53,6 +51,17 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      */
     protected ReadableKVStateBase(@NonNull String stateKey) {
         this.stateKey = Objects.requireNonNull(stateKey);
+    }
+
+    /**
+     * Create a new StateBase from the provided map.
+     *
+     * @param stateKey The state key. Cannot be null.
+     * @param readCache A map that is used to init the cache.
+     */
+    protected ReadableKVStateBase(@NonNull String stateKey, @NonNull ConcurrentMap<K, V> readCache) {
+        this.stateKey = Objects.requireNonNull(stateKey);
+        this.readCache = Objects.requireNonNull(readCache);
     }
 
     /** {@inheritDoc} */
@@ -84,7 +93,7 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      */
     @NonNull
     public final Set<K> readKeys() {
-        return unmodifiableReadKeys;
+        return Collections.unmodifiableSet(readCache.keySet());
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
@@ -30,7 +30,7 @@ import java.util.*;
  */
 public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V> implements WritableKVState<K, V> {
     /** A map of all modified values buffered in this mutable state */
-    private final Map<K, V> modifications = new LinkedHashMap<>();
+    private Map<K, V> modifications = new LinkedHashMap<>();
     /**
      * A list of listeners to be notified of changes to the state.
      */
@@ -43,6 +43,17 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
      */
     protected WritableKVStateBase(@NonNull final String stateKey) {
         super(stateKey);
+    }
+
+    /**
+     * Create a new StateBase from the provided map.
+     *
+     * @param stateKey The state key. Cannot be null.
+     * @param modifications A map that is used to init the cache.
+     */
+    protected WritableKVStateBase(@NonNull final String stateKey, @NonNull final Map<K, V> modifications) {
+        super(stateKey);
+        this.modifications = Objects.requireNonNull(modifications);
     }
 
     /**

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
@@ -30,7 +30,7 @@ import java.util.*;
  */
 public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V> implements WritableKVState<K, V> {
     /** A map of all modified values buffered in this mutable state */
-    private Map<K, V> modifications = new LinkedHashMap<>();
+    private final Map<K, V> modifications;
     /**
      * A list of listeners to be notified of changes to the state.
      */
@@ -42,7 +42,7 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
      * @param stateKey The state key. Cannot be null.
      */
     protected WritableKVStateBase(@NonNull final String stateKey) {
-        super(stateKey);
+        this(stateKey, new LinkedHashMap<>());
     }
 
     /**


### PR DESCRIPTION
**Description:**
This PR modifies `ReadableKVStateBase` and `WritableKVStateBase` classes in order to make the read and write cache more customizable as a structure. This change is needed for the mirror node team in order to substitute our own scoped value based cache for concurrency reasons with historical state.

This PR is opened as a substitute for https://github.com/hiero-ledger/hiero-consensus-node/pull/17819

Fixes: #17818
