### PR TITLE
feat: Extract raw bytes from user input

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/ProtobufUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/ProtobufUtils.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hedera.node.app.util;
+
+import static com.hedera.pbj.runtime.ProtoParserTools.TAG_FIELD_OFFSET;
+
+import com.hedera.pbj.runtime.FieldDefinition;
+import com.hedera.pbj.runtime.FieldType;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.ProtoConstants;
+import com.hedera.pbj.runtime.ProtoParserTools;
+import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.nio.BufferUnderflowException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ProtobufUtils {
+
+    private static final FieldDefinition TRANSACTION_BODY_FIELD =
+            new FieldDefinition("body", FieldType.MESSAGE, false, 1);
+
+    private static final FieldDefinition ATOMIC_BATCH_TRANSACTION_BODY_FIELD =
+            new FieldDefinition("atomicBatch", FieldType.MESSAGE, false, false, true, 74);
+    private static final FieldDefinition INNER_TRANSACTIONS_FIELD =
+            new FieldDefinition("transactions", FieldType.MESSAGE, true, 1);
+
+    private static final FieldDefinition QUERY_HEADER_FIELD =
+            new FieldDefinition("header", FieldType.MESSAGE, false, 1);
+    private static final FieldDefinition PAYMENT_FIELD = new FieldDefinition("payment", FieldType.MESSAGE, false, 1);
+
+    @NonNull
+    public static Bytes extractBodyBytes(@NonNull final Bytes serializedTransaction)
+            throws IOException, ParseException {
+        return extractFieldBytes(serializedTransaction.toReadableSequentialData(), TRANSACTION_BODY_FIELD);
+    }
+
+    @NonNull
+    public static List<Bytes> extractInnerTransactionBytes(@NonNull final Bytes serializedAtomicBatchTxn)
+            throws IOException, ParseException {
+        final var atomicTransactionBody = extractFieldBytes(
+                serializedAtomicBatchTxn.toReadableSequentialData(), ATOMIC_BATCH_TRANSACTION_BODY_FIELD);
+        return extractRepeatedFieldBytes(atomicTransactionBody.toReadableSequentialData(), INNER_TRANSACTIONS_FIELD);
+    }
+
+    @NonNull
+    public static Bytes extractPaymentBytes(@NonNull final Bytes serializedQuery) throws IOException, ParseException {
+        final var queryBody = extractFirstFieldBytes(serializedQuery.toReadableSequentialData());
+        final var queryHeader = extractFieldBytes(queryBody.toReadableSequentialData(), QUERY_HEADER_FIELD);
+        return extractFieldBytes(queryHeader.toReadableSequentialData(), PAYMENT_FIELD);
+    }
+
+    @NonNull
+    private static Bytes extractFieldBytes(
+            @NonNull final ReadableSequentialData input, @NonNull final FieldDefinition field)
+            throws IOException, ParseException {
+        if (field.repeated()) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a repeated field: " + field);
+        }
+        if (ProtoWriterTools.wireType(field) != ProtoConstants.WIRE_TYPE_DELIMITED) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a non-length-delimited field: " + field);
+        }
+        while (input.hasRemaining()) {
+            final int tag;
+            // hasRemaining() doesn't work very well for streaming data, it returns false only when
+            // the end of input is already reached using a read operation. Let's catch an underflow
+            // (actually, EOF) exception here and exit cleanly. Underflow exception in any other
+            // place means malformed input and should be rethrown
+            try {
+                tag = input.readVarInt(false);
+            } catch (final BufferUnderflowException e) {
+                // No more fields
+                break;
+            }
+            final int fieldNum = tag >> TAG_FIELD_OFFSET;
+            final ProtoConstants wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+            if (fieldNum == field.number()) {
+                if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    throw new ParseException("Unexpected wire type: " + tag);
+                }
+                final int length = input.readVarInt(false);
+                return input.readBytes(length);
+            } else {
+                ProtoParserTools.skipField(input, wireType);
+            }
+        }
+        throw new ParseException("Field not found: " + field);
+    }
+
+    @NonNull
+    private static List<Bytes> extractRepeatedFieldBytes(
+            @NonNull final ReadableSequentialData input, @NonNull final FieldDefinition field)
+            throws IOException, ParseException {
+        if (!field.repeated()) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a repeated field: " + field);
+        }
+        if (ProtoWriterTools.wireType(field) != ProtoConstants.WIRE_TYPE_DELIMITED) {
+            throw new IllegalArgumentException("Cannot extract field bytes for a non-length-delimited field: " + field);
+        }
+        final var result = new ArrayList<Bytes>();
+        while (input.hasRemaining()) {
+            final int tag;
+            // hasRemaining() doesn't work very well for streaming data, it returns false only when
+            // the end of input is already reached using a read operation. Let's catch an underflow
+            // (actually, EOF) exception here and exit cleanly. Underflow exception in any other
+            // place means malformed input and should be rethrown
+            try {
+                tag = input.readVarInt(false);
+            } catch (final BufferUnderflowException e) {
+                // No more fields
+                break;
+            }
+            final int fieldNum = tag >> TAG_FIELD_OFFSET;
+            final ProtoConstants wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+            if (fieldNum == field.number()) {
+                if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    throw new ParseException("Unexpected wire type: " + tag);
+                }
+                final int length = input.readVarInt(false);
+                result.add(input.readBytes(length));
+            } else {
+                ProtoParserTools.skipField(input, wireType);
+            }
+        }
+        return result;
+    }
+
+    @NonNull
+    private static Bytes extractFirstFieldBytes(@NonNull final ReadableSequentialData input) throws ParseException {
+        if (input.hasRemaining()) {
+            final int tag;
+            try {
+                tag = input.readVarInt(false);
+            } catch (final BufferUnderflowException e) {
+                // No more fields
+                return Bytes.EMPTY;
+            }
+            final ProtoConstants wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+            if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
+                throw new ParseException("Unexpected wire type: " + tag);
+            }
+            final int length = input.readVarInt(false);
+            return input.readBytes(length);
+        }
+        return Bytes.EMPTY;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/ProtobufUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/ProtobufUtils.java
@@ -18,8 +18,13 @@ package com.hedera.node.app.util;
 
 import static com.hedera.pbj.runtime.ProtoParserTools.TAG_FIELD_OFFSET;
 
+import com.hedera.hapi.node.base.schema.QueryHeaderSchema;
+import com.hedera.hapi.node.base.schema.TransactionSchema;
+import com.hedera.hapi.node.transaction.Query.QueryOneOfType;
+import com.hedera.hapi.node.transaction.schema.TransactionBodySchema;
+import com.hedera.hapi.node.transaction.schema.TransactionGetReceiptQuerySchema;
+import com.hedera.hapi.node.util.schema.AtomicBatchTransactionBodySchema;
 import com.hedera.pbj.runtime.FieldDefinition;
-import com.hedera.pbj.runtime.FieldType;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
@@ -31,40 +36,39 @@ import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class ProtobufUtils {
 
-    private static final FieldDefinition TRANSACTION_BODY_FIELD =
-            new FieldDefinition("body", FieldType.MESSAGE, false, 1);
+    private ProtobufUtils() {}
 
-    private static final FieldDefinition ATOMIC_BATCH_TRANSACTION_BODY_FIELD =
-            new FieldDefinition("atomicBatch", FieldType.MESSAGE, false, false, true, 74);
-    private static final FieldDefinition INNER_TRANSACTIONS_FIELD =
-            new FieldDefinition("transactions", FieldType.MESSAGE, true, 1);
-
-    private static final FieldDefinition QUERY_HEADER_FIELD =
-            new FieldDefinition("header", FieldType.MESSAGE, false, 1);
-    private static final FieldDefinition PAYMENT_FIELD = new FieldDefinition("payment", FieldType.MESSAGE, false, 1);
+    private static final Set<Integer> QUERY_FIELDS = Stream.of(QueryOneOfType.values())
+            .map(QueryOneOfType::protoOrdinal)
+            .collect(Collectors.toUnmodifiableSet());
 
     @NonNull
     public static Bytes extractBodyBytes(@NonNull final Bytes serializedTransaction)
             throws IOException, ParseException {
-        return extractFieldBytes(serializedTransaction.toReadableSequentialData(), TRANSACTION_BODY_FIELD);
+        return extractFieldBytes(serializedTransaction.toReadableSequentialData(), TransactionSchema.BODY);
     }
 
     @NonNull
     public static List<Bytes> extractInnerTransactionBytes(@NonNull final Bytes serializedAtomicBatchTxn)
             throws IOException, ParseException {
         final var atomicTransactionBody = extractFieldBytes(
-                serializedAtomicBatchTxn.toReadableSequentialData(), ATOMIC_BATCH_TRANSACTION_BODY_FIELD);
-        return extractRepeatedFieldBytes(atomicTransactionBody.toReadableSequentialData(), INNER_TRANSACTIONS_FIELD);
+                serializedAtomicBatchTxn.toReadableSequentialData(), TransactionBodySchema.ATOMIC_BATCH);
+        return extractRepeatedFieldBytes(
+                atomicTransactionBody.toReadableSequentialData(), AtomicBatchTransactionBodySchema.TRANSACTIONS);
     }
 
     @NonNull
     public static Bytes extractPaymentBytes(@NonNull final Bytes serializedQuery) throws IOException, ParseException {
-        final var queryBody = extractFirstFieldBytes(serializedQuery.toReadableSequentialData());
-        final var queryHeader = extractFieldBytes(queryBody.toReadableSequentialData(), QUERY_HEADER_FIELD);
-        return extractFieldBytes(queryHeader.toReadableSequentialData(), PAYMENT_FIELD);
+        final var queryBody = extractQuery(serializedQuery.toReadableSequentialData());
+        final var queryHeader =
+                extractFieldBytes(queryBody.toReadableSequentialData(), TransactionGetReceiptQuerySchema.HEADER);
+        return extractFieldBytes(queryHeader.toReadableSequentialData(), QueryHeaderSchema.PAYMENT);
     }
 
     @NonNull
@@ -109,7 +113,7 @@ public class ProtobufUtils {
             @NonNull final ReadableSequentialData input, @NonNull final FieldDefinition field)
             throws IOException, ParseException {
         if (!field.repeated()) {
-            throw new IllegalArgumentException("Cannot extract field bytes for a repeated field: " + field);
+            throw new IllegalArgumentException("Cannot extract field bytes for a non-repeated field: " + field);
         }
         if (ProtoWriterTools.wireType(field) != ProtoConstants.WIRE_TYPE_DELIMITED) {
             throw new IllegalArgumentException("Cannot extract field bytes for a non-length-delimited field: " + field);
@@ -143,22 +147,31 @@ public class ProtobufUtils {
     }
 
     @NonNull
-    private static Bytes extractFirstFieldBytes(@NonNull final ReadableSequentialData input) throws ParseException {
-        if (input.hasRemaining()) {
+    private static Bytes extractQuery(@NonNull final ReadableSequentialData input) throws IOException, ParseException {
+        while (input.hasRemaining()) {
             final int tag;
+            // hasRemaining() doesn't work very well for streaming data, it returns false only when
+            // the end of input is already reached using a read operation. Let's catch an underflow
+            // (actually, EOF) exception here and exit cleanly. Underflow exception in any other
+            // place means malformed input and should be rethrown
             try {
                 tag = input.readVarInt(false);
             } catch (final BufferUnderflowException e) {
                 // No more fields
-                return Bytes.EMPTY;
+                break;
             }
+            final int fieldNum = tag >> TAG_FIELD_OFFSET;
             final ProtoConstants wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
-            if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
-                throw new ParseException("Unexpected wire type: " + tag);
+            if (QUERY_FIELDS.contains(fieldNum)) {
+                if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    throw new ParseException("Unexpected wire type: " + tag);
+                }
+                final int length = input.readVarInt(false);
+                return input.readBytes(length);
+            } else {
+                ProtoParserTools.skipField(input, wireType);
             }
-            final int length = input.readVarInt(false);
-            return input.readBytes(length);
         }
-        return Bytes.EMPTY;
+        throw new ParseException("Query not found");
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -33,6 +33,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_ID_FIELD_NO
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_OVERSIZE;
 import static java.util.Objects.requireNonNull;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
@@ -49,6 +50,7 @@ import com.hedera.hapi.util.UnknownHederaFunctionality;
 import com.hedera.node.app.annotations.MaxSignedTxnSize;
 import com.hedera.node.app.annotations.NodeSelfId;
 import com.hedera.node.app.spi.workflows.PreCheckException;
+import com.hedera.node.app.util.ProtobufUtils;
 import com.hedera.node.app.workflows.prehandle.DueDiligenceException;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.HederaConfig;
@@ -61,6 +63,7 @@ import com.swirlds.metrics.api.Counter;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -148,29 +151,13 @@ public class TransactionChecker {
      */
     @NonNull
     public TransactionInfo parseAndCheck(@NonNull final Bytes buffer) throws PreCheckException {
-        final var tx = parse(buffer);
-        return check(tx, buffer);
-    }
-
-    /**
-     * Parse the given {@link Bytes} into a transaction.
-     *
-     * <p>After verifying that the number of bytes comprising the transaction does not exceed the maximum allowed, the
-     * transaction is parsed. A transaction can be checked with {@link #check(Transaction, Bytes)}.
-     *
-     * @param buffer the {@code ByteBuffer} with the serialized transaction
-     * @return an {@link TransactionInfo} with the parsed and checked entities
-     * @throws PreCheckException if the data is not valid
-     * @throws NullPointerException if one of the arguments is {@code null}
-     */
-    @NonNull
-    public Transaction parse(@NonNull final Bytes buffer) throws PreCheckException {
         // Fail fast if there are too many transaction bytes
         if (buffer.length() > maxSignedTxnSize) {
             throw new PreCheckException(TRANSACTION_OVERSIZE);
         }
 
-        return parseStrict(buffer.toReadableSequentialData(), Transaction.PROTOBUF, INVALID_TRANSACTION);
+        final var tx = parseStrict(buffer.toReadableSequentialData(), Transaction.PROTOBUF, INVALID_TRANSACTION);
+        return check(tx, buffer);
     }
 
     /**
@@ -209,7 +196,8 @@ public class TransactionChecker {
      * @throws NullPointerException if one of the arguments is {@code null}
      */
     @NonNull
-    public TransactionInfo check(@NonNull final Transaction tx, @Nullable Bytes serializedTx) throws PreCheckException {
+    @VisibleForTesting
+    TransactionInfo check(@NonNull final Transaction tx, @Nullable Bytes serializedTx) throws PreCheckException {
         // NOTE: Since we've already parsed the transaction, we assume that the
         // transaction was not too many bytes. This is a safe assumption because
         // the code that receives the transaction bytes and parses/ the transaction
@@ -221,7 +209,11 @@ public class TransactionChecker {
         final SignatureMap signatureMap;
         if (tx.hasBody()) {
             txBody = tx.bodyOrThrow();
-            bodyBytes = TransactionBody.PROTOBUF.toBytes(txBody);
+            try {
+                bodyBytes = serializedTx == null ? Bytes.EMPTY : ProtobufUtils.extractBodyBytes(serializedTx);
+            } catch (IOException | ParseException e) {
+                throw new PreCheckException(INVALID_TRANSACTION);
+            }
             signatureMap = tx.sigMap();
         } else {
             if (tx.signedTransactionBytes().length() > 0) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -197,7 +197,7 @@ public class TransactionChecker {
      */
     @NonNull
     @VisibleForTesting
-    TransactionInfo check(@NonNull final Transaction tx, @Nullable Bytes serializedTx) throws PreCheckException {
+    TransactionInfo check(@NonNull final Transaction tx, @NonNull Bytes serializedTx) throws PreCheckException {
         // NOTE: Since we've already parsed the transaction, we assume that the
         // transaction was not too many bytes. This is a safe assumption because
         // the code that receives the transaction bytes and parses/ the transaction
@@ -210,7 +210,7 @@ public class TransactionChecker {
         if (tx.hasBody()) {
             txBody = tx.bodyOrThrow();
             try {
-                bodyBytes = serializedTx == null ? Bytes.EMPTY : ProtobufUtils.extractBodyBytes(serializedTx);
+                bodyBytes = ProtobufUtils.extractBodyBytes(serializedTx);
             } catch (IOException | ParseException e) {
                 throw new PreCheckException(INVALID_TRANSACTION);
             }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -185,19 +185,21 @@ public final class IngestChecker {
      * Runs all the ingest checks on a {@link Transaction}
      *
      * @param state the {@link State} to use
-     * @param tx the {@link Transaction} to check
+     * @param serializedTransaction the {@link Bytes} of the {@link Transaction} to check
      * @param configuration the {@link Configuration} to use
      * @return the {@link TransactionInfo} with the extracted information
      * @throws PreCheckException if a check fails
      */
     public TransactionInfo runAllChecks(
-            @NonNull final State state, @NonNull final Transaction tx, @NonNull final Configuration configuration)
+            @NonNull final State state,
+            @NonNull final Bytes serializedTransaction,
+            @NonNull final Configuration configuration)
             throws PreCheckException {
         // During ingest we approximate consensus time with wall clock time
         final var consensusTime = instantSource.instant();
 
         // 1. Check the syntax
-        final var txInfo = transactionChecker.check(tx, null);
+        final var txInfo = transactionChecker.parseAndCheck(serializedTransaction);
         final var txBody = txInfo.txBody();
         final var functionality = txInfo.functionality();
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
@@ -86,10 +86,9 @@ public final class IngestWorkflowImpl implements IngestWorkflow {
             ingestChecker.verifyReadyForTransactions();
 
             // 1.-6. Parse and check the transaction
-            final var tx = transactionChecker.parse(requestBuffer);
             final var state = wrappedState.get();
             final var configuration = configProvider.getConfiguration();
-            final var transactionInfo = ingestChecker.runAllChecks(state, tx, configuration);
+            final var transactionInfo = ingestChecker.runAllChecks(state, requestBuffer, configuration);
 
             // 7. Submit to platform
             submissionManager.submit(transactionInfo.txBody(), requestBuffer);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowInjectionModule.java
@@ -16,22 +16,15 @@
 
 package com.hedera.node.app.workflows.prehandle;
 
-import com.hedera.hapi.node.base.Transaction;
-import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.signature.SignatureExpander;
 import com.hedera.node.app.signature.SignatureVerifier;
 import com.hedera.node.app.signature.impl.SignatureExpanderImpl;
 import com.hedera.node.app.signature.impl.SignatureVerifierImpl;
-import com.hedera.node.app.spi.workflows.HandleException;
-import com.hedera.node.app.spi.workflows.PreCheckException;
-import com.hedera.node.app.workflows.TransactionChecker;
 import dagger.Binds;
 import dagger.Module;
 import dagger.Provides;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
-import java.util.function.Function;
-import javax.inject.Singleton;
 
 @Module
 public interface PreHandleWorkflowInjectionModule {
@@ -47,19 +40,5 @@ public interface PreHandleWorkflowInjectionModule {
     @Provides
     static ExecutorService provideExecutorService() {
         return ForkJoinPool.commonPool();
-    }
-
-    @Provides
-    @Singleton
-    static Function<Transaction, TransactionBody> provideBodyParser(TransactionChecker transactionChecker)
-            throws HandleException {
-        return tx -> {
-            try {
-                final var transactionInfo = transactionChecker.check(tx, null);
-                return transactionInfo.txBody();
-            } catch (PreCheckException e) {
-                throw new HandleException(e.responseCode());
-            }
-        };
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -345,13 +345,6 @@ final class TransactionCheckerTest extends AppTestBase {
     @Nested
     @DisplayName("Check Tests")
     class CheckTest {
-        @Test
-        @SuppressWarnings("ConstantConditions")
-        @DisplayName("`check` requires a transaction")
-        void checkWithNull() {
-            assertThatThrownBy(() -> checker.check(null, null)).isInstanceOf(NullPointerException.class);
-        }
-
         @Nested
         @DisplayName("Happy Paths")
         class HappyPaths {
@@ -365,7 +358,7 @@ final class TransactionCheckerTest extends AppTestBase {
             @DisplayName("A valid transaction passes parseAndCheck with a BufferedData")
             void happyPath() throws PreCheckException {
                 // Given a valid serialized transaction, when we parse and check
-                final var info = checker.check(tx, null);
+                final var info = checker.check(tx, inputBuffer);
 
                 // Then the parsed data is as we expected
                 assertThat(info.transaction()).isEqualTo(tx);
@@ -392,7 +385,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check
-                final var info = checker.check(localTx, null);
+                final var info = checker.check(localTx, inputBuffer);
 
                 // Then everything works because the deprecated fields are supported
                 assertThat(info.transaction()).isEqualTo(localTx);
@@ -420,7 +413,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check
-                final var info = checker.check(localTx, null);
+                final var info = checker.check(localTx, inputBuffer);
 
                 // Then everything works because the deprecated fields are supported
                 assertThat(info.transaction()).isEqualTo(localTx);
@@ -449,7 +442,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we check the transaction, then we find it is invalid
-                assertThatThrownBy(() -> checker.check(localTx, null))
+                assertThatThrownBy(() -> checker.check(localTx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION));
 
@@ -469,7 +462,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we check the transaction, then we find it is invalid
-                assertThatThrownBy(() -> checker.check(localTx, null))
+                assertThatThrownBy(() -> checker.check(localTx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION));
 
@@ -488,7 +481,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we check the transaction, then we find it is invalid
-                assertThatThrownBy(() -> checker.check(localTx, null))
+                assertThatThrownBy(() -> checker.check(localTx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION));
 
@@ -508,7 +501,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION));
 
@@ -541,7 +534,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // Given a valid serialized transaction, when we parse and check
-                final var info = checker.check(localTx, null);
+                final var info = checker.check(localTx, inputBuffer);
 
                 // Then the parsed data is as we expected
                 assertThat(info.transaction()).isEqualTo(localTx);
@@ -572,7 +565,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check
-                final var info = checker.check(localTx, null);
+                final var info = checker.check(localTx, inputBuffer);
 
                 // Then everything works because the deprecated fields are supported
                 assertThat(info.transaction()).isEqualTo(localTx);
@@ -602,7 +595,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check
-                final var info = checker.check(localTx, null);
+                final var info = checker.check(localTx, inputBuffer);
 
                 // Then everything works because the deprecated fields are supported
                 assertThat(info.transaction()).isEqualTo(localTx);
@@ -660,7 +653,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         txBuilder(signedTxBuilder(txBody, localSignatureMap)).build();
 
                 // When we check the transaction, we find it is invalid due to duplicate prefixes
-                assertThatThrownBy(() -> checker.check(localTx, null))
+                assertThatThrownBy(() -> checker.check(localTx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(KEY_PREFIX_MISMATCH));
             }
@@ -678,7 +671,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check, then the parsing fails because this is an INVALID_TRANSACTION
-                assertThatThrownBy(() -> checker.check(localTx, null))
+                assertThatThrownBy(() -> checker.check(localTx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION));
             }
@@ -693,7 +686,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check, then the parsing fails because has unknown fields
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(TRANSACTION_HAS_UNKNOWN_FIELDS));
             }
@@ -717,7 +710,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check, then the parsing fails because has unknown fields
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION_BODY));
             }
@@ -738,7 +731,7 @@ final class TransactionCheckerTest extends AppTestBase {
                         .build();
 
                 // When we parse and check, then the parsing fails because this is an TRANSACTION_HAS_UNKNOWN_FIELDS
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(TRANSACTION_HAS_UNKNOWN_FIELDS));
             }
@@ -751,7 +744,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(INVALID_TRANSACTION_ID));
             }
@@ -765,7 +758,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var body = bodyBuilder(txIdBuilder().accountID(payerId));
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(PAYER_ACCOUNT_NOT_FOUND));
             }
@@ -780,7 +773,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(PAYER_ACCOUNT_NOT_FOUND));
             }
@@ -796,7 +789,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(PAYER_ACCOUNT_NOT_FOUND));
             }
@@ -812,7 +805,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(PAYER_ACCOUNT_NOT_FOUND));
             }
@@ -824,7 +817,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(TRANSACTION_ID_FIELD_NOT_ALLOWED));
             }
@@ -836,7 +829,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .has(responseCode(TRANSACTION_ID_FIELD_NOT_ALLOWED));
             }
@@ -850,7 +843,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .hasFieldOrPropertyWithValue("responseCode", MEMO_TOO_LONG);
             }
@@ -866,7 +859,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // Then the checker should throw a PreCheckException
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .hasFieldOrPropertyWithValue("responseCode", INVALID_ZERO_BYTE_IN_STRING);
             }
@@ -884,7 +877,7 @@ final class TransactionCheckerTest extends AppTestBase {
                 final var tx = txBuilder(signedTxBuilder(body, sigMapBuilder())).build();
 
                 // When we check the transaction body
-                assertThatThrownBy(() -> checker.check(tx, null))
+                assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                         .isInstanceOf(PreCheckException.class)
                         .hasFieldOrPropertyWithValue("responseCode", INSUFFICIENT_TX_FEE);
             }
@@ -976,7 +969,7 @@ final class TransactionCheckerTest extends AppTestBase {
                     hapiUtils.when(() -> HapiUtils.functionOf(eq(txBody))).thenThrow(new UnknownHederaFunctionality());
 
                     // When we parse and check, then the parsing fails due to the exception
-                    assertThatThrownBy(() -> checker.check(tx, null))
+                    assertThatThrownBy(() -> checker.check(tx, inputBuffer))
                             .isInstanceOf(PreCheckException.class)
                             .hasFieldOrPropertyWithValue("responseCode", INVALID_TRANSACTION_BODY);
                 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
@@ -89,6 +89,7 @@ import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.system.status.PlatformStatus;
 import java.time.Instant;
@@ -156,6 +157,7 @@ class IngestCheckerTest extends AppTestBase {
     private TransactionInfo transactionInfo;
     private TransactionBody txBody;
     private Transaction tx;
+    private Bytes serializedTx;
 
     private Configuration configuration;
 
@@ -182,10 +184,11 @@ class IngestCheckerTest extends AppTestBase {
         tx = Transaction.newBuilder()
                 .signedTransactionBytes(asBytes(SignedTransaction.PROTOBUF, signedTx))
                 .build();
+        serializedTx = Transaction.PROTOBUF.toBytes(tx);
 
         transactionInfo = new TransactionInfo(
-                tx, txBody, MOCK_SIGNATURE_MAP, tx.signedTransactionBytes(), UNCHECKED_SUBMIT, null);
-        when(transactionChecker.check(tx, null)).thenReturn(transactionInfo);
+                tx, txBody, MOCK_SIGNATURE_MAP, tx.signedTransactionBytes(), UNCHECKED_SUBMIT, serializedTx);
+        when(transactionChecker.parseAndCheck(serializedTx)).thenReturn(transactionInfo);
 
         final var configProvider = HederaTestConfigBuilder.createConfigProvider();
         this.deduplicationCache = new DeduplicationCacheImpl(configProvider, instantSource);
@@ -278,7 +281,7 @@ class IngestCheckerTest extends AppTestBase {
                 ServicesSoftwareVersion::new);
 
         // Then the checker should throw a PreCheckException
-        assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+        assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                 .isInstanceOf(PreCheckException.class)
                 .has(responseCode(INVALID_NODE_ACCOUNT));
         verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -289,7 +292,7 @@ class IngestCheckerTest extends AppTestBase {
     void testRunAllChecksSuccessfully() throws Exception {
         // given
         final var expected = new TransactionInfo(
-                tx, txBody, MOCK_SIGNATURE_MAP, tx.signedTransactionBytes(), UNCHECKED_SUBMIT, null);
+                tx, txBody, MOCK_SIGNATURE_MAP, tx.signedTransactionBytes(), UNCHECKED_SUBMIT, serializedTx);
         final var verificationResultFuture = mock(SignatureVerificationFuture.class);
         final var verificationResult = mock(SignatureVerification.class);
         when(verificationResult.failed()).thenReturn(false);
@@ -298,7 +301,7 @@ class IngestCheckerTest extends AppTestBase {
                 .thenReturn(Map.of(ALICE.account().keyOrThrow(), verificationResultFuture));
 
         // when
-        final var actual = subject.runAllChecks(state, tx, configuration);
+        final var actual = subject.runAllChecks(state, serializedTx, configuration);
 
         // then
         assertThat(actual).isEqualTo(expected);
@@ -322,10 +325,10 @@ class IngestCheckerTest extends AppTestBase {
         @DisplayName("If the transaction fails TransactionChecker, a failure response is returned with the right error")
         void onsetFailsWithPreCheckException(ResponseCodeEnum failureReason) throws PreCheckException {
             // Given a TransactionChecker that will throw a PreCheckException with the given failure reason
-            when(transactionChecker.check(any(), eq(null))).thenThrow(new PreCheckException(failureReason));
+            when(transactionChecker.parseAndCheck(any())).thenThrow(new PreCheckException(failureReason));
 
             // When the transaction is checked
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(failureReason));
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -335,10 +338,10 @@ class IngestCheckerTest extends AppTestBase {
         @DisplayName("If some random exception is thrown from TransactionChecker, the exception is bubbled up")
         void randomException() throws PreCheckException {
             // Given a WorkflowOnset that will throw a RuntimeException
-            when(transactionChecker.check(any(), eq(null))).thenThrow(new RuntimeException("check exception"));
+            when(transactionChecker.parseAndCheck(any())).thenThrow(new RuntimeException("check exception"));
 
             // When the transaction is submitted, then the exception is bubbled up
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("check exception");
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -355,7 +358,7 @@ class IngestCheckerTest extends AppTestBase {
             final var id = txBody.transactionIDOrThrow();
             deduplicationCache.add(id);
             // When the transaction is checked, then it throws a PreCheckException due to duplication
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .hasFieldOrPropertyWithValue("responseCode", DUPLICATE_TRANSACTION);
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -374,7 +377,7 @@ class IngestCheckerTest extends AppTestBase {
                     .thenReturn(true);
 
             // When the transaction is submitted
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .hasFieldOrPropertyWithValue("responseCode", BUSY);
             verify(opWorkflowMetrics).incrementThrottled(UNCHECKED_SUBMIT);
@@ -398,6 +401,7 @@ class IngestCheckerTest extends AppTestBase {
             final var cryptoAddLiveHashTx = Transaction.newBuilder()
                     .signedTransactionBytes(asBytes(SignedTransaction.PROTOBUF, signedTx))
                     .build();
+            final var serializedCryptoAddLiveHashTx = Transaction.PROTOBUF.toBytes(cryptoAddLiveHashTx);
 
             final var cryptoAddLiveHashTransactionInfo = new TransactionInfo(
                     cryptoAddLiveHashTx,
@@ -405,10 +409,11 @@ class IngestCheckerTest extends AppTestBase {
                     MOCK_SIGNATURE_MAP,
                     cryptoAddLiveHashTx.signedTransactionBytes(),
                     CRYPTO_ADD_LIVE_HASH,
-                    null);
-            when(transactionChecker.check(cryptoAddLiveHashTx, null)).thenReturn(cryptoAddLiveHashTransactionInfo);
+                    serializedCryptoAddLiveHashTx);
+            when(transactionChecker.parseAndCheck(serializedCryptoAddLiveHashTx))
+                    .thenReturn(cryptoAddLiveHashTransactionInfo);
 
-            assertThatThrownBy(() -> subject.runAllChecks(state, cryptoAddLiveHashTx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedCryptoAddLiveHashTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .hasFieldOrPropertyWithValue("responseCode", NOT_SUPPORTED);
         }
@@ -430,12 +435,18 @@ class IngestCheckerTest extends AppTestBase {
             final var freezeTx = Transaction.newBuilder()
                     .signedTransactionBytes(asBytes(SignedTransaction.PROTOBUF, signedTx))
                     .build();
+            final var serializedFreezeTx = Transaction.PROTOBUF.toBytes(freezeTx);
 
             final var freezeTransactionInfo = new TransactionInfo(
-                    freezeTx, freezeTxBody, MOCK_SIGNATURE_MAP, freezeTx.signedTransactionBytes(), FREEZE, null);
-            when(transactionChecker.check(freezeTx, null)).thenReturn(freezeTransactionInfo);
+                    freezeTx,
+                    freezeTxBody,
+                    MOCK_SIGNATURE_MAP,
+                    freezeTx.signedTransactionBytes(),
+                    FREEZE,
+                    serializedFreezeTx);
+            when(transactionChecker.parseAndCheck(serializedFreezeTx)).thenReturn(freezeTransactionInfo);
 
-            assertThatThrownBy(() -> subject.runAllChecks(state, freezeTx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedFreezeTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .hasFieldOrPropertyWithValue("responseCode", NOT_SUPPORTED);
         }
@@ -448,7 +459,7 @@ class IngestCheckerTest extends AppTestBase {
                     .thenThrow(new RuntimeException("shouldThrottle exception"));
 
             // When the transaction is submitted, then the exception is bubbled up
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("shouldThrottle exception");
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -469,7 +480,7 @@ class IngestCheckerTest extends AppTestBase {
         void payerAccountStatusFails(ResponseCodeEnum failureReason) throws PreCheckException {
             doThrow(new PreCheckException(failureReason)).when(solvencyPreCheck).getPayerAccount(any(), any());
 
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(failureReason));
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -484,7 +495,7 @@ class IngestCheckerTest extends AppTestBase {
                     .getPayerAccount(any(), any());
 
             // When the transaction is submitted, then the exception is bubbled up
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("checkPayerAccountStatus exception");
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -499,7 +510,7 @@ class IngestCheckerTest extends AppTestBase {
             when(solvencyPreCheck.getPayerAccount(any(), eq(ALICE.accountID()))).thenReturn(account);
 
             // When the transaction is submitted, then the exception is thrown
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(UNAUTHORIZED));
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -527,7 +538,7 @@ class IngestCheckerTest extends AppTestBase {
                     .when(solvencyPreCheck)
                     .checkSolvency(any(), any(), any(), eq(INGEST));
 
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(InsufficientBalanceException.class)
                     .has(responseCode(failureReason))
                     .has(estimatedFee(123L));
@@ -544,7 +555,7 @@ class IngestCheckerTest extends AppTestBase {
                     .checkSolvency(any(), any(), any(), eq(INGEST));
 
             // When the transaction is submitted, then the exception is bubbled up
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("checkSolvency exception");
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -572,7 +583,7 @@ class IngestCheckerTest extends AppTestBase {
             when(signatureVerifier.verify(any(), any())).thenReturn(Map.of());
 
             // When the transaction is submitted, then the exception is thrown
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(INVALID_SIGNATURE));
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -588,7 +599,7 @@ class IngestCheckerTest extends AppTestBase {
             when(signatureVerifier.verify(any(), any()))
                     .thenReturn(Map.of(ALICE.account().keyOrThrow(), verificationResultFuture));
 
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(INVALID_SIGNATURE));
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -618,9 +629,15 @@ class IngestCheckerTest extends AppTestBase {
                                     .bodyBytes(asBytes(TransactionBody.PROTOBUF, myTxBody))
                                     .build()))
                     .build();
+            final var mySerializedTx = Transaction.PROTOBUF.toBytes(myTx);
             final var myTransactionInfo = new TransactionInfo(
-                    myTx, myTxBody, MOCK_SIGNATURE_MAP, myTx.signedTransactionBytes(), UNCHECKED_SUBMIT, null);
-            when(transactionChecker.check(myTx, null)).thenReturn(myTransactionInfo);
+                    myTx,
+                    myTxBody,
+                    MOCK_SIGNATURE_MAP,
+                    myTx.signedTransactionBytes(),
+                    UNCHECKED_SUBMIT,
+                    mySerializedTx);
+            when(transactionChecker.parseAndCheck(serializedTx)).thenReturn(myTransactionInfo);
             when(solvencyPreCheck.getPayerAccount(any(), eq(accountID))).thenReturn(account);
             final var verificationResultFutureAlice = mock(SignatureVerificationFuture.class);
             final var verificationResultAlice = mock(SignatureVerification.class);
@@ -636,7 +653,7 @@ class IngestCheckerTest extends AppTestBase {
                             BOB.account().keyOrThrow(), verificationResultFutureBob));
 
             // when
-            final var actual = subject.runAllChecks(state, myTx, configuration);
+            final var actual = subject.runAllChecks(state, serializedTx, configuration);
 
             // then
             assertThat(actual).isEqualTo(myTransactionInfo);
@@ -667,9 +684,15 @@ class IngestCheckerTest extends AppTestBase {
                                     .bodyBytes(asBytes(TransactionBody.PROTOBUF, myTxBody))
                                     .build()))
                     .build();
+            final var mySerializedTx = Transaction.PROTOBUF.toBytes(myTx);
             final var myTransactionInfo = new TransactionInfo(
-                    myTx, myTxBody, MOCK_SIGNATURE_MAP, myTx.signedTransactionBytes(), UNCHECKED_SUBMIT, null);
-            when(transactionChecker.check(myTx, null)).thenReturn(myTransactionInfo);
+                    myTx,
+                    myTxBody,
+                    MOCK_SIGNATURE_MAP,
+                    myTx.signedTransactionBytes(),
+                    UNCHECKED_SUBMIT,
+                    mySerializedTx);
+            when(transactionChecker.parseAndCheck(mySerializedTx)).thenReturn(myTransactionInfo);
             when(solvencyPreCheck.getPayerAccount(any(), eq(accountID))).thenReturn(account);
             final var verificationResultFutureAlice = mock(SignatureVerificationFuture.class);
             final var verificationResultAlice = mock(SignatureVerification.class);
@@ -685,7 +708,7 @@ class IngestCheckerTest extends AppTestBase {
                             BOB.account().keyOrThrow(), verificationResultFutureBob));
 
             // when
-            assertThatThrownBy(() -> subject.runAllChecks(state, myTx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, mySerializedTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(INVALID_SIGNATURE));
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -717,9 +740,15 @@ class IngestCheckerTest extends AppTestBase {
                                     .bodyBytes(asBytes(TransactionBody.PROTOBUF, myTxBody))
                                     .build()))
                     .build();
+            final var mySerializedTx = Transaction.PROTOBUF.toBytes(myTx);
             final var myTransactionInfo = new TransactionInfo(
-                    myTx, myTxBody, MOCK_SIGNATURE_MAP, myTx.signedTransactionBytes(), UNCHECKED_SUBMIT, null);
-            when(transactionChecker.check(myTx, null)).thenReturn(myTransactionInfo);
+                    myTx,
+                    myTxBody,
+                    MOCK_SIGNATURE_MAP,
+                    myTx.signedTransactionBytes(),
+                    UNCHECKED_SUBMIT,
+                    mySerializedTx);
+            when(transactionChecker.parseAndCheck(mySerializedTx)).thenReturn(myTransactionInfo);
             when(solvencyPreCheck.getPayerAccount(any(), eq(accountID))).thenReturn(account);
             final var verificationResultFutureAlice = mock(SignatureVerificationFuture.class);
             final var verificationResultAlice = mock(SignatureVerification.class);
@@ -735,7 +764,7 @@ class IngestCheckerTest extends AppTestBase {
                             BOB.account().keyOrThrow(), verificationResultFutureBob));
 
             // when
-            final var actual = subject.runAllChecks(state, myTx, configuration);
+            final var actual = subject.runAllChecks(state, mySerializedTx, configuration);
 
             // then
             assertThat(actual).isEqualTo(myTransactionInfo);
@@ -768,9 +797,15 @@ class IngestCheckerTest extends AppTestBase {
                                     .bodyBytes(asBytes(TransactionBody.PROTOBUF, myTxBody))
                                     .build()))
                     .build();
+            final var mySerializedTx = Transaction.PROTOBUF.toBytes(myTx);
             final var myTransactionInfo = new TransactionInfo(
-                    myTx, myTxBody, MOCK_SIGNATURE_MAP, myTx.signedTransactionBytes(), UNCHECKED_SUBMIT, null);
-            when(transactionChecker.check(myTx, null)).thenReturn(myTransactionInfo);
+                    myTx,
+                    myTxBody,
+                    MOCK_SIGNATURE_MAP,
+                    myTx.signedTransactionBytes(),
+                    UNCHECKED_SUBMIT,
+                    mySerializedTx);
+            when(transactionChecker.parseAndCheck(mySerializedTx)).thenReturn(myTransactionInfo);
             when(solvencyPreCheck.getPayerAccount(any(), eq(accountID))).thenReturn(account);
             final var verificationResultFutureAlice = mock(SignatureVerificationFuture.class);
             final var verificationResultAlice = mock(SignatureVerification.class);
@@ -786,7 +821,7 @@ class IngestCheckerTest extends AppTestBase {
                             BOB.account().keyOrThrow(), verificationResultFutureBob));
 
             // when
-            assertThatThrownBy(() -> subject.runAllChecks(state, myTx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, mySerializedTx, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(INVALID_SIGNATURE));
             verify(opWorkflowMetrics, never()).incrementThrottled(any());
@@ -804,7 +839,7 @@ class IngestCheckerTest extends AppTestBase {
                     .thenReturn(Map.of(ALICE.account().keyOrThrow(), verificationResultFuture));
 
             // When the transaction is submitted, then the exception is bubbled up
-            assertThatThrownBy(() -> subject.runAllChecks(state, tx, configuration))
+            assertThatThrownBy(() -> subject.runAllChecks(state, serializedTx, configuration))
                     .isInstanceOf(RuntimeException.class)
                     .hasMessageContaining("checkPayerSignature exception");
             verify(opWorkflowMetrics, never()).incrementThrottled(any());

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
@@ -135,15 +135,14 @@ class IngestWorkflowImplTest extends AppTestBase {
 
         // Mock out the onset to always return a valid parsed object
         transaction = Transaction.newBuilder().body(transactionBody).build();
-        when(transactionChecker.parse(requestBuffer)).thenReturn(transaction);
         final var transactionInfo = new TransactionInfo(
                 transaction,
                 transactionBody,
                 SignatureMap.newBuilder().build(),
                 randomBytes(100), // Not used in this test, so random bytes is OK
                 HederaFunctionality.CONSENSUS_CREATE_TOPIC,
-                null);
-        when(ingestChecker.runAllChecks(state, transaction, configuration)).thenReturn(transactionInfo);
+                requestBuffer);
+        when(ingestChecker.runAllChecks(state, requestBuffer, configuration)).thenReturn(transactionInfo);
 
         // Create the workflow we are going to test with
         workflow = new IngestWorkflowImpl(
@@ -236,7 +235,7 @@ class IngestWorkflowImplTest extends AppTestBase {
         @DisplayName("If the transaction fails WorkflowOnset, a failure response is returned with the right error")
         void onsetFailsWithPreCheckException(ResponseCodeEnum failureReason) throws PreCheckException, ParseException {
             // Given a WorkflowOnset that will throw a PreCheckException with the given failure reason
-            when(transactionChecker.parse(any())).thenThrow(new PreCheckException(failureReason));
+            when(ingestChecker.runAllChecks(any(), any(), any())).thenThrow(new PreCheckException(failureReason));
 
             // When the transaction is submitted
             workflow.submitTransaction(requestBuffer, responseBuffer);
@@ -251,10 +250,11 @@ class IngestWorkflowImplTest extends AppTestBase {
         }
 
         @Test
-        @DisplayName("If some random exception is thrown from TransactionChecker, the exception is bubbled up")
+        @DisplayName("If some random exception is thrown from IngestChecker, the exception is bubbled up")
         void randomException() throws PreCheckException, ParseException {
             // Given a WorkflowOnset that will throw a RuntimeException
-            when(transactionChecker.parse(any())).thenThrow(new RuntimeException("parseAndCheck exception"));
+            when(ingestChecker.runAllChecks(any(), any(), any()))
+                    .thenThrow(new RuntimeException("parseAndCheck exception"));
 
             // When the transaction is submitted
             workflow.submitTransaction(requestBuffer, responseBuffer);
@@ -285,7 +285,7 @@ class IngestWorkflowImplTest extends AppTestBase {
         @DisplayName("When ingest checks fail, the transaction should be rejected")
         void testIngestChecksFail(ResponseCodeEnum failureReason) throws PreCheckException, ParseException {
             // Given a throttle on CONSENSUS_CREATE_TOPIC transactions (i.e. it is time to throttle)
-            when(ingestChecker.runAllChecks(state, transaction, configuration))
+            when(ingestChecker.runAllChecks(state, requestBuffer, configuration))
                     .thenThrow(new PreCheckException(failureReason));
 
             // When the transaction is submitted
@@ -304,7 +304,7 @@ class IngestWorkflowImplTest extends AppTestBase {
         @DisplayName("If some random exception is thrown from IngestChecker, the exception is bubbled up")
         void randomException() throws PreCheckException, ParseException {
             // Given a ThrottleAccumulator that will throw a RuntimeException
-            when(ingestChecker.runAllChecks(state, transaction, configuration))
+            when(ingestChecker.runAllChecks(state, requestBuffer, configuration))
                     .thenThrow(new RuntimeException("runAllChecks exception"));
 
             // When the transaction is submitted

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -156,7 +156,7 @@ class QueryWorkflowImplTest extends AppTestBase {
     private OpWorkflowMetrics opWorkflowMetrics;
 
     private VersionedConfiguration configuration;
-    private Transaction payment;
+    private Bytes serializedPayment;
     private TransactionBody txBody;
     private Bytes requestBuffer;
     private TransactionInfo transactionInfo;
@@ -169,12 +169,16 @@ class QueryWorkflowImplTest extends AppTestBase {
         setupStandardStates();
 
         when(stateAccessor.apply(any())).thenReturn(new AutoCloseableWrapper<>(state, () -> {}));
-        requestBuffer = Bytes.wrap(new byte[] {1, 2, 3});
-        payment = Transaction.newBuilder().build();
+        final var transactionID =
+                TransactionID.newBuilder().accountID(ALICE.accountID()).build();
+        txBody = TransactionBody.newBuilder().transactionID(transactionID).build();
+        final var payment = Transaction.newBuilder().body(txBody).build();
+        serializedPayment = Transaction.PROTOBUF.toBytes(payment);
         final var queryHeader = QueryHeader.newBuilder().payment(payment).build();
         final var query = Query.newBuilder()
                 .fileGetInfo(FileGetInfoQuery.newBuilder().header(queryHeader))
                 .build();
+        requestBuffer = Query.PROTOBUF.toBytes(query);
         when(queryParser.parseStrict((ReadableSequentialData) notNull())).thenReturn(query);
 
         configuration = new VersionedConfigImpl(HederaTestConfigBuilder.createConfig(), DEFAULT_CONFIG_VERSION);
@@ -182,14 +186,11 @@ class QueryWorkflowImplTest extends AppTestBase {
 
         when(feeManager.createFeeCalculator(eq(FILE_GET_INFO), any(), any())).thenReturn(feeCalculator);
 
-        final var transactionID =
-                TransactionID.newBuilder().accountID(ALICE.accountID()).build();
-        txBody = TransactionBody.newBuilder().transactionID(transactionID).build();
-
         final var signatureMap = SignatureMap.newBuilder().build();
         transactionInfo = new TransactionInfo(
-                payment, txBody, signatureMap, payment.signedTransactionBytes(), CRYPTO_TRANSFER, null);
-        when(ingestChecker.runAllChecks(state, payment, configuration)).thenReturn(transactionInfo);
+                payment, txBody, signatureMap, payment.signedTransactionBytes(), CRYPTO_TRANSFER, serializedPayment);
+        when(ingestChecker.runAllChecks(state, serializedPayment, configuration))
+                .thenReturn(transactionInfo);
 
         when(handler.extractHeader(query)).thenReturn(queryHeader);
         when(handler.createEmptyResponse(any())).thenAnswer((Answer<Response>) invocation -> {
@@ -803,7 +804,7 @@ class QueryWorkflowImplTest extends AppTestBase {
         when(handler.requiresNodePayment(ANSWER_ONLY)).thenReturn(true);
         doThrow(new PreCheckException(INVALID_TRANSACTION_BODY))
                 .when(ingestChecker)
-                .runAllChecks(state, payment, configuration);
+                .runAllChecks(state, serializedPayment, configuration);
         final var responseBuffer = newEmptyBuffer();
 
         // when
@@ -989,7 +990,7 @@ class QueryWorkflowImplTest extends AppTestBase {
         when(handler.requiresNodePayment(ANSWER_ONLY)).thenReturn(true);
         doThrow(new PreCheckException(PLATFORM_TRANSACTION_NOT_CREATED))
                 .when(submissionManager)
-                .submit(txBody, payment.bodyBytes());
+                .submit(txBody, serializedPayment);
         given(handler.computeFees(any(QueryContext.class))).willReturn(new Fees(100L, 0L, 100L));
         final var responseBuffer = newEmptyBuffer();
 


### PR DESCRIPTION
This PR ensures we use the raw bytes of `TransactionBody` sent by the user. This is critical because the deserializing and serializing a Protobuf object may lead to different results which would break any signatures.