### PR TITLE
fix: 18363: Random test failures because MapTest destroys virtual map copies asynchronously

### DIFF
--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/map/MapTest.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/map/MapTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.virtual.merkle.map;
 
+import static com.swirlds.common.test.fixtures.AssertionUtils.assertEventuallyTrue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,6 +28,7 @@ import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
 import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
 import com.swirlds.virtualmap.internal.RecordAccessor;
 import com.swirlds.virtualmap.internal.merkle.VirtualRootNode;
+import java.time.Duration;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Tags;
@@ -114,7 +116,14 @@ final class MapTest {
                 assertNull(map.get(new TestKey(i)), "The old value should not exist anymore");
             }
         } finally {
+            // Make sure all the created virtual map copies are fully processed before this test
+            // is complete, otherwise OOME can be observed in random tests run after this one
+            final VirtualRootNode<TestKey, TestValue> root = map.getRight();
+            root.enableFlush();
+            final VirtualMap<TestKey, TestValue> lastCopy = map.copy();
             map.release();
+            lastCopy.release();
+            assertEventuallyTrue(root::isFlushed, Duration.ofSeconds(30), "The map must be flushed");
         }
     }
 


### PR DESCRIPTION
Fix summary: make sure all virtual map copies created in `MapTest.insertRemoveAndModifyOneMillion()` are released and fully processed before the test is complete.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/18363
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
