### PR TITLE
feat: decouple backend throttle config from front end and add support for burst

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/LeakyBucketDeterministicThrottle.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/throttles/LeakyBucketDeterministicThrottle.java
@@ -26,10 +26,10 @@ public class LeakyBucketDeterministicThrottle implements CongestibleThrottle {
      *
      * @param capacity - the total amount of gas allowed per sec.
      */
-    public LeakyBucketDeterministicThrottle(long capacity, String name) {
+    public LeakyBucketDeterministicThrottle(final long capacity, final String name, final int burstSeconds) {
         this.throttleName = name;
         this.capacity = capacity;
-        this.delegate = new LeakyBucketThrottle(capacity);
+        this.delegate = new LeakyBucketThrottle(capacity, burstSeconds);
     }
 
     /**

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/LeakyBucketDeterministicThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/LeakyBucketDeterministicThrottleTest.java
@@ -24,7 +24,7 @@ class LeakyBucketDeterministicThrottleTest {
 
     @BeforeEach
     void setup() {
-        subject = new LeakyBucketDeterministicThrottle(DEFAULT_CAPACITY, THROTTLE_NAME);
+        subject = new LeakyBucketDeterministicThrottle(DEFAULT_CAPACITY, THROTTLE_NAME, 1);
     }
 
     @Test
@@ -52,7 +52,7 @@ class LeakyBucketDeterministicThrottleTest {
     void canGetPercentUsed() {
         final var now = Instant.ofEpochSecond(1_234_567L);
         final var capacity = 1_000_000;
-        final var subject = new LeakyBucketDeterministicThrottle(capacity, THROTTLE_NAME);
+        final var subject = new LeakyBucketDeterministicThrottle(capacity, THROTTLE_NAME, 1);
         assertEquals(0.0, subject.percentUsed(now));
         subject.allow(now, capacity / 2);
         assertEquals(50.0, subject.percentUsed(now));
@@ -63,7 +63,7 @@ class LeakyBucketDeterministicThrottleTest {
     void canGetInstantaneousPercentUsed() {
         final var now = Instant.ofEpochSecond(1_234_567L);
         final var capacity = 1_000_000;
-        final var subject = new LeakyBucketDeterministicThrottle(capacity, THROTTLE_NAME);
+        final var subject = new LeakyBucketDeterministicThrottle(capacity, THROTTLE_NAME, 1);
         assertEquals(0.0, subject.instantaneousPercentUsed());
         subject.allow(now, capacity / 2);
         assertEquals(50.0, subject.instantaneousPercentUsed());
@@ -73,7 +73,7 @@ class LeakyBucketDeterministicThrottleTest {
     void canGetFreeToUsedRatio() {
         final var now = Instant.ofEpochSecond(1_234_567L);
         final var capacity = 1_000_000;
-        final var subject = new LeakyBucketDeterministicThrottle(capacity, THROTTLE_NAME);
+        final var subject = new LeakyBucketDeterministicThrottle(capacity, THROTTLE_NAME, 1);
         subject.allow(now, capacity / 4);
         assertEquals(3, subject.instantaneousFreeToUsedRatio());
     }
@@ -81,7 +81,7 @@ class LeakyBucketDeterministicThrottleTest {
     @Test
     void leaksUntilNowBeforeEstimatingFreeToUsed() {
         final var capacity = 1_000_000;
-        final var subject = new LeakyBucketDeterministicThrottle(capacity, THROTTLE_NAME);
+        final var subject = new LeakyBucketDeterministicThrottle(capacity, THROTTLE_NAME, 1);
         assertEquals(Long.MAX_VALUE, subject.instantaneousFreeToUsedRatio());
     }
 

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/LeakyBucketThrottleTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/throttles/LeakyBucketThrottleTest.java
@@ -103,4 +103,13 @@ class LeakyBucketThrottleTest {
         assertEquals(
                 BUCKET_CAPACITY - ((BUCKET_CAPACITY / 3) * 2), subject.bucket().capacityFree());
     }
+
+    @Test
+    void testAllowsInitialBurst() {
+        LeakyBucketThrottle throttle = new LeakyBucketThrottle(BUCKET_CAPACITY, 2);
+        for (int i = 0; i < 3; i++) {
+            assertTrue(throttle.allow(BUCKET_CAPACITY, SECONDS_TO_NANOSECONDS / 2));
+        }
+        assertFalse(throttle.allow(BUCKET_CAPACITY, 0));
+    }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -873,13 +873,13 @@ public class ThrottleAccumulator {
         }
     }
 
-    private long maxGasPerSecOf(ContractsConfig contractsConfig) {
+    private long maxGasPerSecOf(@NonNull final ContractsConfig contractsConfig) {
         return throttleType.equals(ThrottleType.BACKEND_THROTTLE)
                 ? contractsConfig.maxGasPerSecBackend()
                 : contractsConfig.maxGasPerSec();
     }
 
-    private int gasThrottleBurstSecondsOf(ContractsConfig contractsConfig) {
+    private int gasThrottleBurstSecondsOf(@NonNull final ContractsConfig contractsConfig) {
         return throttleType.equals(ThrottleType.BACKEND_THROTTLE)
                 ? contractsConfig.gasThrottleBurstSeconds()
                 : DEFAULT_BURST_SECONDS;
@@ -892,7 +892,7 @@ public class ThrottleAccumulator {
         if (jumboConfig.isEnabled() && bytesPerSec == 0) {
             log.warn("{} jumbo transactions are enabled, but limited to 0 bytes/sec", throttleType.name());
         }
-        bytesThrottle = new LeakyBucketDeterministicThrottle(bytesPerSec, "Bytes", 1);
+        bytesThrottle = new LeakyBucketDeterministicThrottle(bytesPerSec, "Bytes", DEFAULT_BURST_SECONDS);
         if (throttleMetrics != null) {
             throttleMetrics.setupBytesThrottleMetric(bytesThrottle, configuration);
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -13,6 +13,7 @@ import static com.hedera.hapi.util.HapiUtils.functionOf;
 import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
 import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.populateEthTxData;
 import static com.hedera.node.app.hapi.utils.sysfiles.domain.throttling.ScaleFactor.ONE_TO_ONE;
+import static com.hedera.node.app.hapi.utils.throttles.LeakyBucketThrottle.DEFAULT_BURST_SECONDS;
 import static com.hedera.node.app.service.schedule.impl.handlers.HandlerUtility.childAsOrdinary;
 import static com.hedera.node.app.service.token.AliasUtils.isAlias;
 import static com.hedera.node.app.service.token.AliasUtils.isEntityNumAlias;
@@ -853,10 +854,13 @@ public class ThrottleAccumulator {
     public void applyGasConfig() {
         final var configuration = configSupplier.get();
         final var contractsConfig = configuration.getConfigData(ContractsConfig.class);
-        if (contractsConfig.throttleThrottleByGas() && contractsConfig.maxGasPerSec() == 0) {
+        final var maxGasPerSec = maxGasPerSecOf(contractsConfig);
+        if (contractsConfig.throttleThrottleByGas() && maxGasPerSec == 0) {
             log.warn("{} gas throttling enabled, but limited to 0 gas/sec", throttleType.name());
         }
-        gasThrottle = new LeakyBucketDeterministicThrottle(contractsConfig.maxGasPerSec(), "Gas");
+
+        gasThrottle =
+                new LeakyBucketDeterministicThrottle(maxGasPerSec, "Gas", gasThrottleBurstSecondsOf(contractsConfig));
         if (throttleMetrics != null) {
             throttleMetrics.setupGasThrottleMetric(gasThrottle, configuration);
         }
@@ -869,6 +873,18 @@ public class ThrottleAccumulator {
         }
     }
 
+    private long maxGasPerSecOf(ContractsConfig contractsConfig) {
+        return throttleType.equals(ThrottleType.BACKEND_THROTTLE)
+                ? contractsConfig.maxGasPerSecBackend()
+                : contractsConfig.maxGasPerSec();
+    }
+
+    private int gasThrottleBurstSecondsOf(ContractsConfig contractsConfig) {
+        return throttleType.equals(ThrottleType.BACKEND_THROTTLE)
+                ? contractsConfig.gasThrottleBurstSeconds()
+                : DEFAULT_BURST_SECONDS;
+    }
+
     public void applyBytesConfig() {
         final var configuration = configSupplier.get();
         final var jumboConfig = configuration.getConfigData(JumboTransactionsConfig.class);
@@ -876,7 +892,7 @@ public class ThrottleAccumulator {
         if (jumboConfig.isEnabled() && bytesPerSec == 0) {
             log.warn("{} jumbo transactions are enabled, but limited to 0 bytes/sec", throttleType.name());
         }
-        bytesThrottle = new LeakyBucketDeterministicThrottle(bytesPerSec, "Bytes");
+        bytesThrottle = new LeakyBucketDeterministicThrottle(bytesPerSec, "Bytes", 1);
         if (throttleMetrics != null) {
             throttleMetrics.setupBytesThrottleMetric(bytesThrottle, configuration);
         }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/impl/NetworkUtilizationManagerImplTest.java
@@ -37,7 +37,7 @@ class NetworkUtilizationManagerImplTest {
     private final Instant consensusNow = Instant.ofEpochSecond(1_234_567L, 123);
 
     private final DeterministicThrottle throttle = DeterministicThrottle.withTpsAndBurstPeriodMsNamed(500, 10, "test");
-    private final LeakyBucketDeterministicThrottle gasThrottle = new LeakyBucketDeterministicThrottle(100, "Gas");
+    private final LeakyBucketDeterministicThrottle gasThrottle = new LeakyBucketDeterministicThrottle(100, "Gas", 1);
 
     @LoggingSubject
     private NetworkUtilizationManagerImpl subject;

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -26,6 +26,8 @@ public record ContractsConfig(
                 boolean noncesExternalizationEnabled,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean enforceCreationThrottle,
         @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSec,
+        @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSecBackend,
+        @ConfigProperty(defaultValue = "2") @NetworkProperty int gasThrottleBurstSeconds,
         @ConfigProperty(value = "maxKvPairs.aggregate", defaultValue = "500000000") @NetworkProperty
                 long maxKvPairsAggregate,
         @ConfigProperty(value = "maxKvPairs.individual", defaultValue = "16384000") @NetworkProperty

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -27,7 +27,7 @@ public record ContractsConfig(
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean enforceCreationThrottle,
         @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSec,
         @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSecBackend,
-        @ConfigProperty(defaultValue = "2") @NetworkProperty int gasThrottleBurstSeconds,
+        @ConfigProperty(defaultValue = "1") @NetworkProperty int gasThrottleBurstSeconds,
         @ConfigProperty(value = "maxKvPairs.aggregate", defaultValue = "500000000") @NetworkProperty
                 long maxKvPairsAggregate,
         @ConfigProperty(value = "maxKvPairs.individual", defaultValue = "16384000") @NetworkProperty

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip423Tests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip423Tests.java
@@ -1354,7 +1354,7 @@ public class RepeatableHip423Tests {
 
     @LeakyRepeatableHapiTest(
             value = NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION,
-            overrides = {"scheduling.whitelist", "contracts.maxGasPerSec"})
+            overrides = {"scheduling.whitelist", "contracts.maxGasPerSec", "contracts.maxGasPerSecBackend"})
     @DisplayName("Gas throttle works as expected")
     final Stream<DynamicTest> gasThrottleWorksAsExpected() {
         final var contract = "TestContract";
@@ -1365,6 +1365,7 @@ public class RepeatableHip423Tests {
         final var gasToOffer = 2_000_000L;
         return hapiTest(flattened(
                 overriding("contracts.maxGasPerSec", "4000000"),
+                overriding("contracts.maxGasPerSecBackend", "4000000"),
                 cryptoCreate("PAYING_ACCOUNT"),
                 uploadTestContracts(contract),
                 contractCreate(contract, addressTwo, BigInteger.ONE)


### PR DESCRIPTION
**Description**:
Add a separate config for backend max gas throttle.  Also add support for optional burst capability across multiple seconds.

**Related issue(s)**:

Fixes #18614 

