### PR TITLE
fix: rename atomic batch enum code (#18085)

### DIFF
--- a/hapi/hedera-protobufs/services/response_code.proto
+++ b/hapi/hedera-protobufs/services/response_code.proto
@@ -1709,9 +1709,10 @@ enum ResponseCodeEnum {
     BATCH_LIST_CONTAINS_DUPLICATES = 389;
 
     /**
-     * The list of batch transactions contains a transaction type that is not supported to be submitted in a batch.
+     * The list of batch transactions contains a transaction type that is
+     * in the AtomicBatch blacklist as configured in the network.
      */
-    BATCH_TRANSACTION_NOT_IN_WHITELIST = 390;
+    BATCH_TRANSACTION_IN_BLACKLIST = 390;
 
     /**
      * The inner transaction of a batch transaction failed

--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/AtomicBatchHandler.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/AtomicBatchHandler.java
@@ -4,7 +4,7 @@ package com.hedera.node.app.service.util.impl.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_LIST_CONTAINS_DUPLICATES;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_LIST_EMPTY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_SIZE_LIMIT_EXCEEDED;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_TRANSACTION_NOT_IN_WHITELIST;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_TRANSACTION_IN_BLACKLIST;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_BATCH_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT_ID;
@@ -95,7 +95,7 @@ public class AtomicBatchHandler implements TransactionHandler {
         Set<TransactionID> txIds = new HashSet<>();
         for (final var innerTx : innerTxs) {
             if (!innerTx.hasBody()) {
-                throw new PreCheckException(BATCH_TRANSACTION_NOT_IN_WHITELIST);
+                throw new PreCheckException(BATCH_TRANSACTION_IN_BLACKLIST);
             }
             final var txBody = innerTx.bodyOrThrow(); // inner txs are required to use body
 
@@ -124,8 +124,7 @@ public class AtomicBatchHandler implements TransactionHandler {
         // not using stream below as throwing exception from middle of functional pipeline is a terrible idea
         for (final var txn : txns) {
             final var innerTxBody = txn.bodyOrThrow();
-            validateFalsePreCheck(
-                    isNotAllowedFunction(innerTxBody, atomicBatchConfig), BATCH_TRANSACTION_NOT_IN_WHITELIST);
+            validateFalsePreCheck(isNotAllowedFunction(innerTxBody, atomicBatchConfig), BATCH_TRANSACTION_IN_BLACKLIST);
             context.requireKeyOrThrow(innerTxBody.batchKey(), INVALID_BATCH_KEY);
             // the inner prehandle of each inner transaction happens in the prehandle workflow.
         }

--- a/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/AtomicBatchHandlerTest.java
+++ b/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/AtomicBatchHandlerTest.java
@@ -3,7 +3,7 @@ package com.hedera.node.app.service.util.impl.test.handlers;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_LIST_CONTAINS_DUPLICATES;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_LIST_EMPTY;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_TRANSACTION_NOT_IN_WHITELIST;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_TRANSACTION_IN_BLACKLIST;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_BATCH_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT_ID;
@@ -133,7 +133,7 @@ class AtomicBatchHandlerTest {
         final var txnBody = newAtomicBatch(payerId1, consensusTimestamp, transaction);
         given(preHandleContext.body()).willReturn(txnBody);
         final var msg = assertThrows(PreCheckException.class, () -> subject.preHandle(preHandleContext));
-        assertEquals(BATCH_TRANSACTION_NOT_IN_WHITELIST, msg.responseCode());
+        assertEquals(BATCH_TRANSACTION_IN_BLACKLIST, msg.responseCode());
     }
 
     @Test
@@ -147,7 +147,7 @@ class AtomicBatchHandlerTest {
         final var txnBody = newAtomicBatch(payerId1, consensusTimestamp, transaction);
         given(preHandleContext.body()).willReturn(txnBody);
         final var msg = assertThrows(PreCheckException.class, () -> subject.preHandle(preHandleContext));
-        assertEquals(BATCH_TRANSACTION_NOT_IN_WHITELIST, msg.responseCode());
+        assertEquals(BATCH_TRANSACTION_IN_BLACKLIST, msg.responseCode());
     }
 
     @Test
@@ -244,7 +244,7 @@ class AtomicBatchHandlerTest {
         final var txnBody = newAtomicBatch(payerId1, consensusTimestamp, transaction1, transaction2);
         given(preHandleContext.body()).willReturn(txnBody);
         final var msg = assertThrows(PreCheckException.class, () -> subject.preHandle(preHandleContext));
-        assertEquals(BATCH_TRANSACTION_NOT_IN_WHITELIST, msg.responseCode());
+        assertEquals(BATCH_TRANSACTION_IN_BLACKLIST, msg.responseCode());
     }
 
     @Test
@@ -258,7 +258,7 @@ class AtomicBatchHandlerTest {
         final var txnBody = newAtomicBatch(payerId1, consensusTimestamp, transaction1, transaction2);
         given(preHandleContext.body()).willReturn(txnBody);
         final var msg = assertThrows(PreCheckException.class, () -> subject.preHandle(preHandleContext));
-        assertEquals(BATCH_TRANSACTION_NOT_IN_WHITELIST, msg.responseCode());
+        assertEquals(BATCH_TRANSACTION_IN_BLACKLIST, msg.responseCode());
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
@@ -40,7 +40,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_LIST_CONTAINS_DUPLICATES;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_LIST_EMPTY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_SIZE_LIMIT_EXCEEDED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_TRANSACTION_NOT_IN_WHITELIST;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_TRANSACTION_IN_BLACKLIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
@@ -586,7 +586,7 @@ public class AtomicBatchNegativeTest {
                                     .withProtoStructure(TxnProtoStructure.NORMALIZED)
                                     .batchKey("batchOperator"))
                             .signedByPayerAnd("batchOperator")
-                            .hasKnownStatus(BATCH_TRANSACTION_NOT_IN_WHITELIST));
+                            .hasKnownStatus(BATCH_TRANSACTION_IN_BLACKLIST));
         }
 
         @HapiTest
@@ -601,7 +601,7 @@ public class AtomicBatchNegativeTest {
                                     .withProtoStructure(TxnProtoStructure.NORMALIZED)
                                     .batchKey("batchOperator")
                                     .signedByPayerAnd("batchOperator"))
-                            .hasKnownStatus(BATCH_TRANSACTION_NOT_IN_WHITELIST));
+                            .hasKnownStatus(BATCH_TRANSACTION_IN_BLACKLIST));
         }
 
         @HapiTest
@@ -620,7 +620,7 @@ public class AtomicBatchNegativeTest {
                                             .withProtoStructure(TxnProtoStructure.NORMALIZED)
                                             .batchKey("batchOperator")
                                             .signedByPayerAnd("batchOperator"))
-                            .hasKnownStatus(BATCH_TRANSACTION_NOT_IN_WHITELIST));
+                            .hasKnownStatus(BATCH_TRANSACTION_IN_BLACKLIST));
         }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchTest.java
@@ -53,7 +53,7 @@ import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.createHollow
 import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
 import static com.hedera.services.bdd.suites.utils.sysfiles.serdes.ThrottleDefsLoader.protoDefsFromResource;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_KEY_SET_ON_NON_INNER_TRANSACTION;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_TRANSACTION_NOT_IN_WHITELIST;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_TRANSACTION_IN_BLACKLIST;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MISSING_BATCH_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -101,7 +101,7 @@ public class AtomicBatchTest {
                 cryptoCreate(innerTxnPayer).balance(ONE_HBAR),
                 usableTxnIdNamed(innerTxnId).payerId(innerTxnPayer),
                 // Since the inner txn is not normalized, it should fail
-                atomicBatch(innerTxn).payingWith(batchOperator).hasPrecheck(BATCH_TRANSACTION_NOT_IN_WHITELIST));
+                atomicBatch(innerTxn).payingWith(batchOperator).hasPrecheck(BATCH_TRANSACTION_IN_BLACKLIST));
     }
 
     @HapiTest
@@ -126,7 +126,7 @@ public class AtomicBatchTest {
                 cryptoCreate(innerTxnPayer).balance(ONE_HBAR),
                 usableTxnIdNamed(innerTxnId).payerId(innerTxnPayer),
                 // Since the inner txn is not normalized, it should fail
-                atomicBatch(innerTxn).payingWith(batchOperator).hasPrecheck(BATCH_TRANSACTION_NOT_IN_WHITELIST));
+                atomicBatch(innerTxn).payingWith(batchOperator).hasPrecheck(BATCH_TRANSACTION_IN_BLACKLIST));
     }
 
     @HapiTest


### PR DESCRIPTION
Signed-off-by: Kim Rader <kim.rader@swirldslabs.com>
(cherry picked from commit 08f3d21e3bae1b2bb5e82b0d15e6743203f4aa75)

Description:
Rename response code BATCH_TRANSACTION_NOT_IN_WHITELIST to BATCH_TRANSACTION_IN_BLACKLIST

Related issue(s):
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/18065
Cherry-pick from main of PR #18085 