### PR TITLE
fix: Utilize more than one thread for SSL accept handling (#18557)

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/PeerConnectionServer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/modular/PeerConnectionServer.java
@@ -15,7 +15,7 @@ import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
@@ -54,14 +54,15 @@ public class PeerConnectionServer implements InterruptableRunnable {
         this.newConnectionHandler = inboundConnectionHandler;
         this.socketFactory = socketFactory;
         this.incomingConnPool = new ThreadPoolExecutor(
-                1,
+                0,
                 maxThreads,
-                0L,
-                TimeUnit.MILLISECONDS,
-                new LinkedBlockingQueue<Runnable>(),
+                60L,
+                TimeUnit.SECONDS,
+                new SynchronousQueue<Runnable>(),
                 new ThreadConfiguration(threadManager)
-                        .setThreadName("sync_server")
-                        .buildFactory());
+                        .setThreadName("peer_sync_server")
+                        .buildFactory(),
+                new ThreadPoolExecutor.CallerRunsPolicy());
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: Artur Biesiadowski <artur.biesiadowski@swirldslabs.com>
(cherry picked from commit 9865e31fc36379aec232c91a6ba5f967f983fc87)

**Description**:
Due to one of the previous changes, amount of threads handling SSL certification resolution for new connections was only one, which could have starved the processing. This change reintroduces the possibility of using more threads concurrently (30 at the moment, based on configuration), while still having max number of them, with overflow being handled in the caller thread (which will block the acceptance rate of new connections, but won't crash the server with runaway threads). Behavior from before the original change (infinite number of threads) can be achieved by changing configuration (maxSocketAcceptThreads) to a very large number.

**Related issue(s)**:

Fixes #18498 

**Notes for reviewer**:
Cherry pick from already accepted https://github.com/hiero-ledger/hiero-consensus-node/pull/18557 into 0.61

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
