### PR TITLE
chore: cherry-pick Set `blockPeriod` to 0 in `BlockStreamConfig`

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
@@ -35,7 +35,7 @@ public record BlockStreamConfig(
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean compressFilesOnCreation,
         @ConfigProperty(defaultValue = "32") @NetworkProperty int hashCombineBatchSize,
         @ConfigProperty(defaultValue = "1") @NetworkProperty int roundsPerBlock,
-        @ConfigProperty(defaultValue = "2s") @Min(0) @NetworkProperty Duration blockPeriod,
+        @ConfigProperty(defaultValue = "0") @Min(0) @NetworkProperty Duration blockPeriod,
         @ConfigProperty(defaultValue = "2") @NetworkProperty long waitPeriodForActiveConnection,
         @ConfigProperty(defaultValue = "localhost") String grpcAddress,
         @ConfigProperty(defaultValue = "8080") @Min(0) @Max(65535) int grpcPort) {


### PR DESCRIPTION
**Description**:
Cherry pick's cc03859208c0719b6f488c966e590bc278a5209e regarding the issue as described below.

Currently there is an issue with `DefaultIssDetector` only looking at `StateSignatureTransaction`'s from boundary rounds, therefore ISS's will most likely be missed.

Let's fall back to `roundsPerBlock` of 1 until this issue is fixed.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
