### PR TITLE
chore: removing T&L from hapi reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,7 +15,7 @@
 ##### HAPI protobuf #####
 #########################
 
-/hapi/                                          @hiero-ledger/hcn-execution-codeowners @hiero-ledger/hcn-smart-contract-codeowners @hiero-ledger/hcn-consensus-codeowners @hiero-ledger/hcn-tools-and-libs-codeowners
+/hapi/                                          @hiero-ledger/hcn-execution-codeowners @hiero-ledger/hcn-smart-contract-codeowners @hiero-ledger/hcn-consensus-codeowners
 /hapi/hedera-protobufs/services                 @hiero-ledger/hcn-execution-codeowners @hiero-ledger/hcn-smart-contract-codeowners @jsync-swirlds @hiero-ledger/hiero-mirror-node-maintainers
 
 
@@ -91,7 +91,7 @@
 ####################
 #####   HAPI  ######
 ####################
-/hapi/                                              @hiero-ledger/hcn-consensus-codeowners @hiero-ledger/hcn-tools-and-libs-codeowners @hiero-ledger/hcn-execution-codeowners @hiero-ledger/hcn-smart-contract-codeowners
+/hapi/                                              @hiero-ledger/hcn-consensus-codeowners @hiero-ledger/hcn-execution-codeowners @hiero-ledger/hcn-smart-contract-codeowners
 
 # Documentation
 /platform-sdk/docs/platformWiki.md                  @hiero-ledger/hcn-consensus-codeowners @hiero-ledger/hcn-tools-and-libs-codeowners


### PR DESCRIPTION
Removing T&L team from hapi reviews as they arenot involved in these. This is to reduce review request noise
