### PR TITLE
fix: HIP-632 fix alias length check

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/getevmaddressalias/EvmAddressAliasCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/getevmaddressalias/EvmAddressAliasCall.java
@@ -19,6 +19,7 @@ import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
+import com.hedera.node.app.service.token.AliasUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 /**
@@ -53,11 +54,12 @@ public class EvmAddressAliasCall extends AbstractCall {
         }
 
         // If the account does not have an evm address as an alias
-        if (account.alias().length() != 20) {
+        final var evmAlias = AliasUtils.extractEvmAddress(account.alias());
+        if (evmAlias == null) {
             return gasOnly(fullResultsFor(INVALID_ACCOUNT_ID, ZERO_ADDRESS), INVALID_ACCOUNT_ID, true);
         }
 
-        final var aliasAddress = asHeadlongAddress(account.alias().toByteArray());
+        final var aliasAddress = asHeadlongAddress(evmAlias.toByteArray());
         return gasOnly(fullResultsFor(SUCCESS, aliasAddress), SUCCESS, true);
     }
 


### PR DESCRIPTION
**Description**:
This PR fixed a behaviour that was checking whether the alias is 20 bytes long.
Now it uses a helper method from `AliasUtils` to verify and extract the given alias

**Related issue(s)**:

Fixes #17570 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
