### PR TITLE
refactor: 18083 Remove redundant `Configuration` parameter

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -507,21 +507,14 @@ public class ServicesMain implements SwirldMain<MerkleNodeState> {
             @NonNull final PlatformStateFacade platformStateFacade,
             @NonNull final PlatformContext platformContext) {
         final var loadedState = StartupStateUtils.loadStateFile(
-                configuration,
-                recycleBin,
-                selfId,
-                mainClassName,
-                swirldName,
-                softwareVersion,
-                platformStateFacade,
-                platformContext);
+                recycleBin, selfId, mainClassName, swirldName, softwareVersion, platformStateFacade, platformContext);
         try (loadedState) {
             if (loadedState.isNotNull()) {
                 logger.info(
                         STARTUP.getMarker(),
                         new SavedStateLoadedPayload(
                                 loadedState.get().getRound(), loadedState.get().getConsensusTimestamp()));
-                return copyInitialSignedState(configuration, loadedState.get(), platformStateFacade, platformContext);
+                return copyInitialSignedState(loadedState.get(), platformStateFacade, platformContext);
             }
         }
         final var stateRoot = stateRootSupplier.get();
@@ -537,8 +530,7 @@ public class ServicesMain implements SwirldMain<MerkleNodeState> {
         signedState.init(platformContext);
         final var reservedSignedState = signedState.reserve("initial reservation on genesis state");
         try (reservedSignedState) {
-            return copyInitialSignedState(
-                    configuration, reservedSignedState.get(), platformStateFacade, platformContext);
+            return copyInitialSignedState(reservedSignedState.get(), platformStateFacade, platformContext);
         }
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -262,7 +262,6 @@ public class Browser {
             // Create the initial state for the platform
             StateLifecycles stateLifecycles = appMain.newStateLifecycles();
             final HashedReservedSignedState reservedState = getInitialState(
-                    configuration,
                     recycleBin,
                     appMain.getSoftwareVersion(),
                     appMain::newStateRoot,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CompareStatesCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/CompareStatesCommand.java
@@ -122,7 +122,7 @@ public final class CompareStatesCommand extends AbstractCommand {
         logger.info(LogMarker.CLI.getMarker(), "Loading state from {}", statePath);
 
         final ReservedSignedState signedState = SignedStateFileReader.readStateFile(
-                        platformContext.getConfiguration(), statePath, DEFAULT_PLATFORM_STATE_FACADE, platformContext)
+                        statePath, DEFAULT_PLATFORM_STATE_FACADE, platformContext)
                 .reservedSignedState();
         logger.info(LogMarker.CLI.getMarker(), "Hashing state");
         try {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/GenesisPlatformStateCommand.java
@@ -66,7 +66,7 @@ public class GenesisPlatformStateCommand extends AbstractCommand {
         System.out.printf("Reading from %s %n", statePath.toAbsolutePath());
         final PlatformStateFacade stateFacade = DEFAULT_PLATFORM_STATE_FACADE;
         final DeserializedSignedState deserializedSignedState =
-                SignedStateFileReader.readStateFile(configuration, statePath, stateFacade, platformContext);
+                SignedStateFileReader.readStateFile(statePath, stateFacade, platformContext);
         try (final ReservedSignedState reservedSignedState = deserializedSignedState.reservedSignedState()) {
             stateFacade.bulkUpdateOf(reservedSignedState.get().getState(), v -> {
                 System.out.printf("Replacing platform data %n");

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/ValidateAddressBookStateCommand.java
@@ -58,8 +58,8 @@ public class ValidateAddressBookStateCommand extends AbstractCommand {
         final PlatformContext platformContext = PlatformContext.create(configuration);
 
         System.out.printf("Reading state from %s %n", statePath.toAbsolutePath());
-        final DeserializedSignedState deserializedSignedState = SignedStateFileReader.readStateFile(
-                configuration, statePath, DEFAULT_PLATFORM_STATE_FACADE, platformContext);
+        final DeserializedSignedState deserializedSignedState =
+                SignedStateFileReader.readStateFile(statePath, DEFAULT_PLATFORM_STATE_FACADE, platformContext);
 
         System.out.printf("Reading address book from %s %n", addressBookPath.toAbsolutePath());
         final String addressBookString = Files.readString(addressBookPath);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossip.java
@@ -351,7 +351,6 @@ public class SyncGossip implements ConnectionTracker, Gossip {
                 new DefaultSignedStateValidator(platformContext, platformStateFacade),
                 fallenBehindManager,
                 platformStatusSupplier,
-                platformContext.getConfiguration(),
                 platformStateFacade);
 
         final Protocol heartbeatProtocol = new HeartbeatProtocol(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ReconnectProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/ReconnectProtocol.java
@@ -67,7 +67,6 @@ public class ReconnectProtocol implements Protocol {
             @NonNull final SignedStateValidator validator,
             @NonNull final FallenBehindManager fallenBehindManager,
             final Supplier<PlatformStatus> platformStatusSupplier,
-            @NonNull final Configuration configuration,
             @NonNull final PlatformStateFacade platformStateFacade) {
 
         this.platformContext = Objects.requireNonNull(platformContext);
@@ -81,7 +80,7 @@ public class ReconnectProtocol implements Protocol {
         this.fallenBehindManager = Objects.requireNonNull(fallenBehindManager);
         this.platformStateFacade = platformStateFacade;
         this.platformStatusSupplier = Objects.requireNonNull(platformStatusSupplier);
-        this.configuration = Objects.requireNonNull(configuration);
+        this.configuration = Objects.requireNonNull(platformContext.getConfiguration());
         this.time = Objects.requireNonNull(platformContext.getTime());
     }
 
@@ -170,7 +169,6 @@ public class ReconnectProtocol implements Protocol {
                 new DefaultSignedStateValidator(platformContext, platformStateFacade),
                 sharedState.syncManager(),
                 sharedState.currentPlatformStatus()::get,
-                platformContext.getConfiguration(),
                 platformStateFacade);
     }
 
@@ -192,7 +190,6 @@ public class ReconnectProtocol implements Protocol {
                 validator,
                 fallenBehindManager,
                 platformStatusSupplier,
-                configuration,
                 time,
                 platformStateFacade);
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectPeerProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectPeerProtocol.java
@@ -84,7 +84,6 @@ public class ReconnectPeerProtocol implements PeerProtocol {
      * @param reconnectController     controls reconnecting as a learner
      * @param fallenBehindManager     maintains this node's behind status
      * @param platformStatusSupplier  provides the platform status
-     * @param configuration           platform configuration
      * @param time                    the time object to use
      * @param platformStateFacade     provides access to the platform state
      */
@@ -100,7 +99,6 @@ public class ReconnectPeerProtocol implements PeerProtocol {
             @NonNull final SignedStateValidator validator,
             @NonNull final FallenBehindManager fallenBehindManager,
             @NonNull final Supplier<PlatformStatus> platformStatusSupplier,
-            @NonNull final Configuration configuration,
             @NonNull final Time time,
             @NonNull final PlatformStateFacade platformStateFacade) {
 
@@ -115,7 +113,7 @@ public class ReconnectPeerProtocol implements PeerProtocol {
         this.validator = Objects.requireNonNull(validator);
         this.fallenBehindManager = Objects.requireNonNull(fallenBehindManager);
         this.platformStatusSupplier = Objects.requireNonNull(platformStatusSupplier);
-        this.configuration = Objects.requireNonNull(configuration);
+        this.configuration = Objects.requireNonNull(platformContext.getConfiguration());
         this.platformStateFacade = Objects.requireNonNull(platformStateFacade);
         Objects.requireNonNull(time);
 
@@ -304,7 +302,6 @@ public class ReconnectPeerProtocol implements PeerProtocol {
                             connection.getOtherId(),
                             state.get().getRound(),
                             reconnectMetrics,
-                            configuration,
                             platformStateFacade)
                     .execute(state.get());
         } finally {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
@@ -68,7 +68,6 @@ public class ReconnectTeacher {
      * @param otherId                the learner's ID
      * @param lastRoundReceived      the round of the state
      * @param statistics             reconnect metrics
-     * @param configuration          the configuration
      * @param platformStateFacade    the facade to access the platform state
      */
     public ReconnectTeacher(
@@ -81,7 +80,6 @@ public class ReconnectTeacher {
             @NonNull final NodeId otherId,
             final long lastRoundReceived,
             @NonNull final ReconnectMetrics statistics,
-            @NonNull final Configuration configuration,
             @NonNull final PlatformStateFacade platformStateFacade) {
 
         this.platformContext = Objects.requireNonNull(platformContext);
@@ -94,7 +92,7 @@ public class ReconnectTeacher {
         this.otherId = Objects.requireNonNull(otherId);
         this.lastRoundReceived = lastRoundReceived;
         this.statistics = Objects.requireNonNull(statistics);
-        this.configuration = Objects.requireNonNull(configuration);
+        this.configuration = Objects.requireNonNull(platformContext.getConfiguration());
         this.platformStateFacade = platformStateFacade;
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditor.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/editor/StateEditor.java
@@ -52,8 +52,8 @@ public class StateEditor {
 
         platformContext = PlatformContext.create(configuration);
 
-        final DeserializedSignedState deserializedSignedState = SignedStateFileReader.readStateFile(
-                configuration, statePath, DEFAULT_PLATFORM_STATE_FACADE, platformContext);
+        final DeserializedSignedState deserializedSignedState =
+                SignedStateFileReader.readStateFile(statePath, DEFAULT_PLATFORM_STATE_FACADE, platformContext);
 
         try (final ReservedSignedState reservedSignedState = deserializedSignedState.reservedSignedState()) {
             System.out.println("\nLoading state from " + statePath);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -53,7 +53,6 @@ public final class StartupStateUtils {
      * Used exclusively by {@link com.swirlds.platform.Browser} to get the initial state to be used by this node.
      * May return a state loaded from disk, or may return a genesis state if no valid state is found on disk.
      *
-     * @param configuration      the configuration for this node
      * @param softwareVersion     the software version of the app
      * @param genesisStateBuilder a supplier that can build a genesis state
      * @param mainClassName       the name of the app's SwirldMain class
@@ -67,7 +66,6 @@ public final class StartupStateUtils {
     @NonNull
     @Deprecated(forRemoval = true)
     public static HashedReservedSignedState getInitialState(
-            @NonNull final Configuration configuration,
             @NonNull final RecycleBin recycleBin,
             @NonNull final SoftwareVersion softwareVersion,
             @NonNull final Supplier<MerkleNodeState> genesisStateBuilder,
@@ -79,21 +77,15 @@ public final class StartupStateUtils {
             @NonNull final PlatformContext platformContext)
             throws SignedStateLoadingException {
 
-        requireNonNull(configuration);
         requireNonNull(mainClassName);
         requireNonNull(swirldName);
         requireNonNull(selfId);
         requireNonNull(configAddressBook);
+        requireNonNull(platformContext);
+        requireNonNull(platformContext.getConfiguration());
 
         final ReservedSignedState loadedState = StartupStateUtils.loadStateFile(
-                configuration,
-                recycleBin,
-                selfId,
-                mainClassName,
-                swirldName,
-                softwareVersion,
-                platformStateFacade,
-                platformContext);
+                recycleBin, selfId, mainClassName, swirldName, softwareVersion, platformStateFacade, platformContext);
 
         try (loadedState) {
             if (loadedState.isNotNull()) {
@@ -102,27 +94,21 @@ public final class StartupStateUtils {
                         new SavedStateLoadedPayload(
                                 loadedState.get().getRound(), loadedState.get().getConsensusTimestamp()));
 
-                return copyInitialSignedState(configuration, loadedState.get(), platformStateFacade, platformContext);
+                return copyInitialSignedState(loadedState.get(), platformStateFacade, platformContext);
             }
         }
 
         final ReservedSignedState genesisState = buildGenesisState(
-                configuration,
-                configAddressBook,
-                softwareVersion,
-                genesisStateBuilder.get(),
-                platformStateFacade,
-                platformContext);
+                configAddressBook, softwareVersion, genesisStateBuilder.get(), platformStateFacade, platformContext);
 
         try (genesisState) {
-            return copyInitialSignedState(configuration, genesisState.get(), platformStateFacade, platformContext);
+            return copyInitialSignedState(genesisState.get(), platformStateFacade, platformContext);
         }
     }
 
     /**
      * Looks at the states on disk, chooses one to load, and then loads the chosen state.
      *
-     * @param configuration            the configuration for this node
      * @param selfId                   the ID of this node
      * @param mainClassName            the name of the main class
      * @param swirldName               the name of the swirld
@@ -133,7 +119,6 @@ public final class StartupStateUtils {
      */
     @NonNull
     public static ReservedSignedState loadStateFile(
-            @NonNull final Configuration configuration,
             @NonNull final RecycleBin recycleBin,
             @NonNull final NodeId selfId,
             @NonNull final String mainClassName,
@@ -142,11 +127,12 @@ public final class StartupStateUtils {
             @NonNull final PlatformStateFacade platformStateFacade,
             @NonNull final PlatformContext platformContext) {
 
-        final StateConfig stateConfig = configuration.getConfigData(StateConfig.class);
+        final Configuration config = platformContext.getConfiguration();
+        final StateConfig stateConfig = config.getConfigData(StateConfig.class);
         final String actualMainClassName = stateConfig.getMainClassName(mainClassName);
 
         final List<SavedStateInfo> savedStateFiles = new SignedStateFilePath(
-                        configuration.getConfigData(StateCommonConfig.class))
+                        config.getConfigData(StateCommonConfig.class))
                 .getSavedStateFiles(actualMainClassName, selfId, swirldName);
         logStatesFound(savedStateFiles);
 
@@ -156,12 +142,7 @@ public final class StartupStateUtils {
         }
 
         final ReservedSignedState state = loadLatestState(
-                configuration,
-                recycleBin,
-                currentSoftwareVersion,
-                savedStateFiles,
-                platformStateFacade,
-                platformContext);
+                recycleBin, currentSoftwareVersion, savedStateFiles, platformStateFacade, platformContext);
         return state;
     }
 
@@ -169,21 +150,20 @@ public final class StartupStateUtils {
      * Create a copy of the initial signed state. There are currently data structures that become immutable after being
      * hashed, and we need to make a copy to force it to become mutable again.
      *
-     * @param configuration      the configuration for this node
      * @param initialSignedState the initial signed state
      * @return a copy of the initial signed state
      */
     public static @NonNull HashedReservedSignedState copyInitialSignedState(
-            @NonNull final Configuration configuration,
             @NonNull final SignedState initialSignedState,
             @NonNull final PlatformStateFacade platformStateFacade,
             @NonNull final PlatformContext platformContext) {
-        requireNonNull(configuration);
+        requireNonNull(platformContext);
+        requireNonNull(platformContext.getConfiguration());
         requireNonNull(initialSignedState);
 
         final MerkleNodeState stateCopy = initialSignedState.getState().copy();
         final SignedState signedStateCopy = new SignedState(
-                configuration,
+                platformContext.getConfiguration(),
                 CryptoStatic::verifySignature,
                 stateCopy,
                 "StartupStateUtils: copy initial state",
@@ -226,7 +206,6 @@ public final class StartupStateUtils {
      * @return the loaded state
      */
     private static ReservedSignedState loadLatestState(
-            @NonNull final Configuration configuration,
             @NonNull final RecycleBin recycleBin,
             @NonNull final SoftwareVersion currentSoftwareVersion,
             @NonNull final List<SavedStateInfo> savedStateFiles,
@@ -238,12 +217,7 @@ public final class StartupStateUtils {
 
         for (final SavedStateInfo savedStateFile : savedStateFiles) {
             final ReservedSignedState state = loadStateFile(
-                    configuration,
-                    recycleBin,
-                    currentSoftwareVersion,
-                    savedStateFile,
-                    platformStateFacade,
-                    platformContext);
+                    recycleBin, currentSoftwareVersion, savedStateFile, platformStateFacade, platformContext);
             if (state != null) {
                 return state;
             }
@@ -262,7 +236,6 @@ public final class StartupStateUtils {
      */
     @Nullable
     private static ReservedSignedState loadStateFile(
-            @NonNull final Configuration configuration,
             @NonNull final RecycleBin recycleBin,
             @NonNull final SoftwareVersion currentSoftwareVersion,
             @NonNull final SavedStateInfo savedStateFile,
@@ -273,9 +246,9 @@ public final class StartupStateUtils {
         logger.info(STARTUP.getMarker(), "Loading signed state from disk: {}", savedStateFile.stateFile());
 
         final DeserializedSignedState deserializedSignedState;
+        final Configuration configuration = platformContext.getConfiguration();
         try {
-            deserializedSignedState =
-                    readStateFile(configuration, savedStateFile.stateFile(), platformStateFacade, platformContext);
+            deserializedSignedState = readStateFile(savedStateFile.stateFile(), platformStateFacade, platformContext);
         } catch (final IOException e) {
             logger.error(EXCEPTION.getMarker(), "unable to load state file {}", savedStateFile.stateFile(), e);
 
@@ -339,23 +312,21 @@ public final class StartupStateUtils {
      * Build and initialize a genesis state.
      * <p>
      * <b>Important:</b> Only used by {@link com.swirlds.platform.Browser}.
-     * @param configuration         the configuration for this node
      * @param addressBook           the current address book
      * @param appVersion            the software version of the app
      * @param stateRoot             the merkle root node of the state
      * @return a reserved genesis signed state
      */
     private static ReservedSignedState buildGenesisState(
-            @NonNull final Configuration configuration,
             @NonNull final AddressBook addressBook,
             @NonNull final SoftwareVersion appVersion,
             @NonNull final MerkleNodeState stateRoot,
             @NonNull final PlatformStateFacade platformStateFacade,
             @NonNull final PlatformContext platformContext) {
-        initGenesisState(configuration, stateRoot, platformStateFacade, addressBook, appVersion);
+        initGenesisState(platformContext.getConfiguration(), stateRoot, platformStateFacade, addressBook, appVersion);
 
         final SignedState signedState = new SignedState(
-                configuration,
+                platformContext.getConfiguration(),
                 CryptoStatic::verifySignature,
                 stateRoot,
                 "genesis state",

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/snapshot/SignedStateFileReader.java
@@ -5,6 +5,7 @@ import static com.swirlds.common.io.streams.StreamDebugUtils.deserializeAndDebug
 import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.SIGNATURE_SET_FILE_NAME;
 import static com.swirlds.platform.state.snapshot.SignedStateFileUtils.SUPPORTED_SIGSET_VERSIONS;
 import static java.nio.file.Files.exists;
+import static java.util.Objects.requireNonNull;
 
 import com.swirlds.common.RosterStateId;
 import com.swirlds.common.context.PlatformContext;
@@ -30,7 +31,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
-import java.util.Objects;
 
 /**
  * Utility methods for reading a signed state from disk.
@@ -41,20 +41,19 @@ public final class SignedStateFileReader {
     /**
      * Reads a SignedState from disk. If the reader throws an exception, it is propagated by this method to the caller.
      *
-     * @param configuration                 the configuration for this node
      * @param stateFile                     the file to read from
      * @return a signed state with it's associated hash (as computed when the state was serialized)
      * @throws IOException if there is any problems with reading from a file
      */
     public static @NonNull DeserializedSignedState readStateFile(
-            @NonNull final Configuration configuration,
             @NonNull final Path stateFile,
             @NonNull final PlatformStateFacade stateFacade,
             @NonNull final PlatformContext platformContext)
             throws IOException {
 
-        Objects.requireNonNull(configuration);
-        Objects.requireNonNull(stateFile);
+        requireNonNull(stateFile);
+        requireNonNull(platformContext);
+        final Configuration conf = platformContext.getConfiguration();
 
         checkSignedStatePath(stateFile);
 
@@ -69,7 +68,7 @@ public final class SignedStateFileReader {
                 });
 
         final SignedState newSignedState = new SignedState(
-                configuration,
+                conf,
                 CryptoStatic::verifySignature,
                 (MerkleNodeState) data.stateRoot(),
                 "SignedStateFileReader.readStateFile()",

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -138,8 +138,8 @@ class SignedStateFileReadWriteTest {
         MerkleDb.resetDefaultInstancePath();
         Configuration configuration =
                 TestPlatformContextBuilder.create().build().getConfiguration();
-        final DeserializedSignedState deserializedSignedState = readStateFile(
-                configuration, stateFile, TEST_PLATFORM_STATE_FACADE, PlatformContext.create(configuration));
+        final DeserializedSignedState deserializedSignedState =
+                readStateFile(stateFile, TEST_PLATFORM_STATE_FACADE, PlatformContext.create(configuration));
         MerkleCryptoFactory.getInstance()
                 .digestTreeSync(deserializedSignedState
                         .reservedSignedState()

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -148,8 +148,8 @@ class StateFileManagerTests {
         MerkleDb.resetDefaultInstancePath();
         Configuration configuration =
                 TestPlatformContextBuilder.create().build().getConfiguration();
-        final DeserializedSignedState deserializedSignedState = readStateFile(
-                configuration, stateFile, TEST_PLATFORM_STATE_FACADE, PlatformContext.create(configuration));
+        final DeserializedSignedState deserializedSignedState =
+                readStateFile(stateFile, TEST_PLATFORM_STATE_FACADE, PlatformContext.create(configuration));
         MerkleCryptoFactory.getInstance()
                 .digestTreeSync(deserializedSignedState
                         .reservedSignedState()
@@ -353,7 +353,6 @@ class StateFileManagerTests {
                             TestPlatformContextBuilder.create().build().getConfiguration();
                     final SignedState stateFromDisk = assertDoesNotThrow(
                             () -> SignedStateFileReader.readStateFile(
-                                            configuration,
                                             savedStateInfo.stateFile(),
                                             TEST_PLATFORM_STATE_FACADE,
                                             PlatformContext.create(configuration))

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectPeerProtocolTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectPeerProtocolTests.java
@@ -162,7 +162,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration,
                 TEST_PLATFORM_STATE_FACADE);
 
         assertEquals(
@@ -206,7 +205,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration,
                 TEST_PLATFORM_STATE_FACADE);
 
         assertEquals(
@@ -241,7 +239,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration,
                 TEST_PLATFORM_STATE_FACADE);
 
         // the ReconnectController must be running in order to provide permits
@@ -293,7 +290,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration,
                 Time.getCurrent(),
                 TEST_PLATFORM_STATE_FACADE);
         final SignedState signedState = spy(new RandomSignedStateGenerator().build());
@@ -315,7 +311,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration,
                 Time.getCurrent(),
                 TEST_PLATFORM_STATE_FACADE);
 
@@ -361,7 +356,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration,
                 TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertTrue(peerProtocol.shouldInitiate());
@@ -406,7 +400,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration,
                 TEST_PLATFORM_STATE_FACADE);
 
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
@@ -445,7 +438,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> ACTIVE,
-                configuration,
                 TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertFalse(peerProtocol.shouldAccept());
@@ -476,7 +468,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 fallenBehindManager,
                 () -> PlatformStatus.CHECKING,
-                configuration,
                 TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertFalse(peerProtocol.shouldAccept());
@@ -503,7 +494,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 mock(FallenBehindManager.class),
                 () -> ACTIVE,
-                configuration,
                 TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertTrue(peerProtocol.shouldAccept());
@@ -550,7 +540,6 @@ class ReconnectPeerProtocolTests {
                 mock(SignedStateValidator.class),
                 mock(FallenBehindManager.class),
                 () -> ACTIVE,
-                configuration,
                 TEST_PLATFORM_STATE_FACADE);
         final PeerProtocol peerProtocol = reconnectProtocol.createPeerInstance(NodeId.of(0));
         assertFalse(peerProtocol.shouldAccept());

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/ReconnectTest.java
@@ -173,7 +173,6 @@ final class ReconnectTest {
                 otherId,
                 lastRoundReceived,
                 reconnectMetrics,
-                platformContext.getConfiguration(),
                 platformStateFacade);
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -162,7 +162,6 @@ public class StartupStateUtilsTests {
         final RecycleBin recycleBin = initializeRecycleBin(platformContext, selfId);
 
         final SignedState loadedState = StartupStateUtils.loadStateFile(
-                        platformContext.getConfiguration(),
                         recycleBin,
                         selfId,
                         mainClassName,
@@ -193,7 +192,6 @@ public class StartupStateUtilsTests {
         final RecycleBin recycleBin = initializeRecycleBin(platformContext, selfId);
         MerkleDb.resetDefaultInstancePath();
         final SignedState loadedState = StartupStateUtils.loadStateFile(
-                        platformContext.getConfiguration(),
                         recycleBin,
                         selfId,
                         mainClassName,
@@ -228,7 +226,6 @@ public class StartupStateUtilsTests {
         final RecycleBin recycleBin = initializeRecycleBin(platformContext, selfId);
 
         assertThrows(SignedStateLoadingException.class, () -> StartupStateUtils.loadStateFile(
-                        platformContext.getConfiguration(),
                         recycleBin,
                         selfId,
                         mainClassName,
@@ -275,7 +272,6 @@ public class StartupStateUtilsTests {
 
         MerkleDb.resetDefaultInstancePath();
         final SignedState loadedState = StartupStateUtils.loadStateFile(
-                        platformContext.getConfiguration(),
                         recycleBin,
                         selfId,
                         mainClassName,

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleNode.java
@@ -118,7 +118,6 @@ public class TurtleNode {
                 RecycleBin.create(metrics, configuration, getStaticThreadManager(), time, fileSystemManager, nodeId);
 
         final var reservedState = getInitialState(
-                configuration,
                 recycleBin,
                 version,
                 TurtleTestingToolState::getStateRootNode,


### PR DESCRIPTION
**Description**:

This PR is a follow-up to [[this pull request](https://github.com/hiero-ledger/hiero-consensus-node/pull/18050)](https://github.com/hiero-ledger/hiero-consensus-node/pull/18050) and addresses [[this comment](https://github.com/hiero-ledger/hiero-consensus-node/pull/18050#discussion_r1973206024)](https://github.com/hiero-ledger/hiero-consensus-node/pull/18050#discussion_r1973206024). It removes redundant parameters of the `Configuration` type when they can be taken from a `PlatformContext` instance.

**Related issue(s)**:

Fixes #18083 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
