### PR TITLE
chore: (0.58) Cherry-pick misc fixes

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -365,6 +365,69 @@ public record EthTxData(
                 v,
                 r,
                 s);
+    }
+
+    @VisibleForTesting
+    public EthTxData replaceRecId(final int newRecId) {
+        return new EthTxData(
+                null,
+                type,
+                chainId,
+                nonce,
+                gasPrice,
+                maxPriorityGas,
+                maxGas,
+                gasLimit,
+                to,
+                value,
+                callData,
+                accessList,
+                newRecId,
+                v,
+                r,
+                s);
+    }
+
+    @VisibleForTesting
+    public EthTxData replaceR(final byte[] newR) {
+        return new EthTxData(
+                null,
+                type,
+                chainId,
+                nonce,
+                gasPrice,
+                maxPriorityGas,
+                maxGas,
+                gasLimit,
+                to,
+                value,
+                callData,
+                accessList,
+                recId,
+                v,
+                newR,
+                s);
+    }
+
+    @VisibleForTesting
+    public EthTxData replaceS(final byte[] newS) {
+        return new EthTxData(
+                null,
+                type,
+                chainId,
+                nonce,
+                gasPrice,
+                maxPriorityGas,
+                maxGas,
+                gasLimit,
+                to,
+                value,
+                callData,
+                accessList,
+                recId,
+                v,
+                r,
+                newS);
     }
 
     /**

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,6 +18,7 @@ package com.hedera.node.app.hapi.utils.ethereum;
 
 import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.DETERMINISTIC_DEPLOYER_TRANSACTION;
 import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.WEIBARS_IN_A_TINYBAR;
+import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -35,6 +36,7 @@ import com.swirlds.common.utility.CommonUtils;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
+import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.bouncycastle.util.BigIntegers;
 import org.bouncycastle.util.encoders.Hex;
 import org.junit.jupiter.api.Test;
@@ -42,6 +44,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
 class EthTxDataTest {
+    private static final BigInteger N = SECNamedCurves.getByName("secp256k1").getN();
 
     static final String SIGNATURE_ADDRESS = "a94f5374fce5edbc8e2a8697c15331677e6ebf0b";
     static final String SIGNATURE_PUBKEY = "033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d";
@@ -196,6 +199,38 @@ class EthTxDataTest {
         assertNotNull(eip155Sigs);
         assertEquals(EIP_155_DEMO_ADDRESS, Hex.toHexString(eip155Sigs.address()));
         assertEquals(EIP_155_DEMO_PUBKEY, Hex.toHexString(eip155Sigs.publicKey()));
+    }
+
+    @Test
+    void extractEIP155SignatureWithNegativeRecoveryIdThrowsIAE() {
+        final var invalidRecoveryEip155Tx = requireNonNull(EthTxData.populateEthTxData(Hex.decode(EIP155_DEMO)))
+                .replaceRecId(-1);
+
+        final var sigs = EthTxSigs.extractSignatures(invalidRecoveryEip155Tx);
+
+        // We changed the bytes signed in the test vector
+        assertNotEquals(EIP_155_DEMO_ADDRESS, Hex.toHexString(sigs.address()));
+        assertNotEquals(EIP_155_DEMO_PUBKEY, Hex.toHexString(sigs.publicKey()));
+    }
+
+    @Test
+    void extractSignatureThrowsWithInvalidR() {
+        final var rCurvePointAtNEip155Tx = requireNonNull(EthTxData.populateEthTxData(Hex.decode(EIP155_DEMO)))
+                .replaceR(N.toByteArray());
+        assertThrows(IllegalArgumentException.class, () -> EthTxSigs.extractSignatures(rCurvePointAtNEip155Tx));
+        final var rCurvePointAt0Eip155Tx = requireNonNull(EthTxData.populateEthTxData(Hex.decode(EIP155_DEMO)))
+                .replaceR(BigInteger.ZERO.toByteArray());
+        assertThrows(IllegalArgumentException.class, () -> EthTxSigs.extractSignatures(rCurvePointAt0Eip155Tx));
+    }
+
+    @Test
+    void extractSignatureThrowsWithInvalidS() {
+        final var sCurvePointAtNEip155Tx = requireNonNull(EthTxData.populateEthTxData(Hex.decode(EIP155_DEMO)))
+                .replaceS(N.toByteArray());
+        assertThrows(IllegalArgumentException.class, () -> EthTxSigs.extractSignatures(sCurvePointAtNEip155Tx));
+        final var sCurvePointAt0Eip155Tx = requireNonNull(EthTxData.populateEthTxData(Hex.decode(EIP155_DEMO)))
+                .replaceS(BigInteger.ZERO.toByteArray());
+        assertThrows(IllegalArgumentException.class, () -> EthTxSigs.extractSignatures(sCurvePointAt0Eip155Tx));
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeRecordHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/FinalizeRecordHandler.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2023-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -136,9 +136,10 @@ public class FinalizeRecordHandler extends RecordFinalizerBase {
         }
         // If the function is not a crypto transfer, then we filter all zero amounts from token transfer list.
         // To be compatible with mono-service records, we _don't_ filter zero token transfers in the record
-        final var isCryptoTransfer = functionality == HederaFunctionality.CRYPTO_TRANSFER;
+        final var isCryptoTransfer =
+                functionality == HederaFunctionality.CRYPTO_TRANSFER ? IsCryptoTransfer.YES : IsCryptoTransfer.NO;
         // get all the token relation changes for fungible and non-fungible tokens
-        final var tokenRelChanges = tokenRelChangesFrom(writableTokenRelStore, !isCryptoTransfer);
+        final var tokenRelChanges = tokenRelChangesFrom(writableTokenRelStore, isCryptoTransfer);
         // get all the NFT changes. Go through the nft changes and see if there are any token relation changes
         // for the sender and receiver of the NFTs. If there are, then reduce the balance change for that relation
         // by 1 for receiver and increment the balance change for sender by 1. This is to ensure that the NFT
@@ -158,7 +159,7 @@ public class FinalizeRecordHandler extends RecordFinalizerBase {
         }
         final var hasTokenTransferLists = !tokenRelChanges.isEmpty() || !nftChanges.isEmpty();
         if (hasTokenTransferLists) {
-            final var tokenTransferLists = asTokenTransferListFrom(tokenRelChanges, !isCryptoTransfer);
+            final var tokenTransferLists = asTokenTransferListFrom(tokenRelChanges, isCryptoTransfer);
             final var nftTokenTransferLists = asTokenTransferListFromNftChanges(nftChanges);
             tokenTransferLists.addAll(nftTokenTransferLists);
             tokenTransferLists.sort(TOKEN_TRANSFER_LIST_COMPARATOR);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoTransferValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoTransferValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2023-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,7 +53,6 @@ import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-import org.apache.commons.lang3.tuple.Pair;
 
 /**
  * A validator for the crypto transfer transaction.
@@ -77,12 +76,12 @@ public class CryptoTransferValidator {
         final var acctAmounts = op.transfersOrElse(TransferList.DEFAULT).accountAmounts();
         validateTruePreCheck(isNetZeroAdjustment(acctAmounts), INVALID_ACCOUNT_AMOUNTS);
 
-        final var uniqueAcctIds = new HashSet<Pair<AccountID, Boolean>>();
+        final var uniqueAcctIds = new HashSet<AccountID>();
         // Validate hbar transfers
         for (final AccountAmount acctAmount : acctAmounts) {
             validateTruePreCheck(acctAmount.hasAccountID(), INVALID_ACCOUNT_ID);
             final var acctId = validateAccountID(acctAmount.accountIDOrThrow(), null);
-            uniqueAcctIds.add(Pair.of(acctId, acctAmount.isApproval()));
+            uniqueAcctIds.add(acctId);
         }
         validateFalsePreCheck(uniqueAcctIds.size() < acctAmounts.size(), ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS);
 
@@ -177,13 +176,11 @@ public class CryptoTransferValidator {
             validateTruePreCheck(tokenID != null && !tokenID.equals(TokenID.DEFAULT), INVALID_TOKEN_ID);
 
             // Validate the fungible transfers
-            final var uniqueTokenAcctIds = new HashSet<Pair<AccountID, Boolean>>();
-            validateFungibleTransfers(tokenTransfer.transfers(), uniqueTokenAcctIds, allowanceStrategy);
-
+            final var uniqueTokenAcctIds = new HashSet<AccountID>();
+            validateNonDuplicateFungibleTransfers(tokenTransfer.transfers(), uniqueTokenAcctIds, allowanceStrategy);
             // Validate the nft transfers
             final var nftIds = new HashSet<Long>();
             validateNftTransfers(tokenTransfer.nftTransfers(), nftIds, allowanceStrategy);
-
             // Verify that one and only one of the two types of transfers (fungible or non-fungible) is present
             validateFalsePreCheck(
                     uniqueTokenAcctIds.isEmpty() && nftIds.isEmpty(), EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS);
@@ -191,9 +188,9 @@ public class CryptoTransferValidator {
         validateFalsePreCheck(tokenIds.size() < tokenTransfers.size(), TOKEN_ID_REPEATED_IN_TOKEN_LIST);
     }
 
-    public static void validateFungibleTransfers(
+    public static void validateNonDuplicateFungibleTransfers(
             final List<AccountAmount> fungibleTransfers,
-            final Set<Pair<AccountID, Boolean>> uniqueTokenAcctIds,
+            final Set<AccountID> uniqueTokenAcctIds,
             final AllowanceStrategy allowanceStrategy)
             throws PreCheckException {
         validateTruePreCheck(isNetZeroAdjustment(fungibleTransfers), TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN);
@@ -203,7 +200,7 @@ public class CryptoTransferValidator {
                 validateFalsePreCheck(acctAmount.isApproval(), NOT_SUPPORTED);
             }
             validateTruePreCheck(acctAmount.hasAccountID(), INVALID_TRANSFER_ACCOUNT_ID);
-            uniqueTokenAcctIds.add(Pair.of(acctAmount.accountIDOrThrow(), acctAmount.isApproval()));
+            uniqueTokenAcctIds.add(acctAmount.accountIDOrThrow());
             if (!nonZeroFungibleValueFound && acctAmount.amount() != 0) {
                 nonZeroFungibleValueFound = true;
             }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -91,6 +91,7 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
     private ByteString alias = null;
     private byte[] explicitTo = null;
     private Integer chainId = CHAIN_ID;
+    private boolean wrongRecId;
 
     public HapiEthereumCall withExplicitParams(final Supplier<String> supplier) {
         explicitHexedParams = Optional.of(supplier);
@@ -101,6 +102,11 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
         HapiEthereumCall call = new HapiEthereumCall();
         call.details = Optional.of(actionable);
         return call;
+    }
+
+    public HapiEthereumCall withWrongParityRecId() {
+        wrongRecId = true;
+        return this;
     }
 
     private HapiEthereumCall() {}
@@ -352,7 +358,7 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
                 null);
 
         byte[] privateKeyByteArray = getEcdsaPrivateKeyFromSpec(spec, privateKeyRef);
-        var signedEthTxData = Signing.signMessage(ethTxData, privateKeyByteArray);
+        var signedEthTxData = Signing.signMessage(ethTxData, privateKeyByteArray, wrongRecId);
         spec.registry().saveBytes(ETH_HASH_KEY, ByteString.copyFrom((signedEthTxData.getEthereumHash())));
 
         if (createCallDataFile || callData.length > MAX_CALL_DATA_SIZE) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoTransferSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2020-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,21 +56,14 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.grantTokenKyc;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.revokeTokenKyc;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenDissociate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenFreeze;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenPause;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUnfreeze;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUnpause;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.wipeTokenAccount;
-import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.allowanceTinyBarsFromTo;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromToWithAlias;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
@@ -82,7 +75,6 @@ import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.roy
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.royaltyFeeWithFallback;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
-import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbarWithAllowance;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUniqueWithAllowance;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingWithAllowance;
@@ -119,12 +111,8 @@ import static com.hedera.services.bdd.suites.contract.evm.Evm46ValidationSuite.e
 import static com.hedera.services.bdd.suites.contract.evm.Evm46ValidationSuite.nonExistingSystemAccounts;
 import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.A_TOKEN;
 import static com.hedera.services.bdd.suites.file.FileUpdateSuite.CIVILIAN;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AMOUNT_EXCEEDS_ALLOWANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALIAS_KEY;
@@ -136,9 +124,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_MAX_AU
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_REMAINING_AUTOMATIC_ASSOCIATIONS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SPENDER_DOES_NOT_HAVE_ALLOWANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_PAUSED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNEXPECTED_TOKEN_DECIMALS;
@@ -703,345 +689,6 @@ public class CryptoTransferSuite {
                         .fee(ONE_HBAR)
                         .addCryptoAllowance(NODE_REWARD, FUNDING, 100L)
                         .hasKnownStatus(INVALID_ALLOWANCE_OWNER_ID));
-    }
-
-    @HapiTest
-    final Stream<DynamicTest> allowanceTransfersWithComplexTransfersWork() {
-        return hapiTest(
-                newKeyNamed(ADMIN_KEY),
-                newKeyNamed(FREEZE_KEY),
-                newKeyNamed(KYC_KEY),
-                newKeyNamed(SUPPLY_KEY),
-                cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
-                cryptoCreate(OTHER_OWNER).balance(ONE_HUNDRED_HBARS),
-                cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
-                cryptoCreate(RECEIVER).balance(0L),
-                cryptoCreate(OTHER_RECEIVER).balance(ONE_HBAR),
-                cryptoCreate(ANOTHER_RECEIVER).balance(0L),
-                cryptoCreate(TOKEN_TREASURY),
-                tokenCreate(FUNGIBLE_TOKEN)
-                        .supplyType(TokenSupplyType.FINITE)
-                        .tokenType(FUNGIBLE_COMMON)
-                        .treasury(TOKEN_TREASURY)
-                        .maxSupply(10000)
-                        .initialSupply(5000)
-                        .adminKey(ADMIN_KEY)
-                        .kycKey(KYC_KEY),
-                tokenCreate(NON_FUNGIBLE_TOKEN)
-                        .supplyType(TokenSupplyType.FINITE)
-                        .tokenType(NON_FUNGIBLE_UNIQUE)
-                        .treasury(TOKEN_TREASURY)
-                        .maxSupply(12L)
-                        .supplyKey(SUPPLY_KEY)
-                        .adminKey(ADMIN_KEY)
-                        .kycKey(KYC_KEY)
-                        .initialSupply(0L),
-                mintToken(
-                        NON_FUNGIBLE_TOKEN,
-                        List.of(
-                                ByteString.copyFromUtf8("a"),
-                                ByteString.copyFromUtf8("b"),
-                                ByteString.copyFromUtf8("c"),
-                                ByteString.copyFromUtf8("d"),
-                                ByteString.copyFromUtf8("e"))),
-                tokenAssociate(OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
-                tokenAssociate(OTHER_OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
-                tokenAssociate(RECEIVER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
-                tokenAssociate(SPENDER, FUNGIBLE_TOKEN),
-                tokenAssociate(ANOTHER_RECEIVER, FUNGIBLE_TOKEN),
-                grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
-                grantTokenKyc(FUNGIBLE_TOKEN, OTHER_OWNER),
-                grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-                grantTokenKyc(FUNGIBLE_TOKEN, ANOTHER_RECEIVER),
-                grantTokenKyc(FUNGIBLE_TOKEN, SPENDER),
-                grantTokenKyc(NON_FUNGIBLE_TOKEN, OWNER),
-                grantTokenKyc(NON_FUNGIBLE_TOKEN, OTHER_OWNER),
-                grantTokenKyc(NON_FUNGIBLE_TOKEN, RECEIVER),
-                cryptoTransfer(
-                        moving(100, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, SPENDER),
-                        moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
-                        movingUnique(NON_FUNGIBLE_TOKEN, 1, 2).between(TOKEN_TREASURY, OWNER),
-                        moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OTHER_OWNER),
-                        movingUnique(NON_FUNGIBLE_TOKEN, 3, 4).between(TOKEN_TREASURY, OTHER_OWNER)),
-                cryptoApproveAllowance()
-                        .payingWith(OWNER)
-                        .addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
-                        .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 500)
-                        .addNftAllowance(OWNER, NON_FUNGIBLE_TOKEN, SPENDER, false, List.of(1L, 2L))
-                        .fee(ONE_HUNDRED_HBARS),
-                cryptoApproveAllowance()
-                        .payingWith(OTHER_OWNER)
-                        .addCryptoAllowance(OTHER_OWNER, SPENDER, 5 * ONE_HBAR)
-                        .addTokenAllowance(OTHER_OWNER, FUNGIBLE_TOKEN, SPENDER, 100)
-                        .addNftAllowance(OTHER_OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of(3L))
-                        .fee(ONE_HUNDRED_HBARS),
-                cryptoTransfer(
-                                movingHbar(ONE_HBAR).between(SPENDER, RECEIVER),
-                                movingHbar(ONE_HBAR).between(OTHER_RECEIVER, ANOTHER_RECEIVER),
-                                movingHbar(ONE_HBAR).between(OWNER, RECEIVER),
-                                movingHbar(ONE_HBAR).between(OTHER_OWNER, RECEIVER),
-                                movingHbarWithAllowance(ONE_HBAR).between(OWNER, RECEIVER),
-                                movingHbarWithAllowance(ONE_HBAR).between(OTHER_OWNER, RECEIVER),
-                                moving(50, FUNGIBLE_TOKEN).between(RECEIVER, ANOTHER_RECEIVER),
-                                moving(50, FUNGIBLE_TOKEN).between(SPENDER, RECEIVER),
-                                moving(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-                                moving(15, FUNGIBLE_TOKEN).between(OTHER_OWNER, RECEIVER),
-                                movingWithAllowance(30, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-                                movingWithAllowance(10, FUNGIBLE_TOKEN).between(OTHER_OWNER, RECEIVER),
-                                movingWithAllowance(5, FUNGIBLE_TOKEN).between(OTHER_OWNER, OWNER),
-                                movingUnique(NON_FUNGIBLE_TOKEN, 1L).between(OWNER, RECEIVER),
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-                                        .between(OWNER, RECEIVER),
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4L)
-                                        .between(OTHER_OWNER, RECEIVER),
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3L)
-                                        .between(OTHER_OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER, OWNER, OTHER_RECEIVER, OTHER_OWNER)
-                        .via("complexAllowanceTransfer"),
-                getTxnRecord("complexAllowanceTransfer").logged(),
-                getAccountDetails(OWNER)
-                        .payingWith(GENESIS)
-                        .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(925))
-                        .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
-                        .has(AccountDetailsAsserts.accountDetailsWith()
-                                .balanceLessThan(98 * ONE_HBAR)
-                                .cryptoAllowancesContaining(SPENDER, 9 * ONE_HBAR)
-                                .tokenAllowancesContaining(FUNGIBLE_TOKEN, SPENDER, 475)),
-                getAccountDetails(OTHER_OWNER)
-                        .payingWith(GENESIS)
-                        .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(970))
-                        .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(0))
-                        .has(AccountDetailsAsserts.accountDetailsWith()
-                                .balanceLessThan(98 * ONE_HBAR)
-                                .cryptoAllowancesContaining(SPENDER, 4 * ONE_HBAR)
-                                .tokenAllowancesContaining(FUNGIBLE_TOKEN, SPENDER, 85)
-                                .nftApprovedAllowancesContaining(NON_FUNGIBLE_TOKEN, SPENDER)),
-                getAccountInfo(RECEIVER)
-                        .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(105))
-                        .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(4))
-                        .has(accountWith().balance(5 * ONE_HBAR)),
-                getAccountInfo(ANOTHER_RECEIVER)
-                        .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(50))
-                        .has(accountWith().balance(ONE_HBAR)));
-    }
-
-    @HapiTest
-    final Stream<DynamicTest> allowanceTransfersWorkAsExpected() {
-        return hapiTest(
-                newKeyNamed(ADMIN_KEY),
-                newKeyNamed(FREEZE_KEY),
-                newKeyNamed(KYC_KEY),
-                newKeyNamed(PAUSE_KEY),
-                newKeyNamed(SUPPLY_KEY),
-                newKeyNamed(WIPE_KEY),
-                cryptoCreate(TOKEN_TREASURY),
-                cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS),
-                cryptoCreate(SPENDER).balance(ONE_HUNDRED_HBARS),
-                cryptoCreate(RECEIVER),
-                cryptoCreate(OTHER_RECEIVER).balance(ONE_HBAR).maxAutomaticTokenAssociations(1),
-                tokenCreate(FUNGIBLE_TOKEN)
-                        .supplyType(TokenSupplyType.FINITE)
-                        .tokenType(FUNGIBLE_COMMON)
-                        .treasury(TOKEN_TREASURY)
-                        .maxSupply(10000)
-                        .initialSupply(5000)
-                        .adminKey(ADMIN_KEY)
-                        .pauseKey(PAUSE_KEY)
-                        .kycKey(KYC_KEY)
-                        .freezeKey(FREEZE_KEY),
-                tokenCreate(NON_FUNGIBLE_TOKEN)
-                        .supplyType(TokenSupplyType.FINITE)
-                        .tokenType(NON_FUNGIBLE_UNIQUE)
-                        .treasury(TOKEN_TREASURY)
-                        .maxSupply(12L)
-                        .supplyKey(SUPPLY_KEY)
-                        .adminKey(ADMIN_KEY)
-                        .freezeKey(FREEZE_KEY)
-                        .wipeKey(WIPE_KEY)
-                        .pauseKey(PAUSE_KEY)
-                        .initialSupply(0L),
-                tokenCreate(TOKEN_WITH_CUSTOM_FEE)
-                        .treasury(TOKEN_TREASURY)
-                        .supplyType(TokenSupplyType.FINITE)
-                        .initialSupply(1000)
-                        .maxSupply(5000)
-                        .adminKey(ADMIN_KEY)
-                        .withCustom(fixedHtsFee(10, "0.0.0", TOKEN_TREASURY)),
-                mintToken(
-                        NON_FUNGIBLE_TOKEN,
-                        List.of(
-                                ByteString.copyFromUtf8("a"),
-                                ByteString.copyFromUtf8("b"),
-                                ByteString.copyFromUtf8("c"),
-                                ByteString.copyFromUtf8("d"),
-                                ByteString.copyFromUtf8("e"),
-                                ByteString.copyFromUtf8("f"))),
-                tokenAssociate(OWNER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN, TOKEN_WITH_CUSTOM_FEE),
-                tokenAssociate(RECEIVER, FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN, TOKEN_WITH_CUSTOM_FEE),
-                grantTokenKyc(FUNGIBLE_TOKEN, OWNER),
-                grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-                cryptoTransfer(
-                        moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER),
-                        moving(15, TOKEN_WITH_CUSTOM_FEE).between(TOKEN_TREASURY, OWNER),
-                        movingUnique(NON_FUNGIBLE_TOKEN, 1L, 2L, 3L, 4L, 5L, 6L).between(TOKEN_TREASURY, OWNER)),
-                cryptoApproveAllowance()
-                        .payingWith(OWNER)
-                        .addCryptoAllowance(OWNER, SPENDER, 10 * ONE_HBAR)
-                        .addTokenAllowance(OWNER, FUNGIBLE_TOKEN, SPENDER, 1500)
-                        .addTokenAllowance(OWNER, TOKEN_WITH_CUSTOM_FEE, SPENDER, 100)
-                        .addNftAllowance(OWNER, NON_FUNGIBLE_TOKEN, SPENDER, false, List.of(1L, 2L, 3L, 4L, 6L))
-                        .fee(ONE_HUNDRED_HBARS),
-                cryptoTransfer(movingWithAllowance(10, TOKEN_WITH_CUSTOM_FEE).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .fee(ONE_HBAR)
-                        // INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE is the expected mono service
-                        // outcome here, but the modularized implementation doesn't provide enough information
-                        // to differentiate these error codes. Since this is an extreme edge case and a
-                        // difficult issue to fix, we'll allow either error code here for now. However, we may
-                        // need to revert back to only accepting the original error code in the future.
-                        .hasKnownStatusFrom(
-                                INSUFFICIENT_TOKEN_BALANCE, INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE),
-                cryptoTransfer(movingWithAllowance(100, FUNGIBLE_TOKEN).between(OWNER, OWNER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .dontFullyAggregateTokenTransfers()
-                        .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS),
-                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 3).between(OWNER, OTHER_RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER),
-                cryptoTransfer(movingWithAllowance(100, FUNGIBLE_TOKEN).between(OWNER, OTHER_RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(NO_REMAINING_AUTOMATIC_ASSOCIATIONS),
-                cryptoUpdate(OTHER_RECEIVER).receiverSigRequired(true).maxAutomaticAssociations(2),
-                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4).between(OWNER, OTHER_RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(INVALID_SIGNATURE),
-                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 4).between(OWNER, OTHER_RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER, OTHER_RECEIVER),
-                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
-                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6).between(RECEIVER, OWNER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 6).between(RECEIVER, OWNER)),
-                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 6).between(OWNER, RECEIVER)),
-                tokenAssociate(OTHER_RECEIVER, FUNGIBLE_TOKEN),
-                grantTokenKyc(FUNGIBLE_TOKEN, OTHER_RECEIVER),
-                cryptoTransfer(movingWithAllowance(1100, FUNGIBLE_TOKEN).between(OWNER, OTHER_RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER, OTHER_RECEIVER)
-                        .hasKnownStatus(INSUFFICIENT_TOKEN_BALANCE),
-                cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
-                        .payingWith(DEFAULT_PAYER)
-                        .signedBy(DEFAULT_PAYER)
-                        .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                tokenPause(FUNGIBLE_TOKEN),
-                cryptoTransfer(
-                                movingWithAllowance(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(TOKEN_IS_PAUSED),
-                tokenUnpause(FUNGIBLE_TOKEN),
-                tokenFreeze(FUNGIBLE_TOKEN, OWNER),
-                cryptoTransfer(
-                                movingWithAllowance(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(ACCOUNT_FROZEN_FOR_TOKEN),
-                tokenUnfreeze(FUNGIBLE_TOKEN, OWNER),
-                revokeTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-                cryptoTransfer(
-                                movingWithAllowance(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN),
-                grantTokenKyc(FUNGIBLE_TOKEN, RECEIVER),
-                cryptoTransfer(
-                                allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR),
-                                tinyBarsFromTo(SPENDER, RECEIVER, ONE_HBAR))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER),
-                cryptoTransfer(
-                                movingWithAllowance(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 1).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER),
-                cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR + 1))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
-                cryptoTransfer(
-                                movingWithAllowance(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 5).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                getAccountDetails(OWNER)
-                        .payingWith(GENESIS)
-                        .has(AccountDetailsAsserts.accountDetailsWith()
-                                .tokenAllowancesContaining(FUNGIBLE_TOKEN, SPENDER, 1450))
-                        .hasToken(relationshipWith(FUNGIBLE_TOKEN).balance(950L)),
-                cryptoTransfer(moving(1000, FUNGIBLE_TOKEN).between(TOKEN_TREASURY, OWNER)),
-                cryptoTransfer(
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-                                        .between(OWNER, RECEIVER),
-                                movingWithAllowance(1451, FUNGIBLE_TOKEN).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(AMOUNT_EXCEEDS_ALLOWANCE),
-                getAccountInfo(OWNER)
-                        .hasToken(relationshipWith(NON_FUNGIBLE_TOKEN).balance(2)),
-                cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER),
-                cryptoTransfer(
-                                movingWithAllowance(50, FUNGIBLE_TOKEN).between(OWNER, RECEIVER),
-                                movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L)
-                                        .between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER),
-                cryptoTransfer(allowanceTinyBarsFromTo(OWNER, RECEIVER, 5 * ONE_HBAR))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
-                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER)
-                        .hasKnownStatus(SPENDER_DOES_NOT_HAVE_ALLOWANCE),
-                cryptoApproveAllowance()
-                        .payingWith(OWNER)
-                        .addNftAllowance(OWNER, NON_FUNGIBLE_TOKEN, SPENDER, true, List.of())
-                        .fee(ONE_HUNDRED_HBARS),
-                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER),
-                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 2L).between(RECEIVER, OWNER)),
-                cryptoTransfer(movingUniqueWithAllowance(NON_FUNGIBLE_TOKEN, 2L).between(OWNER, RECEIVER))
-                        .payingWith(SPENDER)
-                        .signedBy(SPENDER),
-                getAccountDetails(OWNER)
-                        .payingWith(GENESIS)
-                        .has(AccountDetailsAsserts.accountDetailsWith()
-                                .cryptoAllowancesCount(0)
-                                .tokenAllowancesContaining(FUNGIBLE_TOKEN, SPENDER, 1400)
-                                .nftApprovedAllowancesContaining(NON_FUNGIBLE_TOKEN, SPENDER)));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomRoyaltyFees.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomRoyaltyFees.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2021-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,12 +16,18 @@
 
 package com.hedera.services.bdd.suites.crypto;
 
+import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
+import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.asEvmAddress;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
 import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.uniqueWithFullPrefixesFor;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountDetails;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.asTokenId;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoApproveAllowance;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
@@ -40,6 +46,7 @@ import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movi
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUniqueWithAllowance;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingWithAllowance;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createHip32Auto;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
@@ -49,15 +56,24 @@ import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
 import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hedera.services.bdd.suites.crypto.AutoAccountUpdateSuite.TRANSFER_TXN_2;
 import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.createHollowAccountFrom;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
+import static java.util.Collections.emptyList;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hederahashgraph.api.proto.java.AccountAmount;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.NftTransfer;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TokenType;
+import com.hederahashgraph.api.proto.java.TransferList;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
@@ -1298,5 +1314,279 @@ public class TransferWithCustomRoyaltyFees {
                                     .hasTinyBars(ONE_MILLION_HBARS - 100),
                             getAccountBalance(hollowAccountCollector).hasTinyBars(ONE_HUNDRED_HBARS + 100));
                 })));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> transferRoyaltyFeeExplicitlyDuplicatedHbarSenderIds() {
+        final var bufferAccount = "account2";
+        final var feeCollector = "feeCollector";
+        final var xferAmount = Long.MAX_VALUE / 8;
+        return hapiTest(
+                newKeyNamed(NFT_KEY),
+                cryptoCreate(feeCollector).balance(0L),
+                cryptoCreate(tokenReceiver).balance(ONE_MILLION_HBARS),
+                cryptoCreate(tokenTreasury),
+                cryptoCreate(tokenOwner).balance(ONE_MILLION_HBARS),
+                cryptoCreate(bufferAccount).balance(ONE_MILLION_HBARS),
+                tokenCreate(nonFungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(NFT_KEY)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .withCustom(royaltyFeeNoFallback(1, 2, feeCollector)),
+                tokenAssociate(tokenReceiver, nonFungibleToken),
+                tokenAssociate(tokenOwner, nonFungibleToken),
+                mintToken(nonFungibleToken, List.of(ByteStringUtils.wrapUnsafely("meta1".getBytes()))),
+                cryptoTransfer(movingUnique(nonFungibleToken, 1L).between(tokenTreasury, tokenOwner)),
+                cryptoApproveAllowance()
+                        .addCryptoAllowance(tokenOwner, bufferAccount, xferAmount)
+                        .signedByPayerAnd(tokenOwner, bufferAccount),
+                cryptoTransfer((spec, tl) -> tl.setTransfers(TransferList.newBuilder()
+                                        .addAccountAmounts(AccountAmount.newBuilder()
+                                                .setAccountID(asId(tokenOwner, spec))
+                                                .setAmount(-xferAmount)
+                                                .setIsApproval(true)
+                                                .build())
+                                        .addAccountAmounts(AccountAmount.newBuilder()
+                                                .setAccountID(asId(tokenOwner, spec))
+                                                .setAmount(xferAmount)
+                                                .setIsApproval(false)
+                                                .build()))
+                                .addTokenTransfers(TokenTransferList.newBuilder()
+                                        .setToken(asTokenId(nonFungibleToken, spec))
+                                        .addNftTransfers(NftTransfer.newBuilder()
+                                                .setSenderAccountID(asId(tokenOwner, spec))
+                                                .setReceiverAccountID(asId(tokenReceiver, spec))
+                                                .setSerialNumber(1))))
+                        .fee(ONE_HUNDRED_HBARS)
+                        .payingWith(bufferAccount)
+                        .signedBy(bufferAccount, tokenOwner, tokenReceiver)
+                        .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> transferRoyaltyFeeDuplicatedEvmAddressFungibleSenderIds() {
+        final var bufferAccount = "account2";
+        final var fungibleToken = "fungibleToken";
+        final var feeCollector = "feeCollector";
+
+        // amount of fungible tokens to mint / 2
+        final var xferAmount = Long.MAX_VALUE / 2;
+        return hapiTest(
+                newKeyNamed(NFT_KEY),
+                cryptoCreate(feeCollector).balance(0L),
+                cryptoCreate(tokenReceiver).balance(ONE_MILLION_HBARS),
+                cryptoCreate(tokenTreasury),
+                createHip32Auto(1, SECP_256K1_SHAPE, i -> tokenOwner),
+                cryptoCreate(bufferAccount).balance(ONE_MILLION_HBARS),
+                tokenCreate(nonFungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(NFT_KEY)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .withCustom(royaltyFeeNoFallback(1, 2, feeCollector)),
+                tokenCreate(fungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(10_000L),
+                tokenAssociate(tokenReceiver, nonFungibleToken),
+                tokenAssociate(tokenOwner, nonFungibleToken),
+                tokenAssociate(tokenOwner, fungibleToken),
+                tokenAssociate(bufferAccount, fungibleToken),
+                tokenAssociate(feeCollector, fungibleToken),
+                mintToken(nonFungibleToken, List.of(ByteStringUtils.wrapUnsafely("meta1".getBytes()))),
+                cryptoTransfer(movingUnique(nonFungibleToken, 1L).between(tokenTreasury, tokenOwner)),
+
+                // token balance of attacker is initially 0
+                getAccountBalance(tokenOwner).hasTokenBalance(fungibleToken, 0),
+                cryptoApproveAllowance()
+                        .addTokenAllowance(tokenOwner, fungibleToken, bufferAccount, xferAmount)
+                        .signedByPayerAnd(tokenOwner, bufferAccount),
+                cryptoTransfer((spec, tl) -> {
+                            final var ownerKey = spec.registry().getKey(tokenOwner);
+                            final var ownerEcKey = ownerKey.getECDSASecp256K1();
+                            final var evmAddress =
+                                    ByteString.copyFrom(recoverAddressFromPubKey(ownerEcKey.toByteArray()));
+                            tl.addTokenTransfers(TokenTransferList.newBuilder()
+                                            .setToken(asTokenId(fungibleToken, spec))
+                                            .addTransfers(AccountAmount.newBuilder()
+                                                    .setAccountID(AccountID.newBuilder()
+                                                            .setAlias(ownerKey.toByteString())
+                                                            .build())
+                                                    .setAmount(-xferAmount)
+                                                    .setIsApproval(true)
+                                                    .build())
+                                            .addTransfers(AccountAmount.newBuilder()
+                                                    .setAccountID(AccountID.newBuilder()
+                                                            .setAlias(evmAddress)
+                                                            .build())
+                                                    .setAmount(xferAmount)
+                                                    .setIsApproval(false)
+                                                    .build()))
+                                    .addTokenTransfers(TokenTransferList.newBuilder()
+                                            .setToken(asTokenId(nonFungibleToken, spec))
+                                            .addNftTransfers(NftTransfer.newBuilder()
+                                                    .setSenderAccountID(asId(tokenOwner, spec))
+                                                    .setReceiverAccountID(asId(tokenReceiver, spec))
+                                                    .setSerialNumber(1)));
+                        })
+                        .fee(ONE_HUNDRED_HBARS)
+                        .payingWith(bufferAccount)
+                        .signedBy(bufferAccount, tokenOwner, tokenReceiver)
+                        .hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS)
+                        .via("txn"),
+                getTxnRecord("txn").hasPriority(recordWith().tokenTransfers(spec -> tokenTransfers -> {
+                    try {
+                        assertTrue(tokenTransfers.isEmpty());
+                    } catch (Throwable t) {
+                        return List.of(t);
+                    }
+                    return emptyList();
+                })),
+                getAccountBalance(feeCollector).hasTokenBalance(fungibleToken, 0));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> transferRoyaltyFeeLongZeroAddressFungibleSenderIds() {
+        final var bufferAccount = "account2";
+        final var fungibleToken = "fungibleToken";
+        final var feeCollector = "feeCollector";
+
+        // amount of fungible tokens to mint / 2
+        final var xferAmount = Long.MAX_VALUE / 2;
+        return hapiTest(
+                newKeyNamed(NFT_KEY),
+                cryptoCreate(feeCollector).balance(0L),
+                cryptoCreate(tokenReceiver).balance(ONE_MILLION_HBARS),
+                cryptoCreate(tokenTreasury),
+                cryptoCreate(tokenOwner).balance(ONE_MILLION_HBARS),
+                cryptoCreate(bufferAccount).balance(ONE_MILLION_HBARS),
+                tokenCreate(nonFungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(NFT_KEY)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .withCustom(royaltyFeeNoFallback(1, 2, feeCollector)),
+                tokenCreate(fungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(10_000L),
+                tokenAssociate(tokenReceiver, nonFungibleToken),
+                tokenAssociate(tokenOwner, nonFungibleToken),
+                tokenAssociate(tokenOwner, fungibleToken),
+                tokenAssociate(bufferAccount, fungibleToken),
+                tokenAssociate(feeCollector, fungibleToken),
+                mintToken(nonFungibleToken, List.of(ByteStringUtils.wrapUnsafely("meta1".getBytes()))),
+                cryptoTransfer(movingUnique(nonFungibleToken, 1L).between(tokenTreasury, tokenOwner)),
+
+                // token balance of attacker is initially 0
+                getAccountBalance(tokenOwner).hasTokenBalance(fungibleToken, 0),
+                cryptoApproveAllowance()
+                        .addTokenAllowance(tokenOwner, fungibleToken, bufferAccount, xferAmount)
+                        .signedByPayerAnd(tokenOwner, bufferAccount),
+                cryptoTransfer((spec, tl) -> {
+                            final var ownerId = asId(tokenOwner, spec);
+                            tl.addTokenTransfers(TokenTransferList.newBuilder()
+                                            .setToken(asTokenId(fungibleToken, spec))
+                                            .addTransfers(AccountAmount.newBuilder()
+                                                    .setAccountID(ownerId)
+                                                    .setAmount(-xferAmount)
+                                                    .setIsApproval(true)
+                                                    .build())
+                                            .addTransfers(AccountAmount.newBuilder()
+                                                    .setAccountID(AccountID.newBuilder()
+                                                            .setAlias(ByteString.copyFrom(
+                                                                    asEvmAddress(ownerId.getAccountNum())))
+                                                            .build())
+                                                    .setAmount(xferAmount)
+                                                    .setIsApproval(false)
+                                                    .build()))
+                                    .addTokenTransfers(TokenTransferList.newBuilder()
+                                            .setToken(asTokenId(nonFungibleToken, spec))
+                                            .addNftTransfers(NftTransfer.newBuilder()
+                                                    .setSenderAccountID(asId(tokenOwner, spec))
+                                                    .setReceiverAccountID(asId(tokenReceiver, spec))
+                                                    .setSerialNumber(1)));
+                        })
+                        .fee(ONE_HUNDRED_HBARS)
+                        .payingWith(bufferAccount)
+                        .signedBy(bufferAccount, tokenOwner, tokenReceiver)
+                        .hasKnownStatus(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS)
+                        .via("txn"),
+                getTxnRecord("txn").hasPriority(recordWith().tokenTransfers(spec -> tokenTransfers -> {
+                    try {
+                        assertTrue(tokenTransfers.isEmpty());
+                    } catch (Throwable t) {
+                        return List.of(t);
+                    }
+                    return emptyList();
+                })),
+                getAccountBalance(feeCollector).hasTokenBalance(fungibleToken, 0));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> transferRoyaltyFeeExplicitlyDuplicatedFungibleSenderIds() {
+        final var bufferAccount = "account2";
+        final var fungibleToken = "fungibleToken";
+        final var feeCollector = "feeCollector";
+
+        // amount of fungible tokens to mint / 2
+        final var xferAmount = Long.MAX_VALUE / 2;
+        return hapiTest(
+                newKeyNamed(NFT_KEY),
+                cryptoCreate(feeCollector).balance(0L),
+                cryptoCreate(tokenReceiver).balance(ONE_MILLION_HBARS),
+                cryptoCreate(tokenTreasury),
+                cryptoCreate(tokenOwner).balance(ONE_MILLION_HBARS),
+                cryptoCreate(bufferAccount).balance(ONE_MILLION_HBARS),
+                tokenCreate(nonFungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(NFT_KEY)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .withCustom(royaltyFeeNoFallback(1, 2, feeCollector)),
+                tokenCreate(fungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .initialSupply(10_000L),
+                tokenAssociate(tokenReceiver, nonFungibleToken),
+                tokenAssociate(tokenOwner, nonFungibleToken),
+                tokenAssociate(tokenOwner, fungibleToken),
+                tokenAssociate(bufferAccount, fungibleToken),
+                tokenAssociate(feeCollector, fungibleToken),
+                mintToken(nonFungibleToken, List.of(ByteStringUtils.wrapUnsafely("meta1".getBytes()))),
+                cryptoTransfer(movingUnique(nonFungibleToken, 1L).between(tokenTreasury, tokenOwner)),
+
+                // token balance of attacker is initially 0
+                getAccountBalance(tokenOwner).hasTokenBalance(fungibleToken, 0),
+                cryptoApproveAllowance()
+                        .addTokenAllowance(tokenOwner, fungibleToken, bufferAccount, xferAmount)
+                        .signedByPayerAnd(tokenOwner, bufferAccount),
+                cryptoTransfer((spec, tl) -> tl.addTokenTransfers(TokenTransferList.newBuilder()
+                                        .setToken(asTokenId(fungibleToken, spec))
+                                        .addTransfers(AccountAmount.newBuilder()
+                                                .setAccountID(asId(tokenOwner, spec))
+                                                .setAmount(-xferAmount)
+                                                .setIsApproval(true)
+                                                .build())
+                                        .addTransfers(AccountAmount.newBuilder()
+                                                .setAccountID(asId(tokenOwner, spec))
+                                                .setAmount(xferAmount)
+                                                .setIsApproval(false)
+                                                .build()))
+                                .addTokenTransfers(TokenTransferList.newBuilder()
+                                        .setToken(asTokenId(nonFungibleToken, spec))
+                                        .addNftTransfers(NftTransfer.newBuilder()
+                                                .setSenderAccountID(asId(tokenOwner, spec))
+                                                .setReceiverAccountID(asId(tokenReceiver, spec))
+                                                .setSerialNumber(1))))
+                        .fee(ONE_HUNDRED_HBARS)
+                        .payingWith(bufferAccount)
+                        .signedBy(bufferAccount, tokenOwner, tokenReceiver)
+                        .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/ethereum/HelloWorldEthereumSuite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022-2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2022-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,6 +79,7 @@ import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
 import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ALIAS_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FULL_PREFIX_SIGNATURE_FOR_PRECOMPILE;
@@ -197,6 +198,31 @@ public class HelloWorldEthereumSuite {
                         getTxnRecord("creationActivatingAdminKeyViaEthTxSig")
                                 .exposingTokenCreationsTo(
                                         createdIds -> assertFalse(createdIds.isEmpty(), "EthTx sig creation failed")));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> badRecIdGivesInvalidSignature() {
+        return hapiTest(
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                        .via("autoAccount"),
+                getTxnRecord("autoAccount").andAllChildRecords(),
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                contractCreate(PAY_RECEIVABLE_CONTRACT).adminKey(THRESHOLD),
+                // EIP1559 Ethereum Calls fail with invalid rec ids
+                ethereumCall(PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(depositAmount))
+                        .type(EthTxData.EthTransactionType.EIP1559)
+                        .signingWith(SECP_256K1_SOURCE_KEY)
+                        .payingWith(RELAYER)
+                        .via("payTxn")
+                        .nonce(0)
+                        .maxFeePerGas(50L)
+                        .maxPriorityGas(2L)
+                        .gasLimit(1_000_000L)
+                        .sending(depositAmount)
+                        .withWrongParityRecId()
+                        .hasKnownStatus(INVALID_ACCOUNT_ID));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/utils/Signing.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/utils/Signing.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,7 +33,15 @@ import org.hyperledger.besu.nativelib.secp256k1.LibSecp256k1;
  */
 public final class Signing {
 
+    public static EthTxData signMessage(EthTxData ethTx, byte[] privateKey, boolean flipRecId) {
+        return signMessageInternal(ethTx, privateKey, flipRecId);
+    }
+
     public static EthTxData signMessage(EthTxData ethTx, byte[] privateKey) {
+        return signMessageInternal(ethTx, privateKey, false);
+    }
+
+    private static EthTxData signMessageInternal(EthTxData ethTx, byte[] privateKey, boolean flipRecId) {
         byte[] signableMessage = EthTxSigs.calculateSignableMessage(ethTx);
         final LibSecp256k1.secp256k1_ecdsa_recoverable_signature signature =
                 new LibSecp256k1.secp256k1_ecdsa_recoverable_signature();
@@ -79,7 +87,7 @@ public final class Signing {
                 ethTx.value(),
                 ethTx.callData(),
                 ethTx.accessList(),
-                (byte) recId.getValue(),
+                flipRecId ? ((byte) recId.getValue()) ^ 1 : (byte) recId.getValue(),
                 val == null ? null : val.toByteArray(),
                 r,
                 s);


### PR DESCRIPTION
**Description**:
 - Validates arguments given to secp256k1 native lib.
 - Unifies `AccountAmount` deduplication logic to ignore `is_approval` in settings in pure checks as well.