### PR TITLE
fix: 18410: Bucket integrity check in HDHM.ReadUpdateBucketTask can be improved 

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -613,10 +613,12 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                             MERKLE_DB.getMarker(),
                             "Bucket index integrity check " + bucketIndex + " != " + bucket.getBucketIndex());
                     /*
-                      This is a workaround for issue #18250, which caused possible corruption in snapshots.
-                      If we read a bucket from the file and the bucket index is different from the expected one,
-                      we clear the bucket (as it contains garbage anyway) and set the correct index.
-                     */
+                       This is a workaround for the issue https://github.com/hiero-ledger/hiero-consensus-node/pull/18250,
+                       which caused possible corruption in snapshots.
+                       If the snapshot is corrupted, the code may read a bucket from the file, and the bucket index
+                       may be different from the expected one. In this case, we clear the bucket (as it contains garbage
+                       anyway) and set the correct index.
+                    */
                     bucket.clear();
                     bucket.setBucketIndex(bucketIndex);
                 }

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -609,8 +609,11 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                 // Read from bytes
                 bucket.readFrom(bucketData);
                 if (bucketIndex != bucket.getBucketIndex()) {
-                    throw new RuntimeException(
+                    logger.warn(
+                            MERKLE_DB.getMarker(),
                             "Bucket index integrity check " + bucketIndex + " != " + bucket.getBucketIndex());
+                    bucket.clear();
+                    bucket.setBucketIndex(bucketIndex);
                 }
             }
             // Apply all updates

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -609,7 +609,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                 // Read from bytes
                 bucket.readFrom(bucketData);
                 if (bucketIndex != bucket.getBucketIndex()) {
-                    logger.warn(
+                    logger.error(
                             MERKLE_DB.getMarker(),
                             "Bucket index integrity check " + bucketIndex + " != " + bucket.getBucketIndex());
                     bucket.clear();

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -612,6 +612,11 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                     logger.error(
                             MERKLE_DB.getMarker(),
                             "Bucket index integrity check " + bucketIndex + " != " + bucket.getBucketIndex());
+                    /*
+                      This is a workaround for issue #18250, which caused possible corruption in snapshots.
+                      If we read a bucket from the file and the bucket index is different from the expected one,
+                      we clear the bucket (as it contains garbage anyway) and set the correct index.
+                     */
                     bucket.clear();
                     bucket.setBucketIndex(bucketIndex);
                 }


### PR DESCRIPTION
**Description**:

This is a cherry-pick of https://github.com/hiero-ledger/hiero-consensus-node/pull/18406


**Related issue(s)**:

Fixes #18410
