### PR TITLE
chore: Intercept GRPC calls to capture client usage metrics (POC)

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/obs/ObservabilityInterceptor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/obs/ObservabilityInterceptor.java
@@ -1,0 +1,133 @@
+package com.hedera.node.app.grpc.impl.obs;
+
+import static java.util.Objects.requireNonNull;
+
+import com.swirlds.metrics.api.Counter;
+import com.swirlds.metrics.api.Metrics;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import io.grpc.Metadata;
+import io.grpc.Metadata.Key;
+import io.grpc.MethodDescriptor;
+import io.grpc.ServerCall;
+import io.grpc.ServerCall.Listener;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+/**
+ * Interceptor for GRPC calls received by the server. This interceptor captures the user-agent and service/method being
+ * invoked and records them as a metric.
+ */
+public class ObservabilityInterceptor implements ServerInterceptor {
+
+    private static final String CATEGORY = "grpc";
+    private static final Key<String> USER_AGENT_KEY = Key.of("X-User-Agent", Metadata.ASCII_STRING_MARSHALLER);
+
+    private final Metrics metrics;
+    private final ConcurrentMap<String, Counter> counters = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> rpcNames = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, UserAgent> userAgents = new ConcurrentHashMap<>();
+
+    public ObservabilityInterceptor(@NonNull final Metrics metrics) {
+        this.metrics = requireNonNull(metrics);
+    }
+
+    @Override
+    public <ReqT, RespT> Listener<ReqT> interceptCall(final ServerCall<ReqT, RespT> serverCall, final Metadata metadata,
+            final ServerCallHandler<ReqT, RespT> serverCallHandler) {
+
+        final MethodDescriptor<ReqT, RespT> methodDescriptor = serverCall.getMethodDescriptor();
+        final String rpcName = getRpcName(methodDescriptor);
+        final UserAgent userAgent = getUserAgent(metadata.get(USER_AGENT_KEY));
+
+        final Counter counter = getCounter(userAgent, rpcName);
+        counter.increment();
+
+        System.out.println("OBS Interceptor:: userAgent=" + userAgent + ", rpcName=" + rpcName
+                + ", counter=" + counter.getName());
+
+        return serverCallHandler.startCall(serverCall, metadata);
+    }
+
+    private Counter getCounter(final UserAgent userAgent, final String rpcName) {
+        // metric name format: <RpcName>_<UserAgentType>_<UserAgentVersion>
+        final String metricName = rpcName + '_' + userAgent.type.key() + '_' + userAgent.version.key();
+        return counters.computeIfAbsent(metricName, __ -> {
+            final Counter.Config config = new Counter.Config(CATEGORY, metricName)
+                    .withUnit("invocations")
+                    .withDescription("The number of invocations made to RPC method " + rpcName + " from "
+                            + userAgent.type.key() + " (version " + userAgent.version.key() + ")");
+            return metrics.getOrCreate(config);
+        });
+    }
+
+    private UserAgent getUserAgent(final String rawUserAgent) {
+        UserAgent userAgent = userAgents.get(rawUserAgent);
+        if (userAgent != null) {
+            return userAgent;
+        }
+
+        // we don't have the user agent cached, so parse it
+        // these are formatted as "<sdk-type>/<sdk-version>[ <other-type>/<other-version>]"
+        String userAgentStr = rawUserAgent;
+        final int sepIdx = rawUserAgent.indexOf(' ');
+        if (sepIdx != -1) {
+            // if the user agent has multiple parts, extract just the first one
+            userAgentStr = userAgentStr.substring(0, sepIdx);
+        }
+
+        final int typeVersionSepIdx = userAgentStr.indexOf('/');
+        if (typeVersionSepIdx == -1) {
+            return new UserAgent(UserAgentType.UNKNOWN, UserAgentVersion.UNKNOWN);
+        }
+
+        final String agentTypeStr = userAgentStr.substring(0, typeVersionSepIdx);
+        final String agentVersionStr = userAgentStr.substring(typeVersionSepIdx + 1);
+        final UserAgentType userAgentType = UserAgentType.fromString(agentTypeStr);
+        final UserAgentVersion userAgentVersion = getVersionLabel(userAgentType, agentVersionStr);
+
+        userAgent = new UserAgent(userAgentType, userAgentVersion);
+        userAgents.put(rawUserAgent, userAgent);
+        return userAgent;
+    }
+
+    private record UserAgent(UserAgentType type, UserAgentVersion version) { }
+
+    private UserAgentVersion getVersionLabel(final UserAgentType userAgent, final String version) {
+        if (version == null || version.isBlank()) {
+            return UserAgentVersion.UNKNOWN;
+        }
+        if (version.contains("dev") || version.contains("beta")) {
+            return UserAgentVersion.PRE_RELEASE;
+        }
+        // TODO: add latest/old determination
+        return UserAgentVersion.LATEST;
+    }
+
+    private String getRpcName(final MethodDescriptor<?, ?> descriptor) {
+        String rpcName = rpcNames.get(descriptor.getFullMethodName());
+
+        if (rpcName != null) {
+            return rpcName;
+        }
+
+        String svcName = descriptor.getServiceName();
+        String methodName = descriptor.getBareMethodName();
+
+        // remove "proto." from service name
+        if (svcName.startsWith("proto.")) {
+            svcName = svcName.substring(6);
+        }
+
+        // capitalize first letter of method
+        methodName = Character.toUpperCase(methodName.charAt(0)) + methodName.substring(1);
+
+        // combine and store
+        rpcName = svcName + '_' + methodName;
+        rpcNames.put(descriptor.getFullMethodName(), rpcName);
+
+        return rpcName;
+    }
+
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/obs/UserAgentType.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/obs/UserAgentType.java
@@ -1,0 +1,66 @@
+package com.hedera.node.app.grpc.impl.obs;
+
+import static java.util.Objects.requireNonNull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.HashMap;
+import java.util.Map;
+
+public enum UserAgentType {
+    HIERO_SDK_CPP("HieroSdkCpp", "hiero-sdk-cpp"),
+    HIERO_SDK_GO("HieroSdkGo", "hiero-sdk-go"),
+    HIERO_SDK_JAVA("HieroSdkJava", "hiero-sdk-java"),
+    HIERO_SDK_JS("HieroSdkJs", "hiero-sdk-js"),
+    HIERO_SDK_PYTHON("HieroSdkPython", "hiero-sdk-python"),
+    HIERO_SDK_RUST("HieroSdkRust", "hiero-sdk-rust"),
+    HIERO_SDK_SWIFT("HieroSdkSwift", "hiero-sdk-swift"),
+    OTHER("Other"),
+    UNKNOWN("Unknown");
+
+    private static final Map<String, UserAgentType> values = new HashMap<>();
+    static {
+        for (final UserAgentType userAgent : values()) {
+            values.put(userAgent.key, userAgent);
+            if (userAgent.alternatives != null) {
+                for (final String alt : userAgent.alternatives) {
+                    values.put(alt.toLowerCase(), userAgent);
+                }
+            }
+        }
+    }
+
+    private final String key;
+    private final String[] alternatives;
+
+    UserAgentType(@NonNull final String key, final String... alternatives) {
+        this.key = requireNonNull(key);
+        this.alternatives = requireNonNull(alternatives);
+    }
+
+    public String key() {
+        return key;
+    }
+
+    public static UserAgentType fromString(@Nullable String string) {
+        if (string == null || string.isBlank()) {
+            // No user agent was specified
+            return UNKNOWN;
+        }
+
+        string = string.trim();
+
+        UserAgentType userAgent = values.get(string);
+        if (userAgent != null) {
+            return userAgent;
+        }
+
+        userAgent = values.get(string.toLowerCase());
+        if (userAgent != null) {
+            return userAgent;
+        }
+
+        // There was a user agent, but it is not a known one
+        return OTHER;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/obs/UserAgentVersion.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/obs/UserAgentVersion.java
@@ -1,0 +1,18 @@
+package com.hedera.node.app.grpc.impl.obs;
+
+public enum UserAgentVersion {
+    LATEST("Latest"),
+    OLD("Old"),
+    PRE_RELEASE("PreRelease"),
+    UNKNOWN("Unknown");
+
+    private final String key;
+
+    UserAgentVersion(final String key) {
+        this.key = key;
+    }
+
+    public String key() {
+        return key;
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/test/grpc/GrpcTransactionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/test/grpc/GrpcTransactionTest.java
@@ -38,7 +38,7 @@ class GrpcTransactionTest extends GrpcTestBase {
 
     private void setUp(@NonNull final IngestWorkflow ingest) {
         registerIngest(METHOD, ingest, UNIMPLEMENTED_QUERY, UNIMPLEMENTED_QUERY);
-        startServer(false);
+        startServer(false, "hiero-sdk-java/1.2.3");
     }
 
     @Test


### PR DESCRIPTION
**Description**:
POC for capturing GRPC client usage metrics.

**Related issue(s)**:

Fixes #18152

**Notes for reviewer**:
This is a POC; to see it happening, run a test in `GrpcTransactionTest` like `#sendGoodTransaction`. In the logs you should see something like the following printed:
```
OBS Interceptor:: userAgent=UserAgent[type=HIERO_SDK_JAVA, version=LATEST], rpcName=TestService_TestMethod, counter=TestService_TestMethod_HieroSdkJava_Latest
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
