### PR TITLE
feat: rewrite GasLimitDeterministicThrottle using DeterministicThrottle

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -851,10 +851,13 @@ public class ThrottleAccumulator {
     public void applyGasConfig() {
         final var configuration = configSupplier.get();
         final var contractsConfig = configuration.getConfigData(ContractsConfig.class);
-        if (contractsConfig.throttleThrottleByGas() && contractsConfig.maxGasPerSec() == 0) {
+        final var maxGasPerSec = throttleType.equals(ThrottleType.BACKEND_THROTTLE)
+                ? contractsConfig.maxGasPerSecBackend()
+                : contractsConfig.maxGasPerSec();
+        if (contractsConfig.throttleThrottleByGas() && maxGasPerSec == 0) {
             log.warn("{} gas throttling enabled, but limited to 0 gas/sec", throttleType.name());
         }
-        gasThrottle = new GasLimitDeterministicThrottle(contractsConfig.maxGasPerSec());
+        gasThrottle = new GasLimitDeterministicThrottle(maxGasPerSec, contractsConfig.throttleBurstPeriod());
         if (throttleMetrics != null) {
             throttleMetrics.setupGasThrottleMetric(gasThrottle, configuration);
         }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
@@ -37,7 +37,7 @@ class NetworkUtilizationManagerImplTest {
     private final Instant consensusNow = Instant.ofEpochSecond(1_234_567L, 123);
 
     private final DeterministicThrottle throttle = DeterministicThrottle.withTpsAndBurstPeriodMsNamed(500, 10, "test");
-    private final GasLimitDeterministicThrottle gasThrottle = new GasLimitDeterministicThrottle(100);
+    private final GasLimitDeterministicThrottle gasThrottle = new GasLimitDeterministicThrottle(100, 10);
 
     @LoggingSubject
     private NetworkUtilizationManagerImpl subject;

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -26,6 +26,8 @@ public record ContractsConfig(
                 boolean noncesExternalizationEnabled,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean enforceCreationThrottle,
         @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSec,
+        @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSecBackend,
+        @ConfigProperty(defaultValue = "1000") @NetworkProperty long throttleBurstPeriod,
         @ConfigProperty(value = "maxKvPairs.aggregate", defaultValue = "500000000") @NetworkProperty
                 long maxKvPairsAggregate,
         @ConfigProperty(value = "maxKvPairs.individual", defaultValue = "16384000") @NetworkProperty


### PR DESCRIPTION
**Description**:
The existing implementation of `GasLimitDeterministicThrottle` does not support burst capabilities.  Rewrite to internally use `DeterministicThrottle` in order to support burst capabilities and be more consistent with other throttles.
**Related issue(s)**:

Fixes #18614 

