### PR TITLE
feat: Limit the callData field instead of ethereumData

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -376,17 +376,10 @@ public class TransactionChecker {
     void checkJumboTransactionBody(TransactionInfo txInfo) throws PreCheckException {
         final var jumboTxnEnabled = jumboTransactionsConfig.isEnabled();
         final var allowedJumboHederaFunctionalities = jumboTransactionsConfig.allowedHederaFunctionalities();
-        final var maxJumboEthereumCallDataSize = jumboTransactionsConfig.ethereumMaxCallDataSize();
 
         if (jumboTxnEnabled
                 && txInfo.serializedTransaction().length() > hederaConfig.transactionMaxBytes()
                 && !allowedJumboHederaFunctionalities.contains(fromPbj(txInfo.functionality()))) {
-            throw new PreCheckException(TRANSACTION_OVERSIZE);
-        }
-
-        if (txInfo.txBody() != null
-                && txInfo.txBody().hasEthereumTransaction()
-                && txInfo.txBody().ethereumTransaction().ethereumData().length() > maxJumboEthereumCallDataSize) {
             throw new PreCheckException(TRANSACTION_OVERSIZE);
         }
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/ContextTransactionProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/ContextTransactionProcessor.java
@@ -2,6 +2,7 @@
 package com.hedera.node.app.service.contract.impl.exec;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_OVERSIZE;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -25,6 +26,7 @@ import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.data.ContractsConfig;
+import com.hedera.node.config.data.JumboTransactionsConfig;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -111,6 +113,7 @@ public class ContextTransactionProcessor implements Callable<CallOutcome> {
         // if an exception occurs during a ContractCall, charge fees to the sender and return a CallOutcome reflecting
         // the error.
         final var hevmTransaction = safeCreateHevmTransaction();
+        validateHevmTransaction(hevmTransaction);
         if (hevmTransaction.isException()) {
             return maybeChargeFeesAndReturnOutcome(
                     hevmTransaction,
@@ -154,6 +157,15 @@ public class ContextTransactionProcessor implements Callable<CallOutcome> {
                     senderId,
                     sender,
                     hevmTransaction.isContractCall() && contractsConfig.chargeGasOnEvmHandleException());
+        }
+    }
+
+    private void validateHevmTransaction(HederaEvmTransaction hevmTransaction) {
+        final var maxJumboEthereumCallDataSize = configuration
+            .getConfigData(JumboTransactionsConfig.class).ethereumMaxCallDataSize();
+
+        if (hevmTransaction.payload().length() > maxJumboEthereumCallDataSize) {
+            throw new HandleException(TRANSACTION_OVERSIZE);
         }
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/ContextTransactionProcessor.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/ContextTransactionProcessor.java
@@ -161,8 +161,8 @@ public class ContextTransactionProcessor implements Callable<CallOutcome> {
     }
 
     private void validateHevmTransaction(HederaEvmTransaction hevmTransaction) {
-        final var maxJumboEthereumCallDataSize = configuration
-            .getConfigData(JumboTransactionsConfig.class).ethereumMaxCallDataSize();
+        final var maxJumboEthereumCallDataSize =
+                configuration.getConfigData(JumboTransactionsConfig.class).ethereumMaxCallDataSize();
 
         if (hevmTransaction.payload().length() > maxJumboEthereumCallDataSize) {
             throw new HandleException(TRANSACTION_OVERSIZE);


### PR DESCRIPTION
**Description**:
There is an error in the HIP description. We should limit the `callData` to 128kb instead of `ethereumData`.

**Related issue(s)**:

Fixes #18629

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
