### PR TITLE
ci: Enable IssHandlingTestSuite in CI PR Checks

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -52,6 +52,7 @@ jobs:
       enable-unit-tests: ${{ github.event_name == 'push' || github.event.inputs.enable-unit-tests == 'true' }}
       enable-hapi-tests-misc: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
       enable-hapi-tests-crypto: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
+      enable-hapi-tests-iss: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
       enable-hapi-tests-token: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
       enable-hapi-tests-smart-contract: ${{ github.event.inputs.enable-hapi-tests == 'true' }}
       enable-hapi-tests-time-consuming: ${{ github.event.inputs.enable-hapi-tests == 'true' }}

--- a/.github/workflows/node-flow-pull-request-checks.yaml
+++ b/.github/workflows/node-flow-pull-request-checks.yaml
@@ -102,6 +102,19 @@ jobs:
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
       gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
 
+  hapi-tests-iss:
+    name: HAPI Tests (ISS)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    with:
+      custom-job-label: Standard
+      enable-unit-tests: false
+      enable-hapi-tests-iss: true
+      enable-network-log-capture: true
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
   hapi-tests-token:
     name: HAPI Tests (Token)
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingTestSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingTestSuite.java
@@ -20,7 +20,6 @@ import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.crypto.ParseableIssBlockStreamValidationOp;
 import java.time.Duration;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
@@ -28,7 +27,6 @@ import org.junit.jupiter.api.Tag;
 @Tag(ISS)
 @IssHapiTest
 @Order(Integer.MAX_VALUE - 3)
-
 class IssHandlingTestSuite {
     private static final long NODE_0_ACCT_ID = 3; // The ISS node
     private static final long NODE_1_ACCT_ID = 4; // One of the Non-ISS nodes

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingTestSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingTestSuite.java
@@ -28,9 +28,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(ISS)
 @IssHapiTest
 @Order(Integer.MAX_VALUE - 3)
-// This test requires a specific network configuration to run in CI. We will enable it when we can get it running as a
-// separate PR check
-@Disabled
+
 class IssHandlingTestSuite {
     private static final long NODE_0_ACCT_ID = 3; // The ISS node
     private static final long NODE_1_ACCT_ID = 4; // One of the Non-ISS nodes


### PR DESCRIPTION
**Description**:

Enables hapi-iss-tests to run as part of Standard PR Checks Adds hapi-iss-tests to build-application workflow-dispatch triggers Enables the IssHandlingTestSuite

**Related Issue(s)**:

Fixes #18198