### PR TITLE
fix: Update expiry when adminKey is not set and autoRenew is set

### DIFF
--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusUpdateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusUpdateTopicHandler.java
@@ -167,12 +167,15 @@ public class ConsensusUpdateTopicHandler implements TransactionHandler {
         // preHandle already checks for topic existence, so topic should never be null.
 
         // First validate this topic is mutable; and the pending mutations are allowed
-        validateFalse(topic.adminKey() == null && wantsToMutateNonExpiryField(op), UNAUTHORIZED);
-        if (!(op.hasAutoRenewAccount() && designatesAccountRemoval(op.autoRenewAccount()))
-                && topic.hasAutoRenewAccountId()) {
-            validateFalse(
-                    !topic.hasAdminKey() || (op.hasAdminKey() && isEmpty(op.adminKey())),
-                    AUTORENEW_ACCOUNT_NOT_ALLOWED);
+        if (wantsToMutateNonExpiryField(op)) {
+            validateTrue(topic.hasAdminKey(), UNAUTHORIZED);
+            final var opRemovesAutoRenewId =
+                    op.hasAutoRenewAccount() && designatesAccountRemoval(op.autoRenewAccount());
+            if (!opRemovesAutoRenewId && topic.hasAutoRenewAccountId()) {
+                validateFalse(
+                        !topic.hasAdminKey() || (op.hasAdminKey() && isEmpty(op.adminKey())),
+                        AUTORENEW_ACCOUNT_NOT_ALLOWED);
+            }
         }
 
         validateMaybeNewAttributes(handleContext, op, topic);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenUpdateSpecs.java
@@ -118,12 +118,12 @@ public class TokenUpdateSpecs {
                         newKeyNamed("pauseKey"),
                         newKeyNamed("newPauseKey"),
                         tokenCreate("primary")
+                                .autoRenewAccount(civilian)
                                 .name(saltedName)
                                 .entityMemo(originalMemo)
                                 .treasury(TOKEN_TREASURY)
                                 .initialSupply(500)
                                 .decimals(1)
-                                .adminKey("adminKey")
                                 .freezeKey("freezeKey")
                                 .kycKey("kycKey")
                                 .supplyKey("supplyKey")


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/18045

Allow setting expiry when adminKey is not set and autoRenewAccount is set