### PR TITLE
feat: Enhance yahcli rekey with ECDSA support

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/KeyUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/KeyUtils.java
@@ -223,6 +223,24 @@ public final class KeyUtils {
         return true;
     }
 
+    public static PrivateKey readUnknownTypeKeyFrom(final File pem, final String passphrase) {
+        try {
+            return Ed25519Utils.readKeyFrom(pem, passphrase);
+        } catch (final Exception e) {
+            // Try to read as ECDSA key; otherwise throw
+            return Secp256k1Utils.readECKeyFrom(pem, passphrase);
+        }
+    }
+
+    public static PrivateKey readUnknownTypeKeyFrom(final byte[] bytes) {
+        try {
+            return Ed25519Utils.keyFrom(bytes);
+        } catch (final Exception e) {
+            // Try to read as ECDSA key; otherwise throw
+            return Secp256k1Utils.readECKeyFrom(bytes);
+        }
+    }
+
     private static String withDedupedHederaNodePathSegments(@NonNull final String loc) {
         final var firstSegmentI = loc.indexOf("hedera-node");
         if (firstSegmentI == -1) {

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
@@ -8,8 +8,12 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hederahashgraph.api.proto.java.Key;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
+import java.math.BigInteger;
+import java.security.KeyFactory;
 import java.security.interfaces.ECPrivateKey;
 import org.bouncycastle.jce.ECNamedCurveTable;
+import org.bouncycastle.jce.spec.ECParameterSpec;
+import org.bouncycastle.jce.spec.ECPrivateKeySpec;
 import org.bouncycastle.math.ec.ECPoint;
 
 /**
@@ -48,5 +52,18 @@ public class Secp256k1Utils {
     static boolean isValidEcdsaSecp256k1Key(@NonNull final Bytes key) {
         return key.length() == ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH
                 && (key.getByte(0) == EVEN_PARITY || key.getByte(0) == ODD_PARITY);
+    }
+
+    public static ECPrivateKey readECKeyFrom(final byte[] keyBytes) {
+        final BigInteger s = new BigInteger(1, keyBytes);
+        final ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256k1");
+        final ECPrivateKeySpec keySpec = new ECPrivateKeySpec(s, ecSpec);
+
+        try {
+            final KeyFactory keyFactory = KeyFactory.getInstance("EC", BC_PROVIDER);
+            return (ECPrivateKey) keyFactory.generatePrivate(keySpec);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
@@ -100,10 +100,21 @@ public interface HapiPropertySource {
     }
 
     default AccountID getAccount(String property) {
+        final var value = get(property);
+
+        if (value.matches("\\d+\\.\\d+\\.\\d+")) {
+            try {
+                var parts = value.split("\\.");
+                return asAccount(parts[0], parts[1], parts[2]);
+            } catch (Exception ignore) {
+            }
+        }
+
         try {
             return asAccount(get("default.shard"), get("default.realm"), get(property));
         } catch (Exception ignore) {
         }
+
         return AccountID.getDefaultInstance();
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -17,6 +17,8 @@ import com.hedera.services.bdd.spec.infrastructure.listeners.TokenAccountRegistr
 import com.hedera.services.bdd.spec.infrastructure.meta.ActionableContractCall;
 import com.hedera.services.bdd.spec.infrastructure.meta.ActionableContractCallLocal;
 import com.hedera.services.bdd.spec.infrastructure.meta.SupportedContract;
+import com.hedera.services.bdd.spec.keys.SigControl;
+import com.hedera.services.bdd.spec.utilops.inventory.TypedKey;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
@@ -47,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
-import org.hiero.consensus.model.utility.CommonUtils;
 
 public class HapiSpecRegistry {
     private final Map<String, Object> registry = new HashMap<>();
@@ -59,8 +60,8 @@ public class HapiSpecRegistry {
     public HapiSpecRegistry(HapiSpecSetup setup) throws Exception {
         this.setup = setup;
 
-        final var key = setup.payerKeyAsEd25519();
-        final var genesisKey = asPublicKey(CommonUtils.hex(key.getAbyte()));
+        final var key = TypedKey.from(setup.payerKey());
+        final var genesisKey = asPublicKey(key.pubKey(), key.type());
 
         saveAccountId(setup.genesisAccountName(), setup.genesisAccount());
         saveKey(setup.genesisAccountName(), asKeyList(genesisKey));
@@ -131,10 +132,14 @@ public class HapiSpecRegistry {
         return Key.getDefaultInstance();
     }
 
-    private Key asPublicKey(String pubKeyHex) {
-        return Key.newBuilder()
-                .setEd25519(ByteString.copyFrom(CommonUtils.unhex(pubKeyHex)))
-                .build();
+    private Key asPublicKey(byte[] pubKey, SigControl control) {
+        if (control == SigControl.SECP256K1_ON) {
+            return Key.newBuilder()
+                    .setECDSASecp256K1(ByteString.copyFrom(pubKey))
+                    .build();
+        } else {
+            return Key.newBuilder().setEd25519(ByteString.copyFrom(pubKey)).build();
+        }
     }
 
     private Key asKeyList(Key key) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigControl.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigControl.java
@@ -171,6 +171,8 @@ public class SigControl implements Serializable {
         return "SigControl{"
                 + "nature="
                 + nature
+                + ", keyAlgo="
+                + keyAlgo
                 + ", threshold="
                 + threshold
                 + ", childControls="

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/AccessoryUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/AccessoryUtils.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.spec.utilops.inventory;
 
 import static com.hedera.node.app.hapi.utils.keys.Ed25519Utils.readKeyPairFrom;
 
+import com.hedera.node.app.hapi.utils.keys.Secp256k1Utils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedReader;
 import java.io.File;
@@ -91,7 +92,12 @@ public class AccessoryUtils {
             readKeyPairFrom(keyFile, passphrase);
             return true;
         } catch (Exception ignore) {
-            return false;
+            try {
+                Secp256k1Utils.readECKeyFrom(keyFile, passphrase);
+                return true;
+            } catch (Exception alsoIgnore) {
+                return false;
+            }
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromLiteral.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromLiteral.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.utilops.inventory;
 
-import static com.hedera.services.bdd.spec.utilops.inventory.SpecKeyFromMnemonic.createAndLinkSimpleKey;
+import static com.hedera.services.bdd.spec.utilops.inventory.SpecKeyFromMnemonic.createAndLinkSimpleEdKey;
 
 import com.google.common.base.MoreObjects;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -31,7 +31,7 @@ public class SpecKeyFromLiteral extends UtilOp {
     @Override
     protected boolean submitOp(HapiSpec spec) throws Throwable {
         byte[] privateKey = CommonUtils.unhex(hexEncodedPrivateKey);
-        createAndLinkSimpleKey(spec, privateKey, name, linkedId, log);
+        createAndLinkSimpleEdKey(spec, privateKey, name, linkedId, log);
         return false;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromMnemonic.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/SpecKeyFromMnemonic.java
@@ -48,10 +48,10 @@ public class SpecKeyFromMnemonic extends UtilOp {
             throws ShortBufferException, NoSuchAlgorithmException, InvalidKeyException {
         byte[] seed = Bip0032.seedFrom(mnemonic);
         byte[] privateKey = Bip0032.privateKeyFrom(seed);
-        createAndLinkSimpleKey(spec, privateKey, name, linkedId, logToUse);
+        createAndLinkSimpleEdKey(spec, privateKey, name, linkedId, logToUse);
     }
 
-    static void createAndLinkSimpleKey(
+    static void createAndLinkSimpleEdKey(
             HapiSpec spec, byte[] privateKey, String name, Optional<String> linkedId, @Nullable Logger logToUse) {
         var params = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
         var privateKeySpec = new EdDSAPrivateKeySpec(privateKey, params);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/TypedKey.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/inventory/TypedKey.java
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.spec.utilops.inventory;
+
+import static com.hedera.services.bdd.spec.keys.SigControl.ED25519_ON;
+
+import com.hedera.node.app.hapi.utils.keys.Ed25519Utils;
+import com.hedera.node.app.hapi.utils.keys.Secp256k1Utils;
+import com.hedera.services.bdd.spec.keys.SigControl;
+import java.security.PrivateKey;
+import java.security.interfaces.ECPrivateKey;
+import net.i2p.crypto.eddsa.EdDSAPrivateKey;
+
+public record TypedKey(PrivateKey privateKey, byte[] pubKey, SigControl type) {
+    public static TypedKey from(final PrivateKey privateKey) {
+        final var type = deriveTypeFrom(privateKey);
+        final var pubKey = type == SigControl.SECP256K1_ON
+                ? Secp256k1Utils.extractEcdsaPublicKey((ECPrivateKey) privateKey)
+                : Ed25519Utils.extractEd25519PublicKey((EdDSAPrivateKey) privateKey);
+        return new TypedKey(privateKey, pubKey, type);
+    }
+
+    private static SigControl deriveTypeFrom(final PrivateKey pk) {
+        return (pk instanceof ECPrivateKey) ? SigControl.SECP256K1_ON : ED25519_ON;
+    }
+}

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/CreateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/CreateCommand.java
@@ -9,6 +9,7 @@ import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.CreateSuite;
+import com.hedera.services.yahcli.util.ParseUtils;
 import java.io.File;
 import java.util.concurrent.Callable;
 import picocli.CommandLine;
@@ -66,12 +67,9 @@ public class CreateCommand implements Callable<Integer> {
         var config = ConfigUtils.configFrom(yahcli);
 
         final var noveltyLoc = config.keysLoc() + File.separator + NOVELTY + ".pem";
-        final SigControl sigType;
-        if ("SECP256K1".equalsIgnoreCase(keyType)) {
-            sigType = SigControl.SECP256K1_ON;
-        } else if ("ED25519".equalsIgnoreCase(keyType)) {
-            sigType = SigControl.ED25519_ON;
-        } else {
+        final SigControl sigType = ParseUtils.keyTypeFromParam(keyType);
+        // Since we are creating an account, we expect the caller to explicitly specify the key type
+        if (sigType == null) {
             COMMON_MESSAGES.warn("Invalid key type: " + keyType + ". Must be 'ED25519' or 'SECP256K1'");
             return 1;
         }

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/keys/ExtractDetailsCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/keys/ExtractDetailsCommand.java
@@ -18,6 +18,8 @@ import java.security.interfaces.ECPrivateKey;
 import java.util.concurrent.Callable;
 import javax.crypto.ShortBufferException;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.utility.CommonUtils;
 import picocli.CommandLine;
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/keys/ExtractDetailsCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/keys/ExtractDetailsCommand.java
@@ -18,8 +18,6 @@ import java.security.interfaces.ECPrivateKey;
 import java.util.concurrent.Callable;
 import javax.crypto.ShortBufferException;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.utility.CommonUtils;
 import picocli.CommandLine;
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/util/ParseUtils.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/util/ParseUtils.java
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.yahcli.util;
+
+import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+
+import com.hedera.services.bdd.spec.keys.SigControl;
+
+public class ParseUtils {
+
+    private ParseUtils() {
+        // Utility class
+    }
+
+    /**
+     * Parses the key type–ED25519 or SECP256K1–from a string (typically a command line parameter)
+     * @param keyType the key type string
+     * @return the corresponding SigControl value, or null if the key type is not one of the expected values
+     */
+    public static SigControl keyTypeFromParam(final String keyType) {
+        final SigControl sigType;
+        if ("SECP256K1".equalsIgnoreCase(keyType)) {
+            sigType = SigControl.SECP256K1_ON;
+        } else if ("ED25519".equalsIgnoreCase(keyType)) {
+            sigType = SigControl.ED25519_ON;
+        } else {
+            COMMON_MESSAGES.warn("Invalid key type: " + keyType + ". Must be 'ED25519' or 'SECP256K1'");
+            sigType = null;
+        }
+
+        return sigType;
+    }
+}

--- a/hedera-node/test-clients/yahcli/run/build.sh
+++ b/hedera-node/test-clients/yahcli/run/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.6.3'}
+TAG=${1:-'0.6.4'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""

--- a/hedera-node/test-clients/yahcli/run/publish.sh
+++ b/hedera-node/test-clients/yahcli/run/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.6.3'}
+TAG=${1:-'0.6.4'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""


### PR DESCRIPTION
**Description**:

This PR adds support for ecdsa keys to the accounts `rekey` command. Accounts with an admin ecdsa key can now use `rekey` to 'import' a new key (via `-k`) without running into an error trying to incorrectly unmarshall the key. 

Other noteworthy modifications:

* Adds ecdsa support to the framework's default payer key
* Fixes a stub exception encountered when the default shard/realm is applied
* When rekeying with a pre-existing key, relax the assumption of super-admin privileges to an account's normal administrative key instead

Closes #18327 
