### PR TITLE
chore: Prohibit all airdrop royalty fees

### DIFF
--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -230,8 +230,8 @@ jobs:
         # not supporting BuildKit and the Buildx plugin.
         # GitHub hosted MacOS and Ubuntu runners are temporarily disabled.
         os:
+          #- ubuntu-24.04
           #- ubuntu-22.04
-          #- ubuntu-20.04
           #- macos-12
           #- macos-11
           - hiero-network-node-linux-medium

--- a/.github/workflows/zxc-verify-gradle-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-gradle-build-determinism.yaml
@@ -145,8 +145,8 @@ jobs:
       matrix:
         # Disabled MacOS runner testing due to concurrency issues with the Github hosted runners.
         os:
+          - ubuntu-24.04
           - ubuntu-22.04
-          - ubuntu-20.04
           #- macos-12
           #- macos-11
           - windows-2022

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Hedera Hashgraph, LLC
+ * Copyright (C) 2024-2025 Hedera Hashgraph, LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -29,6 +29,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_TRANSFER_LIST_SIZ
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsableForAliasedId;
 import static com.hedera.node.app.service.token.impl.validators.CryptoTransferValidator.validateTokenTransfers;
+import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
 import static java.util.Objects.requireNonNull;
@@ -130,9 +131,23 @@ public class TokenAirdropValidator {
                 for (var transfer : xfers.nftTransfers()) {
                     final var receiver = transfer.receiverAccountID();
                     for (final var fee : token.customFees()) {
-                        if (fee.hasRoyaltyFee() && fee.royaltyFeeOrThrow().hasFallbackFee()) {
-                            validateTrue(
-                                    isExemptFromCustomFees(token, receiver, fee), TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY);
+                        if (fee.hasRoyaltyFee()) {
+                            // Fallbacks are completely prohibited on token types used in airdrops
+                            if (fee.royaltyFeeOrThrow().hasFallbackFee()) {
+                                validateTrue(
+                                        isExemptFromCustomFees(token, receiver, fee),
+                                        TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY);
+                            } else {
+                                // And even without a fallback, there must be no implied royalty fee payment (that is,
+                                // the sender must be fee exempt or receive no fungible value in the airdrop)
+                                final var senderId = transfer.senderAccountIDOrThrow();
+                                if (!isExemptFromCustomFees(token, senderId, fee)) {
+                                    // (FUTURE) Use a different response code for this failure mode
+                                    validateFalse(
+                                            senderIsCreditedFungibleValue(op, senderId),
+                                            TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY);
+                                }
+                            }
                         }
                     }
                 }
@@ -149,6 +164,24 @@ public class TokenAirdropValidator {
                 validateTrue(totalNftTransfers <= ledgerConfig.nftTransfersMaxLen(), BATCH_SIZE_LIMIT_EXCEEDED);
             }
         }
+    }
+
+    /**
+     * Check if the sender is credited with fungible value in the given airdrop.
+     * @param op the token airdrop transaction body
+     * @param senderId the sender account ID
+     * @return true if the sender is credited with fungible value, false otherwise
+     */
+    private boolean senderIsCreditedFungibleValue(
+            @NonNull final TokenAirdropTransactionBody op, @NonNull final AccountID senderId) {
+        for (final var tokenTransfers : op.tokenTransfers()) {
+            for (final var adjustment : tokenTransfers.transfers()) {
+                if (adjustment.accountIDOrThrow().equals(senderId) && adjustment.amount() > 0) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomRoyaltyFees.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomRoyaltyFees.java
@@ -32,6 +32,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoApproveAl
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAirdrop;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
@@ -60,6 +61,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_REPEAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_SENDER_ACCOUNT_BALANCE_FOR_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -1588,5 +1590,58 @@ public class TransferWithCustomRoyaltyFees {
                         .payingWith(bufferAccount)
                         .signedBy(bufferAccount, tokenOwner, tokenReceiver)
                         .hasPrecheck(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS));
+    }
+
+    /**
+     * Verifies that bidirectional airdrops cannot trigger NFT royalty fee payments.
+     * <p>
+     * That is, checks that if an NFT is airdropped by a sender that also <i>receives</i> a fungible airdrop in
+     * the same transaction, that can only succeed if the sender is exempt from the non-fungible token type's
+     * fees.
+     */
+    @HapiTest
+    final Stream<DynamicTest> biDirectionalAirdropsCannotTriggerRoyaltyPayments() {
+        return hapiTest(
+                newKeyNamed(NFT_KEY),
+                cryptoCreate(htsCollector),
+                cryptoCreate(tokenReceiver).balance(ONE_MILLION_HBARS),
+                cryptoCreate(tokenTreasury),
+                cryptoCreate(tokenOwner),
+                tokenCreate(feeDenom).treasury(tokenTreasury).initialSupply(2000),
+                tokenAssociate(tokenOwner, feeDenom),
+                tokenAssociate(tokenReceiver, feeDenom),
+                tokenAssociate(htsCollector, feeDenom),
+                cryptoTransfer(moving(1000, feeDenom).between(tokenTreasury, tokenReceiver)),
+                tokenCreate(nonFungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(NFT_KEY)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .withCustom(royaltyFeeNoFallback(1, 1, htsCollector)),
+                tokenAssociate(tokenReceiver, nonFungibleToken),
+                tokenAssociate(tokenOwner, nonFungibleToken),
+                mintToken(
+                        nonFungibleToken,
+                        List.of(
+                                ByteStringUtils.wrapUnsafely("meta1".getBytes()),
+                                ByteStringUtils.wrapUnsafely("meta2".getBytes()))),
+                cryptoTransfer(movingUnique(nonFungibleToken, 1L).between(tokenTreasury, tokenOwner)),
+
+                // If the sender in a bidirectional airdrop would pay a royalty fee for the NFT it is sending, we fail
+                tokenAirdrop(
+                                movingUnique(nonFungibleToken, 1L).between(tokenOwner, tokenReceiver),
+                                moving(1000, feeDenom).between(tokenReceiver, tokenOwner))
+                        .signedByPayerAnd(tokenOwner, tokenReceiver)
+                        .hasKnownStatus(TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY),
+                // But an exempt sender in the exact situation is fine (no royalty charged)
+                tokenAirdrop(
+                                movingUnique(nonFungibleToken, 2L).between(tokenTreasury, tokenReceiver),
+                                moving(1000, feeDenom).between(tokenReceiver, tokenTreasury))
+                        .signedByPayerAnd(tokenTreasury, tokenReceiver),
+                // And even the non-sender can still airdrop without receiving a bidirectional airdrop
+                tokenAirdrop(movingUnique(nonFungibleToken, 1L).between(tokenOwner, tokenReceiver))
+                        .signedByPayerAnd(tokenOwner),
+                getAccountBalance(htsCollector).hasTokenBalance(feeDenom, 0));
     }
 }


### PR DESCRIPTION
**Description**:
 - Fail airdrops that use royalties with _or without_ fallback fees.