### PR TITLE
fix: Remove mono logic returning the wrong response code

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/ExpiryValidator.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/validation/ExpiryValidator.java
@@ -38,13 +38,11 @@ public interface ExpiryValidator {
      *
      * @param currentMetadata the current expiry metadata for the entity
      * @param updateMetadata the expiry metadata for the attempted update
-     * @param isForTokenUpdate if the expiry metadata is for token update
      * @return the expiry metadata that will result from the update
      * @throws HandleException if the metadata is invalid
      */
     @NonNull
-    ExpiryMeta resolveUpdateAttempt(
-            @NonNull ExpiryMeta currentMetadata, @NonNull ExpiryMeta updateMetadata, boolean isForTokenUpdate);
+    ExpiryMeta resolveUpdateAttempt(@NonNull ExpiryMeta currentMetadata, @NonNull ExpiryMeta updateMetadata);
 
     /**
      * Gets the expiration status of an entity based on the {@link EntityType}.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/ExpiryValidatorImplTest.java
@@ -231,7 +231,7 @@ class ExpiryValidatorImplTest {
         final var current = new ExpiryMeta(A_TIME, NA, null);
         final var update = new ExpiryMeta(A_TIME - 1, NA, null);
 
-        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update, false))
+        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(EXPIRATION_REDUCTION_NOT_ALLOWED));
     }
@@ -241,7 +241,7 @@ class ExpiryValidatorImplTest {
         final var current = new ExpiryMeta(A_TIME, NA, null);
         final var update = new ExpiryMeta(A_TIME - 1, NA, null);
 
-        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update, false))
+        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(EXPIRATION_REDUCTION_NOT_ALLOWED));
     }
@@ -255,7 +255,7 @@ class ExpiryValidatorImplTest {
                 .given(attributeValidator)
                 .validateAutoRenewPeriod(0L);
 
-        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update, false))
+        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(AUTORENEW_DURATION_NOT_IN_RANGE));
     }
@@ -269,7 +269,7 @@ class ExpiryValidatorImplTest {
                 .given(attributeValidator)
                 .validateAutoRenewPeriod(B_PERIOD);
 
-        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update, false))
+        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(AUTORENEW_DURATION_NOT_IN_RANGE));
     }
@@ -283,7 +283,7 @@ class ExpiryValidatorImplTest {
                 .willThrow(new InvalidTransactionException(
                         com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT));
 
-        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update, false))
+        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(INVALID_AUTORENEW_ACCOUNT));
     }
@@ -297,7 +297,7 @@ class ExpiryValidatorImplTest {
                 .given(attributeValidator)
                 .validateExpiry(B_TIME);
 
-        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update, false))
+        assertThatThrownBy(() -> subject.resolveUpdateAttempt(current, update))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(INVALID_EXPIRATION_TIME));
     }
@@ -307,7 +307,7 @@ class ExpiryValidatorImplTest {
         final var current = new ExpiryMeta(A_TIME, 0, null);
         final var update = new ExpiryMeta(B_TIME, B_PERIOD, AN_AUTO_RENEW_ID);
 
-        assertThat(subject.resolveUpdateAttempt(current, update, false)).isEqualTo(update);
+        assertThat(subject.resolveUpdateAttempt(current, update)).isEqualTo(update);
     }
 
     @Test
@@ -318,7 +318,7 @@ class ExpiryValidatorImplTest {
                 B_PERIOD,
                 AccountID.newBuilder().shardNum(0L).realmNum(0L).accountNum(0L).build());
 
-        assertThat(subject.resolveUpdateAttempt(current, update, false)).isEqualTo(update);
+        assertThat(subject.resolveUpdateAttempt(current, update)).isEqualTo(update);
     }
 
     @Test

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusUpdateTopicHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusUpdateTopicHandler.java
@@ -273,7 +273,7 @@ public class ConsensusUpdateTopicHandler implements TransactionHandler {
         if (updatesExpiryMeta(op)) {
             final var updateMeta = new ExpiryMeta(effExpiryOf(op), effAutoRenewPeriodOf(op), op.autoRenewAccount());
             try {
-                return expiryValidator.resolveUpdateAttempt(currentMeta, updateMeta, false);
+                return expiryValidator.resolveUpdateAttempt(currentMeta, updateMeta);
             } catch (final HandleException e) {
                 if (e.getStatus() == INVALID_RENEWAL_PERIOD) {
                     // Tokens throw INVALID_EXPIRATION_TIME, but for topic it's expected currently to throw

--- a/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusUpdateTopicHandlerTest.java
+++ b/hedera-node/hedera-consensus-service-impl/src/test/java/com/hedera/node/app/service/consensus/impl/test/handlers/ConsensusUpdateTopicHandlerTest.java
@@ -287,7 +287,7 @@ class ConsensusUpdateTopicHandlerTest extends ConsensusTestBase {
         final var impliedMeta = new ExpiryMeta(123L, NA, null);
         willThrow(new HandleException(ResponseCodeEnum.INVALID_EXPIRATION_TIME))
                 .given(expiryValidator)
-                .resolveUpdateAttempt(currentExpiryMeta, impliedMeta, false);
+                .resolveUpdateAttempt(currentExpiryMeta, impliedMeta);
 
         // expect:
         assertFailsWith(ResponseCodeEnum.INVALID_EXPIRATION_TIME, () -> subject.handle(handleContext));
@@ -305,7 +305,7 @@ class ConsensusUpdateTopicHandlerTest extends ConsensusTestBase {
         given(handleContext.expiryValidator()).willReturn(expiryValidator);
         given(handleContext.attributeValidator()).willReturn(attributeValidator);
         final var impliedMeta = new ExpiryMeta(123L, NA, null);
-        given(expiryValidator.resolveUpdateAttempt(currentExpiryMeta, impliedMeta, false))
+        given(expiryValidator.resolveUpdateAttempt(currentExpiryMeta, impliedMeta))
                 .willReturn(new ExpiryMeta(
                         123L, currentExpiryMeta.autoRenewPeriod(), currentExpiryMeta.autoRenewAccountId()));
 
@@ -330,7 +330,7 @@ class ConsensusUpdateTopicHandlerTest extends ConsensusTestBase {
         final var impliedMeta = new ExpiryMeta(NA, 123L, null);
         willThrow(new HandleException(ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE))
                 .given(expiryValidator)
-                .resolveUpdateAttempt(currentExpiryMeta, impliedMeta, false);
+                .resolveUpdateAttempt(currentExpiryMeta, impliedMeta);
 
         // expect:
         assertFailsWith(ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE, () -> subject.handle(handleContext));
@@ -348,7 +348,7 @@ class ConsensusUpdateTopicHandlerTest extends ConsensusTestBase {
         given(handleContext.attributeValidator()).willReturn(attributeValidator);
         given(handleContext.expiryValidator()).willReturn(expiryValidator);
         final var impliedMeta = new ExpiryMeta(NA, 123L, null);
-        given(expiryValidator.resolveUpdateAttempt(currentExpiryMeta, impliedMeta, false))
+        given(expiryValidator.resolveUpdateAttempt(currentExpiryMeta, impliedMeta))
                 .willReturn(new ExpiryMeta(currentExpiryMeta.expiry(), 123L, null));
 
         subject.handle(handleContext);
@@ -370,7 +370,7 @@ class ConsensusUpdateTopicHandlerTest extends ConsensusTestBase {
         final var impliedMeta = new ExpiryMeta(NA, NA, autoRenewId);
         willThrow(new HandleException(INVALID_AUTORENEW_ACCOUNT))
                 .given(expiryValidator)
-                .resolveUpdateAttempt(currentExpiryMeta, impliedMeta, false);
+                .resolveUpdateAttempt(currentExpiryMeta, impliedMeta);
 
         // expect:
         assertFailsWith(INVALID_AUTORENEW_ACCOUNT, () -> subject.handle(handleContext));
@@ -392,7 +392,7 @@ class ConsensusUpdateTopicHandlerTest extends ConsensusTestBase {
                 NA,
                 NA,
                 AccountID.newBuilder().shardNum(0).realmNum(0).accountNum(666).build());
-        given(expiryValidator.resolveUpdateAttempt(currentExpiryMeta, impliedMeta, false))
+        given(expiryValidator.resolveUpdateAttempt(currentExpiryMeta, impliedMeta))
                 .willReturn(new ExpiryMeta(
                         currentExpiryMeta.expiry(),
                         currentExpiryMeta.autoRenewPeriod(),

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/handlers/ContractUpdateHandler.java
@@ -191,7 +191,7 @@ public class ContractUpdateHandler implements TransactionHandler {
                 op.hasExpirationTime() ? op.expirationTimeOrThrow().seconds() : NA,
                 op.hasAutoRenewPeriod() ? op.autoRenewPeriodOrThrow().seconds() : NA,
                 null);
-        context.expiryValidator().resolveUpdateAttempt(currentMetadata, updateMeta, false);
+        context.expiryValidator().resolveUpdateAttempt(currentMetadata, updateMeta);
 
         context.storeFactory()
                 .serviceApi(TokenServiceApi.class)

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/handlers/ContractUpdateHandlerTest.java
@@ -516,7 +516,7 @@ class ContractUpdateHandlerTest extends ContractHandlerTestBase {
 
         subject.handle(context);
 
-        verify(expiryValidator, times(1)).resolveUpdateAttempt(any(), any(), anyBoolean());
+        verify(expiryValidator, times(1)).resolveUpdateAttempt(any(), any());
         verify(tokenServiceApi, times(1))
                 .assertValidStakingElectionForUpdate(anyBoolean(), anyBoolean(), any(), any(), any(), any(), any());
         verify(tokenServiceApi, times(1)).updateContract(any());
@@ -747,7 +747,7 @@ class ContractUpdateHandlerTest extends ContractHandlerTestBase {
 
         subject.handle(context);
 
-        verify(expiryValidator, times(1)).resolveUpdateAttempt(any(), any(), anyBoolean());
+        verify(expiryValidator, times(1)).resolveUpdateAttempt(any(), any());
         verify(tokenServiceApi, times(1))
                 .assertValidStakingElectionForUpdate(anyBoolean(), anyBoolean(), any(), any(), any(), any(), any());
         verify(tokenServiceApi, times(1)).updateContract(any());

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -244,7 +244,7 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
                 op.hasExpirationTime() ? op.expirationTime().seconds() : NA,
                 op.hasAutoRenewPeriod() ? op.autoRenewPeriod().seconds() : NA,
                 null);
-        context.expiryValidator().resolveUpdateAttempt(currentMetadata, updateMeta, false);
+        context.expiryValidator().resolveUpdateAttempt(currentMetadata, updateMeta);
 
         // If an account is detached and pending removal, it cannot be updated
         // It can only be updated to extend expiration time

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenUpdateValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenUpdateValidator.java
@@ -105,6 +105,6 @@ public class TokenUpdateValidator {
                 op.hasExpiry() ? op.expiryOrThrow().seconds() : NA,
                 op.hasAutoRenewPeriod() ? op.autoRenewPeriodOrThrow().seconds() : NA,
                 op.autoRenewAccount());
-        return expiryValidator.resolveUpdateAttempt(givenExpiryMeta, updateExpiryMeta, true);
+        return expiryValidator.resolveUpdateAttempt(givenExpiryMeta, updateExpiryMeta);
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -658,7 +658,7 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
     void rejectsInvalidExpiryIfExpiryValidatorFails() {
         final var txn = new CryptoUpdateBuilder().withExpiration(1234567).build();
         givenTxnWith(txn);
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willThrow(new HandleException(INVALID_EXPIRATION_TIME));
 
         assertThatThrownBy(() -> subject.handle(handleContext))
@@ -691,7 +691,7 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         final var txn = new CryptoUpdateBuilder().withExpiration(10L).build();
         givenTxnWith(txn);
         assertEquals(1234567L, writableStore.get(updateAccountId).expirationSecond());
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willThrow(new HandleException(EXPIRATION_REDUCTION_NOT_ALLOWED));
 
         assertThatThrownBy(() -> subject.handle(handleContext))

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
@@ -135,7 +135,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     void happyPathForFungibleTokenUpdate() {
         txn = new TokenUpdateBuilder().build();
         given(handleContext.body()).willReturn(txn);
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
 
@@ -205,7 +205,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         assertThat(token.metadata()).isEqualTo(nonFungibleToken.metadata());
         assertThat(token.autoRenewSeconds()).isEqualTo(nonFungibleToken.autoRenewSeconds());
         assertThat(token.tokenType()).isEqualTo(NON_FUNGIBLE_UNIQUE);
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
 
@@ -364,7 +364,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
                 .withMetadataKey(invalidAllZeros)
                 .build();
         given(handleContext.body()).willReturn(txn);
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         assertThatNoException().isThrownBy(() -> subject.handle(handleContext));
@@ -409,7 +409,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
                 .withFeeScheduleKey(A_KEY_LIST)
                 .withMetadataKey(A_KEY_LIST)
                 .build();
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         given(handleContext.body()).willReturn(txn);
@@ -432,7 +432,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
                 .copyBuilder()
                 .kycGranted(false)
                 .build();
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         writableTokenRelStore.put(copyTokenRel);
@@ -446,7 +446,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void failsIfTokenRelIsFrozen() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         final var copyTokenRel = writableTokenRelStore
@@ -490,7 +490,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     @Test
     void doesntFailForZeroLengthSymbolUpdate() {
         txn = new TokenUpdateBuilder().withSymbol("").build();
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         given(handleContext.body()).willReturn(txn);
@@ -502,7 +502,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     @Test
     void doesntFailForNullSymbol() {
         setUpTxnContext();
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         txn = new TokenUpdateBuilder().withSymbol(null).build();
@@ -535,7 +535,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     @Test
     void doesntFailForZeroLengthName() {
         txn = new TokenUpdateBuilder().withName("").build();
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         given(handleContext.body()).willReturn(txn);
@@ -547,7 +547,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void doesntFailForNullName() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         txn = new TokenUpdateBuilder().withName(null).build();
@@ -610,7 +610,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         assertThat(token.memo()).isEqualTo(fungibleToken.memo());
         assertThat(token.autoRenewSeconds()).isEqualTo(fungibleToken.autoRenewSeconds());
         assertThat(token.tokenType()).isEqualTo(FUNGIBLE_COMMON);
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
 
@@ -662,7 +662,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         given(storeFactory.writableStore(WritableTokenRelationStore.class)).willReturn(writableTokenRelStore);
         given(storeFactory.readableStore(ReadableTokenRelationStore.class)).willReturn(writableTokenRelStore);
         assertThat(writableTokenRelStore.get(payerId, nonFungibleTokenId)).isNull();
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
 
@@ -734,7 +734,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void failsIfNoAutoAssociationsAvailableForNewUnassociatedTreasury() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         txn = new TokenUpdateBuilder()
@@ -764,7 +764,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     @Test
     void failsOnInvalidNewTreasury() {
         txn = new TokenUpdateBuilder().withTreasury(asAccount(0L, 0L, 2000000)).build();
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         given(handleContext.body()).willReturn(txn);
@@ -776,7 +776,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void failsOnDetachedNewTreasury() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         txn = new TokenUpdateBuilder().withTreasury(payerId).build();
@@ -808,7 +808,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void failsOnDetachedOldTreasury() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         txn = new TokenUpdateBuilder().build();
@@ -835,7 +835,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void failsOnDetachedNewAutoRenewAccount() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         txn = new TokenUpdateBuilder().withAutoRenewAccount(payerId).build();
@@ -883,7 +883,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(config, 1));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong()))
                 .willReturn(ACCOUNT_EXPIRED_AND_PENDING_REMOVAL);
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
 
         assertThatThrownBy(() -> subject.handle(handleContext))
@@ -898,8 +898,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         given(handleContext.body()).willReturn(txn);
         given(storeFactory.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
         given(storeFactory.readableStore(ReadableAccountStore.class)).willReturn(writableAccountStore);
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
-                .willThrow(new HandleException(ACCOUNT_DELETED));
+        given(expiryValidator.resolveUpdateAttempt(any(), any())).willThrow(new HandleException(ACCOUNT_DELETED));
 
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
@@ -913,8 +912,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         given(handleContext.body()).willReturn(txn);
         given(storeFactory.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
         given(storeFactory.readableStore(ReadableAccountStore.class)).willReturn(writableAccountStore);
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
-                .willThrow(new HandleException(ACCOUNT_DELETED));
+        given(expiryValidator.resolveUpdateAttempt(any(), any())).willThrow(new HandleException(ACCOUNT_DELETED));
 
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
@@ -923,7 +921,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void permitsExtendingOnlyExpiryWithoutAdminKey() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         final var transactionID =
                 TransactionID.newBuilder().accountID(payerId).transactionValidStart(consensusTimestamp);
@@ -943,7 +941,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void failsOnReducedNewExpiry() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willThrow(new HandleException(EXPIRATION_REDUCTION_NOT_ALLOWED));
         txn = new TokenUpdateBuilder()
                 .withExpiry(consensusInstant.getEpochSecond() - 72000)
@@ -958,7 +956,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
     void failsOnInvalidNewExpiry() {
         txn = new TokenUpdateBuilder().withExpiry(3_000_000_000L + 10).build();
         given(handleContext.body()).willReturn(txn);
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willThrow(new HandleException(INVALID_EXPIRATION_TIME));
         assertThatThrownBy(() -> subject.handle(handleContext))
                 .isInstanceOf(HandleException.class)
@@ -1043,7 +1041,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         given(storeFactory.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
         given(storeFactory.readableStore(ReadableAccountStore.class)).willReturn(writableAccountStore);
         assertThat(writableTokenRelStore.get(payerId, fungibleTokenId)).isNull();
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
 
@@ -1076,7 +1074,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void doesntGrantKycOrUnfreezeNewTreasuryIfNoKeyIsPresent() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         txn = new TokenUpdateBuilder()
@@ -1172,7 +1170,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void rejectsTreasuryUpdateIfNonzeroBalanceForNFTs() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         final var copyTokenRel = writableTokenRelStore
@@ -1214,7 +1212,7 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
 
     @Test
     void validateZeroTreasuryIsUpdatedForHapiCalls() {
-        given(expiryValidator.resolveUpdateAttempt(any(), any(), anyBoolean()))
+        given(expiryValidator.resolveUpdateAttempt(any(), any()))
                 .willReturn(new ExpiryMeta(1234600L, autoRenewSecs, ownerId));
         given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
         txn = new TokenUpdateBuilder()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenExpiryInfoSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/TokenExpiryInfoSuite.java
@@ -32,10 +32,10 @@ import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
 import static com.hedera.services.bdd.suites.contract.Utils.asToken;
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.VANILLA_TOKEN;
 import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -172,7 +172,8 @@ public class TokenExpiryInfoSuite {
                     // set an invalid auto-renew account period of 1 second
                     tokenExpiryContract
                             .call("updateExpiryInfoForToken", mutableToken, 0L, ZERO_ADDRESS, 1L)
-                            .andAssert(txn -> txn.hasKnownStatuses(CONTRACT_REVERT_EXECUTED, INVALID_RENEWAL_PERIOD)));
+                            .andAssert(txn ->
+                                    txn.hasKnownStatuses(CONTRACT_REVERT_EXECUTED, AUTORENEW_DURATION_NOT_IN_RANGE)));
         }
 
         @HapiTest


### PR DESCRIPTION
**Description**:
- When we update a token's expiry with less than the current expiry time, we should get `EXPIRATION_REDUCTION_NOT_ALLOWED` error response code.  However, due to the differential testing with mono, we've mirrored the logic from there. Now that we are past the differential testing, we can return the correct error code.
- Additionally, I saw that we are doing the same for `AUTORENEW_DURATION_NOT_IN_RANGE`. I cleaned that.
- Making these changes made the `isForTokenUpdate` param in `resolveUpdateAttempt` not needed. I deleted that.

**Related issue(s)**:

Fixes #18697

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
