### PR TITLE
fix: 18360: MerkleDbTableConfig should be immutable

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/merkle/disk/OnDiskTest.java
@@ -15,7 +15,6 @@ import com.swirlds.common.io.utility.LegacyTemporaryFileBuilder;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.merkledb.MerkleDbTableConfig;
-import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.platform.test.fixtures.state.MerkleTestBase;
 import com.swirlds.state.lifecycle.Schema;
 import com.swirlds.state.lifecycle.StateDefinition;
@@ -75,16 +74,13 @@ class OnDiskTest extends MerkleTestBase {
                 onDiskValueSerializerClassId(SERVICE_NAME, ACCOUNT_STATE_KEY),
                 onDiskValueClassId(SERVICE_NAME, ACCOUNT_STATE_KEY),
                 Account.PROTOBUF);
-        final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
         final var tableConfig = new MerkleDbTableConfig(
                 (short) 1,
                 DigestType.SHA_384,
-                merkleDbConfig.maxNumOfKeys(),
-                merkleDbConfig.hashesRamToDiskThreshold());
-        // Force all hashes to disk, to make sure we're going through all the
-        // serialization paths we can
-        tableConfig.hashesRamToDiskThreshold(0);
-        tableConfig.maxNumberOfKeys(100);
+                100,
+                // Force all hashes to disk, to make sure we're going through all the
+                // serialization paths we can
+                0);
 
         final var builder = new MerkleDbDataSourceBuilder(storageDir, tableConfig, CONFIGURATION);
         virtualMap = new VirtualMap<>(

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/state/VirtualMerkleStateInitializer.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/state/VirtualMerkleStateInitializer.java
@@ -78,8 +78,7 @@ public final class VirtualMerkleStateInitializer {
             logger.info(LOGM_DEMO_INFO, "total accounts = {}", totalAccounts);
             if (state.getVirtualMap() == null && totalAccounts > 0) {
                 logger.info(LOGM_DEMO_INFO, "Creating virtualmap for {} accounts.", totalAccounts);
-                final VirtualMap<AccountVirtualMapKey, AccountVirtualMapValue> virtualMap =
-                        createAccountsVM(totalAccounts);
+                final VirtualMap<AccountVirtualMapKey, AccountVirtualMapValue> virtualMap = createAccountsVM();
                 logger.info(LOGM_DEMO_INFO, "accounts VM = {}, DS = {}", virtualMap, virtualMap.getDataSource());
                 virtualMap.registerMetrics(platform.getContext().getMetrics());
                 state.setVirtualMap(virtualMap);
@@ -92,8 +91,7 @@ public final class VirtualMerkleStateInitializer {
                         LOGM_DEMO_INFO,
                         "Creating virtualmap for max {} key value pairs.",
                         maximumNumberOfKeyValuePairs);
-                final VirtualMap<SmartContractMapKey, SmartContractMapValue> virtualMap =
-                        createSmartContractsVM(maximumNumberOfKeyValuePairs);
+                final VirtualMap<SmartContractMapKey, SmartContractMapValue> virtualMap = createSmartContractsVM();
                 logger.info(LOGM_DEMO_INFO, "SC VM = {}, DS = {}", virtualMap, virtualMap.getDataSource());
                 virtualMap.registerMetrics(platform.getContext().getMetrics());
                 state.setVirtualMapForSmartContracts(virtualMap);
@@ -104,7 +102,7 @@ public final class VirtualMerkleStateInitializer {
             if (state.getVirtualMapForSmartContractsByteCode() == null && totalSmartContracts > 0) {
                 logger.info(LOGM_DEMO_INFO, "Creating virtualmap for {} bytecodes.", totalSmartContracts);
                 final VirtualMap<SmartContractByteCodeMapKey, SmartContractByteCodeMapValue> virtualMap =
-                        createSmartContractByteCodeVM(totalSmartContracts);
+                        createSmartContractByteCodeVM();
                 logger.info(LOGM_DEMO_INFO, "SCBC VM = {}, DS = {}", virtualMap, virtualMap.getDataSource());
                 virtualMap.registerMetrics(platform.getContext().getMetrics());
                 state.setVirtualMapForSmartContractsByteCode(virtualMap);
@@ -112,8 +110,7 @@ public final class VirtualMerkleStateInitializer {
         }
     }
 
-    private static VirtualMap<AccountVirtualMapKey, AccountVirtualMapValue> createAccountsVM(final long numOfKeys) {
-        TABLE_CONFIG.maxNumberOfKeys(numOfKeys);
+    private static VirtualMap<AccountVirtualMapKey, AccountVirtualMapValue> createAccountsVM() {
         final VirtualDataSourceBuilder dsBuilder = new MerkleDbDataSourceBuilder(TABLE_CONFIG, CONFIGURATION);
         return new VirtualMap<>(
                 "accounts",
@@ -123,8 +120,7 @@ public final class VirtualMerkleStateInitializer {
                 CONFIGURATION);
     }
 
-    private static VirtualMap<SmartContractMapKey, SmartContractMapValue> createSmartContractsVM(final long numOfKeys) {
-        TABLE_CONFIG.maxNumberOfKeys(numOfKeys);
+    private static VirtualMap<SmartContractMapKey, SmartContractMapValue> createSmartContractsVM() {
         final VirtualDataSourceBuilder dsBuilder = new MerkleDbDataSourceBuilder(TABLE_CONFIG, CONFIGURATION);
         return new VirtualMap<>(
                 "smartContracts",
@@ -134,9 +130,8 @@ public final class VirtualMerkleStateInitializer {
                 CONFIGURATION);
     }
 
-    private static VirtualMap<SmartContractByteCodeMapKey, SmartContractByteCodeMapValue> createSmartContractByteCodeVM(
-            final long numOfKeys) {
-        TABLE_CONFIG.maxNumberOfKeys(numOfKeys);
+    private static VirtualMap<SmartContractByteCodeMapKey, SmartContractByteCodeMapValue>
+            createSmartContractByteCodeVM() {
         final VirtualDataSourceBuilder dsBuilder = new MerkleDbDataSourceBuilder(TABLE_CONFIG, CONFIGURATION);
         return new VirtualMap<>(
                 "smartContractByteCode",

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasherTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasherTest.java
@@ -53,14 +53,7 @@ class VirtualMerkleLeafHasherTest {
         keySerializer = new SmartContractByteCodeMapKeySerializer();
         valueSerializer = new SmartContractByteCodeMapValueSerializer();
 
-        final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
-        final MerkleDbTableConfig tableConfig = new MerkleDbTableConfig(
-                        (short) 1,
-                        DigestType.SHA_384,
-                        merkleDbConfig.maxNumOfKeys(),
-                        merkleDbConfig.hashesRamToDiskThreshold())
-                .maxNumberOfKeys(50_000_000)
-                .hashesRamToDiskThreshold(0);
+        final MerkleDbTableConfig tableConfig = new MerkleDbTableConfig((short) 1, DigestType.SHA_384, 50_000_000, 0);
         dataSourceBuilder = new MerkleDbDataSourceBuilder(tableConfig, CONFIGURATION);
     }
 

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/transaction/handler/VirtualMerkleTransactionHandlerTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/virtualmerkle/transaction/handler/VirtualMerkleTransactionHandlerTest.java
@@ -43,14 +43,8 @@ public class VirtualMerkleTransactionHandlerTest {
         final long maximumNumberOfKeyValuePairsCreation = 28750;
         final SmartContractMapKeySerializer keySerializer = new SmartContractMapKeySerializer();
         final SmartContractMapValueSerializer valueSerializer = new SmartContractMapValueSerializer();
-        final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
-        final MerkleDbTableConfig tableConfig = new MerkleDbTableConfig(
-                        (short) 1,
-                        DigestType.SHA_384,
-                        merkleDbConfig.maxNumOfKeys(),
-                        merkleDbConfig.hashesRamToDiskThreshold())
-                .maxNumberOfKeys(maximumNumberOfKeyValuePairsCreation)
-                .hashesRamToDiskThreshold(0);
+        final MerkleDbTableConfig tableConfig =
+                new MerkleDbTableConfig((short) 1, DigestType.SHA_384, maximumNumberOfKeyValuePairsCreation, 0);
         final MerkleDbDataSourceBuilder dataSourceBuilder = new MerkleDbDataSourceBuilder(tableConfig, CONFIGURATION);
 
         smartContract =
@@ -60,13 +54,8 @@ public class VirtualMerkleTransactionHandlerTest {
 
         final SmartContractByteCodeMapKeySerializer keySerializer2 = new SmartContractByteCodeMapKeySerializer();
         final SmartContractByteCodeMapValueSerializer valueSerializer2 = new SmartContractByteCodeMapValueSerializer();
-        final MerkleDbTableConfig tableConfig2 = new MerkleDbTableConfig(
-                        (short) 1,
-                        DigestType.SHA_384,
-                        merkleDbConfig.maxNumOfKeys(),
-                        merkleDbConfig.hashesRamToDiskThreshold())
-                .maxNumberOfKeys(totalSmartContractCreations)
-                .hashesRamToDiskThreshold(0);
+        final MerkleDbTableConfig tableConfig2 =
+                new MerkleDbTableConfig((short) 1, DigestType.SHA_384, totalSmartContractCreations, 0);
         final MerkleDbDataSourceBuilder dataSourceBuilder2 = new MerkleDbDataSourceBuilder(tableConfig2, CONFIGURATION);
 
         smartContractByteCodeVM = new VirtualMap<>(

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
@@ -96,12 +96,8 @@ public class VirtualMapReconnectTestBase {
         final Path defaultVirtualMapPath = LegacyTemporaryFileBuilder.buildTemporaryFile(CONFIGURATION);
         MerkleDb.setDefaultPath(defaultVirtualMapPath);
         final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
-        final MerkleDbTableConfig tableConfig = new MerkleDbTableConfig(
-                (short) 1,
-                DigestType.SHA_384,
-                merkleDbConfig.maxNumOfKeys(),
-                merkleDbConfig.hashesRamToDiskThreshold());
-        tableConfig.hashesRamToDiskThreshold(0);
+        final MerkleDbTableConfig tableConfig =
+                new MerkleDbTableConfig((short) 1, DigestType.SHA_384, merkleDbConfig.maxNumOfKeys(), 0);
         return new MerkleDbDataSourceBuilder(tableConfig, CONFIGURATION);
     }
 

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbTableConfig.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbTableConfig.java
@@ -297,22 +297,6 @@ public final class MerkleDbTableConfig implements SelfSerializable {
     }
 
     /**
-     * Specifies the max number of keys that can be stored in the table. Must be greater than zero.
-     *
-     * @param maxNumberOfKeys
-     *      Max number of keys
-     * @return
-     *      This table config object
-     */
-    public MerkleDbTableConfig maxNumberOfKeys(final long maxNumberOfKeys) {
-        if (maxNumberOfKeys <= 0) {
-            throw new IllegalArgumentException("Max number of keys must be greater than 0");
-        }
-        this.maxNumberOfKeys = maxNumberOfKeys;
-        return this;
-    }
-
-    /**
      * Internal hashes RAM/disk threshold. Value {@code 0} means all hashes are to be stored on disk.
      * Value {@link Integer#MAX_VALUE} indicates that all hashes are to be stored in memory.
      *
@@ -321,22 +305,6 @@ public final class MerkleDbTableConfig implements SelfSerializable {
      */
     public long getHashesRamToDiskThreshold() {
         return hashesRamToDiskThreshold;
-    }
-
-    /**
-     * Specifies internal hashes RAM/disk threshold. Must be greater or equal to zero.
-     *
-     * @param hashesRamToDiskThreshold
-     *      Internal hashes RAM/disk threshold
-     * @return
-     *      This table config object
-     */
-    public MerkleDbTableConfig hashesRamToDiskThreshold(final long hashesRamToDiskThreshold) {
-        if (hashesRamToDiskThreshold < 0) {
-            throw new IllegalArgumentException("Hashes RAM/disk threshold must be greater or equal to 0");
-        }
-        this.hashesRamToDiskThreshold = hashesRamToDiskThreshold;
-        return this;
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -43,6 +43,11 @@ class MerkleDbBuilderTest {
                 merkleDbConfig.hashesRamToDiskThreshold());
     }
 
+    private MerkleDbTableConfig createTableConfig(final long maxNumOfKeys, final long hashesRamToDiskThreshold) {
+        final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
+        return new MerkleDbTableConfig((short) 1, DigestType.SHA_384, maxNumOfKeys, hashesRamToDiskThreshold);
+    }
+
     @Test
     @DisplayName("Test table config is passed to data source")
     public void testTableConfig() throws IOException {
@@ -94,10 +99,9 @@ class MerkleDbBuilderTest {
     }
 
     @Test
-    @DisplayName("Test data source config overrides")
-    public void testBuilderOverrides() throws IOException {
-        final MerkleDbTableConfig tableConfig = createTableConfig();
-        tableConfig.maxNumberOfKeys(1999).hashesRamToDiskThreshold(Integer.MAX_VALUE >> 4);
+    @DisplayName("Test custom table config values")
+    public void testCustomTableConfig() throws IOException {
+        final MerkleDbTableConfig tableConfig = createTableConfig(1999, Integer.MAX_VALUE >> 4);
         final MerkleDbDataSourceBuilder builder = new MerkleDbDataSourceBuilder(tableConfig, CONFIGURATION);
         final Path defaultDbPath = testDirectory.resolve("defaultDatabasePath");
         MerkleDb.setDefaultPath(defaultDbPath);

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleTestBase.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleTestBase.java
@@ -284,14 +284,7 @@ public class MerkleTestBase extends StateTestBase {
                 new OnDiskKeySerializer<>(keySerializerClassId, keyClassId, keyCodec);
         final ValueSerializer<OnDiskValue<String>> valueSerializer =
                 new OnDiskValueSerializer<>(valueSerializerClassId, valueClassId, valueCodec);
-        final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
-        final MerkleDbTableConfig merkleDbTableConfig = new MerkleDbTableConfig(
-                (short) 1,
-                DigestType.SHA_384,
-                merkleDbConfig.maxNumOfKeys(),
-                merkleDbConfig.hashesRamToDiskThreshold());
-        merkleDbTableConfig.hashesRamToDiskThreshold(0);
-        merkleDbTableConfig.maxNumberOfKeys(100);
+        final MerkleDbTableConfig merkleDbTableConfig = new MerkleDbTableConfig((short) 1, DigestType.SHA_384, 100, 0);
         final var builder = new MerkleDbDataSourceBuilder(virtualDbPath, merkleDbTableConfig, CONFIGURATION);
         return new VirtualMap<>(label, keySerializer, valueSerializer, builder, CONFIGURATION);
     }


### PR DESCRIPTION
Fix summary: `maxNumberOfKeys()` and `hashesRamToDiskThreshold()` methods in `MerkleDbTableConfig` are dropped, they are redundant.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/18360
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
