### PR TITLE
ci: fix typo in workflow input file 

### DIFF
--- a/.github/workflows/flow-increment-next-main-release.yaml
+++ b/.github/workflows/flow-increment-next-main-release.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: "0"
-          ref: ${{ input.ref }}
+          ref: ${{ inputs.ref }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Setup Java


### PR DESCRIPTION
**Description**:

Fix a typo in workflow file, change `input` to `inputs`

**Related Issue(s)**:

Fixes #18472
