### PR TITLE
chore: cherry-pick: Change some log info statements to debug level in `FileBlockItemWriter`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
@@ -127,7 +127,9 @@ public class FileBlockItemWriter implements BlockItemWriter {
         }
 
         state = State.OPEN;
-        logger.info("Started new block in FileBlockItemWriter {}", blockNumber);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Started new block in FileBlockItemWriter {}", blockNumber);
+        }
     }
 
     @Override
@@ -158,7 +160,9 @@ public class FileBlockItemWriter implements BlockItemWriter {
         try {
             writableStreamingData.close();
             state = State.CLOSED;
-            logger.info("Closed block in FileBlockItemWriter {}", blockNumber);
+            if (logger.isDebugEnabled()) {
+                logger.debug("Closed block in FileBlockItemWriter {}", blockNumber);
+            }
 
             // Write a .mf file to indicate that the block file is complete.
             final Path markerFile = getBlockFilePath(blockNumber).resolveSibling(longToFileName(blockNumber) + ".mf");


### PR DESCRIPTION
**Description**:
This pull request cherry-picks the changes to the logging level in the `FileBlockItemWriter` class.

Logging level adjustments:

* [`hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java`](diffhunk://#diff-c7ba90e615b00d8264c70c4eab891ed4e504538d4a19e157d2d2f6ae562026afL130-R132): Changed the logging level from `info` to `debug` for the messages indicating the start and close of a block, and added checks to ensure these messages are only logged if debug logging is enabled. [[1]](diffhunk://#diff-c7ba90e615b00d8264c70c4eab891ed4e504538d4a19e157d2d2f6ae562026afL130-R132) [[2]](diffhunk://#diff-c7ba90e615b00d8264c70c4eab891ed4e504538d4a19e157d2d2f6ae562026afL161-R165)

**Related issue(s)**:

Fixes #18069 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
