### PR TITLE
chore: remove incorrect/unused 'requires' entries

### DIFF
--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -17,7 +17,6 @@ mainModuleInfo {
     runtimeOnly("io.helidon.grpc.core")
     runtimeOnly("io.helidon.webclient")
     runtimeOnly("io.helidon.webclient.grpc")
-    runtimeOnly("com.hedera.cryptography.altbn128")
 }
 
 testModuleInfo {

--- a/platform-sdk/swirlds-platform-core/build.gradle.kts
+++ b/platform-sdk/swirlds-platform-core/build.gradle.kts
@@ -34,7 +34,6 @@ testModuleInfo {
     requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.platform.core")
     requires("com.swirlds.platform.core.test.fixtures")
-    requires("com.swirlds.platform.test")
     requires("com.swirlds.config.extensions.test.fixtures")
     requires("com.swirlds.state.api.test.fixtures")
     requires("com.swirlds.state.impl.test.fixtures")


### PR DESCRIPTION
**Description**:
This addresses these warnings currently emitted on `main`:

```
[WARN] [Java Module Dependencies] com.hedera.cryptography.altbn128=group:artifact missing
[WARN] [Java Module Dependencies] com.swirlds.platform.test=group:artifact missing
```

The modules in questions no longer exist. This was an oversight in the corresponding PRs that removed the use of these modules.
