### PR TITLE
fix: Should reject a FILE_UPDATE to 0.0.123 with an invalid throttle definition

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1743,4 +1743,10 @@ enum ResponseCodeEnum {
      * The network just started at genesis and is creating system entities.
      */
     CREATING_SYSTEM_ENTITIES = 396;
+
+    /**
+    * The least common multiple of the throttle group's milliOpsPerSec is 
+    * too large and it's overflowing.
+     */
+    THROTTLE_GROUP_LCM_OVERFLOW = 397;
 }

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/HapiThrottleUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/HapiThrottleUtils.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.hapi.utils.sysfiles.domain.throttling;
 
+import static com.hedera.node.app.hapi.utils.CommonUtils.productWouldOverflow;
+
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 
 public class HapiThrottleUtils {
@@ -36,6 +38,25 @@ public class HapiThrottleUtils {
                 .setMilliOpsPerSec(group.impliedMilliOpsPerSec())
                 .addAllOperations(group.getOperations())
                 .build();
+    }
+
+    /**
+     * Computes the least common multiple of the given two numbers.
+     *
+     * @param lhs the first number
+     * @param rhs the second number
+     * @return the least common multiple of {@code a} and {@code b}
+     * @throws ArithmeticException if the result overflows a {@code long}
+     */
+    public static long lcm(final long lhs, final long rhs) {
+        if (productWouldOverflow(lhs, rhs)) {
+            throw new ArithmeticException();
+        }
+        return (lhs * rhs) / gcd(Math.min(lhs, rhs), Math.max(lhs, rhs));
+    }
+
+    private static long gcd(final long lhs, final long rhs) {
+        return (lhs == 0) ? rhs : gcd(rhs % lhs, lhs);
     }
 
     private HapiThrottleUtils() {

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleBucket.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/sysfiles/domain/throttling/ThrottleBucket.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.hapi.utils.sysfiles.domain.throttling;
 
-import static com.hedera.node.app.hapi.utils.CommonUtils.productWouldOverflow;
+import static com.hedera.node.app.hapi.utils.sysfiles.domain.throttling.HapiThrottleUtils.lcm;
 import static com.hedera.node.app.hapi.utils.sysfiles.validation.ErrorCodeUtils.exceptionMsgFor;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUCKET_CAPACITY_OVERFLOW;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUCKET_HAS_NO_THROTTLE_GROUPS;
@@ -222,24 +222,5 @@ public final class ThrottleBucket<E extends Enum<E>> {
 
     public long impliedBurstPeriodMs() {
         return burstPeriodMs > 0 ? burstPeriodMs : 1_000L * burstPeriod;
-    }
-
-    /**
-     * Computes the least common multiple of the given two numbers.
-     *
-     * @param lhs the first number
-     * @param rhs the second number
-     * @return the least common multiple of {@code a} and {@code b}
-     * @throws ArithmeticException if the result overflows a {@code long}
-     */
-    private long lcm(final long lhs, final long rhs) {
-        if (productWouldOverflow(lhs, rhs)) {
-            throw new ArithmeticException();
-        }
-        return (lhs * rhs) / gcd(Math.min(lhs, rhs), Math.max(lhs, rhs));
-    }
-
-    private long gcd(final long lhs, final long rhs) {
-        return (lhs == 0) ? rhs : gcd(rhs % lhs, lhs);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleParser.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleParser.java
@@ -6,12 +6,17 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS_BUT_MISSING_EXPECTED_OPERATION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNPARSEABLE_THROTTLE_DEFINITIONS;
+import static com.hedera.node.app.hapi.utils.CommonUtils.productWouldOverflow;
+import static com.hedera.node.app.hapi.utils.sysfiles.domain.throttling.HapiThrottleUtils.lcm;
+import static com.hedera.node.app.hapi.utils.throttles.BucketThrottle.CAPACITY_UNITS_PER_NANO_TXN;
+import static com.hedera.node.app.hapi.utils.throttles.BucketThrottle.NTPS_PER_MTPS;
 import static java.util.Collections.disjoint;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.transaction.ThrottleDefinitions;
+import com.hedera.hapi.node.transaction.ThrottleGroup;
 import com.hedera.node.app.hapi.utils.sysfiles.validation.ExpectedCustomThrottles;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.pbj.runtime.ParseException;
@@ -19,6 +24,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -75,6 +81,7 @@ public class ThrottleParser {
     private void validate(ThrottleDefinitions throttleDefinitions) {
         checkForZeroOpsPerSec(throttleDefinitions);
         checkForRepeatedOperations(throttleDefinitions);
+        validateLeastCommonMultipleDoesNotOverflow(throttleDefinitions);
     }
 
     /**
@@ -117,5 +124,29 @@ public class ThrottleParser {
                 seenSoFar.addAll(functions);
             }
         }
+    }
+
+    /**
+     * Validates that scaled bucket capacity calculations, involving LCM and burst periods, don't overflow.
+     *
+     * @param throttleDefinitions The throttle definitions to validate.
+     * @throws IllegalArgumentException If scaled capacity calculation overflows.
+     */
+    private void validateLeastCommonMultipleDoesNotOverflow(ThrottleDefinitions throttleDefinitions) {
+        for (var bucket : throttleDefinitions.throttleBuckets()) {
+            var lcm = leastCommonMultiple(bucket.throttleGroups());
+            final var unscaledCapacity = lcm * NTPS_PER_MTPS * CAPACITY_UNITS_PER_NANO_TXN / 1_000;
+            if (productWouldOverflow(unscaledCapacity, bucket.burstPeriodMs())) {
+                throw new IllegalArgumentException("Scaled bucket capacity calculation outside numeric range");
+            }
+        }
+    }
+
+    private long leastCommonMultiple(List<ThrottleGroup> throttleGroups) {
+        var lcm = throttleGroups.get(0).milliOpsPerSec();
+        for (int i = 1, n = throttleGroups.size(); i < n; i++) {
+            lcm = lcm(lcm, throttleGroups.get(i).milliOpsPerSec());
+        }
+        return lcm;
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleParser.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleParser.java
@@ -5,6 +5,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.OPERATION_REPEATED_IN_B
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS_BUT_MISSING_EXPECTED_OPERATION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.THROTTLE_GROUP_LCM_OVERFLOW;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNPARSEABLE_THROTTLE_DEFINITIONS;
 import static com.hedera.node.app.hapi.utils.CommonUtils.productWouldOverflow;
 import static com.hedera.node.app.hapi.utils.sysfiles.domain.throttling.HapiThrottleUtils.lcm;
@@ -137,7 +138,7 @@ public class ThrottleParser {
             var lcm = leastCommonMultiple(bucket.throttleGroups());
             final var unscaledCapacity = lcm * NTPS_PER_MTPS * CAPACITY_UNITS_PER_NANO_TXN / 1_000;
             if (productWouldOverflow(unscaledCapacity, bucket.burstPeriodMs())) {
-                throw new IllegalArgumentException("Scaled bucket capacity calculation outside numeric range");
+                throw new HandleException(THROTTLE_GROUP_LCM_OVERFLOW);
             }
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchProcessor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchProcessor.java
@@ -10,7 +10,6 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.THROTTLE_GROUP_LCM_OVERFLOW;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNAUTHORIZED;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.BATCH_INNER;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.NODE;
@@ -150,8 +149,6 @@ public class DispatchProcessor {
             if (functionality == ETHEREUM_TRANSACTION) {
                 ethereumTransactionHandler.handleThrottled(dispatch.handleContext());
             }
-        } catch (final IllegalArgumentException e) {
-            rollbackAndRechargeFee(dispatch, validation, THROTTLE_GROUP_LCM_OVERFLOW);
         } catch (final Exception e) {
             logger.error("{} - exception thrown while handling dispatch", ALERT_MESSAGE, e);
             rollbackAndRechargeFee(dispatch, validation, FAIL_INVALID);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchProcessor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/DispatchProcessor.java
@@ -10,6 +10,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.FAIL_INVALID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.THROTTLE_GROUP_LCM_OVERFLOW;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNAUTHORIZED;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.BATCH_INNER;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.NODE;
@@ -149,6 +150,8 @@ public class DispatchProcessor {
             if (functionality == ETHEREUM_TRANSACTION) {
                 ethereumTransactionHandler.handleThrottled(dispatch.handleContext());
             }
+        } catch (final IllegalArgumentException e) {
+            rollbackAndRechargeFee(dispatch, validation, THROTTLE_GROUP_LCM_OVERFLOW);
         } catch (final Exception e) {
             logger.error("{} - exception thrown while handling dispatch", ALERT_MESSAGE, e);
             rollbackAndRechargeFee(dispatch, validation, FAIL_INVALID);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/ThrottleDefValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/ThrottleDefValidationSuite.java
@@ -18,6 +18,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.THROTTLE_DEFS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTHORIZATION_FAILED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OPERATION_REPEATED_IN_BUCKET_GROUPS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.THROTTLE_GROUP_HAS_ZERO_OPS_PER_SEC;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.THROTTLE_GROUP_LCM_OVERFLOW;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.OrderedInIsolation;
@@ -79,5 +80,12 @@ public class ThrottleDefValidationSuite {
     @Order(6)
     final Stream<DynamicTest> ensureDevLimitsRestored() {
         return hapiTest(withOpContext((spec, opLog) -> throttleRestorationOp.restoreContentsIfNeeded(spec)));
+    }
+
+    @HapiTest
+    @Order(7)
+    final Stream<DynamicTest> leastCommonMultipleOverflow() {
+        return hapiTest(
+                overridingThrottlesFails("testSystemFiles/lcm-overflow-throttles.json", THROTTLE_GROUP_LCM_OVERFLOW));
     }
 }

--- a/hedera-node/test-clients/src/main/resources/testSystemFiles/lcm-overflow-throttles.json
+++ b/hedera-node/test-clients/src/main/resources/testSystemFiles/lcm-overflow-throttles.json
@@ -1,0 +1,53 @@
+{
+  "buckets": [
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 15000,
+      "name": "ThroughputLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 10500000,
+          "operations": [
+            "ScheduleCreate"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 13000,
+          "operations": [
+            "FileCreate"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 100000,
+          "operations": [
+            "ScheduleSign"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 1250000,
+          "operations": [
+            "TokenMint"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 350000,
+          "operations": [
+            "ContractCall"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 3000000,
+          "operations": [
+            "TokenCreate"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Description**:
- Add validation to check if the throttle group's milliOpsPerSec least common multiple is overflowing on FILE_UPDATE to 0.0.123

**Related issue(s)**:

Fixes #13295

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
