### PR TITLE
fix: When falling behind, teacher should stop teaching and start its own learning session.

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/reconnect/ReconnectTeacher.java
@@ -249,4 +249,16 @@ public class ReconnectTeacher {
         connection.getDos().writeSerializable(signedState.getSigSet(), true);
         connection.getDos().flush();
     }
+
+    /**
+     * Forcefully close the teaching connection and let entire learning process fail. This should allow system
+     * to reevaluate what to use what connection for, for example letting ourselves to start learning session against
+     * different node.
+     */
+    public void breakConnection() {
+        logger.warn(
+                RECONNECT.getMarker(),
+                "Forcefully breaking connection while teaching, most probably due to falling behind ourselves");
+        connection.disconnect();
+    }
 }


### PR DESCRIPTION
**Description**:
When the teacher gets behind it should cancel the current reconnect teaching session and start learning.

**Related issue(s)**:
Fixes #18546

** Reviewer comments **
This effectively reverses #9741, but instead of implementing it while trying to preserve connection, it does it simple and brutal way - disconnecting the teaching connection and letting system sort out everything (and start learning eventually). This assumes that reaction to broken connectivity during teaching is already well handled and tested, as it can happen for unrelated reasons. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
