### PR TITLE
fix: Improved error handling for airdrops with multiple senders

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1751,7 +1751,7 @@ enum ResponseCodeEnum {
     THROTTLE_GROUP_LCM_OVERFLOW = 397;
 
     /**
-     * Token airdrop transactions can not contain multiple senders.
+     * Token airdrop transactions can not contain multiple senders for a single token.
      */
-    AIRDROP_CONTAINS_MULTIPLE_SENDERS = 398;
+    AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN = 398;
 }

--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1745,8 +1745,13 @@ enum ResponseCodeEnum {
     CREATING_SYSTEM_ENTITIES = 396;
 
     /**
-    * The least common multiple of the throttle group's milliOpsPerSec is 
-    * too large and it's overflowing.
+     * The least common multiple of the throttle group's milliOpsPerSec is
+     * too large and it's overflowing.
      */
     THROTTLE_GROUP_LCM_OVERFLOW = 397;
+
+    /**
+     * Token airdrop transactions can not contain multiple senders.
+     */
+    AIRDROP_CONTAINS_MULTIPLE_SENDERS = 398;
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
@@ -68,7 +68,7 @@ public class TokenAirdropValidator {
             if (!tokenTransfer.nftTransfers().isEmpty()) {
                 final var sender =
                         tokenTransfer.nftTransfers().stream().findFirst().get().senderAccountID();
-                validateTruePreCheck(sender!= null, INVALID_TRANSFER_ACCOUNT_ID);
+                validateTruePreCheck(sender != null, INVALID_TRANSFER_ACCOUNT_ID);
                 final var allNftsHaveTheSameSender = tokenTransfer.nftTransfers().stream()
                         .allMatch(nftTransfer -> sender.equals(nftTransfer.senderAccountID()));
                 validateTruePreCheck(allNftsHaveTheSameSender, AIRDROP_CONTAINS_MULTIPLE_SENDERS);

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
@@ -9,6 +9,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALA
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NFT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSFER_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED;
@@ -67,15 +68,16 @@ public class TokenAirdropValidator {
             if (!tokenTransfer.nftTransfers().isEmpty()) {
                 final var sender =
                         tokenTransfer.nftTransfers().stream().findFirst().get().senderAccountID();
+                validateTruePreCheck(sender!= null, INVALID_TRANSFER_ACCOUNT_ID);
                 final var allNftsHaveTheSameSender = tokenTransfer.nftTransfers().stream()
-                        .allMatch(nftTransfer -> nftTransfer.senderAccountID().equals(sender));
-                validateTrue(allNftsHaveTheSameSender, AIRDROP_CONTAINS_MULTIPLE_SENDERS);
+                        .allMatch(nftTransfer -> sender.equals(nftTransfer.senderAccountID()));
+                validateTruePreCheck(allNftsHaveTheSameSender, AIRDROP_CONTAINS_MULTIPLE_SENDERS);
             }
             if (!tokenTransfer.transfers().isEmpty()) {
                 List<AccountAmount> negativeTransfers = tokenTransfer.transfers().stream()
                         .filter(fungibleTransfer -> fungibleTransfer.amount() < 0)
                         .toList();
-                validateTrue(negativeTransfers.size() == 1, AIRDROP_CONTAINS_MULTIPLE_SENDERS);
+                validateTruePreCheck(negativeTransfers.size() == 1, AIRDROP_CONTAINS_MULTIPLE_SENDERS);
             }
         }
         validateTokenTransfers(op.tokenTransfers(), CryptoTransferValidator.AllowanceStrategy.ALLOWANCES_REJECTED);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTestBase.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTestBase.java
@@ -59,6 +59,11 @@ class CryptoTransferHandlerTestBase extends StepsBase {
             .senderAccountID(ACCOUNT_ID_3333)
             .receiverAccountID(ACCOUNT_ID_4444)
             .build();
+    protected static final NftTransfer SERIAL_2_FROM_3333_TO_4444 = NftTransfer.newBuilder()
+            .serialNumber(2)
+            .senderAccountID(ACCOUNT_ID_3333)
+            .receiverAccountID(ACCOUNT_ID_4444)
+            .build();
     protected static final NftTransfer SERIAL_2_FROM_4444_TO_3333 = NftTransfer.newBuilder()
             .serialNumber(2)
             .senderAccountID(ACCOUNT_ID_4444)

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
@@ -253,7 +253,6 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
                 .token(TOKEN_2468)
                 .nftTransfers(
                         SERIAL_1_FROM_3333_TO_4444,
-                        SERIAL_2_FROM_4444_TO_3333,
                         SERIAL_1_FROM_3333_TO_4444.copyBuilder().serialNumber(3).build())
                 .build());
         given(pureChecksContext.body()).willReturn(txn);
@@ -325,7 +324,7 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
                 // Valid nft token transfers
                 TokenTransferList.newBuilder()
                         .token(token9753)
-                        .nftTransfers(SERIAL_1_FROM_3333_TO_4444, SERIAL_2_FROM_4444_TO_3333)
+                        .nftTransfers(SERIAL_1_FROM_3333_TO_4444, SERIAL_2_FROM_3333_TO_4444)
                         .build()));
         given(pureChecksContext.body()).willReturn(txn);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -70,6 +70,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_AMOUNT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_HAS_PENDING_AIRDROPS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AIRDROP_CONTAINS_MULTIPLE_SENDERS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_SIZE_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_BODY;
@@ -83,7 +84,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RECEIV
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIAL_NUMBER;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.PENDING_NFT_AIRDROP_ALREADY_EXISTS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY;
@@ -1359,6 +1359,25 @@ public class TokenAirdropTest extends TokenAirdropBase {
         }
 
         @HapiTest
+        @DisplayName("containing multiple senders")
+        final Stream<DynamicTest> airdropWithMultipleSenders() {
+            return hapiTest(
+                    cryptoCreate("sender1"),
+                    cryptoCreate("sender2"),
+                    cryptoCreate("receiver"),
+                    tokenAssociate("sender1", FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
+                    tokenAssociate("sender2", FUNGIBLE_TOKEN, NON_FUNGIBLE_TOKEN),
+                    tokenAirdrop(
+                                    moving(5, FUNGIBLE_TOKEN).between("sender1", "receiver"),
+                                    moving(5, FUNGIBLE_TOKEN).between("sender2", "receiver"))
+                            .hasPrecheck(AIRDROP_CONTAINS_MULTIPLE_SENDERS),
+                    tokenAirdrop(
+                                    movingUnique(NON_FUNGIBLE_TOKEN, 1).between("sender1", "receiver"),
+                                    movingUnique(NON_FUNGIBLE_TOKEN, 2).between("sender2", "receiver"))
+                            .hasPrecheck(AIRDROP_CONTAINS_MULTIPLE_SENDERS));
+        }
+
+        @HapiTest
         @DisplayName("containing invalid token transfer decimals")
         final Stream<DynamicTest> airdropInvalidDecimals() {
             return hapiTest(
@@ -2095,7 +2114,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
             return hapiTest(tokenAirdrop(moving(10, FUNGIBLE_TOKEN).between(OWNER, OWNER))
                     .signedBy(OWNER)
                     .payingWith(OWNER)
-                    .hasPrecheck(INVALID_TRANSACTION_BODY));
+                    .hasPrecheck(AIRDROP_CONTAINS_MULTIPLE_SENDERS));
         }
 
         @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip904/TokenAirdropTest.java
@@ -70,7 +70,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_AMOUNT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_DELETED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_HAS_PENDING_AIRDROPS;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AIRDROP_CONTAINS_MULTIPLE_SENDERS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BATCH_SIZE_LIMIT_EXCEEDED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CUSTOM_FEE_CHARGING_EXCEEDED_MAX_RECURSION_DEPTH;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_BODY;
@@ -1370,11 +1370,11 @@ public class TokenAirdropTest extends TokenAirdropBase {
                     tokenAirdrop(
                                     moving(5, FUNGIBLE_TOKEN).between("sender1", "receiver"),
                                     moving(5, FUNGIBLE_TOKEN).between("sender2", "receiver"))
-                            .hasPrecheck(AIRDROP_CONTAINS_MULTIPLE_SENDERS),
+                            .hasPrecheck(AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN),
                     tokenAirdrop(
                                     movingUnique(NON_FUNGIBLE_TOKEN, 1).between("sender1", "receiver"),
                                     movingUnique(NON_FUNGIBLE_TOKEN, 2).between("sender2", "receiver"))
-                            .hasPrecheck(AIRDROP_CONTAINS_MULTIPLE_SENDERS));
+                            .hasPrecheck(AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN));
         }
 
         @HapiTest
@@ -2114,7 +2114,7 @@ public class TokenAirdropTest extends TokenAirdropBase {
             return hapiTest(tokenAirdrop(moving(10, FUNGIBLE_TOKEN).between(OWNER, OWNER))
                     .signedBy(OWNER)
                     .payingWith(OWNER)
-                    .hasPrecheck(AIRDROP_CONTAINS_MULTIPLE_SENDERS));
+                    .hasPrecheck(AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN));
         }
 
         @HapiTest


### PR DESCRIPTION
**Description**:

Improve error handling for TokenAirdrops with multiple senders.
Currently when there is a FT with multiple senders we throw `INVALID_TRANSACTION_BODY`
 and if there is NFT airdrops with multiple senders we throw `SENDER_DOES_NOT_OWN_NFT_SERIAL_NO`.

**Related issue(s)**:
https://github.com/hiero-ledger/hiero-consensus-node/issues/18610
Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
