### PR TITLE
fix: Ensure `BlockStreamManager#endRound()` is called after dispatching

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -249,10 +249,12 @@ public class HandleWorkflow {
                             .equals(Instant.EPOCH);
                     case BLOCKS, BOTH -> blockStreamManager.pendingWork() == GENESIS_WORK;
                 };
+        boolean systemTransactionsDispatched = false;
         if (isGenesis) {
             final var genesisEventTime = round.iterator().next().getConsensusTimestamp();
             logger.info("Doing genesis setup before {}", genesisEventTime);
             systemTransactions.doGenesisSetup(genesisEventTime, state);
+            systemTransactionsDispatched = true;
             if (streamMode != RECORDS) {
                 blockStreamManager.confirmPendingWorkFinished();
             }
@@ -264,7 +266,7 @@ public class HandleWorkflow {
                 configProvider.getConfiguration().getConfigData(TssConfig.class), state, round.getConsensusTimestamp());
         recordCache.resetRoundReceipts();
         try {
-            handleEvents(state, round, stateSignatureTxnCallback);
+            handleEvents(state, round, systemTransactionsDispatched, stateSignatureTxnCallback);
         } finally {
             // Even if there is an exception somewhere, we need to commit the receipts of any handled transactions
             // to the state so these transactions cannot be replayed in future rounds
@@ -278,13 +280,15 @@ public class HandleWorkflow {
      *
      * @param state the state to apply the effects to
      * @param round the round to apply the effects of
+     * @param systemTransactionsDispatched whether system transactions have been dispatched
      * @param stateSignatureTxnCallback A callback to be called when encountering a {@link StateSignatureTransaction}
      */
     private void handleEvents(
             @NonNull final State state,
             @NonNull final Round round,
+            final boolean systemTransactionsDispatched,
             @NonNull final Consumer<ScopedSystemTransaction<StateSignatureTransaction>> stateSignatureTxnCallback) {
-        boolean userTransactionsHandled = false;
+        boolean transactionsDispatched = systemTransactionsDispatched;
         for (final var event : round) {
             if (streamMode != RECORDS) {
                 final var headerItem = BlockItem.newBuilder()
@@ -322,13 +326,13 @@ public class HandleWorkflow {
             for (final var it = event.consensusTransactionIterator(); it.hasNext(); ) {
                 final var platformTxn = it.next();
                 try {
-                    userTransactionsHandled |= handlePlatformTransaction(
+                    transactionsDispatched |= handlePlatformTransaction(
                             state,
                             creator,
                             platformTxn,
                             event.getSoftwareVersion(),
                             simplifiedStateSignatureTxnCallback,
-                            userTransactionsHandled);
+                            transactionsDispatched);
                 } catch (final Exception e) {
                     logger.fatal(
                             "Possibly CATASTROPHIC failure while running the handle workflow. "
@@ -346,7 +350,7 @@ public class HandleWorkflow {
         // implementation of ConsensusStateEventHandler#onSealConsensusRound(), since the BlockStreamManager cannot do
         // its
         // end-of-block work until the platform has finished all its state changes.
-        if (userTransactionsHandled && streamMode != BLOCKS) {
+        if (transactionsDispatched && streamMode != BLOCKS) {
             blockRecordManager.endRound(state);
         }
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/misc/IssHandlingTest.java
@@ -10,8 +10,10 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getVersionInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertHgcaaLogContains;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertHgcaaLogDoesNotContain;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeOnly;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepForSeconds;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForFrozenNetwork;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
@@ -49,6 +51,9 @@ class IssHandlingTest implements LifecycleTest {
         final AtomicReference<SemanticVersion> startVersion = new AtomicReference<>();
         return hapiTest(
                 getVersionInfo().exposingServicesVersionTo(startVersion::set),
+                // Wait long enough for node1 to have typically written round 1 snapshot
+                // to disk; restarting from this boundary snpshot can surface edge cases
+                sleepForSeconds(2),
                 // Reconnect node1 with an aberrant ledger.transfers.maxLen override
                 sourcing(() -> reconnectIssNode(
                         byNodeId(ISS_NODE_ID),
@@ -63,7 +68,12 @@ class IssHandlingTest implements LifecycleTest {
                         }))),
                 assertHgcaaLogContains(
                         NodeSelector.byNodeId(ISS_NODE_ID), "ledger.transfers.maxLen = 5", Duration.ofSeconds(10)),
-                // Submit a transaction within the normal allowed transfers.maxLen limit
+                // First assert there was no ISS caused by simply reconnecting
+                assertHgcaaLogDoesNotContain(
+                        NodeSelector.byNodeId(ISS_NODE_ID), "ISS detected", Duration.ofSeconds(30)),
+
+                // But now submit a transaction within the normal allowed transfers.maxLen limit, while
+                // _not_ within the artificial limit set on the reconnected node
                 cryptoTransfer(movingHbar(6L)
                                 .distributing(GENESIS, "0.0.3", "0.0.4", "0.0.5", "0.0.6", "0.0.7", "0.0.8"))
                         .signedBy(GENESIS),


### PR DESCRIPTION
 - Cherry-pick https://github.com/hiero-ledger/hiero-consensus-node/pull/18554