### PR TITLE
feat: Create a HAPI test to validate birth round migration

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AncientAgeBirthRoundTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AncientAgeBirthRoundTest.java
@@ -9,7 +9,6 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.suites.regression.system.LifecycleTest;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
@@ -17,7 +16,6 @@ import org.junit.jupiter.api.Tag;
 public class AncientAgeBirthRoundTest implements LifecycleTest {
 
     @HapiTest
-    @Disabled("Disabled due to expected failures while birth round ancient age is completed")
     final Stream<DynamicTest> upgradeToUseBirthRounds() {
         /*
         Note: This test should be run in subprocess mode. This is done by executing it with the 'testSubprocess' task:

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AncientAgeBirthRoundTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AncientAgeBirthRoundTest.java
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.regression;
+
+import static com.hedera.services.bdd.junit.TestTags.UPGRADE;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.suites.regression.system.MixedOperations.burstOfTps;
+
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.suites.regression.system.LifecycleTest;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+@Tag(UPGRADE)
+public class AncientAgeBirthRoundTest implements LifecycleTest {
+
+    @HapiTest
+    @Disabled("Disabled due to expected failures while birth round ancient age is completed")
+    final Stream<DynamicTest> upgradeToUseBirthRounds() {
+        /*
+        Note: This test should be run in subprocess mode. This is done by executing it with the 'testSubprocess' task:
+        :test-clients:testSubprocess --tests "com.hedera.services.bdd.suites.regression.AncientAgeBirthRoundTest"
+         */
+
+        return hapiTest(
+                burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
+                prepareFakeUpgrade(),
+                upgradeToNextConfigVersion(Map.of("event.useBirthRoundAncientThreshold", "true")),
+                burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AncientAgeBirthRoundTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AncientAgeBirthRoundTest.java
@@ -25,6 +25,10 @@ public class AncientAgeBirthRoundTest implements LifecycleTest {
         /*
         Note: This test should be run in subprocess mode. This is done by executing it with the 'testSubprocess' task:
         :test-clients:testSubprocess --tests "com.hedera.services.bdd.suites.regression.AncientAgeBirthRoundTest"
+
+        The purpose of this test is to validate the platform operates normally when birth round migration is enabled.
+        "Operates normally" in this context means the migration is successful, the nodes start successfully and events
+         are still being created and gossiped.
          */
 
         return hapiTest(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AncientAgeBirthRoundTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AncientAgeBirthRoundTest.java
@@ -9,13 +9,18 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.suites.regression.system.LifecycleTest;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(UPGRADE)
+@DisplayName("Ancient age birth round migration")
 public class AncientAgeBirthRoundTest implements LifecycleTest {
 
     @HapiTest
+    @DisplayName("Upgrade to use birth rounds")
+    @Disabled("This test is required to run in isolation, but it is not clear how to do this with the HAPI framework")
     final Stream<DynamicTest> upgradeToUseBirthRounds() {
         /*
         Note: This test should be run in subprocess mode. This is done by executing it with the 'testSubprocess' task:

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -37,8 +37,10 @@ import com.swirlds.platform.event.AncientMode;
 import com.swirlds.platform.event.EventCounter;
 import com.swirlds.platform.event.PlatformEvent;
 import com.swirlds.platform.event.preconsensus.PcesConfig;
+import com.swirlds.platform.event.preconsensus.PcesFileReader;
 import com.swirlds.platform.event.preconsensus.PcesFileTracker;
 import com.swirlds.platform.event.preconsensus.PcesReplayer;
+import com.swirlds.platform.event.preconsensus.PcesUtilities;
 import com.swirlds.platform.eventhandling.EventConfig;
 import com.swirlds.platform.metrics.RuntimeMetrics;
 import com.swirlds.platform.pool.TransactionPoolNexus;
@@ -72,6 +74,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -180,21 +183,29 @@ public class SwirldsPlatform implements Platform {
         PlatformStateFacade platformStateFacade = blocks.platformStateFacade();
         modifyStateForBirthRoundMigration(initialState, ancientMode, appVersion, platformStateFacade);
 
+        selfId = blocks.selfId();
+
         if (ancientMode == AncientMode.BIRTH_ROUND_THRESHOLD) {
             try {
                 // This method is a no-op if we have already completed birth round migration or if we are at genesis.
                 migratePcesToBirthRoundMode(
                         platformContext,
-                        blocks.selfId(),
+                        selfId,
                         initialState.getRound(),
                         platformStateFacade.lowestJudgeGenerationBeforeBirthRoundModeOf(initialState.getState()));
+
+                // re-load the PCES files now that they have been migrated
+                final PcesConfig pcesConfig = platformContext.getConfiguration().getConfigData(PcesConfig.class);
+                final Path databaseDir = PcesUtilities.getDatabaseDirectory(platformContext, selfId);
+                initialPcesFiles = PcesFileReader.readFilesFromDisk(
+                        platformContext, databaseDir, initialState.getRound(), pcesConfig.permitGaps(), ancientMode);
             } catch (final IOException e) {
                 throw new UncheckedIOException("Birth round migration failed during PCES migration.", e);
             }
+        } else {
+            initialPcesFiles = blocks.initialPcesFiles();
         }
 
-        selfId = blocks.selfId();
-        initialPcesFiles = blocks.initialPcesFiles();
         notificationEngine = blocks.notificationEngine();
 
         logger.info(STARTUP.getMarker(), "Starting with roster history:\n{}", blocks.rosterHistory());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -160,6 +160,17 @@ public class SwirldsPlatform implements Platform {
     private final PlatformWiring platformWiring;
 
     /**
+     * Flag to indicate whether PCES events were migrated to use birth rounds instead of generation-based ancient
+     * age. True indicates events were migrated.
+     */
+    private final boolean wereEventsMigratedToBirthRound;
+
+    /**
+     * Indicates how ancient events are determined, e.g. based on the event's birth round or generation.
+     */
+    private final AncientMode ancientMode;
+
+    /**
      * Constructor.
      *
      * @param builder this object is responsible for building platform components and other things needed by the
@@ -170,7 +181,7 @@ public class SwirldsPlatform implements Platform {
         platformContext = blocks.platformContext();
         final ConsensusStateEventHandler consensusStateEventHandler = blocks.consensusStateEventHandler();
 
-        final AncientMode ancientMode = platformContext
+        ancientMode = platformContext
                 .getConfiguration()
                 .getConfigData(EventConfig.class)
                 .getAncientMode();
@@ -188,7 +199,7 @@ public class SwirldsPlatform implements Platform {
         if (ancientMode == AncientMode.BIRTH_ROUND_THRESHOLD) {
             try {
                 // This method is a no-op if we have already completed birth round migration or if we are at genesis.
-                migratePcesToBirthRoundMode(
+                wereEventsMigratedToBirthRound = migratePcesToBirthRoundMode(
                         platformContext,
                         selfId,
                         initialState.getRound(),
@@ -203,6 +214,7 @@ public class SwirldsPlatform implements Platform {
                 throw new UncheckedIOException("Birth round migration failed during PCES migration.", e);
             }
         } else {
+            wereEventsMigratedToBirthRound = false;
             initialPcesFiles = blocks.initialPcesFiles();
         }
 
@@ -443,13 +455,17 @@ public class SwirldsPlatform implements Platform {
     private void replayPreconsensusEvents() {
         platformWiring.getStatusActionSubmitter().submitStatusAction(new StartedReplayingEventsAction());
 
-        final IOIterator<PlatformEvent> iterator =
-                initialPcesFiles.getEventIterator(initialAncientThreshold, startingRound);
+        final long lowerBound = wereEventsMigratedToBirthRound
+                ? 0L // events were migrated so set the lower bound to 0 such that all PCES events will be read
+                : initialAncientThreshold;
+
+        final IOIterator<PlatformEvent> iterator = initialPcesFiles.getEventIterator(lowerBound, startingRound);
 
         logger.info(
                 STARTUP.getMarker(),
-                "replaying preconsensus event stream starting at generation {}",
-                initialAncientThreshold);
+                "replaying preconsensus event stream starting at {} ({})",
+                lowerBound,
+                ancientMode);
 
         platformWiring.getPcesReplayerIteratorInput().inject(iterator);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/PlatformEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/PlatformEvent.java
@@ -62,11 +62,6 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
      * This latch counts down when prehandle has been called on all application transactions contained in this event.
      */
     private final CountDownLatch prehandleCompleted = new CountDownLatch(1);
-    /**
-     * The actual birth round to return. May not be the original birth round if this event was created in the software
-     * version right before the birth round migration.
-     */
-    private long birthRound;
 
     /**
      * Construct a new instance from an unsigned event and a signature.
@@ -111,7 +106,6 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
         this.senderId = null;
         this.consensusData = NO_CONSENSUS;
         Objects.requireNonNull(gossipEvent.eventCore(), "The eventCore must not be null");
-        this.birthRound = gossipEvent.eventCore().birthRound();
     }
 
     /**
@@ -146,7 +140,7 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
      * @return the descriptor for the event
      */
     public @NonNull EventDescriptorWrapper getDescriptor() {
-        return metadata.getDescriptor(getBirthRound());
+        return metadata.getDescriptor();
     }
 
     @Override
@@ -195,7 +189,7 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
      * @return the birth round of the event
      */
     public long getBirthRound() {
-        return birthRound;
+        return metadata.getBirthRound();
     }
 
     /**
@@ -319,7 +313,7 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
      * @param birthRound the birth round that has been assigned to this event
      */
     public void overrideBirthRound(final long birthRound) {
-        this.birthRound = birthRound;
+        metadata.setBirthRoundOverride(birthRound);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/PlatformEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/PlatformEvent.java
@@ -308,12 +308,15 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
 
     /**
      * Override the birth round for this event. This will only be called for events created in the software version
-     * right before the birth round migration.
+     * right before the birth round migration. Parents of this event may also have their birth round overridden if their
+     * generation is greater or equal to the specified {@code lastRoundBeforeBirthRoundMode} value.
      *
      * @param birthRound the birth round that has been assigned to this event
+     * @param lastRoundBeforeBirthRoundMode the threshold to determine if this event's parents should also have their
+     *                                      birth round overridden
      */
-    public void overrideBirthRound(final long birthRound) {
-        metadata.setBirthRoundOverride(birthRound);
+    public void overrideBirthRound(final long birthRound, final long lastRoundBeforeBirthRoundMode) {
+        metadata.setBirthRoundOverride(birthRound, lastRoundBeforeBirthRoundMode);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/PlatformEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/PlatformEvent.java
@@ -309,14 +309,14 @@ public class PlatformEvent implements ConsensusEvent, Hashable {
     /**
      * Override the birth round for this event. This will only be called for events created in the software version
      * right before the birth round migration. Parents of this event may also have their birth round overridden if their
-     * generation is greater or equal to the specified {@code lastRoundBeforeBirthRoundMode} value.
+     * generation is greater or equal to the specified {@code ancientGenerationThreshold} value.
      *
      * @param birthRound the birth round that has been assigned to this event
-     * @param lastRoundBeforeBirthRoundMode the threshold to determine if this event's parents should also have their
-     *                                      birth round overridden
+     * @param ancientGenerationThreshold the threshold to determine if this event's parents should also have their
+     *                                   birth round overridden
      */
-    public void overrideBirthRound(final long birthRound, final long lastRoundBeforeBirthRoundMode) {
-        metadata.setBirthRoundOverride(birthRound, lastRoundBeforeBirthRoundMode);
+    public void overrideBirthRound(final long birthRound, final long ancientGenerationThreshold) {
+        metadata.setBirthRoundOverride(birthRound, ancientGenerationThreshold);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/branching/DefaultBranchDetector.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/branching/DefaultBranchDetector.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.event.branching;
 
-import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
-
 import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.platform.NodeId;
 import com.swirlds.platform.consensus.EventWindow;
@@ -15,7 +13,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -70,20 +67,7 @@ public class DefaultBranchDetector implements BranchDetector {
         final EventDescriptorWrapper previousEvent = mostRecentEvents.get(creator);
         final EventDescriptorWrapper selfParent = event.getSelfParent();
 
-        // Events may have been migrated to use birth rounds and so the birth round on the event may have changed.
-        // Therefore, we will compare the hashes only (the hashes shouldn't be re-calculated to include the updated
-        // birth round)
-        final boolean branching = !(previousEvent == null
-                || (selfParent != null && Objects.equals(selfParent.hash(), previousEvent.hash())));
-
-        if (branching) {
-            logger.error(
-                    EXCEPTION.getMarker(),
-                    "Branch detected: incomingEvent={}, previousEvent={}, selfParent={}",
-                    event.getDescriptor(),
-                    previousEvent,
-                    selfParent);
-        }
+        final boolean branching = !(previousEvent == null || previousEvent.equals(selfParent));
 
         mostRecentEvents.put(creator, event.getDescriptor());
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/branching/DefaultBranchDetector.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/branching/DefaultBranchDetector.java
@@ -13,14 +13,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
 /**
  * A standard implementation of {@link BranchDetector}.
  */
 public class DefaultBranchDetector implements BranchDetector {
-    private static final Logger logger = LogManager.getLogger(DefaultBranchDetector.class);
     /**
      * The current event window.
      */

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesBirthRoundMigration.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesBirthRoundMigration.java
@@ -53,8 +53,9 @@ public final class PcesBirthRoundMigration {
      * @param migrationRound                         the round at which the migration is occurring, this will be equal
      *                                               to the round number of the initial state
      * @param minimumJudgeGenerationInMigrationRound the minimum judge generation in the migration round
+     * @return true if any events were migrated to support birth rounds, else false
      */
-    public static void migratePcesToBirthRoundMode(
+    public static boolean migratePcesToBirthRoundMode(
             @NonNull final PlatformContext platformContext,
             @NonNull final NodeId selfId,
             final long migrationRound,
@@ -69,7 +70,7 @@ public final class PcesBirthRoundMigration {
             // No migration needed if there are no PCES files in generation mode.
 
             logger.info(STARTUP.getMarker(), "PCES birth round migration is not necessary.");
-            return;
+            return false;
         } else if (!findPcesFiles(databaseDirectory, BIRTH_ROUND_THRESHOLD).isEmpty()) {
             // We've found PCES files in both birth round and generation mode.
             // This is a signal that we attempted to do the migration but crashed.
@@ -84,7 +85,7 @@ public final class PcesBirthRoundMigration {
             makeBackupFiles(platformContext.getRecycleBin(), databaseDirectory, platformContext.getConfiguration());
             cleanUpOldFiles(databaseDirectory);
 
-            return;
+            return true;
         }
 
         logger.info(
@@ -101,7 +102,7 @@ public final class PcesBirthRoundMigration {
 
         if (eventsToMigrate.isEmpty()) {
             logger.error(EXCEPTION.getMarker(), "No events to migrate. PCES birth round migration aborted.");
-            return;
+            return false;
         }
 
         migrateEvents(platformContext, selfId, eventsToMigrate, migrationRound);
@@ -109,6 +110,7 @@ public final class PcesBirthRoundMigration {
         cleanUpOldFiles(databaseDirectory);
 
         logger.info(STARTUP.getMarker(), "PCES birth round migration complete.");
+        return true;
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileIterator.java
@@ -4,7 +4,6 @@ package com.swirlds.platform.event.preconsensus;
 import com.hedera.hapi.platform.event.GossipEvent;
 import com.swirlds.common.io.IOIterator;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
-import com.swirlds.platform.consensus.ConsensusConstants;
 import com.swirlds.platform.event.AncientMode;
 import com.swirlds.platform.event.PlatformEvent;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -72,12 +71,8 @@ public class PcesFileIterator implements IOIterator<PlatformEvent> {
                         switch (fileVersion) {
                             case PROTOBUF_EVENTS -> new PlatformEvent(stream.readPbjRecord(GossipEvent.PROTOBUF));
                         };
-                final long candidateAncientIndicator = candidate.getAncientIndicator(fileType);
-                final boolean isEqualToOrGreaterThanLowerBound = candidateAncientIndicator >= lowerBound;
-                // We also want to read events that might have been migrated to birth rounds
-                final boolean isInitialBirthRoundEvent = AncientMode.BIRTH_ROUND_THRESHOLD == fileType
-                        && candidateAncientIndicator == ConsensusConstants.ROUND_FIRST;
-                if (isEqualToOrGreaterThanLowerBound || isInitialBirthRoundEvent) {
+
+                if (candidate.getAncientIndicator(fileType) >= lowerBound) {
                     next = candidate;
                 }
             } catch (final IOException e) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileIterator.java
@@ -4,6 +4,7 @@ package com.swirlds.platform.event.preconsensus;
 import com.hedera.hapi.platform.event.GossipEvent;
 import com.swirlds.common.io.IOIterator;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
+import com.swirlds.platform.consensus.ConsensusConstants;
 import com.swirlds.platform.event.AncientMode;
 import com.swirlds.platform.event.PlatformEvent;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -71,7 +72,12 @@ public class PcesFileIterator implements IOIterator<PlatformEvent> {
                         switch (fileVersion) {
                             case PROTOBUF_EVENTS -> new PlatformEvent(stream.readPbjRecord(GossipEvent.PROTOBUF));
                         };
-                if (candidate.getAncientIndicator(fileType) >= lowerBound) {
+                final long candidateAncientIndicator = candidate.getAncientIndicator(fileType);
+                final boolean isEqualToOrGreaterThanLowerBound = candidateAncientIndicator >= lowerBound;
+                // We also want to read events that might have been migrated to birth rounds
+                final boolean isInitialBirthRoundEvent = AncientMode.BIRTH_ROUND_THRESHOLD == fileType
+                        && candidateAncientIndicator == ConsensusConstants.ROUND_FIRST;
+                if (isEqualToOrGreaterThanLowerBound || isInitialBirthRoundEvent) {
                     next = candidate;
                 }
             } catch (final IOException e) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileIterator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileIterator.java
@@ -71,7 +71,6 @@ public class PcesFileIterator implements IOIterator<PlatformEvent> {
                         switch (fileVersion) {
                             case PROTOBUF_EVENTS -> new PlatformEvent(stream.readPbjRecord(GossipEvent.PROTOBUF));
                         };
-
                 if (candidate.getAncientIndicator(fileType) >= lowerBound) {
                     next = candidate;
                 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/BirthRoundStateMigration.java
@@ -5,7 +5,6 @@ import static com.swirlds.logging.legacy.LogMarker.STARTUP;
 
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.hedera.hapi.platform.state.MinimumJudgeInfo;
-import com.swirlds.common.merkle.crypto.MerkleCryptoFactory;
 import com.swirlds.platform.event.AncientMode;
 import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.SignedState;
@@ -94,6 +93,5 @@ public final class BirthRoundStateMigration {
         platformStateFacade.setSnapshotTo(state, modifiedConsensusSnapshot);
 
         state.invalidateHash();
-        MerkleCryptoFactory.getInstance().digestTreeSync(state.getRoot());
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DefaultBirthRoundMigrationShim.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DefaultBirthRoundMigrationShim.java
@@ -98,11 +98,21 @@ public class DefaultBirthRoundMigrationShim implements BirthRoundMigrationShim {
             if (event.getGeneration() >= lowestJudgeGenerationBeforeBirthRoundMode) {
                 // Any event with a generation greater than or equal to the lowest pre-migration judge generation
                 // is given a birth round that will be non-ancient at migration time.
+                logger.info(
+                        STARTUP.getMarker(),
+                        "Event migrated to use birth rounds prev={} new={} (non-ancient)",
+                        event.getBirthRound(),
+                        lastRoundBeforeBirthRoundMode);
                 event.overrideBirthRound(lastRoundBeforeBirthRoundMode);
                 shimBarelyNonAncientEvents.cycle();
             } else {
                 // All other pre-migration events are given a birth round that will
                 // cause them to be immediately ancient.
+                logger.info(
+                        STARTUP.getMarker(),
+                        "Event migrated to use birth rounds prev={} new={} (ancient)",
+                        event.getBirthRound(),
+                        ROUND_FIRST);
                 event.overrideBirthRound(ROUND_FIRST);
                 shimAncientEvents.cycle();
             }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DefaultBirthRoundMigrationShim.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DefaultBirthRoundMigrationShim.java
@@ -103,7 +103,7 @@ public class DefaultBirthRoundMigrationShim implements BirthRoundMigrationShim {
                         "Event migrated to use birth rounds prev={} new={} (non-ancient)",
                         event.getBirthRound(),
                         lastRoundBeforeBirthRoundMode);
-                event.overrideBirthRound(lastRoundBeforeBirthRoundMode);
+                event.overrideBirthRound(lastRoundBeforeBirthRoundMode, lowestJudgeGenerationBeforeBirthRoundMode);
                 shimBarelyNonAncientEvents.cycle();
             } else {
                 // All other pre-migration events are given a birth round that will
@@ -113,7 +113,7 @@ public class DefaultBirthRoundMigrationShim implements BirthRoundMigrationShim {
                         "Event migrated to use birth rounds prev={} new={} (ancient)",
                         event.getBirthRound(),
                         ROUND_FIRST);
-                event.overrideBirthRound(ROUND_FIRST);
+                event.overrideBirthRound(ROUND_FIRST, lastRoundBeforeBirthRoundMode);
                 shimAncientEvents.cycle();
             }
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DefaultBirthRoundMigrationShim.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DefaultBirthRoundMigrationShim.java
@@ -113,7 +113,7 @@ public class DefaultBirthRoundMigrationShim implements BirthRoundMigrationShim {
                         "Event migrated to use birth rounds prev={} new={} (ancient)",
                         event.getBirthRound(),
                         ROUND_FIRST);
-                event.overrideBirthRound(ROUND_FIRST, lastRoundBeforeBirthRoundMode);
+                event.overrideBirthRound(ROUND_FIRST, lowestJudgeGenerationBeforeBirthRoundMode);
                 shimAncientEvents.cycle();
             }
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DefaultBirthRoundMigrationShim.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/DefaultBirthRoundMigrationShim.java
@@ -98,7 +98,7 @@ public class DefaultBirthRoundMigrationShim implements BirthRoundMigrationShim {
             if (event.getGeneration() >= lowestJudgeGenerationBeforeBirthRoundMode) {
                 // Any event with a generation greater than or equal to the lowest pre-migration judge generation
                 // is given a birth round that will be non-ancient at migration time.
-                logger.info(
+                logger.debug(
                         STARTUP.getMarker(),
                         "Event migrated to use birth rounds prev={} new={} (non-ancient)",
                         event.getBirthRound(),
@@ -108,7 +108,7 @@ public class DefaultBirthRoundMigrationShim implements BirthRoundMigrationShim {
             } else {
                 // All other pre-migration events are given a birth round that will
                 // cause them to be immediately ancient.
-                logger.info(
+                logger.debug(
                         STARTUP.getMarker(),
                         "Event migrated to use birth rounds prev={} new={} (ancient)",
                         event.getBirthRound(),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventMetadata.java
@@ -59,7 +59,11 @@ public class EventMetadata extends AbstractHashable {
      */
     private Long birthRoundOverride = null;
 
-    private Long birthRound;
+    /**
+     * The birth round that was initialized to the event. This may be overridden at a later time via
+     * {@link #setBirthRoundOverride(long)}.
+     */
+    private final long birthRound;
 
     /**
      * Create a EventMetadata object

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventMetadata.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/EventMetadata.java
@@ -241,14 +241,15 @@ public class EventMetadata extends AbstractHashable {
     }
 
     /**
-     * Override the birth round for this event and potentially any parents associated with the event. Parents will be
-     * overridden if their generation is equal to or greater than the round before birth round migration was enabled.
+     * Override the birth round for this event and potentially any parents associated with the event. Parents will
+     * have their birth round overridden if their  generation is greater or equal to the specified
+     * {@code ancientGenerationThreshold} value.
      *
      * @param birthRound the birth round to use for this event and potential parents
-     * @param lastRoundBeforeBirthRoundMode the threshold used to determine if parents will also have their birth round
-     *                                      overridden
+     * @param ancientGenerationThreshold the threshold used to determine if parents will also have their birth round
+     *                                   overridden
      */
-    public void setBirthRoundOverride(final long birthRound, final long lastRoundBeforeBirthRoundMode) {
+    public void setBirthRoundOverride(final long birthRound, final long ancientGenerationThreshold) {
         if (birthRoundOverride != null) {
             throw new IllegalStateException(
                     "The birth round has already been overridden, you cannot override it again");
@@ -256,7 +257,7 @@ public class EventMetadata extends AbstractHashable {
 
         birthRoundOverride = birthRound;
 
-        if (selfParent != null && selfParent.eventDescriptor().generation() >= lastRoundBeforeBirthRoundMode) {
+        if (selfParent != null && selfParent.eventDescriptor().generation() >= ancientGenerationThreshold) {
             selfParent = new EventDescriptorWrapper(new EventDescriptor(
                     selfParent.eventDescriptor().hash(),
                     selfParent.eventDescriptor().creatorNodeId(),
@@ -266,7 +267,7 @@ public class EventMetadata extends AbstractHashable {
 
         otherParents = otherParents.stream()
                 .map(parent -> {
-                    if (parent.eventDescriptor().generation() >= lastRoundBeforeBirthRoundMode) {
+                    if (parent.eventDescriptor().generation() >= ancientGenerationThreshold) {
                         return new EventDescriptorWrapper(new EventDescriptor(
                                 parent.eventDescriptor().hash(),
                                 parent.eventDescriptor().creatorNodeId(),

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/UnsignedEvent.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/events/UnsignedEvent.java
@@ -55,7 +55,7 @@ public class UnsignedEvent implements Hashable {
             @NonNull final Instant timeCreated,
             @NonNull final List<Bytes> transactions) {
         this.transactions = Objects.requireNonNull(transactions, "transactions must not be null");
-        this.metadata = new EventMetadata(creatorId, selfParent, otherParents, timeCreated, transactions);
+        this.metadata = new EventMetadata(creatorId, selfParent, otherParents, timeCreated, transactions, birthRound);
         this.eventCore = new EventCore(
                 creatorId.id(),
                 birthRound,
@@ -95,7 +95,7 @@ public class UnsignedEvent implements Hashable {
      */
     @NonNull
     public EventDescriptorWrapper getDescriptor() {
-        return metadata.getDescriptor(eventCore.birthRound());
+        return metadata.getDescriptor();
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/events/EventMetadataTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/events/EventMetadataTest.java
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.platform.system.events;
+
+import static com.swirlds.common.test.fixtures.RandomUtils.getRandomPrintSeed;
+import static com.swirlds.common.test.fixtures.RandomUtils.randomHash;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.hapi.platform.event.EventDescriptor;
+import com.swirlds.common.platform.NodeId;
+import java.time.Instant;
+import java.util.List;
+import java.util.Random;
+import org.junit.jupiter.api.Test;
+
+class EventMetadataTest {
+
+    @Test
+    void testBirthRoundOverride() {
+        final Random random = getRandomPrintSeed(0);
+        final EventDescriptorWrapper baseSelfParent = new EventDescriptorWrapper(
+                new EventDescriptor(randomHash(random).getBytes(), 0, 1, 100));
+        final EventDescriptorWrapper baseOtherParent = new EventDescriptorWrapper(
+                new EventDescriptor(randomHash(random).getBytes(), 1, 1, 100));
+        final EventMetadata metadata =
+                new EventMetadata(NodeId.of(0), baseSelfParent, List.of(baseOtherParent), Instant.now(), List.of(), 1);
+
+        // validate that everything works as expected before the birth round override
+        {
+            final EventDescriptorWrapper selfParent = metadata.getSelfParent();
+            assertNotNull(selfParent);
+            assertEquals(1, selfParent.eventDescriptor().birthRound());
+            assertEquals(0, selfParent.eventDescriptor().creatorNodeId());
+            assertEquals(100, selfParent.eventDescriptor().generation());
+
+            final List<EventDescriptorWrapper> otherParents = metadata.getOtherParents();
+            assertEquals(1, otherParents.size());
+            final EventDescriptorWrapper otherParent = otherParents.getFirst();
+            assertNotNull(otherParent);
+            assertEquals(1, otherParent.eventDescriptor().birthRound());
+            assertEquals(1, otherParent.eventDescriptor().creatorNodeId());
+            assertEquals(100, otherParent.eventDescriptor().generation());
+        }
+
+        // override the birth round
+        metadata.setBirthRoundOverride(10);
+
+        // validate that the birth round has been overridden with all other properties unchanged
+        {
+            final EventDescriptorWrapper selfParent = metadata.getSelfParent();
+            assertNotNull(selfParent);
+            assertEquals(10, selfParent.eventDescriptor().birthRound());
+            assertEquals(0, selfParent.eventDescriptor().creatorNodeId());
+            assertEquals(100, selfParent.eventDescriptor().generation());
+
+            final List<EventDescriptorWrapper> otherParents = metadata.getOtherParents();
+            assertEquals(1, otherParents.size());
+            final EventDescriptorWrapper otherParent = otherParents.getFirst();
+            assertNotNull(otherParent);
+            assertEquals(10, otherParent.eventDescriptor().birthRound());
+            assertEquals(1, otherParent.eventDescriptor().creatorNodeId());
+            assertEquals(100, otherParent.eventDescriptor().generation());
+        }
+    }
+
+    @Test
+    void testMultipleBirthRoundOverrides() {
+        final Random random = getRandomPrintSeed(0);
+        final EventDescriptorWrapper baseSelfParent = new EventDescriptorWrapper(
+                new EventDescriptor(randomHash(random).getBytes(), 0, 1, 100));
+        final EventDescriptorWrapper baseOtherParent = new EventDescriptorWrapper(
+                new EventDescriptor(randomHash(random).getBytes(), 1, 1, 100));
+        final EventMetadata metadata =
+                new EventMetadata(NodeId.of(0), baseSelfParent, List.of(baseOtherParent), Instant.now(), List.of(), 1);
+
+        metadata.setBirthRoundOverride(150);
+
+        // trying to override it again should fail
+        assertThrows(IllegalStateException.class, () -> metadata.setBirthRoundOverride(200));
+
+        // validate that the birth round has been overridden with the first call only
+        {
+            final EventDescriptorWrapper selfParent = metadata.getSelfParent();
+            assertNotNull(selfParent);
+            assertEquals(150, selfParent.eventDescriptor().birthRound());
+            assertEquals(0, selfParent.eventDescriptor().creatorNodeId());
+            assertEquals(100, selfParent.eventDescriptor().generation());
+
+            final List<EventDescriptorWrapper> otherParents = metadata.getOtherParents();
+            assertEquals(1, otherParents.size());
+            final EventDescriptorWrapper otherParent = otherParents.getFirst();
+            assertNotNull(otherParent);
+            assertEquals(150, otherParent.eventDescriptor().birthRound());
+            assertEquals(1, otherParent.eventDescriptor().creatorNodeId());
+            assertEquals(100, otherParent.eventDescriptor().generation());
+        }
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/events/EventMetadataTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/events/EventMetadataTest.java
@@ -19,81 +19,93 @@ class EventMetadataTest {
     @Test
     void testBirthRoundOverride() {
         final Random random = getRandomPrintSeed(0);
-        final EventDescriptorWrapper baseSelfParent = new EventDescriptorWrapper(
+        final EventDescriptorWrapper selfParent = new EventDescriptorWrapper(
                 new EventDescriptor(randomHash(random).getBytes(), 0, 1, 100));
-        final EventDescriptorWrapper baseOtherParent = new EventDescriptorWrapper(
+        final EventDescriptorWrapper otherParent = new EventDescriptorWrapper(
                 new EventDescriptor(randomHash(random).getBytes(), 1, 1, 100));
         final EventMetadata metadata =
-                new EventMetadata(NodeId.of(0), baseSelfParent, List.of(baseOtherParent), Instant.now(), List.of(), 1);
+                new EventMetadata(NodeId.of(0), selfParent, List.of(otherParent), Instant.now(), List.of(), 1);
 
         // validate that everything works as expected before the birth round override
-        {
-            final EventDescriptorWrapper selfParent = metadata.getSelfParent();
-            assertNotNull(selfParent);
-            assertEquals(1, selfParent.eventDescriptor().birthRound());
-            assertEquals(0, selfParent.eventDescriptor().creatorNodeId());
-            assertEquals(100, selfParent.eventDescriptor().generation());
-
-            final List<EventDescriptorWrapper> otherParents = metadata.getOtherParents();
-            assertEquals(1, otherParents.size());
-            final EventDescriptorWrapper otherParent = otherParents.getFirst();
-            assertNotNull(otherParent);
-            assertEquals(1, otherParent.eventDescriptor().birthRound());
-            assertEquals(1, otherParent.eventDescriptor().creatorNodeId());
-            assertEquals(100, otherParent.eventDescriptor().generation());
-        }
+        verifyEvent(metadata, 0, 101, 1);
+        verifyEvent(metadata.getSelfParent(), 0, 100, 1);
+        final List<EventDescriptorWrapper> otherParentsBeforeOverride = metadata.getOtherParents();
+        assertEquals(1, otherParentsBeforeOverride.size());
+        verifyEvent(otherParentsBeforeOverride.getFirst(), 1, 100, 1);
 
         // override the birth round
-        metadata.setBirthRoundOverride(10);
+        final long newBirthRound = 100L;
+        metadata.setBirthRoundOverride(newBirthRound, 100);
 
         // validate that the birth round has been overridden with all other properties unchanged
-        {
-            final EventDescriptorWrapper selfParent = metadata.getSelfParent();
-            assertNotNull(selfParent);
-            assertEquals(10, selfParent.eventDescriptor().birthRound());
-            assertEquals(0, selfParent.eventDescriptor().creatorNodeId());
-            assertEquals(100, selfParent.eventDescriptor().generation());
-
-            final List<EventDescriptorWrapper> otherParents = metadata.getOtherParents();
-            assertEquals(1, otherParents.size());
-            final EventDescriptorWrapper otherParent = otherParents.getFirst();
-            assertNotNull(otherParent);
-            assertEquals(10, otherParent.eventDescriptor().birthRound());
-            assertEquals(1, otherParent.eventDescriptor().creatorNodeId());
-            assertEquals(100, otherParent.eventDescriptor().generation());
-        }
+        verifyEvent(metadata, 0, 101, newBirthRound);
+        verifyEvent(metadata.getSelfParent(), 0, 100, newBirthRound);
+        final List<EventDescriptorWrapper> otherParentsAfterOverride = metadata.getOtherParents();
+        assertEquals(1, otherParentsAfterOverride.size());
+        verifyEvent(otherParentsAfterOverride.getFirst(), 1, 100, newBirthRound);
     }
 
     @Test
     void testMultipleBirthRoundOverrides() {
         final Random random = getRandomPrintSeed(0);
-        final EventDescriptorWrapper baseSelfParent = new EventDescriptorWrapper(
+        final EventDescriptorWrapper selfParent = new EventDescriptorWrapper(
                 new EventDescriptor(randomHash(random).getBytes(), 0, 1, 100));
-        final EventDescriptorWrapper baseOtherParent = new EventDescriptorWrapper(
+        final EventDescriptorWrapper otherParent = new EventDescriptorWrapper(
                 new EventDescriptor(randomHash(random).getBytes(), 1, 1, 100));
         final EventMetadata metadata =
-                new EventMetadata(NodeId.of(0), baseSelfParent, List.of(baseOtherParent), Instant.now(), List.of(), 1);
+                new EventMetadata(NodeId.of(0), selfParent, List.of(otherParent), Instant.now(), List.of(), 1);
 
-        metadata.setBirthRoundOverride(150);
+        final long newBirthRound = 150;
+        metadata.setBirthRoundOverride(newBirthRound, 100);
 
         // trying to override it again should fail
-        assertThrows(IllegalStateException.class, () -> metadata.setBirthRoundOverride(200));
+        assertThrows(IllegalStateException.class, () -> metadata.setBirthRoundOverride(200, 100));
 
         // validate that the birth round has been overridden with the first call only
-        {
-            final EventDescriptorWrapper selfParent = metadata.getSelfParent();
-            assertNotNull(selfParent);
-            assertEquals(150, selfParent.eventDescriptor().birthRound());
-            assertEquals(0, selfParent.eventDescriptor().creatorNodeId());
-            assertEquals(100, selfParent.eventDescriptor().generation());
+        verifyEvent(metadata, 0, 101, newBirthRound);
+        verifyEvent(metadata.getSelfParent(), 0, 100, newBirthRound);
+        final List<EventDescriptorWrapper> otherParentsAfterOverride = metadata.getOtherParents();
+        assertEquals(1, otherParentsAfterOverride.size());
+        verifyEvent(otherParentsAfterOverride.getFirst(), 1, 100, newBirthRound);
+    }
 
-            final List<EventDescriptorWrapper> otherParents = metadata.getOtherParents();
-            assertEquals(1, otherParents.size());
-            final EventDescriptorWrapper otherParent = otherParents.getFirst();
-            assertNotNull(otherParent);
-            assertEquals(150, otherParent.eventDescriptor().birthRound());
-            assertEquals(1, otherParent.eventDescriptor().creatorNodeId());
-            assertEquals(100, otherParent.eventDescriptor().generation());
-        }
+    @Test
+    void testBirthRoundOverrideWithAncientParents() {
+        final Random random = getRandomPrintSeed(0);
+        final EventDescriptorWrapper selfParent = new EventDescriptorWrapper(
+                new EventDescriptor(randomHash(random).getBytes(), 0, 1, 100));
+        final EventDescriptorWrapper otherParent = new EventDescriptorWrapper(
+                new EventDescriptor(randomHash(random).getBytes(), 1, 1, 90));
+        final EventMetadata metadata =
+                new EventMetadata(NodeId.of(0), selfParent, List.of(otherParent), Instant.now(), List.of(), 1);
+
+        final long newBirthRound = 50;
+        metadata.setBirthRoundOverride(newBirthRound, 100);
+
+        // the self parent is not ancient so its birth round should be updated, but the other parent should not
+        verifyEvent(metadata, 0, 101, newBirthRound);
+        verifyEvent(metadata.getSelfParent(), 0, 100, newBirthRound);
+        final List<EventDescriptorWrapper> otherParentsAfterOverride = metadata.getOtherParents();
+        assertEquals(1, otherParentsAfterOverride.size());
+        verifyEvent(otherParentsAfterOverride.getFirst(), 1, 90, 1);
+    }
+
+    private void verifyEvent(final EventMetadata metadata, final long expectedCreatorNodeId, final long expectedGeneration, final long expectedBirthRound) {
+        assertNotNull(metadata);
+
+        assertEquals(expectedCreatorNodeId, metadata.getCreatorId().id());
+        assertEquals(expectedGeneration, metadata.getGeneration());
+        assertEquals(expectedBirthRound, metadata.getBirthRound());
+    }
+
+    private void verifyEvent(final EventDescriptorWrapper actualDescriptorWrapper, final long expectedCreatorNodeId, final long expectedGeneration, final long expectedBirthRound) {
+        assertNotNull(actualDescriptorWrapper);
+
+        final EventDescriptor actualDescriptor = actualDescriptorWrapper.eventDescriptor();
+        assertNotNull(actualDescriptor);
+
+        assertEquals(expectedCreatorNodeId, actualDescriptor.creatorNodeId());
+        assertEquals(expectedGeneration, actualDescriptor.generation());
+        assertEquals(expectedBirthRound, actualDescriptor.birthRound());
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/events/EventMetadataTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/system/events/EventMetadataTest.java
@@ -90,7 +90,11 @@ class EventMetadataTest {
         verifyEvent(otherParentsAfterOverride.getFirst(), 1, 90, 1);
     }
 
-    private void verifyEvent(final EventMetadata metadata, final long expectedCreatorNodeId, final long expectedGeneration, final long expectedBirthRound) {
+    private void verifyEvent(
+            final EventMetadata metadata,
+            final long expectedCreatorNodeId,
+            final long expectedGeneration,
+            final long expectedBirthRound) {
         assertNotNull(metadata);
 
         assertEquals(expectedCreatorNodeId, metadata.getCreatorId().id());
@@ -98,7 +102,11 @@ class EventMetadataTest {
         assertEquals(expectedBirthRound, metadata.getBirthRound());
     }
 
-    private void verifyEvent(final EventDescriptorWrapper actualDescriptorWrapper, final long expectedCreatorNodeId, final long expectedGeneration, final long expectedBirthRound) {
+    private void verifyEvent(
+            final EventDescriptorWrapper actualDescriptorWrapper,
+            final long expectedCreatorNodeId,
+            final long expectedGeneration,
+            final long expectedBirthRound) {
         assertNotNull(actualDescriptorWrapper);
 
         final EventDescriptor actualDescriptor = actualDescriptorWrapper.eventDescriptor();


### PR DESCRIPTION
**Description**:
This PR creates a HAPI test for birth round migrations.

With that in mind, there are also a couple of code changes included that move us closer to having birth rounds functional. These changes include:
- Re-reading the PCES files after the files have been converted from generation-based to birth round-based. This needs to be done because the PCES files are loaded on startup and the migration replaces those old PCES files with the new migrated ones.
- Remove re-calculating the hashes as the final state in the `BirthRoundStateMigration` because later in startup we expect the state to not be hashed.
- When a birth round migration has happened, set the lower bound to 0 when reading the PCES events such that they are all read and not prematurely filtered out.
- Override the birth round for the event itself and it's parents - if the event was migrated to birth rounds.
- Update the platform wiring such that if the birth round event migration is enabled, have it execute _after_ the `EventHasher` instead of before it. This is to avoid re-calculating hashes with the revised birth rounds. This does create a slight deviation from the event contents vs the hash. Since the birth round has changed, technically the hash no longer "matches" the event itself. However, if we recalculate the hash with the updated birth round, then the hashgraph itself will become disjointed.

**Related issue(s)**:

Fixes #17793