### PR TITLE
chore: fix compiler warning in ByteUtils

### DIFF
--- a/platform-sdk/consensus-utility/build.gradle.kts
+++ b/platform-sdk/consensus-utility/build.gradle.kts
@@ -7,12 +7,4 @@ plugins {
 
 description = "Consensus Utility"
 
-// Remove the following line to enable all 'javac' lint checks that we have turned on by default
-// and then fix the reported issues.
-tasks.withType<JavaCompile>().configureEach {
-    options.compilerArgs.add(
-        "-Xlint:-exports,-lossy-conversions,-overloads,-dep-ann,-text-blocks,-varargs"
-    )
-}
-
 testModuleInfo { requires("org.junit.jupiter.api") }

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/utility/ByteUtils.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/utility/ByteUtils.java
@@ -153,7 +153,7 @@ public final class ByteUtils {
                 if (index >= data.length) {
                     break;
                 }
-                result += (data[index] & 0xff) << (8 * (1 - offset));
+                result += (short) ((data[index] & 0xff) << (8 * (1 - offset)));
             }
             return result;
         }


### PR DESCRIPTION
**Description**:

This PR makes an implicit cast in `ByteUtils` explicit and enables failing on compiler warnings

**Related issue(s)**:

Fixes #18566 

**Checklist**

- [x] Tested (unit, integration, etc.)
