### PR TITLE
feat: Make base read and write state classes more customizable by constructor overload

### DIFF
--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/ReadableKVStateBase.java
@@ -25,9 +25,9 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * changed before we got to handle transaction. If the value is "null", this means it was NOT
      * FOUND when we looked it up.
      */
-    private final ConcurrentMap<K, V> readCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<K, V> readCache;
 
-    private final Set<K> unmodifiableReadKeys = Collections.unmodifiableSet(readCache.keySet());
+    private final Set<K> unmodifiableReadKeys;
 
     private static final Object marker = new Object();
 
@@ -37,7 +37,20 @@ public abstract class ReadableKVStateBase<K, V> implements ReadableKVState<K, V>
      * @param stateKey The state key. Cannot be null.
      */
     protected ReadableKVStateBase(@NonNull String stateKey) {
+        this(stateKey, new ConcurrentHashMap<>());
+    }
+
+    /**
+     * Create a new StateBase from the provided map.
+     *
+     * @param stateKey The state key. Cannot be null.
+     * @param readCache A map that is used to init the cache.
+     */
+    // This constructor is used by some consumers of the API that are outside of this repository.
+    protected ReadableKVStateBase(@NonNull String stateKey, @NonNull ConcurrentMap<K, V> readCache) {
         this.stateKey = Objects.requireNonNull(stateKey);
+        this.readCache = Objects.requireNonNull(readCache);
+        this.unmodifiableReadKeys = Collections.unmodifiableSet(readCache.keySet());
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/spi/WritableKVStateBase.java
@@ -15,7 +15,7 @@ import java.util.*;
  */
 public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V> implements WritableKVState<K, V> {
     /** A map of all modified values buffered in this mutable state */
-    private final Map<K, V> modifications = new LinkedHashMap<>();
+    private final Map<K, V> modifications;
     /**
      * A list of listeners to be notified of changes to the state.
      */
@@ -27,7 +27,18 @@ public abstract class WritableKVStateBase<K, V> extends ReadableKVStateBase<K, V
      * @param stateKey The state key. Cannot be null.
      */
     protected WritableKVStateBase(@NonNull final String stateKey) {
+        this(stateKey, new LinkedHashMap<>());
+    }
+
+    /**
+     * Create a new StateBase from the provided map.
+     *
+     * @param stateKey The state key. Cannot be null.
+     * @param modifications A map that is used to init the cache.
+     */
+    protected WritableKVStateBase(@NonNull final String stateKey, @NonNull final Map<K, V> modifications) {
         super(stateKey);
+        this.modifications = Objects.requireNonNull(modifications);
     }
 
     /**


### PR DESCRIPTION
**Description:**
This PR modifies `ReadableKVStateBase` and `WritableKVStateBase` classes in order to make the read and write cache more customizable as a structure. This change is needed for the mirror node team in order to substitute our own scoped value based cache for concurrency reasons with historical state.

This PR is opened as a substitute for https://github.com/hiero-ledger/hiero-consensus-node/pull/17819

Fixes: #17818


----

**Important notes:**
This PR was recreated from: https://github.com/hiero-ledger/hiero-consensus-node/pull/17943
Author: @bilyana-gospodinova 
