### PR TITLE
fix: Update looking up alias in ReadableAccountStore

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -57,6 +57,7 @@ import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.AutoCreationConfig;
 import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.EntitiesConfig;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LazyCreationConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.SchedulingConfig;
@@ -625,8 +626,8 @@ public class ThrottleAccumulator {
             if (ethTxData == null) {
                 return UNKNOWN_NUM_IMPLICIT_CREATIONS;
             }
-
-            final boolean doesNotExist = !accountStore.containsAlias(0, 0, Bytes.wrap(ethTxData.to()));
+            final var config = configSupplier.get().getConfigData(HederaConfig.class);
+            final boolean doesNotExist = !accountStore.containsAlias(config.shard(), config.realm(), Bytes.wrap(ethTxData.to()));
             if (doesNotExist && ethTxData.value().compareTo(BigInteger.ZERO) > 0) {
                 implicitCreationsCount++;
             }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -627,7 +627,8 @@ public class ThrottleAccumulator {
                 return UNKNOWN_NUM_IMPLICIT_CREATIONS;
             }
             final var config = configSupplier.get().getConfigData(HederaConfig.class);
-            final boolean doesNotExist = !accountStore.containsAlias(config.shard(), config.realm(), Bytes.wrap(ethTxData.to()));
+            final boolean doesNotExist =
+                    !accountStore.containsAlias(config.shard(), config.realm(), Bytes.wrap(ethTxData.to()));
             if (doesNotExist && ethTxData.value().compareTo(BigInteger.ZERO) > 0) {
                 implicitCreationsCount++;
             }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -626,7 +626,7 @@ public class ThrottleAccumulator {
                 return UNKNOWN_NUM_IMPLICIT_CREATIONS;
             }
 
-            final boolean doesNotExist = !accountStore.containsAlias(Bytes.wrap(ethTxData.to()));
+            final boolean doesNotExist = !accountStore.containsAlias(0, 0, Bytes.wrap(ethTxData.to()));
             if (doesNotExist && ethTxData.value().compareTo(BigInteger.ZERO) > 0) {
                 implicitCreationsCount++;
             }
@@ -746,7 +746,7 @@ public class ThrottleAccumulator {
             if (isOfEvmAddressSize(alias) && isEntityNumAlias(alias, idOrAlias.shardNum(), idOrAlias.realmNum())) {
                 return false;
             }
-            return accountStore.getAccountIDByAlias(alias) == null;
+            return accountStore.getAccountIDByAlias(idOrAlias.shardNum(), idOrAlias.realmNum(), alias) == null;
         }
         return false;
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -748,7 +748,8 @@ public class ThrottleAccumulator {
             if (isOfEvmAddressSize(alias) && isEntityNumAlias(alias, idOrAlias.shardNum(), idOrAlias.realmNum())) {
                 return false;
             }
-            return accountStore.getAccountIDByAlias(idOrAlias.shardNum(), idOrAlias.realmNum(), alias) == null;
+            final var config = configSupplier.get().getConfigData(HederaConfig.class);
+            return accountStore.getAccountIDByAlias(config.shard(), config.realm(), alias) == null;
         }
         return false;
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -748,8 +748,7 @@ public class ThrottleAccumulator {
             if (isOfEvmAddressSize(alias) && isEntityNumAlias(alias, idOrAlias.shardNum(), idOrAlias.realmNum())) {
                 return false;
             }
-            final var config = configSupplier.get().getConfigData(HederaConfig.class);
-            return accountStore.getAccountIDByAlias(config.shard(), config.realm(), alias) == null;
+            return accountStore.getAccountIDByAlias(idOrAlias.shardNum(), idOrAlias.realmNum(), alias) == null;
         }
         return false;
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletions.java
@@ -21,6 +21,7 @@ import com.hedera.node.app.signature.impl.SignatureVerificationImpl;
 import com.hedera.node.app.spi.signatures.SignatureVerification;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.workflows.handle.Dispatch;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -87,7 +88,8 @@ public class HollowAccountCompletions {
         if (maybeEthTxSigs != null) {
             final var alias = Bytes.wrap(maybeEthTxSigs.address());
             final var accountStore = userTxn.readableStoreFactory().getStore(ReadableAccountStore.class);
-            final var maybeHollowAccountId = accountStore.getAccountIDByAlias(alias);
+            final var config = userTxn.config().getConfigData(HederaConfig.class);
+            final var maybeHollowAccountId = accountStore.getAccountIDByAlias(config.shard(), config.realm(), alias);
             if (maybeHollowAccountId != null) {
                 final var maybeHollowAccount = requireNonNull(accountStore.getAccountById(maybeHollowAccountId));
                 if (isHollow(maybeHollowAccount)) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
@@ -753,7 +753,6 @@ class ThrottleAccumulatorTest {
         givenTransferWithImplicitCreations(numImplicitCreations);
         given(state.getReadableStates(any())).willReturn(readableStates);
         given(readableStates.get(any())).willReturn(aliases);
-        given(configuration.getConfigData(HederaConfig.class)).willReturn(hederaConfig);
         given(configuration.getConfigData(AutoCreationConfig.class)).willReturn(autoCreationConfig);
         given(autoCreationConfig.enabled()).willReturn(true);
         given(configuration.getConfigData(LazyCreationConfig.class)).willReturn(lazyCreationConfig);
@@ -840,7 +839,6 @@ class ThrottleAccumulatorTest {
         givenTransferWithImplicitCreations(10);
         given(state.getReadableStates(any())).willReturn(readableStates);
         given(readableStates.get(any())).willReturn(aliases);
-        given(configuration.getConfigData(HederaConfig.class)).willReturn(hederaConfig);
         given(configuration.getConfigData(AutoCreationConfig.class)).willReturn(autoCreationConfig);
         given(autoCreationConfig.enabled()).willReturn(true);
         given(configuration.getConfigData(LazyCreationConfig.class)).willReturn(lazyCreationConfig);
@@ -926,7 +924,6 @@ class ThrottleAccumulatorTest {
         givenTransferWithImplicitCreations(1);
         given(state.getReadableStates(any())).willReturn(readableStates);
         given(readableStates.get(any())).willReturn(aliases);
-        given(configuration.getConfigData(HederaConfig.class)).willReturn(hederaConfig);
         given(configuration.getConfigData(AutoCreationConfig.class)).willReturn(autoCreationConfig);
         given(autoCreationConfig.enabled()).willReturn(true);
         given(configuration.getConfigData(LazyCreationConfig.class)).willReturn(lazyCreationConfig);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
@@ -77,6 +77,7 @@ import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.AutoCreationConfig;
 import com.hedera.node.config.data.ContractsConfig;
 import com.hedera.node.config.data.EntitiesConfig;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LazyCreationConfig;
 import com.hedera.node.config.data.SchedulingConfig;
 import com.hedera.node.config.data.TokensConfig;
@@ -191,6 +192,8 @@ class ThrottleAccumulatorTest {
     private TransactionInfo transactionInfo;
 
     private Function<SemanticVersion, SoftwareVersion> softwareVersionFactory = ServicesSoftwareVersion::new;
+    private final HederaConfig hederaConfig =
+            HederaTestConfigBuilder.create().getOrCreateConfig().getConfigData(HederaConfig.class);
 
     @Test
     void worksAsExpectedForKnownQueries() throws IOException, ParseException {
@@ -750,7 +753,7 @@ class ThrottleAccumulatorTest {
         givenTransferWithImplicitCreations(numImplicitCreations);
         given(state.getReadableStates(any())).willReturn(readableStates);
         given(readableStates.get(any())).willReturn(aliases);
-
+        given(configuration.getConfigData(HederaConfig.class)).willReturn(hederaConfig);
         given(configuration.getConfigData(AutoCreationConfig.class)).willReturn(autoCreationConfig);
         given(autoCreationConfig.enabled()).willReturn(true);
         given(configuration.getConfigData(LazyCreationConfig.class)).willReturn(lazyCreationConfig);
@@ -837,7 +840,7 @@ class ThrottleAccumulatorTest {
         givenTransferWithImplicitCreations(10);
         given(state.getReadableStates(any())).willReturn(readableStates);
         given(readableStates.get(any())).willReturn(aliases);
-
+        given(configuration.getConfigData(HederaConfig.class)).willReturn(hederaConfig);
         given(configuration.getConfigData(AutoCreationConfig.class)).willReturn(autoCreationConfig);
         given(autoCreationConfig.enabled()).willReturn(true);
         given(configuration.getConfigData(LazyCreationConfig.class)).willReturn(lazyCreationConfig);
@@ -923,7 +926,7 @@ class ThrottleAccumulatorTest {
         givenTransferWithImplicitCreations(1);
         given(state.getReadableStates(any())).willReturn(readableStates);
         given(readableStates.get(any())).willReturn(aliases);
-
+        given(configuration.getConfigData(HederaConfig.class)).willReturn(hederaConfig);
         given(configuration.getConfigData(AutoCreationConfig.class)).willReturn(autoCreationConfig);
         given(autoCreationConfig.enabled()).willReturn(true);
         given(configuration.getConfigData(LazyCreationConfig.class)).willReturn(lazyCreationConfig);
@@ -1093,6 +1096,7 @@ class ThrottleAccumulatorTest {
                 gasThrottle,
                 softwareVersionFactory);
         given(configProvider.getConfiguration()).willReturn(configuration);
+        given(configuration.getConfigData(HederaConfig.class)).willReturn(hederaConfig);
         given(configuration.getConfigData(AccountsConfig.class)).willReturn(accountsConfig);
         given(accountsConfig.lastThrottleExempt()).willReturn(100L);
         given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletionsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/HollowAccountCompletionsTest.java
@@ -197,7 +197,7 @@ public class HollowAccountCompletionsTest {
                 .build();
         final var ethTxSigs = new EthTxSigs(Bytes.EMPTY.toByteArray(), alias.toByteArray());
         when(ethereumTransactionHandler.maybeEthTxSigsFor(any(), any(), any())).thenReturn(ethTxSigs);
-        when(accountStore.getAccountIDByAlias(alias)).thenReturn(hollowId);
+        when(accountStore.getAccountIDByAlias(0, 0, alias)).thenReturn(hollowId);
         when(accountStore.getAccountById(hollowId)).thenReturn(hollowAccount);
         final var txnBody = TransactionBody.newBuilder()
                 .transactionID(TransactionID.newBuilder()

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
@@ -418,7 +418,8 @@ public abstract class AbstractScheduleHandler {
         if (contractId.hasContractNum()) {
             effectiveId = contractId;
         } else if (contractId.hasEvmAddress()) {
-            final var accountId = accountStore.getAccountIDByAlias(contractId.evmAddressOrThrow());
+            final var accountId = accountStore.getAccountIDByAlias(
+                    contractId.shardNum(), contractId.realmNum(), contractId.evmAddressOrThrow());
             if (accountId != null) {
                 effectiveId = ContractID.newBuilder()
                         .shardNum(accountId.shardNum())

--- a/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
+++ b/hedera-node/hedera-schedule-service-impl/src/test/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandlerTest.java
@@ -75,7 +75,7 @@ class AbstractScheduleHandlerTest {
 
     @Test
     void contractIdAndDelegatableContractIdKeysAreActivatedByIdKey() {
-        given(accountStore.getAccountIDByAlias(CONTRACT_ALIAS.evmAddressOrThrow()))
+        given(accountStore.getAccountIDByAlias(0, 0, CONTRACT_ALIAS.evmAddressOrThrow()))
                 .willReturn(ACCOUNT_CONTRACT_ID);
         final var keyVerifier = AbstractScheduleHandler.simpleKeyVerifierFrom(accountStore, List.of(CONTRACT_ID_KEY));
         assertThat(keyVerifier.test(CONTRACT_ID_KEY)).isTrue();
@@ -91,7 +91,7 @@ class AbstractScheduleHandlerTest {
 
     @Test
     void onlyDelegatableContractIdKeysAreActivatedByDelegatableIdKey() {
-        given(accountStore.getAccountIDByAlias(CONTRACT_ALIAS.evmAddressOrThrow()))
+        given(accountStore.getAccountIDByAlias(0, 0, CONTRACT_ALIAS.evmAddressOrThrow()))
                 .willReturn(ACCOUNT_CONTRACT_ID);
         final var keyVerifier =
                 AbstractScheduleHandler.simpleKeyVerifierFrom(accountStore, List.of(DELEGATABLE_CONTRACT_ID_KEY));

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaNativeOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaNativeOperations.java
@@ -27,6 +27,7 @@ import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
 import com.swirlds.state.lifecycle.EntityIdFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -141,7 +142,9 @@ public class HandleHederaNativeOperations implements HederaNativeOperations {
     public void finalizeHollowAccountAsContract(@NonNull final Bytes evmAddress) {
         requireNonNull(evmAddress);
         final var accountStore = context.storeFactory().readableStore(ReadableAccountStore.class);
-        final var hollowAccountId = requireNonNull(accountStore.getAccountIDByAlias(evmAddress));
+        final var config = context.configuration().getConfigData(HederaConfig.class);
+        final var hollowAccountId =
+                requireNonNull(accountStore.getAccountIDByAlias(config.shard(), config.realm(), evmAddress));
         final var tokenServiceApi = context.storeFactory().serviceApi(TokenServiceApi.class);
         tokenServiceApi.finalizeHollowAccountAsContract(hollowAccountId);
     }
@@ -198,5 +201,10 @@ public class HandleHederaNativeOperations implements HederaNativeOperations {
     @Override
     public EntityIdFactory entityIdFactory() {
         return entityIdFactory;
+    }
+
+    @Override
+    public Configuration configuration() {
+        return context.configuration();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaNativeOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HederaNativeOperations.java
@@ -25,6 +25,7 @@ import com.hedera.node.app.service.token.ReadableNftStore;
 import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
 import com.swirlds.state.lifecycle.EntityIdFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -185,8 +186,8 @@ public interface HederaNativeOperations {
      * @param evmAddress the EVM address
      * @return the account or contract number if it exists, otherwise {@link HederaNativeOperations#MISSING_ENTITY_NUMBER}
      */
-    default long resolveAlias(@NonNull final Bytes evmAddress) {
-        final var account = readableAccountStore().getAccountIDByAlias(evmAddress);
+    default long resolveAlias(long shard, long realm, @NonNull final Bytes evmAddress) {
+        final var account = readableAccountStore().getAccountIDByAlias(shard, realm, evmAddress);
         return account == null ? MISSING_ENTITY_NUMBER : account.accountNumOrThrow();
     }
 
@@ -270,4 +271,10 @@ public interface HederaNativeOperations {
      * @return the {@link com.swirlds.state.lifecycle.EntityIdFactory}
      */
     EntityIdFactory entityIdFactory();
+
+    /**
+     * Returns the {@link Configuration} for this node.
+     * @return the {@link Configuration}
+     */
+    Configuration configuration();
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaNativeOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/QueryHederaNativeOperations.java
@@ -13,6 +13,7 @@ import com.hedera.node.app.service.token.ReadableTokenRelationStore;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.spi.workflows.QueryContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
 import com.swirlds.state.lifecycle.EntityIdFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Objects;
@@ -161,5 +162,10 @@ public class QueryHederaNativeOperations implements HederaNativeOperations {
     @Override
     public EntityIdFactory entityIdFactory() {
         return entityIdFactory;
+    }
+
+    @Override
+    public Configuration configuration() {
+        return context.configuration();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/HasCallAttempt.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/HasCallAttempt.java
@@ -22,6 +22,7 @@ import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethod
 import com.hedera.node.app.service.contract.impl.exec.utils.SystemContractMethodRegistry;
 import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
+import com.hedera.node.config.data.HederaConfig;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -140,9 +141,13 @@ public class HasCallAttempt extends AbstractCallAttempt<HasCallAttempt> {
         if (isLongZero(enhancement().nativeOperations().entityIdFactory(), accountAddress)) {
             return enhancement.nativeOperations().getAccount(numberOfLongZero(accountAddress.toArray()));
         } else {
+            final var config = configuration().getConfigData(HederaConfig.class);
             final var addressNum = enhancement
                     .nativeOperations()
-                    .resolveAlias(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(accountAddress.toArray()));
+                    .resolveAlias(
+                            config.shard(),
+                            config.realm(),
+                            com.hedera.pbj.runtime.io.buffer.Bytes.wrap(accountAddress.toArray()));
             return enhancement.nativeOperations().getAccount(addressNum);
         }
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
@@ -237,8 +237,10 @@ public class ClassicTransfersCall extends AbstractCall {
             for (final var unitAdjust : unitAdjusts) {
                 if (unitAdjust.amount() > 0
                         && unitAdjust.accountIDOrElse(AccountID.DEFAULT).hasAlias()) {
+                    final var accountId = unitAdjust.accountIDOrThrow();
                     final var alias = unitAdjust.accountIDOrThrow().aliasOrThrow();
-                    final var extantAccount = extantAccounts.getAccountIDByAlias(alias);
+                    final var extantAccount =
+                            extantAccounts.getAccountIDByAlias(accountId.shardNum(), accountId.realmNum(), alias);
                     if (extantAccount == null) {
                         aliasesToLazyCreate.add(alias);
                     }
@@ -248,8 +250,10 @@ public class ClassicTransfersCall extends AbstractCall {
             minimumTinycentPrice += nftTransfers.size() * baseNftTransferTinyCentsPrice;
             for (final var nftTransfer : nftTransfers) {
                 if (nftTransfer.receiverAccountIDOrElse(AccountID.DEFAULT).hasAlias()) {
-                    final var alias = nftTransfer.receiverAccountIDOrThrow().aliasOrThrow();
-                    final var extantAccount = extantAccounts.getAccountIDByAlias(alias);
+                    final var receiverAccountId = nftTransfer.receiverAccountIDOrThrow();
+                    final var alias = receiverAccountId.aliasOrThrow();
+                    final var extantAccount = extantAccounts.getAccountIDByAlias(
+                            receiverAccountId.shardNum(), receiverAccountId.realmNum(), alias);
                     if (extantAccount == null) {
                         aliasesToLazyCreate.add(alias);
                     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
@@ -126,7 +126,7 @@ public class ClassicTransfersCall extends AbstractCall {
                     false);
         }
         // When unlimited associations are enabled, will be updated with additional charges for any auto-associations
-        var gasRequirement = transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId, selector);
+        var gasRequirement = transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId);
         if (preemptingFailureStatus != null) {
             return reversionWith(preemptingFailureStatus, gasRequirement);
         }
@@ -176,19 +176,17 @@ public class ClassicTransfersCall extends AbstractCall {
      * Simulates the mono-service gas calculation for a classic transfer, which is significantly complicated by our
      * current strategy for setting the minimum tinycent price based on the canonical prices of various operations.
      *
-     * @param body the transaction body to be dispatched
+     * @param body                        the transaction body to be dispatched
      * @param systemContractGasCalculator the gas calculator to use
-     * @param enhancement the enhancement to use
-     * @param payerId the payer of the transaction
-     * @param selector the selector of the call
+     * @param enhancement                 the enhancement to use
+     * @param payerId                     the payer of the transaction
      * @return the gas requirement for the transaction to be dispatched
      */
     public static long transferGasRequirement(
             @NonNull final TransactionBody body,
             @NonNull final SystemContractGasCalculator systemContractGasCalculator,
             @NonNull final HederaWorldUpdater.Enhancement enhancement,
-            @NonNull final AccountID payerId,
-            @NonNull final byte[] selector) {
+            @NonNull final AccountID payerId) {
         final var op = body.cryptoTransferOrThrow();
         final var hasCustomFees = enhancement.nativeOperations().checkForCustomFees(op);
         // For fungible there are always at least two operations, so only charge half for each
@@ -213,8 +211,7 @@ public class ClassicTransfersCall extends AbstractCall {
                 baseAdjustTinycentsPrice,
                 baseNftTransferTinycentsPrice,
                 baseLazyCreationPrice,
-                extantAccounts,
-                selector);
+                extantAccounts);
         return systemContractGasCalculator.gasRequirementWithTinycents(body, payerId, minimumTinycentPrice);
     }
 
@@ -224,8 +221,7 @@ public class ClassicTransfersCall extends AbstractCall {
             final long baseAdjustTinyCentsPrice,
             final long baseNftTransferTinyCentsPrice,
             final long baseLazyCreationPrice,
-            @NonNull final ReadableAccountStore extantAccounts,
-            @NonNull final byte[] selector) {
+            @NonNull final ReadableAccountStore extantAccounts) {
         long minimumTinycentPrice = 0L;
         final var numTinyCentsAdjusts =
                 op.transfersOrElse(TransferList.DEFAULT).accountAmounts().size();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersCall.java
@@ -98,9 +98,7 @@ public class Erc20TransfersCall extends AbstractCall {
     public @NonNull PricedResult execute(@NonNull final MessageFrame frame) {
         // https://eips.ethereum.org/EIPS/eip-20
         final var syntheticTransfer = syntheticTransferOrTransferFrom(senderId);
-        final var selector = (from == null) ? ERC_20_TRANSFER.selector() : ERC_20_TRANSFER_FROM.selector();
-        final var gasRequirement =
-                transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId, selector);
+        final var gasRequirement = transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId);
         if (tokenId == null) {
             return reversionWith(INVALID_TOKEN_ID, gasRequirement);
         }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromCall.java
@@ -87,8 +87,7 @@ public class Erc721TransferFromCall extends AbstractCall {
             return reversionWith(INVALID_TOKEN_ID, gasCalculator.canonicalGasRequirement(DispatchType.TRANSFER_NFT));
         }
         final var syntheticTransfer = syntheticTransfer(senderId);
-        final var gasRequirement = transferGasRequirement(
-                syntheticTransfer, gasCalculator, enhancement, senderId, ERC_721_TRANSFER_FROM.selector());
+        final var gasRequirement = transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId);
         final var recordBuilder = systemContractOperations()
                 .dispatch(syntheticTransfer, verificationStrategy, senderId, ContractCallStreamBuilder.class);
         final var status = recordBuilder.status();

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -35,6 +35,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperatio
 import com.hedera.node.app.service.contract.impl.state.StorageAccesses;
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.workflows.HandleException;
+import com.hedera.node.config.data.HederaConfig;
 import com.swirlds.state.lifecycle.EntityIdFactory;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -824,9 +825,10 @@ public class ConversionUtils {
                     explicit[19]);
         } else {
             final var evmAddress = extractEvmAddress(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(explicit));
+            final var config = nativeOperations.configuration().getConfigData(HederaConfig.class);
             return evmAddress == null
                     ? HederaNativeOperations.MISSING_ENTITY_NUMBER
-                    : nativeOperations.resolveAlias(evmAddress);
+                    : nativeOperations.resolveAlias(config.shard(), config.realm(), evmAddress);
         }
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaNativeOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaNativeOperationsTest.java
@@ -211,6 +211,8 @@ class HandleHederaNativeOperationsTest {
         given(storeFactory.serviceApi(TokenServiceApi.class)).willReturn(tokenServiceApi);
         given(storeFactory.readableStore(ReadableAccountStore.class)).willReturn(accountStore);
         given(accountStore.getAccountIDByAlias(0, 0, CANONICAL_ALIAS)).willReturn(A_NEW_ACCOUNT_ID);
+        given(context.configuration())
+                .willReturn(HederaTestConfigBuilder.create().getOrCreateConfig());
 
         subject.finalizeHollowAccountAsContract(CANONICAL_ALIAS);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaNativeOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/HandleHederaNativeOperationsTest.java
@@ -152,7 +152,7 @@ class HandleHederaNativeOperationsTest {
     void resolveAliasReturnsMissingNumIfNotPresent() {
         given(context.storeFactory()).willReturn(storeFactory);
         given(storeFactory.readableStore(ReadableAccountStore.class)).willReturn(accountStore);
-        assertEquals(MISSING_ENTITY_NUMBER, subject.resolveAlias(tuweniToPbjBytes(EIP_1014_ADDRESS)));
+        assertEquals(MISSING_ENTITY_NUMBER, subject.resolveAlias(0, 0, tuweniToPbjBytes(EIP_1014_ADDRESS)));
     }
 
     @Test
@@ -160,8 +160,8 @@ class HandleHederaNativeOperationsTest {
         final var alias = tuweniToPbjBytes(EIP_1014_ADDRESS);
         given(context.storeFactory()).willReturn(storeFactory);
         given(storeFactory.readableStore(ReadableAccountStore.class)).willReturn(accountStore);
-        given(accountStore.getAccountIDByAlias(alias)).willReturn(NON_SYSTEM_ACCOUNT_ID);
-        assertEquals(NON_SYSTEM_ACCOUNT_ID.accountNumOrThrow(), subject.resolveAlias(alias));
+        given(accountStore.getAccountIDByAlias(0, 0, alias)).willReturn(NON_SYSTEM_ACCOUNT_ID);
+        assertEquals(NON_SYSTEM_ACCOUNT_ID.accountNumOrThrow(), subject.resolveAlias(0, 0, alias));
     }
 
     @Test
@@ -210,7 +210,7 @@ class HandleHederaNativeOperationsTest {
         given(context.storeFactory()).willReturn(storeFactory);
         given(storeFactory.serviceApi(TokenServiceApi.class)).willReturn(tokenServiceApi);
         given(storeFactory.readableStore(ReadableAccountStore.class)).willReturn(accountStore);
-        given(accountStore.getAccountIDByAlias(CANONICAL_ALIAS)).willReturn(A_NEW_ACCOUNT_ID);
+        given(accountStore.getAccountIDByAlias(0, 0, CANONICAL_ALIAS)).willReturn(A_NEW_ACCOUNT_ID);
 
         subject.finalizeHollowAccountAsContract(CANONICAL_ALIAS);
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QueryHederaNativeOperationsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/scope/QueryHederaNativeOperationsTest.java
@@ -103,15 +103,15 @@ class QueryHederaNativeOperationsTest {
     @Test
     void resolveAliasReturnsMissingNumIfNotPresent() {
         given(context.createStore(ReadableAccountStore.class)).willReturn(accountStore);
-        assertEquals(MISSING_ENTITY_NUMBER, subject.resolveAlias(tuweniToPbjBytes(EIP_1014_ADDRESS)));
+        assertEquals(MISSING_ENTITY_NUMBER, subject.resolveAlias(0, 0, tuweniToPbjBytes(EIP_1014_ADDRESS)));
     }
 
     @Test
     void resolveAliasReturnsNumIfPresent() {
         final var alias = tuweniToPbjBytes(EIP_1014_ADDRESS);
         given(context.createStore(ReadableAccountStore.class)).willReturn(accountStore);
-        given(accountStore.getAccountIDByAlias(alias)).willReturn(NON_SYSTEM_ACCOUNT_ID);
-        assertEquals(NON_SYSTEM_ACCOUNT_ID.accountNumOrThrow(), subject.resolveAlias(alias));
+        given(accountStore.getAccountIDByAlias(0, 0, alias)).willReturn(NON_SYSTEM_ACCOUNT_ID);
+        assertEquals(NON_SYSTEM_ACCOUNT_ID.accountNumOrThrow(), subject.resolveAlias(0, 0, alias));
     }
 
     @Test

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hederaaccountnumalias/HederaAccountNumAliasCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hederaaccountnumalias/HederaAccountNumAliasCallTest.java
@@ -39,7 +39,7 @@ public class HederaAccountNumAliasCallTest extends CallTestBase {
         given(attempt.enhancement()).willReturn(mockEnhancement());
 
         // Arrange to use an account that has an alias
-        given(nativeOperations.resolveAlias(RECEIVER_ADDRESS))
+        given(nativeOperations.resolveAlias(0, 0, RECEIVER_ADDRESS))
                 .willReturn(ALIASED_RECEIVER.accountId().accountNumOrThrow());
         given(nativeOperations.getAccount(RECEIVER_ID.accountNumOrThrow())).willReturn(ALIASED_RECEIVER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
@@ -63,7 +63,7 @@ public class HederaAccountNumAliasCallTest extends CallTestBase {
         given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
         given(attempt.enhancement()).willReturn(mockEnhancement());
 
-        given(nativeOperations.resolveAlias(RECEIVER_ADDRESS))
+        given(nativeOperations.resolveAlias(0, 0, RECEIVER_ADDRESS))
                 .willReturn(ALIASED_RECEIVER.accountId().accountNumOrThrow());
         given(nativeOperations.getAccount(RECEIVER_ID.accountNumOrThrow())).willReturn(null);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
@@ -85,7 +85,7 @@ public class HederaAccountNumAliasCallTest extends CallTestBase {
         given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
         given(attempt.enhancement()).willReturn(mockEnhancement());
 
-        given(nativeOperations.resolveAlias(RECEIVER_ADDRESS)).willReturn(MISSING_ENTITY_NUMBER);
+        given(nativeOperations.resolveAlias(0, 0, RECEIVER_ADDRESS)).willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
 
         subject = new HederaAccountNumAliasCall(attempt, asHeadlongAddress(RECEIVER_ADDRESS.toByteArray()));

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hederaaccountnumalias/HederaAccountNumAliasCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hederaaccountnumalias/HederaAccountNumAliasCallTest.java
@@ -17,6 +17,7 @@ import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hederaaccountnumalias.HederaAccountNumAliasCall;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
 import org.junit.jupiter.api.Test;
@@ -43,6 +44,7 @@ public class HederaAccountNumAliasCallTest extends CallTestBase {
                 .willReturn(ALIASED_RECEIVER.accountId().accountNumOrThrow());
         given(nativeOperations.getAccount(RECEIVER_ID.accountNumOrThrow())).willReturn(ALIASED_RECEIVER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
 
         subject = new HederaAccountNumAliasCall(attempt, asHeadlongAddress(RECEIVER_ADDRESS.toByteArray()));
         final var result = subject.execute(frame).fullResult().result();
@@ -67,7 +69,7 @@ public class HederaAccountNumAliasCallTest extends CallTestBase {
                 .willReturn(ALIASED_RECEIVER.accountId().accountNumOrThrow());
         given(nativeOperations.getAccount(RECEIVER_ID.accountNumOrThrow())).willReturn(null);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         subject = new HederaAccountNumAliasCall(attempt, asHeadlongAddress(RECEIVER_ADDRESS.toByteArray()));
         final var result = subject.execute(frame).fullResult().result();
 
@@ -87,7 +89,7 @@ public class HederaAccountNumAliasCallTest extends CallTestBase {
 
         given(nativeOperations.resolveAlias(0, 0, RECEIVER_ADDRESS)).willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         subject = new HederaAccountNumAliasCall(attempt, asHeadlongAddress(RECEIVER_ADDRESS.toByteArray()));
         final var result = subject.execute(frame).fullResult().result();
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorized/IsAuthorizedCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorized/IsAuthorizedCallTest.java
@@ -12,6 +12,7 @@ import static com.hedera.pbj.runtime.io.buffer.Bytes.wrap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 
@@ -84,7 +85,7 @@ public class IsAuthorizedCallTest extends CallTestBase {
     @Test
     void returnsErrorStatusForInvalidAddress() {
         // Not an account num alias, not an evm alias
-        given(nativeOperations.resolveAlias(any())).willReturn(MISSING_ENTITY_NUMBER);
+        given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
 
         subject = getSubject(APPROVED_HEADLONG_ADDRESS);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorized/IsAuthorizedCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorized/IsAuthorizedCallTest.java
@@ -33,6 +33,7 @@ import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import com.hedera.node.app.spi.signatures.SignatureVerifier.KeyCounts;
 import com.hedera.node.app.spi.signatures.SignatureVerifier.MessageType;
 import com.hedera.node.app.spi.signatures.SignatureVerifier.SimpleKeyStatus;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
@@ -87,7 +88,7 @@ public class IsAuthorizedCallTest extends CallTestBase {
         // Not an account num alias, not an evm alias
         given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         subject = getSubject(APPROVED_HEADLONG_ADDRESS);
 
         final var result = subject.execute(frame).fullResult().result();

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
@@ -30,6 +30,7 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isauth
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isauthorizedraw.IsAuthorizedRawCall.SignatureType;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
@@ -73,7 +74,7 @@ class IsAuthorizedRawCallTest extends CallTestBase {
     void revertsWithNoAccountAtAddress() {
         given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         subject = getSubject(APPROVED_HEADLONG_ADDRESS);
 
         final var result = subject.execute(frame).fullResult().result();

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isauthorizedraw/IsAuthorizedRawCallTest.java
@@ -18,6 +18,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -70,7 +71,7 @@ class IsAuthorizedRawCallTest extends CallTestBase {
 
     @Test
     void revertsWithNoAccountAtAddress() {
-        given(nativeOperations.resolveAlias(any())).willReturn(MISSING_ENTITY_NUMBER);
+        given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
 
         subject = getSubject(APPROVED_HEADLONG_ADDRESS);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isvalidalias/IsValidAliasCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isvalidalias/IsValidAliasCallTest.java
@@ -42,7 +42,7 @@ public class IsValidAliasCallTest extends CallTestBase {
         given(attempt.enhancement()).willReturn(mockEnhancement());
 
         // Arrange to use an account that has an alias
-        given(nativeOperations.resolveAlias(RECEIVER_ADDRESS))
+        given(nativeOperations.resolveAlias(0, 0, RECEIVER_ADDRESS))
                 .willReturn(ALIASED_RECEIVER.accountId().accountNumOrThrow());
         given(nativeOperations.getAccount(RECEIVER_ID.accountNumOrThrow())).willReturn(ALIASED_RECEIVER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
@@ -104,7 +104,7 @@ public class IsValidAliasCallTest extends CallTestBase {
         given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
         given(attempt.enhancement()).willReturn(mockEnhancement());
 
-        given(nativeOperations.resolveAlias(RECEIVER_ADDRESS))
+        given(nativeOperations.resolveAlias(0, 0, RECEIVER_ADDRESS))
                 .willReturn(ALIASED_RECEIVER.accountId().accountNumOrThrow());
         given(nativeOperations.getAccount(RECEIVER_ID.accountNumOrThrow())).willReturn(null);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
@@ -127,7 +127,7 @@ public class IsValidAliasCallTest extends CallTestBase {
         given(attempt.enhancement()).willReturn(mockEnhancement());
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
 
-        given(nativeOperations.resolveAlias(OWNER_ADDRESS)).willReturn(MISSING_ENTITY_NUMBER);
+        given(nativeOperations.resolveAlias(0, 0, OWNER_ADDRESS)).willReturn(MISSING_ENTITY_NUMBER);
 
         subject = new IsValidAliasCall(attempt, asHeadlongAddress(OWNER_ADDRESS.toByteArray()));
         final var result = subject.execute(frame).fullResult().result();

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isvalidalias/IsValidAliasCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/isvalidalias/IsValidAliasCallTest.java
@@ -20,6 +20,7 @@ import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.isvalidalias.IsValidAliasCall;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
 import org.junit.jupiter.api.Test;
@@ -46,7 +47,7 @@ public class IsValidAliasCallTest extends CallTestBase {
                 .willReturn(ALIASED_RECEIVER.accountId().accountNumOrThrow());
         given(nativeOperations.getAccount(RECEIVER_ID.accountNumOrThrow())).willReturn(ALIASED_RECEIVER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         subject = new IsValidAliasCall(attempt, asHeadlongAddress(RECEIVER_ADDRESS.toByteArray()));
         final var result = subject.execute(frame).fullResult().result();
 
@@ -108,7 +109,7 @@ public class IsValidAliasCallTest extends CallTestBase {
                 .willReturn(ALIASED_RECEIVER.accountId().accountNumOrThrow());
         given(nativeOperations.getAccount(RECEIVER_ID.accountNumOrThrow())).willReturn(null);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         subject = new IsValidAliasCall(attempt, asHeadlongAddress(RECEIVER_ADDRESS.toByteArray()));
         final var result = subject.execute(frame).fullResult().result();
 
@@ -126,7 +127,7 @@ public class IsValidAliasCallTest extends CallTestBase {
         given(attempt.systemContractGasCalculator()).willReturn(gasCalculator);
         given(attempt.enhancement()).willReturn(mockEnhancement());
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         given(nativeOperations.resolveAlias(0, 0, OWNER_ADDRESS)).willReturn(MISSING_ENTITY_NUMBER);
 
         subject = new IsValidAliasCall(attempt, asHeadlongAddress(OWNER_ADDRESS.toByteArray()));

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/signschedule/SignScheduleTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hss/signschedule/SignScheduleTranslatorTest.java
@@ -44,6 +44,7 @@ import com.hedera.node.app.service.contract.impl.hevm.HederaWorldUpdater;
 import com.hedera.node.app.spi.signatures.SignatureVerifier;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.data.ContractsConfig;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.config.api.Configuration;
 import java.util.List;
 import java.util.Random;
@@ -307,7 +308,7 @@ class SignScheduleTranslatorTest {
         given(verificationStrategies.activatingOnlyContractKeysFor(OWNER_BESU_ADDRESS, false, nativeOperations))
                 .willReturn(verificationStrategy);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         // when:
         final var input = Bytes.wrapByteBuffer(
                 SignScheduleTranslator.AUTHORIZE_SCHEDULE.encodeCall(Tuple.singleton(APPROVED_HEADLONG_ADDRESS)));
@@ -338,7 +339,7 @@ class SignScheduleTranslatorTest {
         given(verificationStrategies.activatingOnlyContractKeysFor(OWNER_BESU_ADDRESS, true, nativeOperations))
                 .willReturn(verificationStrategy);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         // when:
         final var input = Bytes.wrapByteBuffer(
                 SignScheduleTranslator.AUTHORIZE_SCHEDULE.encodeCall(Tuple.singleton(APPROVED_HEADLONG_ADDRESS)));

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/SyntheticIdsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/SyntheticIdsTest.java
@@ -17,6 +17,7 @@ import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperatio
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.SyntheticIds;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +36,7 @@ class SyntheticIdsTest {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         given(nativeOperations.resolveAlias(0, 0, ConversionUtils.tuweniToPbjBytes(EIP_1014_ADDRESS)))
                 .willReturn(TestHelpers.A_NEW_ACCOUNT_ID.accountNumOrThrow());
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         given(nativeOperations.getAccount(A_NEW_ACCOUNT_ID.accountNumOrThrow())).willReturn(ALIASED_SOMEBODY);
         final var subject = implicitSubject.converterFor(nativeOperations);
         final var synthId = subject.convert(asHeadlongAddress(EIP_1014_ADDRESS));

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/SyntheticIdsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/SyntheticIdsTest.java
@@ -33,7 +33,7 @@ class SyntheticIdsTest {
     @Test
     void returnsNumericIdIfAddressIsCanonicalReference() {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-        given(nativeOperations.resolveAlias(ConversionUtils.tuweniToPbjBytes(EIP_1014_ADDRESS)))
+        given(nativeOperations.resolveAlias(0, 0, ConversionUtils.tuweniToPbjBytes(EIP_1014_ADDRESS)))
                 .willReturn(TestHelpers.A_NEW_ACCOUNT_ID.accountNumOrThrow());
         given(nativeOperations.getAccount(A_NEW_ACCOUNT_ID.accountNumOrThrow())).willReturn(ALIASED_SOMEBODY);
         final var subject = implicitSubject.converterFor(nativeOperations);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/balanceof/BalanceOfCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/balanceof/BalanceOfCallTest.java
@@ -22,6 +22,7 @@ import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.balanceof.BalanceOfCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.balanceof.BalanceOfTranslator;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import java.math.BigInteger;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -47,7 +48,7 @@ class BalanceOfCallTest extends CallTestBase {
         given(nativeOperations.resolveAlias(0, 0, tuweniToPbjBytes(EIP_1014_ADDRESS)))
                 .willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         final var result = subject.execute().fullResult().result();
 
         assertEquals(MessageFrame.State.REVERT, result.getState());
@@ -61,7 +62,7 @@ class BalanceOfCallTest extends CallTestBase {
                 .willReturn(A_NEW_ACCOUNT_ID.accountNumOrThrow());
         given(nativeOperations.getAccount(A_NEW_ACCOUNT_ID.accountNumOrThrow())).willReturn(ALIASED_SOMEBODY);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         final var result = subject.execute().fullResult().result();
 
         assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());
@@ -82,7 +83,7 @@ class BalanceOfCallTest extends CallTestBase {
                 .willReturn(A_FUNGIBLE_RELATION);
         given(nativeOperations.getAccount(A_NEW_ACCOUNT_ID.accountNumOrThrow())).willReturn(ALIASED_SOMEBODY);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-
+        given(nativeOperations.configuration()).willReturn(HederaTestConfigBuilder.createConfig());
         final var result = subject.execute().fullResult().result();
 
         assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/balanceof/BalanceOfCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/balanceof/BalanceOfCallTest.java
@@ -44,7 +44,8 @@ class BalanceOfCallTest extends CallTestBase {
     @Test
     void revertsWithMissingAccount() {
         subject = new BalanceOfCall(mockEnhancement(), gasCalculator, FUNGIBLE_TOKEN, OWNER);
-        given(nativeOperations.resolveAlias(tuweniToPbjBytes(EIP_1014_ADDRESS))).willReturn(MISSING_ENTITY_NUMBER);
+        given(nativeOperations.resolveAlias(0, 0, tuweniToPbjBytes(EIP_1014_ADDRESS)))
+                .willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
 
         final var result = subject.execute().fullResult().result();
@@ -56,7 +57,7 @@ class BalanceOfCallTest extends CallTestBase {
     @Test
     void returnsZeroBalanceForAbsentRelationship() {
         subject = new BalanceOfCall(mockEnhancement(), gasCalculator, FUNGIBLE_TOKEN, OWNER);
-        given(nativeOperations.resolveAlias(tuweniToPbjBytes(EIP_1014_ADDRESS)))
+        given(nativeOperations.resolveAlias(0, 0, tuweniToPbjBytes(EIP_1014_ADDRESS)))
                 .willReturn(A_NEW_ACCOUNT_ID.accountNumOrThrow());
         given(nativeOperations.getAccount(A_NEW_ACCOUNT_ID.accountNumOrThrow())).willReturn(ALIASED_SOMEBODY);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
@@ -75,7 +76,7 @@ class BalanceOfCallTest extends CallTestBase {
     @Test
     void returnsNominalBalanceForPresentRelationship() {
         subject = new BalanceOfCall(mockEnhancement(), gasCalculator, FUNGIBLE_TOKEN, OWNER);
-        given(nativeOperations.resolveAlias(tuweniToPbjBytes(EIP_1014_ADDRESS)))
+        given(nativeOperations.resolveAlias(0, 0, tuweniToPbjBytes(EIP_1014_ADDRESS)))
                 .willReturn(A_NEW_ACCOUNT_ID.accountNumOrThrow());
         given(nativeOperations.getTokenRelation(A_NEW_ACCOUNT_ID.accountNumOrThrow(), FUNGIBLE_TOKEN_ID.tokenNum()))
                 .willReturn(A_FUNGIBLE_RELATION);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersGasCalcTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersGasCalcTest.java
@@ -73,7 +73,7 @@ class ClassicTransfersGasCalcTest extends CallTestBase {
     void doesNotChargeForExtantAliases() {
         givenPretendPricesWithoutCustomFees();
         given(nativeOperations.readableAccountStore()).willReturn(accountStore);
-        given(accountStore.getAccountIDByAlias(TestHelpers.ALIASED_RECEIVER_ID.aliasOrThrow()))
+        given(accountStore.getAccountIDByAlias(0, 0, TestHelpers.ALIASED_RECEIVER_ID.aliasOrThrow()))
                 .willReturn(AccountID.DEFAULT);
 
         final var expectedFtMinimumPrice = PRETEND_FUNGIBLE_TRANSFER_TINYBAR_PRICE / 2;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersGasCalcTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersGasCalcTest.java
@@ -14,7 +14,6 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersCall;
-import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersTranslator;
 import com.hedera.node.app.service.contract.impl.test.TestHelpers;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.service.token.ReadableAccountStore;
@@ -61,11 +60,7 @@ class ClassicTransfersGasCalcTest extends CallTestBase {
                 .willReturn(expectedGasRequirement);
 
         final var actualGasRequirement = ClassicTransfersCall.transferGasRequirement(
-                body,
-                systemContractGasCalculator,
-                mockEnhancement(),
-                AccountID.DEFAULT,
-                ClassicTransfersTranslator.TRANSFER_NFTS.selector());
+                body, systemContractGasCalculator, mockEnhancement(), AccountID.DEFAULT);
         assertEquals(expectedGasRequirement, actualGasRequirement);
     }
 
@@ -87,11 +82,7 @@ class ClassicTransfersGasCalcTest extends CallTestBase {
                 .willReturn(expectedGasRequirement);
 
         final var actualGasRequirement = ClassicTransfersCall.transferGasRequirement(
-                body,
-                systemContractGasCalculator,
-                mockEnhancement(),
-                AccountID.DEFAULT,
-                ClassicTransfersTranslator.CRYPTO_TRANSFER.selector());
+                body, systemContractGasCalculator, mockEnhancement(), AccountID.DEFAULT);
         assertEquals(expectedGasRequirement, actualGasRequirement);
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
@@ -414,14 +414,16 @@ class DispatchingEvmFrameStateTest {
 
     @Test
     void throwsOnMissingAddressWhenGettingHederaIdNumber() {
-        given(nativeOperations.resolveAlias(tuweniToPbjBytes(EVM_ADDRESS))).willReturn(MISSING_ENTITY_NUMBER);
+        given(nativeOperations.resolveAlias(0, 0, tuweniToPbjBytes(EVM_ADDRESS)))
+                .willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         assertThrows(IllegalArgumentException.class, () -> subject.getIdNumber(EVM_ADDRESS));
     }
 
     @Test
     void returnsResolvedNumberForEvmAddress() {
-        given(nativeOperations.resolveAlias(tuweniToPbjBytes(EVM_ADDRESS))).willReturn(ACCOUNT_NUM);
+        given(nativeOperations.resolveAlias(0, 0, tuweniToPbjBytes(EVM_ADDRESS)))
+                .willReturn(ACCOUNT_NUM);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         assertEquals(ACCOUNT_NUM, subject.getIdNumber(EVM_ADDRESS));
     }
@@ -568,7 +570,7 @@ class DispatchingEvmFrameStateTest {
     @Test
     void cannotLazyCreateOverExpiredAccount() {
         givenWellKnownAccount(contractWith(A_ACCOUNT_ID).expiredAndPendingRemoval(true));
-        given(nativeOperations.resolveAlias(Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
+        given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
                 .willReturn(ACCOUNT_NUM);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
 
@@ -611,7 +613,7 @@ class DispatchingEvmFrameStateTest {
     void throwsOnLazyCreateOfNonExpiredAccount() {
         givenWellKnownAccount(contractWith(A_ACCOUNT_ID));
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-        given(nativeOperations.resolveAlias(Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
+        given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
                 .willReturn(ACCOUNT_NUM);
 
         assertThrows(IllegalArgumentException.class, () -> subject.tryLazyCreation(EVM_ADDRESS));
@@ -758,7 +760,7 @@ class DispatchingEvmFrameStateTest {
 
     @Test
     void missingAccountIsNotHollow() {
-        given(nativeOperations.resolveAlias(Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
+        given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
                 .willReturn(ACCOUNT_NUM);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         assertFalse(subject.isHollowAccount(EVM_ADDRESS));
@@ -766,7 +768,7 @@ class DispatchingEvmFrameStateTest {
 
     @Test
     void extantAccountIsHollowOnlyIfHasAnEmptyKey() {
-        given(nativeOperations.resolveAlias(Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
+        given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
                 .willReturn(ACCOUNT_NUM);
         givenWellKnownAccount(contractWith(A_ACCOUNT_ID)
                 .key(Key.newBuilder().keyList(KeyList.DEFAULT).build()));
@@ -776,7 +778,7 @@ class DispatchingEvmFrameStateTest {
 
     @Test
     void usesResolvedNumberFromDispatch() {
-        given(nativeOperations.resolveAlias(Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
+        given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
                 .willReturn(ACCOUNT_NUM);
         givenWellKnownAccount(contractWith(A_ACCOUNT_ID));
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/DispatchingEvmFrameStateTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doCallRealMethod;
@@ -54,7 +55,9 @@ import com.hedera.node.app.service.contract.impl.state.ScheduleEvmAccount;
 import com.hedera.node.app.service.contract.impl.state.StorageAccess;
 import com.hedera.node.app.service.contract.impl.state.StorageAccesses;
 import com.hedera.node.app.service.contract.impl.state.TokenEvmAccount;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -118,6 +121,7 @@ class DispatchingEvmFrameStateTest {
             AccountID.newBuilder().accountNum(ACCOUNT_NUM).build();
     private static final AccountID B_ACCOUNT_ID =
             AccountID.newBuilder().accountNum(BENEFICIARY_NUM).build();
+    private static final Configuration configuration = HederaTestConfigBuilder.createConfig();
 
     @Mock
     private HederaNativeOperations nativeOperations;
@@ -417,6 +421,7 @@ class DispatchingEvmFrameStateTest {
         given(nativeOperations.resolveAlias(0, 0, tuweniToPbjBytes(EVM_ADDRESS)))
                 .willReturn(MISSING_ENTITY_NUMBER);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(nativeOperations.configuration()).willReturn(configuration);
         assertThrows(IllegalArgumentException.class, () -> subject.getIdNumber(EVM_ADDRESS));
     }
 
@@ -424,6 +429,7 @@ class DispatchingEvmFrameStateTest {
     void returnsResolvedNumberForEvmAddress() {
         given(nativeOperations.resolveAlias(0, 0, tuweniToPbjBytes(EVM_ADDRESS)))
                 .willReturn(ACCOUNT_NUM);
+        given(nativeOperations.configuration()).willReturn(configuration);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         assertEquals(ACCOUNT_NUM, subject.getIdNumber(EVM_ADDRESS));
     }
@@ -533,6 +539,7 @@ class DispatchingEvmFrameStateTest {
     @Test
     void missingAccountsCannotTransferFunds() {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(nativeOperations.configuration()).willReturn(configuration);
         final var reasonToHaltDeletion = subject.tryTransfer(EVM_ADDRESS, LONG_ZERO_ADDRESS, 123L, true);
         assertTrue(reasonToHaltDeletion.isPresent());
         assertEquals(INVALID_SOLIDITY_ADDRESS, reasonToHaltDeletion.get());
@@ -542,6 +549,7 @@ class DispatchingEvmFrameStateTest {
     void cannotTransferToMissingAccount() {
         givenWellKnownAccount(contractWith(A_ACCOUNT_ID).smartContract(true));
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(nativeOperations.configuration()).willReturn(configuration);
         final var reasonToHaltDeletion = subject.tryTransfer(LONG_ZERO_ADDRESS, EVM_ADDRESS, 123L, true);
         assertTrue(reasonToHaltDeletion.isPresent());
         assertEquals(INVALID_SOLIDITY_ADDRESS, reasonToHaltDeletion.get());
@@ -572,6 +580,7 @@ class DispatchingEvmFrameStateTest {
         givenWellKnownAccount(contractWith(A_ACCOUNT_ID).expiredAndPendingRemoval(true));
         given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
                 .willReturn(ACCOUNT_NUM);
+        given(nativeOperations.configuration()).willReturn(configuration);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
 
         final var reasonLazyCreationFailed = subject.tryLazyCreation(EVM_ADDRESS);
@@ -584,6 +593,7 @@ class DispatchingEvmFrameStateTest {
     void noHaltIfLazyCreationOk() {
         given(nativeOperations.createHollowAccount(tuweniToPbjBytes(EVM_ADDRESS)))
                 .willReturn(ResponseCodeEnum.SUCCESS);
+        given(nativeOperations.configuration()).willReturn(configuration);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         final var reasonLazyCreationFailed = subject.tryLazyCreation(EVM_ADDRESS);
 
@@ -595,6 +605,7 @@ class DispatchingEvmFrameStateTest {
         given(nativeOperations.createHollowAccount(tuweniToPbjBytes(EVM_ADDRESS)))
                 .willReturn(ResponseCodeEnum.MAX_ENTITIES_IN_PRICE_REGIME_HAVE_BEEN_CREATED);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(nativeOperations.configuration()).willReturn(configuration);
         final var reasonLazyCreationFailed = subject.tryLazyCreation(EVM_ADDRESS);
 
         assertTrue(reasonLazyCreationFailed.isPresent());
@@ -613,7 +624,8 @@ class DispatchingEvmFrameStateTest {
     void throwsOnLazyCreateOfNonExpiredAccount() {
         givenWellKnownAccount(contractWith(A_ACCOUNT_ID));
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
-        given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
+        given(nativeOperations.configuration()).willReturn(configuration);
+        given(nativeOperations.resolveAlias(anyLong(), anyLong(), eq(Bytes.wrap(EVM_ADDRESS.toArrayUnsafe()))))
                 .willReturn(ACCOUNT_NUM);
 
         assertThrows(IllegalArgumentException.class, () -> subject.tryLazyCreation(EVM_ADDRESS));
@@ -749,12 +761,14 @@ class DispatchingEvmFrameStateTest {
     @Test
     void returnsNullForMissingAlias() {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(nativeOperations.configuration()).willReturn(configuration);
         assertNull(subject.getAccount(EVM_ADDRESS));
     }
 
     @Test
     void missingAliasIsNotHollow() {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(nativeOperations.configuration()).willReturn(configuration);
         assertFalse(subject.isHollowAccount(EVM_ADDRESS));
     }
 
@@ -762,6 +776,7 @@ class DispatchingEvmFrameStateTest {
     void missingAccountIsNotHollow() {
         given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
                 .willReturn(ACCOUNT_NUM);
+        given(nativeOperations.configuration()).willReturn(configuration);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         assertFalse(subject.isHollowAccount(EVM_ADDRESS));
     }
@@ -770,6 +785,7 @@ class DispatchingEvmFrameStateTest {
     void extantAccountIsHollowOnlyIfHasAnEmptyKey() {
         given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
                 .willReturn(ACCOUNT_NUM);
+        given(nativeOperations.configuration()).willReturn(configuration);
         givenWellKnownAccount(contractWith(A_ACCOUNT_ID)
                 .key(Key.newBuilder().keyList(KeyList.DEFAULT).build()));
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
@@ -780,6 +796,7 @@ class DispatchingEvmFrameStateTest {
     void usesResolvedNumberFromDispatch() {
         given(nativeOperations.resolveAlias(0, 0, Bytes.wrap(EVM_ADDRESS.toArrayUnsafe())))
                 .willReturn(ACCOUNT_NUM);
+        given(nativeOperations.configuration()).willReturn(configuration);
         givenWellKnownAccount(contractWith(A_ACCOUNT_ID));
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         assertInstanceOf(ProxyEvmContract.class, subject.getAccount(EVM_ADDRESS));

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
@@ -35,6 +35,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.BDDMockito.given;
 
 import com.google.common.primitives.Ints;
@@ -152,7 +153,7 @@ class ConversionUtilsTest {
     void returnsMissingOnAbsentAlias() {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         final var address = Address.fromHexString("0x010000000000000000");
-        given(nativeOperations.resolveAlias(any())).willReturn(MISSING_ENTITY_NUMBER);
+        given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(MISSING_ENTITY_NUMBER);
         final var actual = ConversionUtils.maybeMissingNumberOf(address, nativeOperations);
         assertEquals(-1L, actual);
     }
@@ -162,14 +163,14 @@ class ConversionUtilsTest {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         final var address =
                 asHeadlongAddress(Address.fromHexString("0x010000000000000000").toArray());
-        given(nativeOperations.resolveAlias(any())).willReturn(MISSING_ENTITY_NUMBER);
+        given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(MISSING_ENTITY_NUMBER);
         final var actual = ConversionUtils.accountNumberForEvmReference(address, nativeOperations);
         assertEquals(-1L, actual);
     }
 
     @Test
     void returnsGivenIfPresentAlias() {
-        given(nativeOperations.resolveAlias(any())).willReturn(0x1234L);
+        given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(0x1234L);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         final var address = Address.fromHexString("0x010000000000000000");
         final var actual = ConversionUtils.maybeMissingNumberOf(address, nativeOperations);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
@@ -48,6 +48,8 @@ import com.hedera.hapi.streams.ContractStateChanges;
 import com.hedera.hapi.streams.StorageChange;
 import com.hedera.node.app.service.contract.impl.exec.scope.HederaNativeOperations;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.List;
@@ -66,6 +68,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ConversionUtilsTest {
     @Mock
     private HederaNativeOperations nativeOperations;
+
+    private static final Configuration configuration = HederaTestConfigBuilder.createConfig();
 
     @Test
     void outOfRangeBiValuesAreZero() {
@@ -152,6 +156,7 @@ class ConversionUtilsTest {
     @Test
     void returnsMissingOnAbsentAlias() {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(nativeOperations.configuration()).willReturn(configuration);
         final var address = Address.fromHexString("0x010000000000000000");
         given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(MISSING_ENTITY_NUMBER);
         final var actual = ConversionUtils.maybeMissingNumberOf(address, nativeOperations);
@@ -161,6 +166,7 @@ class ConversionUtilsTest {
     @Test
     void returnsMissingOnAbsentAliasReference() {
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
+        given(nativeOperations.configuration()).willReturn(configuration);
         final var address =
                 asHeadlongAddress(Address.fromHexString("0x010000000000000000").toArray());
         given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(MISSING_ENTITY_NUMBER);
@@ -171,6 +177,7 @@ class ConversionUtilsTest {
     @Test
     void returnsGivenIfPresentAlias() {
         given(nativeOperations.resolveAlias(anyLong(), anyLong(), any())).willReturn(0x1234L);
+        given(nativeOperations.configuration()).willReturn(configuration);
         given(nativeOperations.entityIdFactory()).willReturn(entityIdFactory);
         final var address = Address.fromHexString("0x010000000000000000");
         final var actual = ConversionUtils.maybeMissingNumberOf(address, nativeOperations);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
@@ -102,13 +102,12 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
     @Override
     @Nullable
     public AccountID getAccountIDByAlias(final long shardNum, final long realmNum, @NonNull final Bytes alias) {
-        //        return aliases.get(new ProtoBytes(alias));
         return lookupAlias(shardNum, realmNum, alias);
     }
 
     @Override
     public boolean containsAlias(final long shardNum, final long realmNum, @NonNull Bytes alias) {
-        return lookupAlias(shardNum, realmNum, alias) != null;
+        return getAccountIDByAlias(shardNum, realmNum, alias) != null;
     }
 
     @Override

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/ReadableAccountStoreImpl.java
@@ -101,13 +101,14 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
 
     @Override
     @Nullable
-    public AccountID getAccountIDByAlias(@NonNull final Bytes alias) {
-        return aliases.get(new ProtoBytes(alias));
+    public AccountID getAccountIDByAlias(final long shardNum, final long realmNum, @NonNull final Bytes alias) {
+        //        return aliases.get(new ProtoBytes(alias));
+        return lookupAlias(shardNum, realmNum, alias);
     }
 
     @Override
-    public boolean containsAlias(@NonNull Bytes alias) {
-        return aliases.contains(new ProtoBytes(alias));
+    public boolean containsAlias(final long shardNum, final long realmNum, @NonNull Bytes alias) {
+        return lookupAlias(shardNum, realmNum, alias) != null;
     }
 
     @Override
@@ -191,31 +192,36 @@ public class ReadableAccountStoreImpl implements ReadableAccountStore {
         return switch (accountOneOf.kind()) {
             case ACCOUNT_NUM -> id;
             case ALIAS -> {
-                // An alias may either be long-zero (in which case it isn't in our alias map), or it may be
-                // any other form of valid alias (in which case it will be in the map). So we do a quick check
-                // first to see if it is a valid long zero, and if not, then we look it up in the map.
                 final Bytes alias = accountOneOf.as();
-                if (isEntityNumAlias(alias, id.shardNum(), id.realmNum())) {
-                    yield id.copyBuilder()
-                            .shardNum(extractShardFromAddressAlias(alias))
-                            .realmNum(extractRealmFromAddressAlias(alias))
-                            .accountNum(extractIdFromAddressAlias(alias))
-                            .build();
-                }
-
-                // Since it wasn't long-zero, we will just look up in the aliases map. It may be an EVM address alias,
-                // in which case it is in the map, or it may be a protobuf-encoded key alias, in which case it *may*
-                // also be in the map. When someone gives us a protobuf-encoded ECDSA key, we store both the alias to
-                // the ECDSA key *and* the EVM address in the alias map. But if somebody only gives us the EVM address,
-                // we cannot compute the ECDSA key from it, so we only store the EVM address in the alias map. So if we
-                // do this look up and cannot find the answer, then we have to check if the key is an ECDSA key, and
-                // if it is, we have to compute the EVM address from it, and then look up the EVM address in the map.
-                final var found = aliases.get(new ProtoBytes(alias));
-                if (found != null) yield found;
-                yield aliases.get(new ProtoBytes(extractEvmAddress(asKeyFromAliasOrElse(alias, null))));
+                yield lookupAlias(id.shardNum(), id.realmNum(), alias);
             }
             case UNSET -> null;
         };
+    }
+
+    @Nullable
+    private AccountID lookupAlias(final long shardNum, long realmNum, final Bytes alias) {
+        // An alias may either be long-zero (in which case it isn't in our alias map), or it may be
+        // any other form of valid alias (in which case it will be in the map). So we do a quick check
+        // first to see if it is a valid long zero, and if not, then we look it up in the map.
+        if (isEntityNumAlias(alias, shardNum, realmNum)) {
+            return AccountID.newBuilder()
+                    .shardNum(extractShardFromAddressAlias(alias))
+                    .realmNum(extractRealmFromAddressAlias(alias))
+                    .accountNum(extractIdFromAddressAlias(alias))
+                    .build();
+        }
+
+        // Since it wasn't long-zero, we will just look up in the aliases map. It may be an EVM address alias,
+        // in which case it is in the map, or it may be a protobuf-encoded key alias, in which case it *may*
+        // also be in the map. When someone gives us a protobuf-encoded ECDSA key, we store both the alias to
+        // the ECDSA key *and* the EVM address in the alias map. But if somebody only gives us the EVM address,
+        // we cannot compute the ECDSA key from it, so we only store the EVM address in the alias map. So if we
+        // do this look up and cannot find the answer, then we have to check if the key is an ECDSA key, and
+        // if it is, we have to compute the EVM address from it, and then look up the EVM address in the map.
+        final var found = aliases.get(new ProtoBytes(alias));
+        if (found != null) return found;
+        return aliases.get(new ProtoBytes(extractEvmAddress(asKeyFromAliasOrElse(alias, null))));
     }
 
     public long sizeOfAccountState() {

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
@@ -322,8 +322,9 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
 
         // If there is an alias, then we need to make sure no other account or contract account is using that alias.
         if (hasAlias) {
+            final var config = context.configuration().getConfigData(HederaConfig.class);
             // find account by alias and check if it was deleted
-            var accountId = accountStore.getAccountIDByAlias(alias);
+            var accountId = accountStore.getAccountIDByAlias(config.shard(), config.realm(), alias);
             var account = accountId != null ? accountStore.getAccountById(accountId) : null;
             var isDeleted = account == null || account.deleted();
             validateTrue(accountId == null || isDeleted, ALIAS_ALREADY_ASSIGNED);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/AutoAccountCreator.java
@@ -25,6 +25,7 @@ import com.hedera.node.app.spi.fees.FeeCharging;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.node.config.data.EntitiesConfig;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -88,10 +89,11 @@ public class AutoAccountCreator {
         // If the child transaction failed, we should fail the parent transaction as well and propagate the failure.
         validateTrue(streamBuilder.status() == SUCCESS, streamBuilder.status());
 
+        final var config = handleContext.configuration().getConfigData(HederaConfig.class);
         // Since we succeeded, we can now look up the account ID of the created account. This really should always
         // work, since the child transaction succeeded. If it did not work for some reason, we have a bug in our
         // code (rather than a bad transaction), so we will fail with FAIL_INVALID.
-        final var createdAccountId = accountStore.getAccountIDByAlias(alias);
+        final var createdAccountId = accountStore.getAccountIDByAlias(config.shard(), config.realm(), alias);
         validateTrue(createdAccountId != null, FAIL_INVALID);
         return createdAccountId;
     }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableAccountStoreImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/ReadableAccountStoreImplTest.java
@@ -247,9 +247,9 @@ class ReadableAccountStoreImplTest extends CryptoHandlerTestBase {
 
     @Test
     void getAccountIDByAlias() {
-        final var accountId = subject.getAccountIDByAlias(alias.alias());
+        final var accountId = subject.getAccountIDByAlias(0, 0, alias.alias());
         assertThat(accountId).isEqualTo(id);
-        final var accountId2 = subject.getAccountIDByAlias(Bytes.wrap("test"));
+        final var accountId2 = subject.getAccountIDByAlias(0, 0, Bytes.wrap("test"));
         assertThat(accountId2).isNull();
     }
 

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableAccountStore.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/ReadableAccountStore.java
@@ -40,23 +40,27 @@ public interface ReadableAccountStore {
      * Fetches an {@link Account} object from state with the given alias. If the account could not be
      * fetched because the given account doesn't exist, returns {@code null}.
      *
-     * @param alias alias
+     * @param alias    alias
+     * @param shardNum the shard number
+     * @param realmNum the realm number
      * @return AccountID object if successfully fetched or {@code null} if the account doesn't exist
      */
     @Nullable
-    AccountID getAccountIDByAlias(@NonNull Bytes alias);
+    AccountID getAccountIDByAlias(final long shardNum, final long realmNum, @NonNull Bytes alias);
 
     /**
      * Gets whether the given alias is known to this store. It is known if it is present in the alias-to-accountID
      * map.
-     *
+     * @param shardNum the shard number
+     * @param realmNum the realm number
      * @param alias The alias to check.
      * @return true if the given alias has a mapping to an AccountID in this store
      */
-    boolean containsAlias(@NonNull Bytes alias);
+    boolean containsAlias(final long shardNum, final long realmNum, @NonNull Bytes alias);
 
     /**
      * Returns true if the given account ID exists in state.
+     *
      * @param accountID the ID to check
      * @return true if the account exists in state
      */
@@ -65,6 +69,7 @@ public interface ReadableAccountStore {
     /**
      * Returns true if the given account ID exists in state, or if the given account ID is an alias that exists in
      * state.
+     *
      * @param accountID the ID to check
      * @return true if the account exists in state
      */
@@ -107,6 +112,7 @@ public interface ReadableAccountStore {
 
     /**
      * Returns the number of entities in the account state.
+     *
      * @return the size of the account state
      */
     long sizeOfAccountState();


### PR DESCRIPTION
Fixes #18082 

Re-uses existing logic to lookup alias in `getAccountIDByAlias` similar to `lookupAliasedAccountId` 