### PR TITLE
feat: add SCHEDULE_EXPIRY_NOT_CONFIGURABLE validation

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1733,4 +1733,9 @@ enum ResponseCodeEnum {
      * The batch key is not valid
      */
     INVALID_BATCH_KEY = 394;
+    
+    /**
+     * The provided schedule expiry time is not configurable.
+     */
+    SCHEDULE_EXPIRY_NOT_CONFIGURABLE = 395;
 }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
@@ -172,9 +172,10 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
         final var validationResult = validate(provisionalSchedule, consensusNow, isLongTermEnabled);
         validateTrue(isMaybeExecutable(validationResult), validationResult);
 
-        validateFalse(!isLongTermEnabled && provisionalSchedule.providedExpirationSecond() != 0,
-            SCHEDULE_EXPIRY_NOT_CONFIGURABLE);
-        
+        validateFalse(
+                !isLongTermEnabled && provisionalSchedule.providedExpirationSecond() != 0,
+                SCHEDULE_EXPIRY_NOT_CONFIGURABLE);
+
         // Note that we must store the original ScheduleCreate transaction body in the Schedule so
         // we can compare those bytes to any new ScheduleCreate transaction for detecting duplicate
         // ScheduleCreate transactions. SchedulesByEquality is the virtual map for that task.

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleCreateHandler.java
@@ -13,6 +13,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.SCHEDULED_TRANSACTION_N
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SCHEDULE_EXPIRATION_TIME_MUST_BE_HIGHER_THAN_CONSENSUS_TIME;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SCHEDULE_EXPIRATION_TIME_TOO_FAR_IN_FUTURE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SCHEDULE_EXPIRY_IS_BUSY;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.SCHEDULE_EXPIRY_NOT_CONFIGURABLE;
 import static com.hedera.hapi.node.base.SubType.DEFAULT;
 import static com.hedera.hapi.node.base.SubType.SCHEDULE_CREATE_CONTRACT_CALL;
 import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
@@ -22,6 +23,7 @@ import static com.hedera.node.app.service.schedule.impl.handlers.HandlerUtility.
 import static com.hedera.node.app.service.schedule.impl.handlers.HandlerUtility.scheduledTxnIdFrom;
 import static com.hedera.node.app.service.schedule.impl.handlers.HandlerUtility.transactionIdForScheduled;
 import static com.hedera.node.app.spi.validation.Validations.mustExist;
+import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
@@ -170,6 +172,9 @@ public class ScheduleCreateHandler extends AbstractScheduleHandler implements Tr
         final var validationResult = validate(provisionalSchedule, consensusNow, isLongTermEnabled);
         validateTrue(isMaybeExecutable(validationResult), validationResult);
 
+        validateFalse(!isLongTermEnabled && provisionalSchedule.providedExpirationSecond() != 0,
+            SCHEDULE_EXPIRY_NOT_CONFIGURABLE);
+        
         // Note that we must store the original ScheduleCreate transaction body in the Schedule so
         // we can compare those bytes to any new ScheduleCreate transaction for detecting duplicate
         // ScheduleCreate transactions. SchedulesByEquality is the virtual map for that task.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip423/DisabledLongTermExecutionScheduleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip423/DisabledLongTermExecutionScheduleTest.java
@@ -172,11 +172,10 @@ public class DisabledLongTermExecutionScheduleTest {
     @HapiTest
     public Stream<DynamicTest> scheduleWithExpirationTimeAndLongTermSchedulesDisabled() {
         return hapiTest(
-            cryptoCreate(SENDER),
-            cryptoCreate(RECEIVER),
-            scheduleCreate(BASIC_XFER, cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 1)))
-                .expiringAt(10)
-                .hasKnownStatus(SCHEDULE_EXPIRY_NOT_CONFIGURABLE)
-        );
+                cryptoCreate(SENDER),
+                cryptoCreate(RECEIVER),
+                scheduleCreate(BASIC_XFER, cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 1)))
+                        .expiringAt(10)
+                        .hasKnownStatus(SCHEDULE_EXPIRY_NOT_CONFIGURABLE));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip423/DisabledLongTermExecutionScheduleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip423/DisabledLongTermExecutionScheduleTest.java
@@ -14,6 +14,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SCHEDULE_EXPIRY_NOT_CONFIGURABLE;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
@@ -64,8 +65,6 @@ public class DisabledLongTermExecutionScheduleTest {
                                 THREE_SIG_XFER,
                                 cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 1))
                                         .fee(ONE_HBAR))
-                        .withRelativeExpiry(SENDER_TXN, 50)
-                        .waitForExpiry(true)
                         .designatingPayer(PAYER)
                         .alsoSigningWith(SENDER, RECEIVER),
                 getAccountBalance(RECEIVER).hasTinyBars(0L),
@@ -87,8 +86,6 @@ public class DisabledLongTermExecutionScheduleTest {
                                 THREE_SIG_XFER,
                                 cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 1))
                                         .fee(ONE_HBAR))
-                        .withRelativeExpiry(SENDER_TXN, 20)
-                        .waitForExpiry(true)
                         .designatingPayer(SENDER),
                 scheduleSign(THREE_SIG_XFER).alsoSigningWith(SENDER, RECEIVER),
                 getScheduleInfo(THREE_SIG_XFER)
@@ -101,7 +98,6 @@ public class DisabledLongTermExecutionScheduleTest {
     @HapiTest
     @Order(3)
     public Stream<DynamicTest> waitForExpiryIgnoredWhenLongTermDisabledThenEnabled() {
-
         return hapiTest(
                 cryptoCreate(PAYER).balance(ONE_HBAR),
                 cryptoCreate(SENDER).balance(1L).via(SENDER_TXN),
@@ -110,8 +106,6 @@ public class DisabledLongTermExecutionScheduleTest {
                                 THREE_SIG_XFER,
                                 cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 1))
                                         .fee(ONE_HBAR))
-                        .withRelativeExpiry(SENDER_TXN, 4)
-                        .waitForExpiry(true)
                         .designatingPayer(PAYER)
                         .alsoSigningWith(SENDER, RECEIVER),
                 getAccountBalance(RECEIVER).hasTinyBars(0L),
@@ -137,8 +131,6 @@ public class DisabledLongTermExecutionScheduleTest {
                                 THREE_SIG_XFER,
                                 cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 1))
                                         .fee(ONE_HBAR))
-                        .withRelativeExpiry(SENDER_TXN, 4)
-                        .waitForExpiry(true)
                         .designatingPayer(PAYER)
                         .via(CREATE_TXN),
                 getScheduleInfo(THREE_SIG_XFER)
@@ -175,5 +167,16 @@ public class DisabledLongTermExecutionScheduleTest {
                 sleepFor(TimeUnit.MINUTES.toMillis(31)),
                 cryptoCreate("foo").via("triggerCleanUpTxn"),
                 getScheduleInfo(BASIC_XFER).hasCostAnswerPrecheck(INVALID_SCHEDULE_ID));
+    }
+
+    @HapiTest
+    public Stream<DynamicTest> scheduleWithExpirationTimeAndLongTermSchedulesDisabled() {
+        return hapiTest(
+            cryptoCreate(SENDER),
+            cryptoCreate(RECEIVER),
+            scheduleCreate(BASIC_XFER, cryptoTransfer(tinyBarsFromTo(SENDER, RECEIVER, 1)))
+                .expiringAt(10)
+                .hasKnownStatus(SCHEDULE_EXPIRY_NOT_CONFIGURABLE)
+        );
     }
 }


### PR DESCRIPTION
**Description**:
Validating that if the long-term schedules is disabled the `expiration_time` field is not populated

**Related issue(s)**:

Fixes #7211

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
