### PR TITLE
chore: remove unnecessary runtimeOnly dependencies in test-client

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -11,8 +11,6 @@ description = "Hedera Services Test Clients for End to End Tests (EET)"
 mainModuleInfo {
     runtimeOnly("org.junit.jupiter.engine")
     runtimeOnly("org.junit.platform.launcher")
-    runtimeOnly("org.hiero.event.creator")
-    runtimeOnly("org.hiero.event.creator.impl")
 }
 
 testModuleInfo { runtimeOnly("org.junit.jupiter.api") }


### PR DESCRIPTION
**Description**:

The module has been renamed and thus these dependencies currently have now effect. There is a warning on currently:

```
[WARN] [Java Module Dependencies] org.hiero.event.creator=group:artifact missing ...
[WARN] [Java Module Dependencies] org.hiero.event.creator.impl=group:artifact missing ...
```

Rather than adjusting the name here, I believe the entries can be removed. The modules are already on the (test) runtime classpath.

**Related issue(s)**:

Follow-up to #18568
