### PR TITLE
ci: add empty 'build.gradle' to root for Snyk integration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,3 @@
+// This empty file is only here to make the Snyk integration work until the following is fixed:
+// https://github.com/snyk/snyk-gradle-plugin/issues/298
+// Do not use this file to configure Gradle!


### PR DESCRIPTION
**Description**:

The Synk UI is detecting our projects multiple times because it thinks each "build.gradle.kts" marks a separate project. This is caused by this issue: https://github.com/snyk/snyk-gradle-plugin/issues/298

This is a workaround until it is fixed upstream by Snyk.

#17897