### PR TITLE
refactor: 17991

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -523,8 +523,8 @@ public final class Hedera implements SwirldMain<MerkleNodeState>, PlatformStatus
             stateRootSupplier = blockStreamsEnabled ? () -> withListeners(baseSupplier.get()) : baseSupplier;
             onSealConsensusRound = blockStreamsEnabled ? this::manageBlockEndRound : (round, state) -> {};
             // And the factory for the MerkleStateRoot class id must be our constructor
-            constructableRegistry.registerConstructable(
-                    new ClassConstructorPair(HederaStateRoot.class, stateRootSupplier::get));
+            constructableRegistry.registerConstructable(new ClassConstructorPair(
+                    HederaStateRoot.class, () -> stateRootSupplier.get().getRoot()));
         } catch (final ConstructableRegistryException e) {
             logger.error("Failed to register " + HederaStateRoot.class + " factory with ConstructableRegistry", e);
             throw new IllegalStateException(e);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/SerializationTest.java
@@ -188,11 +188,11 @@ class SerializationTest extends MerkleTestBase {
             // Force flush the VMs to disk to test serialization and deserialization
             forceFlush(originalTree.getReadableStates(FIRST_SERVICE).get(ANIMAL_STATE_KEY));
             copy.copy(); // make a fast copy because we can only write to disk an immutable copy
-            CRYPTO.digestTreeSync(copy);
-            serializedBytes = writeTree(copy, dir);
+            CRYPTO.digestTreeSync(copy.getRoot());
+            serializedBytes = writeTree(copy.getRoot(), dir);
         } else {
-            CRYPTO.digestTreeSync(copy);
-            serializedBytes = writeTree(originalTree, dir);
+            CRYPTO.digestTreeSync(copy.getRoot());
+            serializedBytes = writeTree(originalTree.getRoot(), dir);
         }
 
         final TestMerkleStateRoot loadedTree = loadedMerkleTree(schemaV1, serializedBytes);
@@ -248,8 +248,8 @@ class SerializationTest extends MerkleTestBase {
 
         forceFlush(originalTree.getReadableStates(FIRST_SERVICE).get(ANIMAL_STATE_KEY));
         copy.copy(); // make a fast copy because we can only write to disk an immutable copy
-        CRYPTO.digestTreeSync(copy);
-        final byte[] serializedBytes = writeTree(copy, dir);
+        CRYPTO.digestTreeSync(copy.getRoot());
+        final byte[] serializedBytes = writeTree(copy.getRoot(), dir);
 
         TestMerkleStateRoot loadedTree = loadedMerkleTree(schemaV1, serializedBytes);
         ((OnDiskReadableKVState) originalTree.getReadableStates(FIRST_SERVICE).get(ANIMAL_STATE_KEY)).reset();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
@@ -214,7 +214,7 @@ public class StateChangesValidator implements BlockStreamValidator {
         final var stateToBeCopied = state;
         state = state.copy();
         // get the state hash before applying the state changes from current block
-        this.genesisStateHash = CRYPTO.digestTreeSync(stateToBeCopied);
+        this.genesisStateHash = CRYPTO.digestTreeSync(stateToBeCopied.getRoot());
 
         logger.info("Registered all Service and migrated state definitions to version {}", servicesVersion);
     }
@@ -232,7 +232,8 @@ public class StateChangesValidator implements BlockStreamValidator {
             if (i != 0 && shouldVerifyProof) {
                 final var stateToBeCopied = state;
                 this.state = stateToBeCopied.copy();
-                startOfStateHash = CRYPTO.digestTreeSync(stateToBeCopied).getBytes();
+                startOfStateHash =
+                        CRYPTO.digestTreeSync(stateToBeCopied.getRoot()).getBytes();
             }
             final StreamingTreeHasher inputTreeHasher = new NaiveStreamingTreeHasher();
             final StreamingTreeHasher outputTreeHasher = new NaiveStreamingTreeHasher();
@@ -298,14 +299,14 @@ public class StateChangesValidator implements BlockStreamValidator {
                 state.getWritableStates(EntityIdService.NAME).<EntityCounts>getSingleton(ENTITY_COUNTS_KEY);
         assertEntityCountsMatch(entityCounts);
 
-        CRYPTO.digestTreeSync(state);
+        CRYPTO.digestTreeSync(state.getRoot());
         final var rootHash = requireNonNull(state.getHash()).getBytes();
         if (!expectedRootHash.equals(rootHash)) {
             final var expectedHashes = getMaybeLastHashMnemonics(pathToNode0SwirldsLog);
             if (expectedHashes == null) {
                 throw new AssertionError("No expected hashes found in " + pathToNode0SwirldsLog);
             }
-            final var actualHashes = hashesFor(state);
+            final var actualHashes = hashesFor(state.getRoot());
             final var errorMsg = new StringBuilder("Hashes did not match for the following states,");
             expectedHashes.forEach((stateName, expectedHash) -> {
                 final var actualHash = actualHashes.get(stateName);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/StateInitializer.java
@@ -74,7 +74,7 @@ public final class StateInitializer {
                 () -> {
                     try {
                         MerkleCryptoFactory.getInstance()
-                                .digestTreeAsync(initialState)
+                                .digestTreeAsync(initialState.getRoot())
                                 .get();
                     } catch (final ExecutionException e) {
                         throw new RuntimeException(e);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CompareStatesCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CompareStatesCommand.java
@@ -127,7 +127,7 @@ public final class CompareStatesCommand extends AbstractCommand {
         logger.info(LogMarker.CLI.getMarker(), "Hashing state");
         try {
             MerkleCryptoFactory.getInstance()
-                    .digestTreeAsync(signedState.get().getState())
+                    .digestTreeAsync(signedState.get().getState().getRoot())
                     .get();
         } catch (final InterruptedException | ExecutionException e) {
             throw new RuntimeException("unable to hash state", e);
@@ -153,7 +153,9 @@ public final class CompareStatesCommand extends AbstractCommand {
             try (final ReservedSignedState stateB = loadAndHashState(platformContext, stateBPath)) {
                 SignedStateComparison.printMismatchedNodes(
                         SignedStateComparison.mismatchedNodeIterator(
-                                stateA.get().getState(), stateB.get().getState(), deepComparison),
+                                stateA.get().getState().getRoot(),
+                                stateB.get().getState().getRoot(),
+                                deepComparison),
                         nodeLimit);
             }
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
@@ -88,7 +88,7 @@ public class GenesisPlatformStateCommand extends AbstractCommand {
             }
             System.out.printf("Hashing state %n");
             MerkleCryptoFactory.getInstance()
-                    .digestTreeAsync(reservedSignedState.get().getState())
+                    .digestTreeAsync(reservedSignedState.get().getState().getRoot())
                     .get();
             System.out.printf("Writing modified state to %s %n", outputDir.toAbsolutePath());
             writeSignedStateFilesToDirectory(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectLearner.java
@@ -190,7 +190,7 @@ public class ReconnectLearner {
                 threadManager,
                 in,
                 out,
-                currentState,
+                currentState.getRoot(),
                 connection::disconnect,
                 reconnectConfig,
                 platformContext.getMetrics());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
@@ -218,7 +218,7 @@ public class ReconnectTeacher {
                 threadManager,
                 new MerkleDataInputStream(connection.getDis()),
                 new MerkleDataOutputStream(connection.getDos()),
-                signedState.getState(),
+                signedState.getState().getRoot(),
                 connection::disconnect,
                 reconnectConfig);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectUtils.java
@@ -47,7 +47,9 @@ public final class ReconnectUtils {
      */
     static void hashStateForReconnect(final MerkleNodeState workingState) {
         try {
-            MerkleCryptoFactory.getInstance().digestTreeAsync(workingState).get();
+            MerkleCryptoFactory.getInstance()
+                    .digestTreeAsync(workingState.getRoot())
+                    .get();
         } catch (final ExecutionException e) {
             logger.error(
                     EXCEPTION.getMarker(),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/recovery/EventRecoveryWorkflow.java
@@ -336,7 +336,7 @@ public final class EventRecoveryWorkflow {
         logger.info(STARTUP.getMarker(), "Hashing resulting signed state");
         try {
             MerkleCryptoFactory.getInstance()
-                    .digestTreeAsync(signedState.get().getState())
+                    .digestTreeAsync(signedState.get().getState().getRoot())
                     .get();
         } catch (final InterruptedException e) {
             throw new RuntimeException("interrupted while attempting to hash the state", e);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
@@ -93,6 +93,6 @@ public final class BirthRoundStateMigration {
         platformStateFacade.setSnapshotTo(state, modifiedConsensusSnapshot);
 
         state.invalidateHash();
-        MerkleCryptoFactory.getInstance().digestTreeSync(state);
+        MerkleCryptoFactory.getInstance().digestTreeSync(state.getRoot());
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleNodeState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/MerkleNodeState.java
@@ -11,11 +11,23 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 /**
- * Represent a state backed up by the Merkle tree. It's a {@link MerkleNode} and provides methods to put service states
- * into the merkle tree.
+ * Represent a state backed up by the Merkle tree. It's a {@link State} implementation that is backed by a Merkle tree.
+ * It provides methods to manage the service states in the merkle tree.
  */
-public interface MerkleNodeState extends State, MerkleNode {
+public interface MerkleNodeState extends State {
 
+    /**
+     * @return an instance representing a root of the Merkle tree. For the most of the implementations
+     * this default implementation will be sufficient. But some implementations of the state may be "logical" - they
+     * are not `MerkleNode` themselves but are backed by the Merkle tree implementation (e.g. a Virtual Map).
+     */
+    default MerkleNode getRoot() {
+        return (MerkleNode) this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     @NonNull
     @Override
     MerkleNodeState copy();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManager.java
@@ -204,7 +204,7 @@ public class SwirldStateManager implements FreezePeriodChecker {
         if (currVal != null) {
             currVal.release();
         }
-        immutableState.reserve();
+        immutableState.getRoot().reserve();
         latestImmutableState.set(immutableState);
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/SwirldStateManagerUtils.java
@@ -41,7 +41,7 @@ public final class SwirldStateManagerUtils {
         platformStateFacade.setCreationSoftwareVersionTo(copy, softwareVersion);
 
         // Increment the reference count because this reference becomes the new value
-        copy.reserve();
+        copy.getRoot().reserve();
 
         final long copyEnd = System.nanoTime();
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditor.java
@@ -61,7 +61,7 @@ public class StateEditor {
             System.out.println("Hashing state");
             try {
                 MerkleCryptoFactory.getInstance()
-                        .digestTreeAsync(reservedSignedState.get().getState())
+                        .digestTreeAsync(reservedSignedState.get().getState().getRoot())
                         .get();
             } catch (final InterruptedException | ExecutionException e) {
                 Thread.currentThread().interrupt();
@@ -110,7 +110,7 @@ public class StateEditor {
             while (true) {
                 try (final ReservedSignedState reservedSignedState = getState("StateEditor.start()")) {
                     final MerkleTraversable merkleTraversable =
-                            reservedSignedState.get().getState();
+                            reservedSignedState.get().getState().getRoot();
                     target = merkleTraversable.getNodeAtRoute(currentWorkingRoute);
                     break;
                 } catch (final NoSuchElementException e) {
@@ -164,7 +164,7 @@ public class StateEditor {
     public void setCurrentWorkingRoute(final MerkleRoute currentWorkingRoute) {
         try (final ReservedSignedState reservedSignedState = getState("StateEditor.setCurrentWorkingRoute()")) {
             final MerkleTraversable merkleTraversable =
-                    reservedSignedState.get().getState();
+                    reservedSignedState.get().getState().getRoot();
             merkleTraversable.getNodeAtRoute(currentWorkingRoute); // throws if invalid
             this.currentWorkingRoute = currentWorkingRoute;
         }
@@ -214,7 +214,7 @@ public class StateEditor {
     public MerkleNode getRelativeNode(final String path) {
         try (final ReservedSignedState reservedSignedState = getState("StateEditor.getRelativeNode()")) {
             final MerkleTraversable merkleTraversable =
-                    reservedSignedState.get().getState();
+                    reservedSignedState.get().getState().getRoot();
             return merkleTraversable.getNodeAtRoute(getRelativeRoute(path));
         }
     }
@@ -242,7 +242,7 @@ public class StateEditor {
 
         try (final ReservedSignedState reservedSignedState = signedState.getAndReserve("StateEditor.getParentInfo()")) {
             final MerkleTraversable merkleTraversable =
-                    reservedSignedState.get().getState();
+                    reservedSignedState.get().getState().getRoot();
             final MerkleNode parent = merkleTraversable.getNodeAtRoute(parentPath);
             if (parent == null) {
                 throw new IllegalArgumentException("The node at " + formatRoute(parentPath) + " is null.");

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorCp.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorCp.java
@@ -64,7 +64,7 @@ public class StateEditorCp extends StateEditorOperation {
 
         // Invalidate hashes in path down from root
         try (final ReservedSignedState reservedSignedState = getStateEditor().getState("StateEditorCp.run()")) {
-            new MerkleRouteIterator(reservedSignedState.get().getState(), parent.getRoute())
+            new MerkleRouteIterator(reservedSignedState.get().getState().getRoot(), parent.getRoute())
                     .forEachRemaining(Hashable::invalidateHash);
         }
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorExec.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorExec.java
@@ -78,7 +78,7 @@ public class StateEditorExec extends StateEditorOperation {
                 try (final ReservedSignedState reservedSignedState =
                         getStateEditor().getState("StateEditorExec.run()")) {
                     new MerkleRouteIterator(
-                                    reservedSignedState.get().getState(),
+                                    reservedSignedState.get().getState().getRoot(),
                                     parentInfo.parent().getRoute())
                             .forEachRemaining(Hashable::invalidateHash);
                 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorHash.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorHash.java
@@ -18,7 +18,7 @@ public class StateEditorHash extends StateEditorOperation {
     public void run() {
         try (final ReservedSignedState reservedSignedState = getStateEditor().getState("StateEditorHash.run()")) {
             MerkleCryptoFactory.getInstance()
-                    .digestTreeAsync(reservedSignedState.get().getState())
+                    .digestTreeAsync(reservedSignedState.get().getState().getRoot())
                     .get();
         } catch (final InterruptedException | ExecutionException e) {
             throw new RuntimeException(e);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLoad.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorLoad.java
@@ -82,7 +82,7 @@ public class StateEditorLoad extends StateEditorOperation {
 
         // Invalidate hashes in path down from root
         try (final ReservedSignedState reservedSignedState = getStateEditor().getState("StateEditorLoad.run()")) {
-            new MerkleRouteIterator(reservedSignedState.get().getState(), parent.getRoute())
+            new MerkleRouteIterator(reservedSignedState.get().getState().getRoot(), parent.getRoute())
                     .forEachRemaining(Hashable::invalidateHash);
         }
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRehash.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRehash.java
@@ -19,7 +19,7 @@ public class StateEditorRehash extends StateEditorOperation {
     @Override
     public void run() {
         try (final ReservedSignedState reservedSignedState = getStateEditor().getState("StateEditorRehash.run()")) {
-            MerkleUtils.rehashTree(reservedSignedState.get().getState());
+            MerkleUtils.rehashTree(reservedSignedState.get().getState().getRoot());
         }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRm.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorRm.java
@@ -44,7 +44,7 @@ public class StateEditorRm extends StateEditorOperation {
 
         try (final ReservedSignedState reservedSignedState = getStateEditor().getState("StateEditorRm.run()")) {
             final MerkleNodeState state = reservedSignedState.get().getState();
-            final MerkleNode child = state.getNodeAtRoute(destinationRoute);
+            final MerkleNode child = state.getRoot().getNodeAtRoute(destinationRoute);
 
             if (logger.isInfoEnabled(LogMarker.CLI.getMarker())) {
                 logger.info(
@@ -57,7 +57,7 @@ public class StateEditorRm extends StateEditorOperation {
             parent.setChild(indexInParent, null);
 
             // Invalidate hashes in path down from root
-            new MerkleRouteIterator(state, parent.getRoute()).forEachRemaining(Hashable::invalidateHash);
+            new MerkleRouteIterator(state.getRoot(), parent.getRoute()).forEachRemaining(Hashable::invalidateHash);
         }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSave.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSave.java
@@ -45,7 +45,7 @@ public class StateEditorSave extends StateEditorOperation {
 
             logger.info(LogMarker.CLI.getMarker(), "Hashing state");
             MerkleCryptoFactory.getInstance()
-                    .digestTreeAsync(reservedSignedState.get().getState())
+                    .digestTreeAsync(reservedSignedState.get().getState().getRoot())
                     .get();
 
             if (logger.isInfoEnabled(LogMarker.CLI.getMarker())) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSwap.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditorSwap.java
@@ -40,8 +40,8 @@ public class StateEditorSwap extends StateEditorOperation {
             final StateEditor.ParentInfo parentInfoB = getStateEditor().getParentInfo(pathB);
 
             final MerkleNodeState merkleTraversable = reservedSignedState.get().getState();
-            final MerkleNode nodeA = merkleTraversable.getNodeAtRoute(parentInfoA.target());
-            final MerkleNode nodeB = merkleTraversable.getNodeAtRoute(parentInfoB.target());
+            final MerkleNode nodeA = merkleTraversable.getRoot().getNodeAtRoute(parentInfoA.target());
+            final MerkleNode nodeB = merkleTraversable.getRoot().getNodeAtRoute(parentInfoB.target());
 
             if (logger.isInfoEnabled(LogMarker.CLI.getMarker())) {
                 logger.info(LogMarker.CLI.getMarker(), "Swapping {} and {}", formatNode(nodeA), formatNode(nodeB));
@@ -61,9 +61,11 @@ public class StateEditorSwap extends StateEditorOperation {
             }
 
             // Invalidate hashes in path down from root
-            new MerkleRouteIterator(merkleTraversable, parentInfoA.parent().getRoute())
+            new MerkleRouteIterator(
+                            merkleTraversable.getRoot(), parentInfoA.parent().getRoute())
                     .forEachRemaining(Hashable::invalidateHash);
-            new MerkleRouteIterator(merkleTraversable, parentInfoB.parent().getRoute())
+            new MerkleRouteIterator(
+                            merkleTraversable.getRoot(), parentInfoB.parent().getRoute())
                     .forEachRemaining(Hashable::invalidateHash);
         }
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hasher/DefaultStateHasher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/hasher/DefaultStateHasher.java
@@ -43,7 +43,8 @@ public class DefaultStateHasher implements StateHasher {
         final Instant start = Instant.now();
         try {
             MerkleCryptoFactory.getInstance()
-                    .digestTreeAsync(stateAndRound.reservedSignedState().get().getState())
+                    .digestTreeAsync(
+                            stateAndRound.reservedSignedState().get().getState().getRoot())
                     .get();
 
             metrics.reportHashingTime(Duration.between(start, Instant.now()));

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/SignedState.java
@@ -188,7 +188,7 @@ public class SignedState implements SignedStateInfo {
         this.platformStateFacade = platformStateFacade;
         this.signatureVerifier = requireNonNull(signatureVerifier);
         this.state = requireNonNull(state);
-        state.reserve();
+        state.getRoot().reserve();
 
         final StateConfig stateConfig = configuration.getConfigData(StateConfig.class);
         if (stateConfig.stateHistoryEnabled()) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -172,7 +172,8 @@ public final class StartupStateUtils {
                 platformStateFacade);
         signedStateCopy.setSigSet(initialSignedState.getSigSet());
 
-        final Hash hash = MerkleCryptoFactory.getInstance().digestTreeSync(initialSignedState.getState());
+        final Hash hash = MerkleCryptoFactory.getInstance()
+                .digestTreeSync(initialSignedState.getState().getRoot());
         return new HashedReservedSignedState(signedStateCopy.reserve("Copied initial state"), hash);
     }
 
@@ -261,7 +262,7 @@ public final class StartupStateUtils {
                 deserializedSignedState.reservedSignedState().get().getState();
 
         final Hash oldHash = deserializedSignedState.originalHash();
-        final Hash newHash = rehashTree(state);
+        final Hash newHash = rehashTree(state.getRoot());
 
         final SoftwareVersion loadedVersion = platformStateFacade.creationSoftwareVersionOf(state);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileWriter.java
@@ -73,7 +73,7 @@ public final class SignedStateFileWriter {
 
         final Path hashInfoFile = directory.resolve(HASH_INFO_FILE_NAME);
 
-        final String hashInfo = new MerkleTreeVisualizer(state)
+        final String hashInfo = new MerkleTreeVisualizer(state.getRoot())
                 .setDepth(stateConfig.debugHashDepth())
                 .render();
         try (final BufferedWriter writer = new BufferedWriter(new FileWriter(hashInfoFile.toFile()))) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -104,7 +104,7 @@ class SignedStateFileReadWriteTest {
         final Path hashInfoFile = testDirectory.resolve(SignedStateFileUtils.HASH_INFO_FILE_NAME);
         assertTrue(exists(hashInfoFile), "file should exist");
 
-        final String hashInfoString = new MerkleTreeVisualizer(state)
+        final String hashInfoString = new MerkleTreeVisualizer(state.getRoot())
                 .setDepth(stateConfig.debugHashDepth())
                 .render();
 
@@ -139,8 +139,11 @@ class SignedStateFileReadWriteTest {
         final DeserializedSignedState deserializedSignedState = readStateFile(
                 TestPlatformContextBuilder.create().build().getConfiguration(), stateFile, TEST_PLATFORM_STATE_FACADE);
         MerkleCryptoFactory.getInstance()
-                .digestTreeSync(
-                        deserializedSignedState.reservedSignedState().get().getState());
+                .digestTreeSync(deserializedSignedState
+                        .reservedSignedState()
+                        .get()
+                        .getState()
+                        .getRoot());
 
         assertNotNull(deserializedSignedState.originalHash(), "hash should not be null");
         assertEquals(signedState.getState().getHash(), deserializedSignedState.originalHash(), "hash should match");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -148,8 +148,11 @@ class StateFileManagerTests {
         final DeserializedSignedState deserializedSignedState = readStateFile(
                 TestPlatformContextBuilder.create().build().getConfiguration(), stateFile, TEST_PLATFORM_STATE_FACADE);
         MerkleCryptoFactory.getInstance()
-                .digestTreeSync(
-                        deserializedSignedState.reservedSignedState().get().getState());
+                .digestTreeSync(deserializedSignedState
+                        .reservedSignedState()
+                        .get()
+                        .getState()
+                        .getRoot());
 
         assertNotNull(deserializedSignedState.originalHash(), "hash should not be null");
         assertNotSame(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/eventhandling/TransactionHandlerTester.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.swirlds.common.context.PlatformContext;
+import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.roster.RosterRetriever;
@@ -52,6 +53,7 @@ public class TransactionHandlerTester {
         platformState = new PlatformStateValueAccumulator();
 
         consensusState = mock(MerkleNodeState.class);
+        when(consensusState.getRoot()).thenReturn(mock(MerkleNode.class));
         platformStateFacade = mock(TestPlatformStateFacade.class);
 
         stateLifecycles = mock(StateLifecycles.class);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
@@ -122,7 +122,7 @@ final class ReconnectTest {
             final PlatformStateFacade platformStateFacade = signedStateFacadePair.right();
 
             final MerkleCryptography cryptography = MerkleCryptoFactory.getInstance();
-            cryptography.digestSync(signedState.getState());
+            cryptography.digestSync(signedState.getState().getRoot());
 
             final ReconnectLearner receiver = buildReceiver(
                     signedState.getState(),

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/BirthRoundStateMigrationTests.java
@@ -90,7 +90,7 @@ class BirthRoundStateMigrationTests {
         assertEquals(originalHash, signedState.getState().getHash());
 
         // Rehash the state, just in case
-        rehashTree(signedState.getState());
+        rehashTree(signedState.getState().getRoot());
 
         assertEquals(originalHash, signedState.getState().getHash());
     }
@@ -111,7 +111,7 @@ class BirthRoundStateMigrationTests {
             v.setFirstVersionInBirthRoundMode(previousSoftwareVersion);
             v.setLowestJudgeGenerationBeforeBirthRoundMode(100);
         });
-        rehashTree(signedState.getState());
+        rehashTree(signedState.getState().getRoot());
         final Hash originalHash = signedState.getState().getHash();
 
         BirthRoundStateMigration.modifyStateForBirthRoundMigration(
@@ -120,7 +120,7 @@ class BirthRoundStateMigrationTests {
         assertEquals(originalHash, signedState.getState().getHash());
 
         // Rehash the state, just in case
-        rehashTree(signedState.getState());
+        rehashTree(signedState.getState().getRoot());
 
         assertEquals(originalHash, signedState.getState().getHash());
     }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SignedStateTests.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 
 import com.swirlds.base.utility.Pair;
 import com.swirlds.common.exceptions.ReferenceCountException;
+import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.platform.crypto.SignatureVerifier;
@@ -73,7 +74,7 @@ class SignedStateTests {
                         reserveCallback.run();
                         return null;
                     })
-                    .when(state)
+                    .when((MerkleNode) state)
                     .reserve();
         }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateEventHandlerManagerUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/StateEventHandlerManagerUtilsTests.java
@@ -24,7 +24,7 @@ public class StateEventHandlerManagerUtilsTests {
 
         final MerkleNodeState state = new TestMerkleStateRoot();
         FAKE_MERKLE_STATE_LIFECYCLES.initPlatformState(state);
-        state.reserve();
+        state.getRoot().reserve();
         final StateMetrics stats = mock(StateMetrics.class);
         final State result =
                 SwirldStateManagerUtils.fastCopy(state, stats, new BasicSoftwareVersion(1), TEST_PLATFORM_STATE_FACADE);
@@ -32,9 +32,11 @@ public class StateEventHandlerManagerUtilsTests {
         assertFalse(result.isImmutable(), "The copy state should be mutable.");
         assertEquals(
                 1,
-                state.getReservationCount(),
+                state.getRoot().getReservationCount(),
                 "Fast copy should not change the reference count of the state it copies.");
         assertEquals(
-                1, state.getReservationCount(), "Fast copy should return a new state with a reference count of 1.");
+                1,
+                state.getRoot().getReservationCount(),
+                "Fast copy should return a new state with a reference count of 1.");
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldsStateManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/SwirldsStateManagerTests.java
@@ -66,9 +66,10 @@ class SwirldsStateManagerTests {
     void initialStateReferenceCount() {
         assertEquals(
                 1,
-                initialState.getReservationCount(),
+                initialState.getRoot().getReservationCount(),
                 "The initial state is copied and should be referenced once as the previous immutable state.");
-        Reservable consensusStateAsReservable = swirldStateManager.getConsensusState();
+        Reservable consensusStateAsReservable =
+                swirldStateManager.getConsensusState().getRoot();
         assertEquals(
                 1, consensusStateAsReservable.getReservationCount(), "The consensus state should have one reference.");
     }
@@ -85,7 +86,7 @@ class SwirldsStateManagerTests {
     @DisplayName("Load From Signed State - state reference counts")
     void loadFromSignedStateRefCount() {
         final SignedState ss1 = newSignedState();
-        final Reservable state1 = ss1.getState();
+        final Reservable state1 = ss1.getState().getRoot();
         MerkleDb.resetDefaultInstancePath();
         swirldStateManager.loadFromSignedState(ss1);
 
@@ -94,7 +95,8 @@ class SwirldsStateManagerTests {
                 state1.getReservationCount(),
                 "Loading from signed state should increment the reference count, because it is now referenced by the "
                         + "signed state and the previous immutable state in SwirldStateManager.");
-        final Reservable consensusState1 = swirldStateManager.getConsensusState();
+        final Reservable consensusState1 =
+                swirldStateManager.getConsensusState().getRoot();
         assertEquals(
                 1,
                 consensusState1.getReservationCount(),
@@ -104,9 +106,10 @@ class SwirldsStateManagerTests {
         final SignedState ss2 = newSignedState();
         MerkleDb.resetDefaultInstancePath();
         swirldStateManager.loadFromSignedState(ss2);
-        final Reservable consensusState2 = swirldStateManager.getConsensusState();
+        final Reservable consensusState2 =
+                swirldStateManager.getConsensusState().getRoot();
 
-        Reservable state2 = ss2.getState();
+        Reservable state2 = ss2.getState().getRoot();
         assertEquals(
                 2,
                 state2.getReservationCount(),
@@ -129,13 +132,13 @@ class SwirldsStateManagerTests {
 
         platformStateFacade.setCreationSoftwareVersionTo(state, new BasicSoftwareVersion(nextInt(1, 100)));
 
-        assertEquals(0, state.getReservationCount(), "A brand new state should have no references.");
+        assertEquals(0, state.getRoot().getReservationCount(), "A brand new state should have no references.");
         return state;
     }
 
     private static SignedState newSignedState() {
         final SignedState ss = new RandomSignedStateGenerator().build();
-        final Reservable state = ss.getState();
+        final Reservable state = ss.getState().getRoot();
         assertEquals(
                 1, state.getReservationCount(), "Creating a signed state should increment the state reference count.");
         return ss;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/hashlogger/HashLoggerTest.java
@@ -138,9 +138,11 @@ public class HashLoggerTest {
         MerkleCryptoFactory.getInstance().digestTreeSync(merkleNode);
         final SignedState signedState = mock(SignedState.class);
         final MerkleNodeState state = mock(MerkleNodeState.class);
+        final MerkleNode stateRoot = mock(MerkleNode.class);
         final PlatformStateAccessor platformState = mock(PlatformStateAccessor.class);
         when(platformState.getRound()).thenReturn(round);
-        when(state.getRoute()).thenReturn(merkleNode.getRoute());
+        when(state.getRoot()).thenReturn(stateRoot);
+        when(stateRoot.getRoute()).thenReturn(merkleNode.getRoute());
         when(state.getHash()).thenReturn(merkleNode.getHash());
 
         when(signedState.getState()).thenReturn(state);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/DefaultStateHasherTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/DefaultStateHasherTests.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.platform.internal.ConsensusRound;
+import com.swirlds.platform.state.MerkleNodeState;
 import com.swirlds.platform.state.hasher.DefaultStateHasher;
 import com.swirlds.platform.state.hasher.StateHasher;
 import com.swirlds.platform.wiring.components.StateAndRound;
@@ -30,8 +31,10 @@ public class DefaultStateHasherTests {
 
         // mock a state
         final SignedState signedState = mock(SignedState.class);
+        final MerkleNodeState merkleNodeState = mock(MerkleNodeState.class);
         final ReservedSignedState reservedSignedState = mock(ReservedSignedState.class);
         when(reservedSignedState.get()).thenReturn(signedState);
+        when(signedState.getState()).thenReturn(merkleNodeState);
 
         final StateAndRound stateAndRound =
                 new StateAndRound(reservedSignedState, mock(ConsensusRound.class), mock(ConcurrentLinkedQueue.class));

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -206,7 +206,7 @@ public class StartupStateUtilsTests {
 
         assertEquals(latestState.getRound(), loadedState.getRound());
         assertEquals(latestState.getState().getHash(), loadedState.getState().getHash());
-        RandomSignedStateGenerator.releaseReservable(loadedState.getState());
+        RandomSignedStateGenerator.releaseReservable(loadedState.getState().getRoot());
     }
 
     @Test
@@ -294,7 +294,7 @@ public class StartupStateUtilsTests {
         }
 
         if (loadedState != null) {
-            RandomSignedStateGenerator.releaseReservable(loadedState.getState());
+            RandomSignedStateGenerator.releaseReservable(loadedState.getState().getRoot());
         }
 
         final Path savedStateDirectory = signedStateFilePath

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/SignedStateReserverTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/SignedStateReserverTest.java
@@ -5,8 +5,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import com.swirlds.common.context.PlatformContext;
+import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
 import com.swirlds.common.utility.ValueReference;
 import com.swirlds.component.framework.model.WiringModel;
@@ -34,11 +36,13 @@ class SignedStateReserverTest {
         final PlatformContext platformContext =
                 TestPlatformContextBuilder.create().build();
 
-        MerkleNodeState mock = mock(MerkleNodeState.class);
+        MerkleNodeState mockState = mock(MerkleNodeState.class);
+        MerkleNode root = mock(MerkleNode.class);
+        when(mockState.getRoot()).thenReturn(root);
         final SignedState signedState = new SignedState(
                 platformContext.getConfiguration(),
                 mock(SignatureVerifier.class),
-                mock,
+                mockState,
                 "create",
                 false,
                 false,

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/state/RandomSignedStateGenerator.java
@@ -229,7 +229,7 @@ public class RandomSignedStateGenerator {
                 pcesRound,
                 platformStateFacade);
 
-        MerkleCryptoFactory.getInstance().digestTreeSync(stateInstance);
+        MerkleCryptoFactory.getInstance().digestTreeSync(stateInstance.getRoot());
         if (stateHash != null) {
             stateInstance.setHash(stateHash);
         }
@@ -478,7 +478,7 @@ public class RandomSignedStateGenerator {
      */
     public static void releaseAllBuiltSignedStates() {
         builtSignedStates.get().forEach(signedState -> {
-            releaseReservable(signedState.getState());
+            releaseReservable(signedState.getState().getRoot());
         });
         builtSignedStates.get().clear();
     }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SignedStateSynchronizationTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/SignedStateSynchronizationTests.java
@@ -33,6 +33,6 @@ public class SignedStateSynchronizationTests {
     public void SignedStateSynchronization() throws Exception {
         SignedState state = SignedStateUtils.randomSignedState(1234);
         state.getState().setHash(null); // FUTURE WORK root has a hash but other parts do not...
-        MerkleTestUtils.hashAndTestSynchronization(null, state.getState(), reconnectConfig);
+        MerkleTestUtils.hashAndTestSynchronization(null, state.getState().getRoot(), reconnectConfig);
     }
 }

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTest.java
@@ -38,8 +38,8 @@ class StateTest {
         assertNotSame(state, copy, "copy should not return the same object");
 
         state.invalidateHash();
-        MerkleCryptoFactory.getInstance().digestTreeSync(state);
-        MerkleCryptoFactory.getInstance().digestTreeSync(copy);
+        MerkleCryptoFactory.getInstance().digestTreeSync(state.getRoot());
+        MerkleCryptoFactory.getInstance().digestTreeSync(copy.getRoot());
 
         assertEquals(state.getHash(), copy.getHash(), "copy should be equal to the original");
         assertFalse(state.isDestroyed(), "copy should not have been deleted");
@@ -57,17 +57,17 @@ class StateTest {
         final MerkleNodeState state = randomSignedState().getState();
         assertEquals(
                 1,
-                state.getReservationCount(),
+                state.getRoot().getReservationCount(),
                 "A state referenced only by a signed state should have a ref count of 1");
 
-        assertTrue(state.tryReserve(), "tryReserve() should succeed because the state is not destroyed.");
-        assertEquals(2, state.getReservationCount(), "tryReserve() should increment the reference count.");
+        assertTrue(state.getRoot().tryReserve(), "tryReserve() should succeed because the state is not destroyed.");
+        assertEquals(2, state.getRoot().getReservationCount(), "tryReserve() should increment the reference count.");
 
         state.release();
         state.release();
 
         assertTrue(state.isDestroyed(), "state should be destroyed when fully released.");
-        assertFalse(state.tryReserve(), "tryReserve() should fail when the state is destroyed");
+        assertFalse(state.getRoot().tryReserve(), "tryReserve() should fail when the state is destroyed");
     }
 
     private static SignedState randomSignedState() {

--- a/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTests.java
+++ b/platform-sdk/swirlds-unit-tests/core/swirlds-platform-test/src/test/java/com/swirlds/platform/test/StateTests.java
@@ -56,10 +56,10 @@ class StateTests {
         io.startReading();
 
         final MerkleNodeState decodedState = io.getInput().readMerkleTree(testDirectory, Integer.MAX_VALUE);
-        MerkleCryptoFactory.getInstance().digestTreeSync(decodedState);
+        MerkleCryptoFactory.getInstance().digestTreeSync(decodedState.getRoot());
 
         assertEquals(merkleStateRoot.getHash(), decodedState.getHash(), "expected trees to be equal");
-        assertTrue(areTreesEqual(merkleStateRoot, decodedState), "expected trees to be equal");
+        assertTrue(areTreesEqual(merkleStateRoot, decodedState.getRoot()), "expected trees to be equal");
     }
 
     @Test


### PR DESCRIPTION
**Description** 

This PR removes `MerkleNode`  interface from `MerkeNodeState`. Instead, it adds `MerkleNode getRoot()` method. This refactoring will clean up `MerkleNodeState` API, as `MerkleNode` methods are not used by the app code (this refactoring demonstrates that). Also, it will be handy when it comes to migration to Virtual Megamap 

Fixes: #17991