### PR TITLE
fix(release/0.58): backport changes from release 0.59 related to enhanced key loader private key detection

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -1,4 +1,19 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.node.app;
 
 import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -204,6 +204,7 @@ public class ServicesMain implements SwirldMain {
      * @param args optionally, what node id to run; required if the address book is ambiguous
      */
     public static void main(final String... args) throws Exception {
+        initLogging();
         // --- Configure platform infrastructure and context from the command line and environment ---
         BootstrapUtils.setupConstructableRegistry();
         final var diskAddressBook = loadAddressBook(DEFAULT_CONFIG_FILE_NAME);
@@ -219,7 +220,7 @@ public class ServicesMain implements SwirldMain {
         final var selfId = ensureSingleNode(nodesToRun, commandLineArgs.localNodesToStart());
         final var platformConfig = buildPlatformConfig();
         BootstrapUtils.setupConstructableRegistryWithConfiguration(platformConfig);
-        final var networkKeysAndCerts = initNodeSecurity(diskAddressBook, platformConfig);
+        final var networkKeysAndCerts = initNodeSecurity(diskAddressBook, platformConfig, Set.copyOf(nodesToRun));
         final var keysAndCerts = networkKeysAndCerts.get(selfId);
         setupGlobalMetrics(platformConfig);
         metrics = getMetricsProvider().createPlatformMetrics(selfId);
@@ -245,8 +246,6 @@ public class ServicesMain implements SwirldMain {
         hedera = newHedera(selfId, metrics);
         final var version = hedera.getSoftwareVersion();
         final var isGenesis = new AtomicBoolean(false);
-        // We want to be able to see the schema migration logs, so init logging here
-        initLogging();
         logger.info("Starting node {} with version {}", selfId, version);
         final var reservedState = loadInitialState(
                 platformConfig,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
@@ -320,7 +320,8 @@ public class DiskStartupNetworks implements StartupNetworks {
             final var configFile = LegacyConfigPropertiesLoader.loadConfigFile(Paths.get(DEFAULT_CONFIG_FILE_NAME));
             try {
                 legacyBook = configFile.getAddressBook();
-                CryptoStatic.initNodeSecurity(legacyBook, platformConfig);
+                // Load the public keys into the address book. No private keys should be loaded!
+                CryptoStatic.initNodeSecurity(legacyBook, platformConfig, Set.of());
             } catch (Exception e) {
                 throw new IllegalStateException("Error generating keys and certs", e);
             }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
@@ -1,4 +1,19 @@
-// SPDX-License-Identifier: Apache-2.0
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.hedera.node.app.info;
 
 import static com.hedera.hapi.util.HapiUtils.parseAccount;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2016-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -83,6 +83,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -217,7 +218,7 @@ public class Browser {
                     BootstrapUtils.setupConfigBuilder(configBuilder, getAbsolutePath(DEFAULT_SETTINGS_FILE_NAME)));
             final Configuration configuration = configBuilder.build();
 
-            initNodeSecurity(appDefinition.getConfigAddressBook(), configuration);
+            initNodeSecurity(appDefinition.getConfigAddressBook(), configuration, Set.copyOf(nodesToRun));
             guiEventStorage = new GuiEventStorage(guiConfig, appDefinition.getConfigAddressBook());
 
             guiSource = new StandardGuiSource(appDefinition.getConfigAddressBook(), guiEventStorage);
@@ -253,7 +254,8 @@ public class Browser {
                     nodeId);
             final var cryptography = CryptographyFactory.create();
             CryptographyHolder.set(cryptography);
-            final KeysAndCerts keysAndCerts = initNodeSecurity(appDefinition.getConfigAddressBook(), configuration)
+            final KeysAndCerts keysAndCerts = initNodeSecurity(
+                            appDefinition.getConfigAddressBook(), configuration, Set.copyOf(nodesToRun))
                     .get(nodeId);
 
             // the AddressBook is not changed after this point, so we calculate the hash now

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -40,7 +40,6 @@ import com.swirlds.platform.Utilities;
 import com.swirlds.platform.config.BasicConfig;
 import com.swirlds.platform.config.PathsConfig;
 import com.swirlds.platform.network.PeerInfo;
-import com.swirlds.platform.state.address.AddressBookNetworkUtils;
 import com.swirlds.platform.system.SystemExitCode;
 import com.swirlds.platform.system.SystemExitUtils;
 import com.swirlds.platform.system.address.Address;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
@@ -78,6 +78,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -105,6 +106,7 @@ public final class CryptoStatic {
     private static final int SWIRLD_ID_MULTIPLIER = 163;
     private static final int BITS_IN_BYTE = 8;
     private static final String ADDRESS_BOOK_MUST_NOT_BE_NULL = "addressBook must not be null";
+    private static final String LOCAL_NODES_MUST_NOT_BE_NULL = "the local nodes must not be null";
 
     static {
         // used to generate certificates
@@ -351,12 +353,16 @@ public final class CryptoStatic {
     @NonNull
     @Deprecated(since = "0.47.0", forRemoval = false)
     static Map<NodeId, KeysAndCerts> loadKeysAndCerts(
-            @NonNull final AddressBook addressBook, @NonNull final Path keysDirPath, @NonNull final char[] password)
+            @NonNull final AddressBook addressBook,
+            @NonNull final Path keysDirPath,
+            @NonNull final char[] password,
+            @NonNull final Set<NodeId> localNodes)
             throws KeyStoreException, KeyLoadingException, UnrecoverableKeyException, NoSuchAlgorithmException,
                     KeyGeneratingException, NoSuchProviderException {
         Objects.requireNonNull(addressBook, ADDRESS_BOOK_MUST_NOT_BE_NULL);
         Objects.requireNonNull(keysDirPath, "keysDirPath must not be null");
         Objects.requireNonNull(password, "password must not be null");
+        Objects.requireNonNull(localNodes, LOCAL_NODES_MUST_NOT_BE_NULL);
         final int n = addressBook.getSize();
 
         final List<String> names = new ArrayList<>();
@@ -376,9 +382,9 @@ public final class CryptoStatic {
         for (int i = 0; i < n; i++) {
             final NodeId nodeId = addressBook.getNodeId(i);
             final Address address = addressBook.getAddress(nodeId);
-            if (!AddressBookNetworkUtils.isLocal(address)) {
+            if (!localNodes.contains(address.getNodeId())) {
                 // in case we are not creating keys but loading them from disk, we do not need to create
-                // a KeysAndCerts object for every node, just the local ones
+                // a KeysAndCerts object for every node, just the ones that are started.
                 continue;
             }
             final String name = nameToAlias(addressBook.getAddress(nodeId).getSelfName());
@@ -535,9 +541,12 @@ public final class CryptoStatic {
      * @return a map of KeysAndCerts objects, one for each node
      */
     public static Map<NodeId, KeysAndCerts> initNodeSecurity(
-            @NonNull final AddressBook addressBook, @NonNull final Configuration configuration) {
+            @NonNull final AddressBook addressBook,
+            @NonNull final Configuration configuration,
+            @NonNull final Set<NodeId> localNodes) {
         Objects.requireNonNull(addressBook, ADDRESS_BOOK_MUST_NOT_BE_NULL);
         Objects.requireNonNull(configuration, "configuration must not be null");
+        Objects.requireNonNull(localNodes, LOCAL_NODES_MUST_NOT_BE_NULL);
 
         final PathsConfig pathsConfig = configuration.getConfigData(PathsConfig.class);
         final CryptoConfig cryptoConfig = configuration.getConfigData(CryptoConfig.class);
@@ -556,7 +565,7 @@ public final class CryptoStatic {
                 logger.debug(STARTUP.getMarker(), "About to start loading keys");
                 if (cryptoConfig.enableNewKeyStoreModel()) {
                     logger.debug(STARTUP.getMarker(), "Reading keys using the enhanced key loader");
-                    keysAndCerts = EnhancedKeyStoreLoader.using(addressBook, configuration)
+                    keysAndCerts = EnhancedKeyStoreLoader.using(addressBook, configuration, localNodes)
                             .migrate()
                             .scan()
                             .generate()
@@ -568,7 +577,8 @@ public final class CryptoStatic {
                     keysAndCerts = loadKeysAndCerts(
                             addressBook,
                             pathsConfig.getKeysDirPath(),
-                            cryptoConfig.keystorePassword().toCharArray());
+                            cryptoConfig.keystorePassword().toCharArray(),
+                            localNodes);
                 }
                 logger.debug(STARTUP.getMarker(), "Done loading keys");
             } else {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@ import static com.swirlds.platform.crypto.CryptoConstants.PUBLIC_KEYS_FILE;
 import static com.swirlds.platform.crypto.CryptoStatic.copyPublicKeys;
 import static com.swirlds.platform.crypto.CryptoStatic.createEmptyTrustStore;
 import static com.swirlds.platform.crypto.CryptoStatic.loadKeys;
-import static com.swirlds.platform.state.address.AddressBookNetworkUtils.isLocal;
 
 import com.hedera.cryptography.asciiarmored.AsciiArmoredFiles;
 import com.hedera.cryptography.bls.BlsKeyPair;
@@ -65,7 +64,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoader.java
@@ -63,6 +63,7 @@ import java.security.cert.X509Certificate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -95,7 +96,7 @@ import org.bouncycastle.util.io.pem.PemWriter;
  *
  * <p>
  * The {@link EnhancedKeyStoreLoader} class is a replacement for the now deprecated
- * {@link CryptoStatic#loadKeysAndCerts(AddressBook, Path, char[])} method. This new implementation adds support for
+ * {@link CryptoStatic#loadKeysAndCerts(AddressBook, Path, char[], Set)} method. This new implementation adds support for
  * loading industry standard PEM formatted PKCS #8 private keys and X.509 certificates. The legacy key stores are still
  * supported, but are no longer the preferred format.
  *
@@ -174,6 +175,11 @@ public class EnhancedKeyStoreLoader {
     private static final String MSG_KEY_STORE_PASSPHRASE_NON_NULL = "keyStorePassphrase must not be null";
 
     /**
+     * The constant message to use when the {@code localNodes} required parameter is {@code null}.
+     */
+    private static final String MSG_NODES_TO_START_NON_NULL = "the local nodes must not be null";
+
+    /**
      * The Log4j2 logger instance to use for all logging.
      */
     private static final Logger logger = LogManager.getLogger(EnhancedKeyStoreLoader.class);
@@ -239,17 +245,19 @@ public class EnhancedKeyStoreLoader {
 
     /**
      * Constructs a new {@link EnhancedKeyStoreLoader} instance. Intentionally private to prevent direct instantiation.
-     * Use the {@link #using(AddressBook, Configuration)} method to create a new instance.
+     * Use the {@link #using(AddressBook, Configuration, Set<NodeId>)} method to create a new instance.
      *
      * @param addressBook        the address book to use for loading the key stores.
      * @param keyStoreDirectory  the absolute path to the key store directory.
      * @param keyStorePassphrase the passphrase used to protect the key stores.
+     * @param localNodes         the set of local nodes that need private keys loaded
      * @throws NullPointerException if {@code addressBook} or {@code configuration} is {@code null}.
      */
     private EnhancedKeyStoreLoader(
             @NonNull final AddressBook addressBook,
             @NonNull final Path keyStoreDirectory,
-            @NonNull final char[] keyStorePassphrase) {
+            @NonNull final char[] keyStorePassphrase,
+            @NonNull final Set<NodeId> localNodes) {
         this.addressBook = Objects.requireNonNull(addressBook, MSG_ADDRESS_BOOK_NON_NULL);
         this.keyStoreDirectory = Objects.requireNonNull(keyStoreDirectory, MSG_KEY_STORE_DIRECTORY_NON_NULL);
         this.keyStorePassphrase = Objects.requireNonNull(keyStorePassphrase, MSG_KEY_STORE_PASSPHRASE_NON_NULL);
@@ -257,7 +265,7 @@ public class EnhancedKeyStoreLoader {
         this.sigCertificates = HashMap.newHashMap(addressBook.getSize());
         this.agrPrivateKeys = HashMap.newHashMap(addressBook.getSize());
         this.agrCertificates = HashMap.newHashMap(addressBook.getSize());
-        this.localNodes = HashSet.newHashSet(addressBook.getSize());
+        this.localNodes = Collections.unmodifiableSet(Objects.requireNonNull(localNodes, MSG_NODES_TO_START_NON_NULL));
         this.tssPrivateKeys = HashMap.newHashMap(addressBook.getSize());
         this.tssPublicKeys = HashMap.newHashMap(addressBook.getSize());
     }
@@ -268,6 +276,7 @@ public class EnhancedKeyStoreLoader {
      *
      * @param addressBook   the address book to use for loading the key stores.
      * @param configuration the configuration to use for loading the key stores.
+     * @param localNodes    the local nodes that need private keys loaded.
      * @return a new {@link EnhancedKeyStoreLoader} instance.
      * @throws NullPointerException     if {@code addressBook} or {@code configuration} is {@code null}.
      * @throws IllegalArgumentException if the value from the configuration element {@code crypto.keystorePassword} is
@@ -275,9 +284,12 @@ public class EnhancedKeyStoreLoader {
      */
     @NonNull
     public static EnhancedKeyStoreLoader using(
-            @NonNull final AddressBook addressBook, @NonNull final Configuration configuration) {
+            @NonNull final AddressBook addressBook,
+            @NonNull final Configuration configuration,
+            @NonNull final Set<NodeId> localNodes) {
         Objects.requireNonNull(addressBook, MSG_ADDRESS_BOOK_NON_NULL);
         Objects.requireNonNull(configuration, "configuration must not be null");
+        Objects.requireNonNull(localNodes, MSG_NODES_TO_START_NON_NULL);
 
         final String keyStorePassphrase =
                 configuration.getConfigData(CryptoConfig.class).keystorePassword();
@@ -288,7 +300,7 @@ public class EnhancedKeyStoreLoader {
             throw new IllegalArgumentException("keyStorePassphrase must not be null or blank");
         }
 
-        return new EnhancedKeyStoreLoader(addressBook, keyStoreDirectory, keyStorePassphrase.toCharArray());
+        return new EnhancedKeyStoreLoader(addressBook, keyStoreDirectory, keyStorePassphrase.toCharArray(), localNodes);
     }
 
     /**
@@ -310,8 +322,7 @@ public class EnhancedKeyStoreLoader {
                     nodeId,
                     nodeAlias);
 
-            if (isLocal(address)) {
-                localNodes.add(nodeId);
+            if (localNodes.contains(address.getNodeId())) {
                 sigPrivateKeys.compute(
                         nodeId, (k, v) -> resolveNodePrivateKey(nodeId, nodeAlias, KeyCertPurpose.SIGNING));
 
@@ -434,7 +445,9 @@ public class EnhancedKeyStoreLoader {
     }
 
     /**
-     * Verifies the presence of all required keys based on the supplied address book.
+     * Verifies the presence of all required keys for the nodes being started based on the supplied address book.
+     *
+     * @param validatingBook the address book to use for validation
      *
      * @return this {@link EnhancedKeyStoreLoader} instance.
      * @throws KeyLoadingException  if one or more of the required keys were not loaded.
@@ -454,12 +467,7 @@ public class EnhancedKeyStoreLoader {
         }
 
         iterateAddressBook(validatingBook, (i, nodeId, address, nodeAlias) -> {
-            if (isLocal(address)) {
-                if (!localNodes.contains(nodeId)) {
-                    throw new KeyLoadingException(
-                            "No private key found for local node %s [ alias = %s ]".formatted(nodeId, nodeAlias));
-                }
-
+            if (localNodes.contains(address.getNodeId())) {
                 if (!sigPrivateKeys.containsKey(nodeId)) {
                     throw new KeyLoadingException("No private key found for node %s [ alias = %s, purpose = %s ]"
                             .formatted(nodeId, nodeAlias, KeyCertPurpose.SIGNING));
@@ -644,7 +652,7 @@ public class EnhancedKeyStoreLoader {
                                 .formatted(nodeId, nodeAlias, KeyCertPurpose.SIGNING));
             }
 
-            if (isLocal(address)) {
+            if (localNodes.contains(nodeId)) {
                 // The agreement certificate is loaded by the local nodes and provided to peers through mTLS handshaking
                 logger.trace(
                         STARTUP.getMarker(),
@@ -1340,7 +1348,7 @@ public class EnhancedKeyStoreLoader {
         final AtomicLong errorCount = new AtomicLong(0);
 
         iterateAddressBook(addressBook, (i, nodeId, address, nodeAlias) -> {
-            if (isLocal(address)) {
+            if (localNodes.contains(nodeId)) {
                 // extract private keys for local nodes
                 final Path sPrivateKeyLocation = keyStoreDirectory.resolve("s-private-" + nodeAlias + ".pem");
                 final Path ksLocation = legacyPrivateKeyStore(nodeAlias);
@@ -1435,7 +1443,7 @@ public class EnhancedKeyStoreLoader {
             throws KeyStoreException, KeyLoadingException {
         final AtomicLong errorCount = new AtomicLong(0);
         iterateAddressBook(addressBook, (i, nodeId, address, nodeAlias) -> {
-            if (isLocal(address) && pfxCertificates.containsKey(nodeId)) {
+            if (localNodes.contains(nodeId) && pfxCertificates.containsKey(nodeId)) {
                 // validate private keys for local nodes
                 final Path ksLocation = privateKeyStore(nodeAlias, KeyCertPurpose.SIGNING);
                 final PrivateKey pemPrivateKey = readPrivateKey(nodeId, ksLocation);
@@ -1487,7 +1495,7 @@ public class EnhancedKeyStoreLoader {
         final AtomicLong cleanupErrorCount = new AtomicLong(0);
         iterateAddressBook(addressBook, (i, nodeId, address, nodeAlias) -> {
             // private key rollback
-            if (isLocal(address) && pfxPrivateKeys.containsKey(address.getNodeId())) {
+            if (localNodes.contains(nodeId) && pfxPrivateKeys.containsKey(address.getNodeId())) {
                 try {
                     Files.deleteIfExists(privateKeyStore(nodeAlias, KeyCertPurpose.SIGNING));
                 } catch (final IOException e) {
@@ -1544,7 +1552,7 @@ public class EnhancedKeyStoreLoader {
             }
         }
         iterateAddressBook(addressBook, (i, nodeId, address, nodeAlias) -> {
-            if (isLocal(address)) {
+            if (localNodes.contains(nodeId)) {
                 // move private key PFX files per local node
                 final File sPrivatePfx = legacyPrivateKeyStore(nodeAlias).toFile();
                 if (sPrivatePfx.exists()

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveryPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveryPlatform.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveryPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/internal/RecoveryPlatform.java
@@ -37,6 +37,7 @@ import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.SwirldState;
 import com.swirlds.platform.system.address.AddressBook;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collections;
 import java.util.Objects;
 
 /**
@@ -78,7 +79,8 @@ public class RecoveryPlatform implements Platform, AutoCloseableNonThrowing {
         this.addressBook = RosterUtils.buildAddressBook(this.roster);
 
         if (loadSigningKeys) {
-            keysAndCerts = initNodeSecurity(addressBook, configuration).get(selfId);
+            keysAndCerts = initNodeSecurity(addressBook, configuration, Collections.singleton(selfId))
+                    .get(selfId);
         } else {
             keysAndCerts = null;
         }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,7 +35,6 @@ import java.nio.file.Path;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
-import java.security.UnrecoverableKeyException;
 import java.time.Instant;
 import java.util.Map;
 import java.util.stream.Stream;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/CryptoArgsProvider.java
@@ -102,11 +102,13 @@ public class CryptoArgsProvider {
      */
     @NonNull
     public static RosterAndCerts loadAddressBookWithKeys(final int size)
-            throws URISyntaxException, UnrecoverableKeyException, KeyLoadingException, KeyStoreException,
-                    NoSuchAlgorithmException, KeyGeneratingException, NoSuchProviderException {
+            throws URISyntaxException, KeyLoadingException, KeyStoreException, NoSuchAlgorithmException,
+                    KeyGeneratingException, NoSuchProviderException {
         final AddressBook createdAB = createAddressBook(size);
         final Map<NodeId, KeysAndCerts> loadedC = EnhancedKeyStoreLoader.using(
-                        createdAB, configure(ResourceLoader.getFile("preGeneratedPEMKeysAndCerts/")))
+                        createdAB,
+                        configure(ResourceLoader.getFile("preGeneratedPEMKeysAndCerts/")),
+                        createdAB.getNodeIdSet())
                 .scan()
                 .generate()
                 .verify()

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@
 package com.swirlds.platform.crypto;
 
 import static com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader.loadConfigFile;
-import static com.swirlds.platform.state.address.AddressBookNetworkUtils.isLocal;
 import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/EnhancedKeyStoreLoaderTest.java
@@ -35,6 +35,7 @@ import java.nio.file.Path;
 import java.security.KeyStoreException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -124,7 +125,10 @@ class EnhancedKeyStoreLoaderTest {
             throws IOException, KeyLoadingException, KeyStoreException {
         final Path keyDirectory = testDataDirectory.resolve(directoryName);
         final AddressBook addressBook = addressBook();
-        final EnhancedKeyStoreLoader loader = EnhancedKeyStoreLoader.using(addressBook, configure(keyDirectory));
+        final Set<NodeId> nodesToStart = addressBook.getNodeIdSet();
+
+        final EnhancedKeyStoreLoader loader =
+                EnhancedKeyStoreLoader.using(addressBook, configure(keyDirectory), nodesToStart);
 
         assertThat(keyDirectory).exists().isDirectory().isReadable().isNotEmptyDirectory();
 
@@ -140,7 +144,7 @@ class EnhancedKeyStoreLoaderTest {
             final NodeId nodeId = addressBook.getNodeId(i);
             final Address addr = addressBook.getAddress(nodeId);
 
-            if (!isLocal(addr)) {
+            if (!nodesToStart.contains(addr.getNodeId())) {
                 assertThat(kc).doesNotContainKey(nodeId);
             } else {
                 assertThat(kc).containsKey(nodeId);
@@ -173,7 +177,8 @@ class EnhancedKeyStoreLoaderTest {
     void keyStoreLoaderNegativeCase1Test(final String directoryName) throws IOException {
         final Path keyDirectory = testDataDirectory.resolve(directoryName);
         final AddressBook addressBook = addressBook();
-        final EnhancedKeyStoreLoader loader = EnhancedKeyStoreLoader.using(addressBook, configure(keyDirectory));
+        final EnhancedKeyStoreLoader loader =
+                EnhancedKeyStoreLoader.using(addressBook, configure(keyDirectory), addressBook.getNodeIdSet());
 
         assertThat(keyDirectory).exists().isDirectory().isReadable().isNotEmptyDirectory();
 
@@ -198,7 +203,8 @@ class EnhancedKeyStoreLoaderTest {
     void keyStoreLoaderNegativeCase2Test(final String directoryName) throws IOException {
         final Path keyDirectory = testDataDirectory.resolve(directoryName);
         final AddressBook addressBook = addressBook();
-        final EnhancedKeyStoreLoader loader = EnhancedKeyStoreLoader.using(addressBook, configure(keyDirectory));
+        final EnhancedKeyStoreLoader loader =
+                EnhancedKeyStoreLoader.using(addressBook, configure(keyDirectory), addressBook.getNodeIdSet());
 
         assertThat(keyDirectory).exists().isDirectory().isReadable().isNotEmptyDirectory();
 
@@ -254,7 +260,8 @@ class EnhancedKeyStoreLoaderTest {
     void migraitonNegativeCaseTest(final String directoryName) throws IOException {
         final Path keyDirectory = testDataDirectory.resolve(directoryName);
         final AddressBook addressBook = addressBook();
-        final EnhancedKeyStoreLoader loader = EnhancedKeyStoreLoader.using(addressBook, configure(keyDirectory));
+        final EnhancedKeyStoreLoader loader =
+                EnhancedKeyStoreLoader.using(addressBook, configure(keyDirectory), addressBook.getNodeIdSet());
 
         assertThat(keyDirectory).exists().isDirectory().isReadable().isNotEmptyDirectory();
 


### PR DESCRIPTION
## Description

- Cherry picks changes to `EnhancedKeyLoader` private key detection and loading logic to avoid using `AddressBookNetworkUtils.isLocal()`
- Resolves startup issues when using internal addresses with an overlapping internal IP range

### Related Issues 

- Fixes #17951 