### PR TITLE
fix: delayed start logic for deterministic image

### DIFF
--- a/hedera-node/infrastructure/docker/containers/production-next/consensus-node/etc/s6-overlay/s6-rc.d/consensus/run
+++ b/hedera-node/infrastructure/docker/containers/production-next/consensus-node/etc/s6-overlay/s6-rc.d/consensus/run
@@ -4,6 +4,8 @@
 # Start: /package/admin/s6/command/s6-svc -o /run/service/consensus
 # Stop:  /package/admin/s6/command/s6-svc -d /run/service/consensus
 
+INITIAL_START=$(s6-svstat -o wantedup .)
+
 # Do not restart
 s6-svc -O .
 
@@ -12,10 +14,7 @@ trap "kill 0" EXIT
 
 if [ "${AUTO_START_CONSENSUS_SERVICE:-true}" == false ]; then
   # Exit on initial start
-  file=/tmp/consensus/s6-svc/start
-  if ! ps ho lstart 1 | diff ${file} - 2> /dev/null; then
-    mkdir -p $(dirname ${file})
-    ps ho lstart 1 > ${file}
+  if [ "${INITIAL_START}" = "true" ]; then
     exit
   fi
 fi


### PR DESCRIPTION
The previous check could fail if the clock was stepped.

**Description**:

Fixes problem with delayed start logic for deterministic image. Previous logic relied on start time of pid 1. However, if the system clock was stepped apparent start time of pid 1 can change subsequently preventing the service from starting correctly.

This change replaces file/time based check for initial start with a logical check based on s6 `wantedup` semantics. Initially `wantedup` will be true for this service until the service is configured not to restart on line 10.

**Related issue(s)**:

Fixes #18264 