### PR TITLE
fix(18033): Fix SequentialThreadScheduler stopping and SequentialSchedulerTests exceptionHandling

### DIFF
--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/builders/TaskSchedulerBuilder.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/builders/TaskSchedulerBuilder.java
@@ -147,6 +147,9 @@ public interface TaskSchedulerBuilder<OUT> {
      * Provide a custom uncaught exception handler for this task scheduler. If none is provided then the default
      * uncaught exception handler will be used. The default handler will write a message to the log.
      *
+     * The order in which the UncaughtExceptionHandler is executed is undefined, the only guarantee is that it will
+     * happen after the task that thrown the exception.
+     *
      * @param uncaughtExceptionHandler the uncaught exception handler
      * @return this
      */

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/SequentialTaskScheduler.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/SequentialTaskScheduler.java
@@ -38,7 +38,7 @@ public class SequentialTaskScheduler<OUT> extends TaskScheduler<OUT> {
      * @param model                    the wiring model containing this scheduler
      * @param name                     the name of the task scheduler
      * @param pool                     the fork join pool that will execute tasks on this scheduler
-     * @param uncaughtExceptionHandler the uncaught exception handler
+     * @param uncaughtExceptionHandler the uncaught exception handler. In this scheduler, the handler is executed out of order.
      * @param onRamp                   an object counter that is incremented when data is added to the task scheduler
      * @param offRamp                  an object counter that is decremented when data is removed from the task
      *                                 scheduler

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/SequentialThreadTaskScheduler.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/schedulers/internal/SequentialThreadTaskScheduler.java
@@ -15,7 +15,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import java.util.function.ToLongFunction;
 
@@ -27,6 +26,7 @@ import java.util.function.ToLongFunction;
  */
 public class SequentialThreadTaskScheduler<OUT> extends TaskScheduler<OUT> implements Startable, Stoppable {
 
+    private static final SequentialThreadTask POISON_PILL = new SequentialThreadTask(o -> {}, new Object());
     private final UncaughtExceptionHandler uncaughtExceptionHandler;
     private final ObjectCounter onRamp;
     private final ObjectCounter offRamp;
@@ -38,7 +38,7 @@ public class SequentialThreadTaskScheduler<OUT> extends TaskScheduler<OUT> imple
 
     private static final int BUFFER_SIZE = 1024;
 
-    private final AtomicBoolean alive = new AtomicBoolean(true);
+    private volatile boolean alive = true;
 
     private final Thread thread;
 
@@ -47,7 +47,7 @@ public class SequentialThreadTaskScheduler<OUT> extends TaskScheduler<OUT> imple
      *
      * @param model                    the wiring model containing this task scheduler
      * @param name                     the name of the task scheduler
-     * @param uncaughtExceptionHandler the handler to call when an exception is thrown by a task
+     * @param uncaughtExceptionHandler the handler to call when an exception is thrown by a task. In this scheduler, the handler is executed immediately after the task that thrown the exception.
      * @param onRamp                   the counter to increment when a task is added to the queue
      * @param offRamp                  the counter to decrement when a task is removed from the queue
      * @param dataCounter              the function to weight input data objects for health monitoring
@@ -151,7 +151,8 @@ public class SequentialThreadTaskScheduler<OUT> extends TaskScheduler<OUT> imple
      */
     @Override
     public void stop() {
-        alive.set(false);
+        alive = false;
+        tasks.add(POISON_PILL);
     }
 
     /**
@@ -160,7 +161,7 @@ public class SequentialThreadTaskScheduler<OUT> extends TaskScheduler<OUT> imple
     private void run() {
         final List<SequentialThreadTask> buffer = new ArrayList<>(BUFFER_SIZE);
 
-        while (alive.get()) {
+        while (alive) {
             if (tasks.drainTo(buffer, BUFFER_SIZE) == 0) {
                 try {
                     final SequentialThreadTask task = tasks.take();
@@ -173,6 +174,9 @@ public class SequentialThreadTaskScheduler<OUT> extends TaskScheduler<OUT> imple
 
             busyTimer.activate();
             for (final SequentialThreadTask task : buffer) {
+                if (!alive) {
+                    break;
+                }
                 try {
                     task.handle();
                 } catch (final Throwable t) {

--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/SequentialTaskSchedulerTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/schedulers/SequentialTaskSchedulerTests.java
@@ -39,6 +39,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.RepetitionInfo;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -1207,9 +1209,9 @@ class SequentialTaskSchedulerTests {
         model.stop();
     }
 
-    @ParameterizedTest
-    @ValueSource(strings = {"SEQUENTIAL", "SEQUENTIAL_THREAD"})
-    void exceptionHandlingTest(final String typeString) {
+    @RepeatedTest(1000)
+    void exceptionHandlingTest(final RepetitionInfo info) {
+        final String typeString = (info.getCurrentRepetition() % 2 == 0) ? "SEQUENTIAL" : "SEQUENTIAL_THREAD";
         final WiringModel model = TestWiringModelBuilder.create();
         final TaskSchedulerType type = TaskSchedulerType.valueOf(typeString);
 
@@ -1244,7 +1246,8 @@ class SequentialTaskSchedulerTests {
         }
 
         assertEventuallyEquals(value, wireValue::get, Duration.ofSeconds(10), "Wire sum did not match expected sum");
-        assertEquals(1, exceptionCount.get());
+        assertEventuallyEquals(
+                1, exceptionCount::get, Duration.ofSeconds(10), "Exception handler did not update the expected value");
 
         model.stop();
     }


### PR DESCRIPTION

**Description**:
* Sequential task schedulers cannot guarantee the order of execution of the exception handling; it can only guarantee that it will be executed after the handler has thrown the exception. The test is modified to reflect this behavior. 
* Sequential thread task scheduler has a defect in the run() method that manifests more in short-lived task schedulers that we try to stop: the thread created by the scheduler gets blocked in the take() as soon as there are no more tasks to process, and despite calling the stop() method on the scheduler, the thread lives on, leaking it... This change addresses the problem

**Related issue(s)**:

Fixes #18033 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
