### PR TITLE
fix: Stale event test was failing in 1/100 of cases due to randomness 

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stale/StaleEventDetectorTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stale/StaleEventDetectorTests.java
@@ -117,7 +117,9 @@ class StaleEventDetectorTests {
         final StaleEventDetector detector = new DefaultStaleEventDetector(platformContext, selfId);
 
         final long ancientThreshold = randotron.nextPositiveLong() + 100;
-        final long eventBirthRound = ancientThreshold - randotron.nextLong(100);
+        final long eventBirthRound = ancientThreshold
+                - (randotron.nextLong(100)
+                        + 1); // +1, because birthRound==ancientThreshold is not yet considered ancient
 
         final PlatformEvent event = new TestingEventBuilder(randotron)
                 .setCreatorId(selfId)


### PR DESCRIPTION
**Description**:
StaleEventDetectorTests.eventIsStaleBeforeAddedTest was failing sometimes (in 1/100 of the cases), because it used random(100) to offset stale even from the ancient threshold. Unfortunately, sometimes that random was 0, which meant birthRound==ancientThreshold, which is NOT considered ancient/stale.

**Related issue(s)**:

Fixes #18192 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
