### PR TITLE
fix: adding validation for deleted token on unpause

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUnpauseHandler.java
@@ -12,6 +12,7 @@ import com.hedera.hapi.node.base.SubType;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.node.app.service.token.ReadableTokenStore;
 import com.hedera.node.app.service.token.impl.WritableTokenStore;
+import com.hedera.node.app.service.token.impl.util.TokenHandlerHelper;
 import com.hedera.node.app.service.token.records.TokenBaseStreamBuilder;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
@@ -75,8 +76,9 @@ public class TokenUnpauseHandler implements TransactionHandler {
 
         final var op = context.body().tokenUnpause();
         final var tokenStore = context.storeFactory().writableStore(WritableTokenStore.class);
-        var token = tokenStore.get(op.tokenOrElse(TokenID.DEFAULT));
-        validateTrue(token != null, INVALID_TOKEN_ID);
+        var tokenId = op.tokenOrElse(TokenID.DEFAULT);
+        var token = TokenHandlerHelper.getIfUsable(tokenId, tokenStore);
+
         validateTrue(token.hasPauseKey(), TOKEN_HAS_NO_PAUSE_KEY);
 
         final var copyBuilder = token.copyBuilder();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenPauseSpecs.java
@@ -40,6 +40,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUTABLE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_PAUSED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
 import static com.hederahashgraph.api.proto.java.TokenPauseStatus.Paused;
 import static com.hederahashgraph.api.proto.java.TokenPauseStatus.Unpaused;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
@@ -365,6 +366,16 @@ public class TokenPauseSpecs {
                         tokenUnpause(NON_FUNGIBLE_UNIQUE_PRIMARY)
                                 .signedBy(GENESIS)
                                 .hasKnownStatus(ResponseCodeEnum.TOKEN_HAS_NO_PAUSE_KEY));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> unpauseDeletedToken() {
+        return hapiTest(
+                cryptoCreate(PAUSE_KEY),
+                cryptoCreate(ADMIN_KEY),
+                tokenCreate(PRIMARY).adminKey(ADMIN_KEY).pauseKey(PAUSE_KEY),
+                tokenDelete(PRIMARY),
+                tokenUnpause(PRIMARY).hasKnownStatus(TOKEN_WAS_DELETED));
     }
 
     public static class TokenIdOrderingAsserts extends BaseErroringAssertsProvider<List<TokenTransferList>> {


### PR DESCRIPTION
**Description**:
The TCK team found a bug where you can unpause a deleted token. With this PR, we add a validation for that.

**Related issue(s)**:

Fixes #18670

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
