### PR TITLE
fix: 1280 hip 1056 block item with failed contract create result contains a contract

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -143,6 +143,7 @@ import com.hedera.services.bdd.spec.utilops.mod.TxnModification;
 import com.hedera.services.bdd.spec.utilops.pauses.HapiSpecSleep;
 import com.hedera.services.bdd.spec.utilops.pauses.HapiSpecWaitUntil;
 import com.hedera.services.bdd.spec.utilops.pauses.HapiSpecWaitUntilNextBlock;
+import com.hedera.services.bdd.spec.utilops.streams.BlockStreamValidationOp;
 import com.hedera.services.bdd.spec.utilops.streams.LogContainmentOp;
 import com.hedera.services.bdd.spec.utilops.streams.LogContainmentTimeframeOp;
 import com.hedera.services.bdd.spec.utilops.streams.LogValidationOp;
@@ -371,6 +372,15 @@ public class UtilVerbs {
                 .map(Integer::parseInt)
                 .orElse(0);
         return new StreamValidationOp(proofsToWaitFor, HISTORY_PROOF_WAIT_TIMEOUT);
+    }
+
+    /**
+     * Returns an operation that validates the streams of the target network with dynamic validators
+     *
+     * @return the operation that validates the streams
+     */
+    public static BlockStreamValidationOp validateBlockStream() {
+        return new BlockStreamValidationOp();
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/BlockStreamValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/BlockStreamValidationOp.java
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.spec.utilops.streams;
+
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilNextBlock;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.services.bdd.junit.support.BlockStreamValidator;
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.utilops.UtilOp;
+import com.hedera.services.bdd.suites.regression.system.LifecycleTest;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.Assertions;
+
+/**
+ * A {@link UtilOp} that validates the streams produced by the target network of the given {@link HapiSpec} with dynamic
+ * validators.
+ */
+public class BlockStreamValidationOp extends UtilOp implements LifecycleTest {
+    private static final Logger log = LogManager.getLogger(BlockStreamValidationOp.class);
+
+    private final List<BlockStreamValidator> blockValidators = new ArrayList<>();
+
+    public BlockStreamValidationOp withBlockValidation(Consumer<List<Block>> validation) {
+        this.blockValidators.add(new BlockStreamValidator() {
+            @Override
+            public void validateBlocks(@NotNull List<Block> blocks) {
+                validation.accept(blocks);
+            }
+        });
+        return this;
+    }
+
+    @Override
+    protected boolean submitOp(@NonNull final HapiSpec spec) throws Throwable {
+        // wait for record/block files will be created
+        allRunFor(spec, waitUntilNextBlock().withBackgroundTraffic(true));
+        if (!blockValidators.isEmpty()) {
+            List<Block> blocks = StreamValidationOp.readMaybeBlockStreamsFor(spec)
+                    .orElseGet(() -> Assertions.fail("No block streams found"));
+            blockValidators.forEach(v -> v.validateBlocks(blocks));
+        }
+        return false;
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/StreamValidationOp.java
@@ -164,7 +164,7 @@ public class StreamValidationOp extends UtilOp implements LifecycleTest {
         return false;
     }
 
-    private static Optional<List<Block>> readMaybeBlockStreamsFor(@NonNull final HapiSpec spec) {
+    static Optional<List<Block>> readMaybeBlockStreamsFor(@NonNull final HapiSpec spec) {
         List<Block> blocks = null;
         final var blockPaths = spec.getNetworkNodes().stream()
                 .map(node -> node.getExternalPath(BLOCK_STREAMS_DIR))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateSuite.java
@@ -54,6 +54,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateBlockStream;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuccessivelyVariedBodyIds;
 import static com.hedera.services.bdd.suites.HapiSuite.CHAIN_ID;
@@ -93,10 +94,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.esaulpaugh.headlong.util.Integers;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.BlockItem.ItemOneOfType;
+import com.hedera.hapi.block.stream.output.TransactionOutput;
+import com.hedera.hapi.block.stream.output.TransactionOutput.TransactionOneOfType;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
+import com.hedera.pbj.runtime.OneOf;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.assertions.ContractInfoAsserts;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
@@ -106,6 +114,8 @@ import com.hedera.services.bdd.utils.Signing;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.Timestamp;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigInteger;
@@ -113,12 +123,15 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hiero.consensus.model.utility.CommonUtils;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
@@ -129,7 +142,6 @@ public class ContractCreateSuite {
     public static final String EMPTY_CONSTRUCTOR_CONTRACT = "EmptyConstructor";
     public static final String PARENT_INFO = "parentInfo";
     private static final String PAYER = "payer";
-    private static final String ALICE = "alice";
 
     private static final Logger log = LogManager.getLogger(ContractCreateSuite.class);
 
@@ -140,17 +152,13 @@ public class ContractCreateSuite {
             "f8a58085174876e800830186a08080b853604580600e600039806000f350fe7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe03601600081602082378035828234f58015156039578182fd5b8082525050506014600cf31ba02222222222222222222222222222222222222222222222222222222222222222a02222222222222222222222222222222222222222222222222222222222222222";
     private static final String EXPECTED_DEPLOYER_ADDRESS = "4e59b44847b379578588920ca78fbf26c0b4956c";
     private static final String DEPLOYER = "DeployerContract";
-    public static final String ENTITIES_UNLIMITED_AUTO_ASSOCIATIONS_ENABLED =
-            "entities.unlimitedAutoAssociationsEnabled";
-    public static final String LEDGER_MAX_AUTO_ASSOCIATIONS = "ledger.maxAutoAssociations";
-
     private static final String FUNGIBLE_TOKEN = "fungible";
     private static final String MULTI_KEY = "multiKey";
 
     @HapiTest
     final Stream<DynamicTest> createDeterministicDeployer() {
-        final var creatorAddress = ByteString.copyFrom(CommonUtils.unhex(DEPLOYMENT_SIGNER));
-        final var transaction = ByteString.copyFrom(CommonUtils.unhex(DEPLOYMENT_TRANSACTION));
+        final var creatorAddress = ByteString.copyFrom(Objects.requireNonNull(CommonUtils.unhex(DEPLOYMENT_SIGNER)));
+        final var transaction = ByteString.copyFrom(Objects.requireNonNull(CommonUtils.unhex(DEPLOYMENT_TRANSACTION)));
         final var systemFileId = FileID.newBuilder().setFileNum(159).build();
 
         return hapiTest(
@@ -420,7 +428,7 @@ public class ContractCreateSuite {
                     final var createdIds = creationResult.getCreatedContractIDsList();
                     assertEquals(1, createdIds.size(), "Expected one creations but got " + createdIds);
                     assertTrue(
-                            createdIds.get(0).getContractNum() < 10000,
+                            createdIds.getFirst().getContractNum() < 10000,
                             "Expected contract num < 10000 but got " + createdIds);
                 }));
     }
@@ -443,8 +451,7 @@ public class ContractCreateSuite {
                     final var registry = spec.registry();
                     final var aNum = (int) registry.getAccountID(aBeneficiary).getAccountNum();
                     final var bNum = (int) registry.getAccountID(bBeneficiary).getAccountNum();
-                    final var sendArgs =
-                            new Object[] {Long.valueOf(sendAmount), Long.valueOf(aNum), Long.valueOf(bNum)};
+                    final var sendArgs = new Object[] {(long) sendAmount, (long) aNum, (long) bNum};
 
                     final var op = contractCall(contract, "sendTo", sendArgs)
                             .gas(110_000)
@@ -668,7 +675,7 @@ public class ContractCreateSuite {
                             secondBlockRecord.getContractCallResult().getLogInfoList();
                     assertEquals(2, secondBlockLogs.size());
                     final var secondBlockTimeLogData =
-                            secondBlockLogs.get(0).getData().toByteArray();
+                            secondBlockLogs.getFirst().getData().toByteArray();
                     final var secondBlockTimestamp =
                             Longs.fromByteArray(Arrays.copyOfRange(secondBlockTimeLogData, 24, 32));
                     assertNotEquals(firstBlockTimestamp, secondBlockTimestamp, "Block timestamps should change");
@@ -858,6 +865,115 @@ public class ContractCreateSuite {
                         .refusingEthConversion()
                         .logged(),
                 getContractInfo(contract).has(ContractInfoAsserts.contractWith().maxAutoAssociations(0)));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> contractRevertBlockAndRecordFilesNotContainContractId() {
+        final var txn = "contractRevertBlockAndRecordFilesNotContainContractId";
+        AtomicReference<Timestamp> ts = new AtomicReference<>();
+        return hapiTest(
+                uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),
+                contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
+                        .balance(1L)
+                        .via(txn)
+                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED),
+                // check if CONTRACT_REVERT_EXECUTED record DON`T contains expected contractIds
+                withOpContext((spec, opLog) -> {
+                    final var record = getRecord(spec, txn, CONTRACT_REVERT_EXECUTED);
+                    ts.set(record.getConsensusTimestamp());
+                    asserRecordContractId(record, false);
+                }),
+                // check if CONTRACT_REVERT_EXECUTED block DON`T contains expected contractIds
+                validateBlockStream().withBlockValidation(blocks -> {
+                    // get last TRANSACTION_OUTPUT in all blocks
+                    final var item = getLastContractCreateTx(blocks, ts.get());
+                    asserBlockContractId(item, false);
+                }));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> blockAndRecordFilesNotContainContractId() {
+        final var txn = "blockAndRecordFilesNotContainContractId";
+        AtomicReference<Timestamp> ts = new AtomicReference<>();
+        return hapiTest(
+                uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),
+                contractCreate(EMPTY_CONSTRUCTOR_CONTRACT).via(txn).hasKnownStatus(SUCCESS),
+                // check if record contains expected contractIds
+                withOpContext((spec, opLog) -> {
+                    final var record = getRecord(spec, txn, SUCCESS);
+                    ts.set(record.getConsensusTimestamp());
+                    asserRecordContractId(record, true);
+                }),
+                // check if block contains expected contractIds
+                validateBlockStream().withBlockValidation(blocks -> {
+                    // get last TRANSACTION_OUTPUT in all blocks
+                    final var item = getLastContractCreateTx(blocks, ts.get());
+                    asserBlockContractId(item, true);
+                }));
+    }
+
+    private TransactionRecord getRecord(HapiSpec spec, String txn, ResponseCodeEnum status) {
+        final var hapiGetRecord = getTxnRecord(txn);
+        allRunFor(spec, hapiGetRecord);
+        // Getting record
+        final var respRecord = hapiGetRecord.getResponse();
+        assertTrue(respRecord.hasTransactionGetRecord());
+        final var record = respRecord.getTransactionGetRecord().getTransactionRecord();
+        assertEquals(status, record.getReceipt().getStatus());
+        return record;
+    }
+
+    private TransactionOutput getLastContractCreateTx(List<Block> blocks, Timestamp timestamp) {
+        return blocks.stream()
+                .flatMap(e -> e.items().stream())
+                .map(BlockItem::item)
+                .filter(e -> ItemOneOfType.TRANSACTION_OUTPUT.equals(e.kind()))
+                .<TransactionOutput>map(OneOf::as)
+                .filter(e -> TransactionOneOfType.CONTRACT_CREATE.equals(
+                        e.transaction().kind()))
+                // match txn by timestamp, because there is other CONTRACT_CREATE txn
+                .filter(e -> e.contractCreateOrThrow().sidecars().stream()
+                        .anyMatch(s -> s.consensusTimestamp().seconds() == timestamp.getSeconds()
+                                && s.consensusTimestamp().nanos() == timestamp.getNanos()))
+                .reduce((f, s) -> s)
+                .orElseGet(() -> Assertions.fail("TRANSACTION_OUTPUT -> CONTRACT_CREATE mot found"));
+    }
+
+    private void asserRecordContractId(TransactionRecord record, boolean shouldContractIdExists) {
+        // check record->receipt->contractId
+        assertEquals(shouldContractIdExists, record.getReceipt().hasContractID());
+        // check record->contractCreateResult->contractId
+        assertEquals(shouldContractIdExists, record.getContractCreateResult().hasContractID());
+    }
+
+    private void asserBlockContractId(TransactionOutput item, boolean shouldContractIdExists) {
+        assertTrue(item.hasContractCreate());
+        // check sidecars->actions->recipient, sidecars->bytecode->contractId
+        item.contractCreateOrThrow().sidecars().forEach(sidecar -> {
+            if (sidecar.hasActions()) {
+                sidecar.actionsOrThrow()
+                        .contractActions()
+                        .forEach(action -> assertEquals(shouldContractIdExists, action.hasRecipientContract()));
+            } else if (sidecar.hasBytecode()) {
+                assertEquals(shouldContractIdExists, sidecar.bytecodeOrThrow().hasContractId());
+            }
+        });
+        // check contractCreate->contractCreateResult->contractId
+        assertTrue(item.contractCreateOrThrow().hasContractCreateResult());
+        assertEquals(
+                shouldContractIdExists,
+                item.contractCreateOrThrow().contractCreateResult().hasContractID());
+        // check contractCreate->contractCreateResult->contractNonces->contractId
+        assertEquals(
+                !shouldContractIdExists,
+                item.contractCreateOrThrow()
+                        .contractCreateResult()
+                        .contractNonces()
+                        .isEmpty());
+        item.contractCreateOrThrow()
+                .contractCreateResult()
+                .contractNonces()
+                .forEach(nonce -> assertEquals(shouldContractIdExists, nonce.hasContractId()));
     }
 
     private EthTxData placeholderEthTx() {


### PR DESCRIPTION
❗ This PR is created and maintained by @gkozyryatskyy. It was initially approved by the `hiero-consensus-node-smart-contracts-codeowners` here #18608

**Description**:
When comparing record files to blocks, a failed Contract Create Result should NOT contain an Contract ID, the error message is CONTRACT_REVERT_EXECUTED.

**Related issue(s)**:

Fixes [1280](https://github.com/hashgraph/hedera-smart-contracts/issues/1280)

**Notes for reviewer**:
- the actual fix is in `HederaEvmTransactionResult`
**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
