### PR TITLE
chore: move turtle framework to test.fixtures module

### DIFF
--- a/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/demos/CryptocurrencyDemo/src/main/java/module-info.java
@@ -8,6 +8,7 @@ module com.swirlds.demo.crypto {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.base.utility;
     requires org.hiero.consensus.model;
     requires java.desktop;
     requires org.apache.logging.log4j;

--- a/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/demos/HelloSwirldDemo/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module com.swirlds.demo.hello {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.base.utility;
     requires org.hiero.consensus.model;
     requires java.desktop;
     requires org.apache.logging.log4j;

--- a/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/demos/StatsDemo/src/main/java/module-info.java
@@ -9,6 +9,7 @@ module com.swirlds.demo.stats {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.base.utility;
     requires org.hiero.consensus.model;
     requires java.desktop;
     requires static com.github.spotbugs.annotations;

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/module-info.java
@@ -15,6 +15,7 @@ module com.swirlds.demo.migration {
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
     requires com.swirlds.virtualmap;
+    requires org.hiero.base.utility;
     requires org.hiero.consensus.model;
     requires java.logging;
     requires org.apache.logging.log4j;

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/module-info.java
@@ -42,6 +42,7 @@ module com.swirlds.demo.platform {
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
     requires com.swirlds.virtualmap;
+    requires org.hiero.base.utility;
     requires org.hiero.consensus.model;
     requires com.fasterxml.jackson.annotation;
     requires com.fasterxml.jackson.core;

--- a/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/module-info.java
+++ b/platform-sdk/platform-apps/tests/StatsSigningTestingTool/src/main/java/module-info.java
@@ -10,6 +10,7 @@ module com.swirlds.demo.stats.signing {
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
+    requires org.hiero.base.utility;
     requires org.hiero.consensus.model;
     requires lazysodium.java;
     requires org.apache.logging.log4j;

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/turtle/runner/TurtleTests.java
@@ -3,6 +3,8 @@ package com.swirlds.platform.turtle.runner;
 
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.test.fixtures.consensus.framework.validation.ConsensusRoundValidator;
+import com.swirlds.platform.test.fixtures.turtle.runner.Turtle;
+import com.swirlds.platform.test.fixtures.turtle.runner.TurtleBuilder;
 import java.nio.file.Path;
 import java.time.Duration;
 import org.junit.jupiter.api.Disabled;

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/Turtle.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/Turtle.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.turtle.runner;
+package com.swirlds.platform.test.fixtures.turtle.runner;
 
 import com.swirlds.base.test.fixtures.time.FakeTime;
 import com.swirlds.common.constructable.ClassConstructorPair;

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/TurtleBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/TurtleBuilder.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.turtle.runner;
+package com.swirlds.platform.test.fixtures.turtle.runner;
 
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.test.fixtures.consensus.framework.validation.ConsensusRoundValidator;

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/TurtleConsensusStateEventHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/TurtleConsensusStateEventHandler.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.turtle.runner;
+package com.swirlds.platform.test.fixtures.turtle.runner;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/TurtleNode.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/TurtleNode.java
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.turtle.runner;
+package com.swirlds.platform.test.fixtures.turtle.runner;
 
 import static com.swirlds.common.threading.manager.AdHocThreadManager.getStaticThreadManager;
 import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.getMetricsProvider;
 import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.setupGlobalMetrics;
 import static com.swirlds.platform.state.signed.StartupStateUtils.getInitialState;
-import static com.swirlds.platform.turtle.runner.TurtleConsensusStateEventHandler.TURTLE_CONSENSUS_STATE_EVENT_HANDLER;
+import static com.swirlds.platform.test.fixtures.turtle.runner.TurtleConsensusStateEventHandler.TURTLE_CONSENSUS_STATE_EVENT_HANDLER;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/TurtleTestingToolState.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/runner/TurtleTestingToolState.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.turtle.runner;
+package com.swirlds.platform.test.fixtures.turtle.runner;
 
 import static com.swirlds.platform.test.fixtures.state.FakeConsensusStateEventHandler.FAKE_CONSENSUS_STATE_EVENT_HANDLER;
 

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/module-info.java
@@ -17,6 +17,7 @@ module com.swirlds.platform.core.test.fixtures {
     requires transitive org.hiero.consensus.gossip;
     requires transitive org.hiero.consensus.model;
     requires transitive org.junit.jupiter.api;
+    requires com.swirlds.base.test.fixtures;
     requires com.swirlds.component.framework;
     requires com.swirlds.logging;
     requires com.swirlds.merkledb;


### PR DESCRIPTION
**Description**:

Moved remaining classes of turtle framework to test fixtures to make them available in other modules

**Related issue(s)**:

Part of #18630 
