### PR TITLE
fix: 18405: Bucket integrity check in HDHM.ReadUpdateBucketTask can be improved - cherry-pick.

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -607,8 +607,11 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                 // Read from bytes
                 bucket.readFrom(bucketData);
                 if (bucketIndex != bucket.getBucketIndex()) {
-                    throw new RuntimeException(
+                    logger.warn(
+                            MERKLE_DB.getMarker(),
                             "Bucket index integrity check " + bucketIndex + " != " + bucket.getBucketIndex());
+                    bucket.clear();
+                    bucket.setBucketIndex(bucketIndex);
                 }
             }
             // Apply all updates


### PR DESCRIPTION
**Description**:

This is a cherry-pick from #18272 with resolved merge conflicts

Fixes #18405 

