### PR TITLE
ci: fix and cleanup snyk/gradle integration

### DIFF
--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -576,22 +576,6 @@ jobs:
           name: Test Reports
           path: "**/build/reports/tests/**"
 
-      - name: Disable Gradle Configuration Cache
-        if: >-
-          ${{
-            inputs.enable-snyk-scan &&
-            steps.gradle-build.conclusion == 'success' &&
-            (
-              github.event.pull_request.head.repo.full_name == github.repository ||
-              github.event_name == 'push' ||
-              github.event_name == 'workflow_dispatch'
-            ) &&
-            !cancelled()
-          }}
-        run: |
-          sed -i 's/^org.gradle.configuration-cache=.*$/org.gradle.configuration-cache=false/' gradle.properties
-          touch build.gradle.kts
-
       - name: Setup Snyk
         if: >-
           ${{
@@ -635,7 +619,7 @@ jobs:
             ) &&
             !cancelled()
           }}
-        run: ${CG_EXEC} snyk test --all-sub-projects --severity-threshold=high --policy-path=.snyk --json-file-output=snyk-test.json --org=hiero-consensus-node
+        run: ${CG_EXEC} snyk test --subProject=aggregation --configuration-matching=mainRuntimeClasspath --severity-threshold=high --policy-path=.snyk --json-file-output=snyk-test.json --org=hiero-consensus-node
 
       - name: Snyk Code
         id: snyk-code

--- a/.github/workflows/node-zxf-snyk-monitor.yaml
+++ b/.github/workflows/node-zxf-snyk-monitor.yaml
@@ -39,9 +39,6 @@ jobs:
       - name: Compile
         run: ./gradlew assemble
 
-      - name: Disable Gradle Configuration Cache
-        run: sed -i 's/^org.gradle.configuration-cache=.*$/org.gradle.configuration-cache=false/' gradle.properties
-
       - name: Setup NodeJS
         uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
         with:
@@ -55,4 +52,4 @@ jobs:
       - name: Run Snyk Monitor
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        run: snyk monitor --all-projects --policy-path=.snyk --trust-policies --org=hiero-consensus-node --debug
+        run: snyk monitor --subProject=aggregation --configuration-matching=mainRuntimeClasspath --policy-path=.snyk --trust-policies --org=hiero-consensus-node

--- a/.snyk
+++ b/.snyk
@@ -2,11 +2,6 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  SNYK-JAVA-IONETTY-5953332:
-    - '*':
-        reason: No gRPC version with a fix is available
-        expires: 2024-06-30T00:00:00.000Z
-        created: 2023-12-06T23:35:31.268Z
 patch: {}
 exclude:
   global:

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 plugins {
     id("org.hiero.gradle.base.lifecycle")
+    id("org.hiero.gradle.base.version")
     id("org.hiero.gradle.report.code-coverage")
     id("org.hiero.gradle.check.spotless")
     id("org.hiero.gradle.check.spotless-kotlin")


### PR DESCRIPTION
**Description**:

- No extra step to disable configuration cache needed anymore. [Snyk now does this automatically.](https://github.com/snyk/snyk-gradle-plugin/blob/9589d184dcf5baba8e198074b4f2746e5ec3a8ad/lib/index.ts#L748)
- Make sure we create an empty root `build.gradle.kts` as part of each `Setup Snyk` step to work around https://github.com/snyk/snyk-gradle-plugin/issues/298
- Focus the analysis on the `aggregation` project that contains all dependencies we use in all scopes in the `mainRuntimeClasspath` _configuration_. This is used in the Gradle plugins already for consistent versioning and Jar patching. Hence, this contains all dependencies used in **all** modules.
   - This is done by running with `--subProject=aggregation` and `--configuration-matching=mainRuntimeClasspath` 

**Related issue(s)**:

Fixes #17897
