### PR TITLE
chore: add requires for 'org.hiero.consensus.model'

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/module-info.java
+++ b/hedera-node/hapi-utils/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module com.hedera.node.app.hapi.utils {
     requires transitive org.hyperledger.besu.nativelib.secp256k1;
     requires transitive tuweni.bytes;
     requires com.swirlds.base;
+    requires org.hiero.consensus.model;
     requires com.fasterxml.jackson.databind;
     requires com.google.common;
     requires com.sun.jna;

--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -27,6 +27,7 @@ module com.hedera.node.app {
     requires transitive com.swirlds.platform.core;
     requires transitive com.swirlds.state.api;
     requires transitive com.swirlds.state.impl;
+    requires transitive org.hiero.consensus.model;
     requires transitive dagger;
     requires transitive io.grpc.stub;
     requires transitive io.helidon.webclient.grpc;

--- a/hedera-node/hedera-app/src/testFixtures/java/module-info.java
+++ b/hedera-node/hedera-app/src/testFixtures/java/module-info.java
@@ -12,6 +12,7 @@ module com.hedera.node.app.test.fixtures {
     requires transitive com.swirlds.platform.core;
     requires transitive com.swirlds.state.api.test.fixtures;
     requires transitive com.swirlds.state.api;
+    requires transitive org.hiero.consensus.model;
     requires com.hedera.node.app.hapi.utils;
     requires com.hedera.node.app.service.token;
     requires com.hedera.node.app.spi;

--- a/hedera-node/hedera-file-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/module-info.java
@@ -14,6 +14,7 @@ module com.hedera.node.app.service.file.impl {
     requires transitive java.compiler; // javax.annotation.processing.Generated
     requires transitive javax.inject;
     requires com.swirlds.common;
+    requires org.hiero.consensus.model;
     requires com.fasterxml.jackson.databind;
     requires com.google.protobuf;
     requires org.apache.commons.lang3;

--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/module-info.java
@@ -20,6 +20,7 @@ module com.hedera.node.app.service.network.admin.impl {
     requires com.hedera.node.app.hapi.utils;
     requires com.hedera.node.config;
     requires com.swirlds.common;
+    requires org.hiero.consensus.model;
     requires com.google.common;
     requires org.apache.commons.io;
     requires org.apache.logging.log4j;

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/module-info.java
@@ -26,6 +26,7 @@ module com.hedera.node.app.service.contract.impl {
     requires transitive tuweni.units;
     requires com.swirlds.base;
     requires com.swirlds.common;
+    requires org.hiero.consensus.model;
     requires com.github.benmanes.caffeine;
     requires com.google.common;
     requires com.google.protobuf;

--- a/hedera-node/hedera-token-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-token-service-impl/build.gradle.kts
@@ -13,6 +13,7 @@ testModuleInfo {
     requires("com.hedera.node.app.service.token.test.fixtures")
     requires("com.swirlds.state.api.test.fixtures")
     requires("com.swirlds.config.extensions.test.fixtures")
+    requires("org.hiero.consensus.model")
     requires("net.i2p.crypto.eddsa")
     requires("org.assertj.core")
     requires("org.junit.jupiter.api")

--- a/hedera-node/hedera-token-service/src/main/java/module-info.java
+++ b/hedera-node/hedera-token-service/src/main/java/module-info.java
@@ -17,6 +17,7 @@ module com.hedera.node.app.service.token {
     requires transitive org.apache.logging.log4j;
     requires com.hedera.node.app.hapi.utils;
     requires com.swirlds.common;
+    requires org.hiero.consensus.model;
     requires com.github.spotbugs.annotations;
     requires com.google.common;
 }

--- a/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module com.swirlds.demo.crypto {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.consensus.model;
     requires java.desktop;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;

--- a/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module com.swirlds.demo.hello {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.consensus.model;
     requires java.desktop;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;

--- a/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/module-info.java
@@ -9,6 +9,7 @@ module com.swirlds.demo.stats {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.consensus.model;
     requires java.desktop;
     requires static com.github.spotbugs.annotations;
 }

--- a/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/AddressBookTestingTool/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module com.swirlds.demo.addressbook {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.consensus.model;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
 }

--- a/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/ConsistencyTestingTool/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module com.swirlds.demo.consistency {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.consensus.model;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
 }

--- a/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/ISSTestingTool/src/main/java/module-info.java
@@ -11,6 +11,7 @@ module com.swirlds.demo.iss {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.consensus.model;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
 }

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/module-info.java
@@ -15,6 +15,7 @@ module com.swirlds.demo.migration {
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
     requires com.swirlds.virtualmap;
+    requires org.hiero.consensus.model;
     requires java.logging;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/build.gradle.kts
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/build.gradle.kts
@@ -33,6 +33,7 @@ timingSensitiveModuleInfo {
     requires("com.swirlds.merkle.test.fixtures")
     requires("com.swirlds.platform.core")
     requires("com.swirlds.platform.core.test.fixtures")
+    requires("org.hiero.consensus.model")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.mockito")

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/module-info.java
@@ -42,6 +42,7 @@ module com.swirlds.demo.platform {
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
     requires com.swirlds.virtualmap;
+    requires org.hiero.consensus.model;
     requires com.fasterxml.jackson.annotation;
     requires com.fasterxml.jackson.core;
     requires com.fasterxml.jackson.databind;

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module com.swirlds.demo.stats.signing {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.consensus.model;
     requires lazysodium.java;
     requires org.apache.logging.log4j;
     requires org.bouncycastle.provider;

--- a/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/StressTestingTool/src/main/java/module-info.java
@@ -11,6 +11,7 @@ module com.swirlds.demo.stress {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.consensus.model;
     requires org.apache.logging.log4j;
     requires static com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-benchmarks/build.gradle.kts
+++ b/platform-sdk/swirlds-benchmarks/build.gradle.kts
@@ -22,6 +22,7 @@ jmhModuleInfo {
     requires("com.swirlds.merkledb")
     requires("com.swirlds.virtualmap")
     requires("com.swirlds.platform.core")
+    requires("org.hiero.consensus.model")
     requires("jmh.core")
     requires("org.apache.logging.log4j")
     requiresStatic("com.github.spotbugs.annotations")

--- a/platform-sdk/swirlds-state-api/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/module-info.java
@@ -12,6 +12,7 @@ module com.swirlds.state.api {
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;
+    requires transitive org.hiero.consensus.model;
     requires com.swirlds.logging;
     requires org.apache.logging.log4j;
     requires static transitive com.github.spotbugs.annotations;


### PR DESCRIPTION
**Description**:

For some unknown reasons `qualityCheck` did not detect these when running in #18460. But for PRs based on latest `main` the _Gradle Dependency Scopes Check_ step fails. 

**Related issue(s)**:

Follow up to #18460
