### PR TITLE
fix: Extended suite failure during insertRemoveAndModifyOneMillion

### DIFF
--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/map/MapTest.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/map/MapTest.java
@@ -123,7 +123,7 @@ final class MapTest {
             final VirtualMap<TestKey, TestValue> lastCopy = map.copy();
             map.release();
             lastCopy.release();
-            assertEventuallyTrue(root::isFlushed, Duration.ofSeconds(30), "The map must be flushed");
+            assertEventuallyTrue(root::isFlushed, Duration.ofMinutes(1), "The map must be flushed");
         }
     }
 


### PR DESCRIPTION
**Description**:
This Pr addresses a test flake from this commit: https://github.com/hiero-ledger/hiero-consensus-node/pull/18364/files
by temporarily increasing the duration of the check.

**Related issue(s)**:

Fixes #18363

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
