### PR TITLE
ci: update ubuntu version to 24.04 and 22.04

### DIFF
--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -215,8 +215,8 @@ jobs:
         # not supporting BuildKit and the Buildx plugin.
         # GitHub hosted MacOS and Ubuntu runners are temporarily disabled.
         os:
+          #- ubuntu-24.04
           #- ubuntu-22.04
-          #- ubuntu-20.04
           #- macos-12
           #- macos-11
           - hiero-network-node-linux-medium

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -130,8 +130,8 @@ jobs:
       matrix:
         # Disabled MacOS runner testing due to concurrency issues with the Github hosted runners.
         os:
+          - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           #- macos-12
           #- macos-11
           - windows-2022


### PR DESCRIPTION
**Description**:

Cherry picks fix from main to update ubuntu runners in gradle determinism to use 22.04/24.04 instead of 20.04/22.04
(cherry picked from commit 0a994c1c91ac9cb8779e85c19abe8ca2f0e428d3)

**Related issue(s)**:

Fixes #18180 


