### PR TITLE
chore: Update code owners for `hedera-node/configuration`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@
 /hedera-node/                                   @hiero-ledger/hcn-execution-codeowners
 
 # Hedera Node Deployments - Configuration & Grafana Dashboards
-/hedera-node/configuration/**                   @rbair23 @dalvizu @Jeffrey-morgan34 @akdev @Nana-EC @SimiHunjan @steven-sheehy @nathanklick @rbarker-dev @Ferparishuertas @beeradb
+/hedera-node/configuration/**                   @rbair23 @dalvizu @Jeffrey-morgan34 @Nana-EC @SimiHunjan @steven-sheehy @nathanklick @rbarker-dev @Ferparishuertas @beeradb
 /hedera-node/configuration/dev/**               @hiero-ledger/hcn-execution-codeowners
 /hedera-node/infrastructure/**                  @hiero-ledger/github-maintainers @hiero-ledger/hcn-devops-codeowners @hiero-ledger/hcn-execution-codeowners
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,7 +26,7 @@
 /hedera-node/                                   @hiero-ledger/hcn-execution-codeowners
 
 # Hedera Node Deployments - Configuration & Grafana Dashboards
-/hedera-node/configuration/**                   @rbair23 @dalvizu @poulok @netopyr @Nana-EC @SimiHunjan @steven-sheehy @nathanklick @rbarker-dev @Ferparishuertas @beeradb
+/hedera-node/configuration/**                   @rbair23 @dalvizu @Jeffrey-morgan34 @akdev @Nana-EC @SimiHunjan @steven-sheehy @nathanklick @rbarker-dev @Ferparishuertas @beeradb
 /hedera-node/configuration/dev/**               @hiero-ledger/hcn-execution-codeowners
 /hedera-node/infrastructure/**                  @hiero-ledger/github-maintainers @hiero-ledger/hcn-devops-codeowners @hiero-ledger/hcn-execution-codeowners
 


### PR DESCRIPTION
**Description**:
Removes @netopyr and myself from the code owner list for `hedera-node/configuration`. We were originally added because we were managers and that is no longer the case. This PR adds @Jeffrey-morgan34 as a replacement. When @akdev gets write permissions, he should be added as well.
