### PR TITLE
feat: handle `ResendBlock` block node responses

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
@@ -309,6 +309,42 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
         endStreamAndRestartAtBlock(restartBlockNumber);
     }
 
+    private void handleResendBlock(@NonNull PublishStreamResponse.ResendBlock resendBlock) {
+        final var resendBlockNumber = resendBlock.blockNumber();
+
+        logger.debug(
+                "[{}] Received ResendBlock from block node {} for block {}",
+                Thread.currentThread().getName(),
+                connectionDescriptor,
+                resendBlockNumber);
+
+        if (blockNodeConnectionManager.isBlockAlreadyAcknowledged(resendBlockNumber)) {
+            logger.debug(
+                    "[{}] Block {} already acknowledged, skipping resend for block node {}",
+                    Thread.currentThread().getName(),
+                    resendBlockNumber,
+                    connectionDescriptor);
+            return;
+        }
+
+        final var lastVerifiedBlockNumber = blockNodeConnectionManager.getLastVerifiedBlock(blockNodeConfig);
+        // Check whether the resend block number is the next block after the last verified one
+        if (resendBlockNumber == lastVerifiedBlockNumber + 1L) {
+            logger.debug(
+                    "[{}] Restarting stream at the next block {} after the last verified one for block node {}",
+                    Thread.currentThread().getName(),
+                    resendBlockNumber,
+                    connectionDescriptor);
+            endStreamAndRestartAtBlock(resendBlockNumber);
+        } else {
+            logger.warn(
+                    "[{}] Received ResendBlock for block {} but last verified block is {}",
+                    Thread.currentThread().getName(),
+                    resendBlockNumber,
+                    lastVerifiedBlockNumber);
+        }
+    }
+
     private void removeFromActiveConnections(BlockNodeConfig node) {
         blockNodeConnectionManager.disconnectFromNode(node);
     }
@@ -506,14 +542,11 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
             handleEndOfStream(response.endStream());
         } else if (response.hasSkipBlock()) {
             logger.debug(
-                    "Received SkipBlock from Block Node {}  Block #{}",
+                    "Received SkipBlock from block node {}  Block #{}",
                     connectionDescriptor,
                     response.skipBlock().blockNumber());
         } else if (response.hasResendBlock()) {
-            logger.debug(
-                    "Received ResendBlock from Block Node {}  Block #{}",
-                    connectionDescriptor,
-                    response.resendBlock().blockNumber());
+            handleResendBlock(response.resendBlock());
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
@@ -315,7 +315,7 @@ public class BlockNodeConnectionManager {
             @NonNull final BlockNodeConfig blockNodeConfig, @Nullable final Long blockNumber) {
         requireNonNull(blockNodeConfig);
 
-        final Long latestBlock = lastVerifiedBlockPerConnection.computeIfAbsent(blockNodeConfig, key -> -1L);
+        final Long latestBlock = getLastVerifiedBlock(blockNodeConfig);
         if (blockNumber != null && blockNumber > latestBlock) {
             lastVerifiedBlockPerConnection.put(blockNodeConfig, blockNumber);
         } else {
@@ -325,5 +325,24 @@ public class BlockNodeConnectionManager {
                     blockNumber,
                     latestBlock);
         }
+    }
+
+    /**
+     * @param blockNodeConfig the configuration for the block node
+     * @return the last verified block number by the given block node.
+     */
+    public Long getLastVerifiedBlock(@NonNull final BlockNodeConfig blockNodeConfig) {
+        requireNonNull(blockNodeConfig);
+        return lastVerifiedBlockPerConnection.computeIfAbsent(blockNodeConfig, key -> -1L);
+    }
+
+    /**
+     * @param blockNumber the block number to check for acknowledgements
+     * @return whether the block has been acknowledged by any connection.
+     */
+    public boolean isBlockAlreadyAcknowledged(@NonNull final Long blockNumber) {
+        requireNonNull(blockNumber);
+        return lastVerifiedBlockPerConnection.values().stream()
+                .anyMatch(verifiedBlock -> verifiedBlock.equals(blockNumber));
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
@@ -826,7 +826,13 @@ class BlockNodeConnectionTest {
         connectionSpy.onNext(response);
 
         // Assert connection restarts after the last verified block number
-        verify(connectionSpy).endStreamAndRestartAtBlock(endOfStream.blockNumber() + 1L);
+        verify(connectionSpy, times(1)).endStreamAndRestartAtBlock(endOfStream.blockNumber() + 1L);
+        verify(connectionSpy, times(1)).close();
+        verify(connectionSpy, times(1)).setCurrentBlockNumber(endOfStream.blockNumber() + 1L);
+        verify(connectionSpy, times(1)).establishStream();
+
+        assertEquals(endOfStream.blockNumber() + 1L, connection.getCurrentBlockNumber());
+        assertEquals(0, connection.getCurrentRequestIndex());
 
         // Verify log messages for end of stream
         final String expectedLog =
@@ -856,7 +862,13 @@ class BlockNodeConnectionTest {
         connectionSpy.onNext(response);
 
         // Assert connection restarts after the last verified block number
-        // verify(connectionSpy).endStreamAndRestartAtBlock(resendBlock.blockNumber() + 1L);
+        verify(connectionSpy, times(1)).endStreamAndRestartAtBlock(resendBlock.blockNumber());
+        verify(connectionSpy, times(1)).close();
+        verify(connectionSpy, times(1)).setCurrentBlockNumber(resendBlock.blockNumber());
+        verify(connectionSpy, times(1)).establishStream();
+
+        assertEquals(resendBlock.blockNumber(), connection.getCurrentBlockNumber());
+        assertEquals(0, connection.getCurrentRequestIndex());
 
         // Verify log messages for resend block
         final String expectedLog = "Received ResendBlock from block node " + TEST_CONNECTION_DESCRIPTOR + " for block "
@@ -888,11 +900,9 @@ class BlockNodeConnectionTest {
                 PublishStreamResponse.newBuilder().resendBlock(resendBlock).build();
 
         when(connectionManager.getLastVerifiedBlock(blockNodeConfig)).thenReturn(lastVerifiedBlockNumber);
+
         // Act
         connectionSpy.onNext(response);
-
-        // Assert connection restarts after the last verified block number
-        // verify(connectionSpy).endStreamAndRestartAtBlock(resendBlock.blockNumber() + 1L);
 
         // Verify log messages for resend block
         final String expectedLog = "Received ResendBlock from block node " + TEST_CONNECTION_DESCRIPTOR + " for block "
@@ -922,11 +932,9 @@ class BlockNodeConnectionTest {
                 PublishStreamResponse.newBuilder().resendBlock(resendBlock).build();
 
         when(connectionManager.isBlockAlreadyAcknowledged(TEST_BLOCK_NUMBER)).thenReturn(true);
+
         // Act
         connectionSpy.onNext(response);
-
-        // Assert connection restarts after the last verified block number
-        // verify(connectionSpy).endStreamAndRestartAtBlock(resendBlock.blockNumber() + 1L);
 
         // Verify log messages for resend block
         final String expectedLog = "Received ResendBlock from block node " + TEST_CONNECTION_DESCRIPTOR + " for block "

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
@@ -829,11 +829,117 @@ class BlockNodeConnectionTest {
         verify(connectionSpy).endStreamAndRestartAtBlock(endOfStream.blockNumber() + 1L);
 
         // Verify log messages for end of stream
-        final String expectedLog = "Received EndOfStream from block node";
+        final String expectedLog =
+                "Received EndOfStream from block node " + TEST_CONNECTION_DESCRIPTOR + " at block " + TEST_BLOCK_NUMBER;
         assertTrue(
                 logCaptor.debugLogs().stream().anyMatch(log -> log.contains(expectedLog))
                         || logCaptor.errorLogs().stream().anyMatch(log -> log.contains(expectedLog)),
                 "Expected log message not found: " + expectedLog);
+    }
+
+    /**
+     * Tests the onNext method handling a PublishStreamResponse
+     * with a ResendBlock for the next block after the last verified one.
+     */
+    @Test
+    void testOnNext_WithResendBlock() {
+        // Arrange
+        final BlockNodeConnection connectionSpy = spy(connection);
+        final PublishStreamResponse.ResendBlock resendBlock = PublishStreamResponse.ResendBlock.newBuilder()
+                .blockNumber(TEST_BLOCK_NUMBER)
+                .build();
+        final PublishStreamResponse response =
+                PublishStreamResponse.newBuilder().resendBlock(resendBlock).build();
+
+        when(connectionManager.getLastVerifiedBlock(blockNodeConfig)).thenReturn(TEST_BLOCK_NUMBER - 1L);
+        // Act
+        connectionSpy.onNext(response);
+
+        // Assert connection restarts after the last verified block number
+        // verify(connectionSpy).endStreamAndRestartAtBlock(resendBlock.blockNumber() + 1L);
+
+        // Verify log messages for resend block
+        final String expectedLog = "Received ResendBlock from block node " + TEST_CONNECTION_DESCRIPTOR + " for block "
+                + TEST_BLOCK_NUMBER;
+        assertTrue(
+                logCaptor.debugLogs().stream().anyMatch(log -> log.contains(expectedLog)),
+                "Expected log message not found: " + expectedLog);
+        final String expectedLogForCorrectResendBlock = "Restarting stream at the next block " + TEST_BLOCK_NUMBER
+                + " after the last verified one for block node " + TEST_CONNECTION_DESCRIPTOR;
+        assertTrue(
+                logCaptor.debugLogs().stream().anyMatch(log -> log.contains(expectedLogForCorrectResendBlock)),
+                "Expected log message not found: " + expectedLogForCorrectResendBlock);
+    }
+
+    /**
+     * Tests the onNext method handling a PublishStreamResponse
+     * with a ResendBlock for the next block after the last verified one.
+     */
+    @Test
+    void testOnNext_WithResendBlockDifferentThanExpected() {
+        final var lastVerifiedBlockNumber = TEST_BLOCK_NUMBER * 2L;
+
+        // Arrange
+        final BlockNodeConnection connectionSpy = spy(connection);
+        final PublishStreamResponse.ResendBlock resendBlock = PublishStreamResponse.ResendBlock.newBuilder()
+                .blockNumber(TEST_BLOCK_NUMBER)
+                .build();
+        final PublishStreamResponse response =
+                PublishStreamResponse.newBuilder().resendBlock(resendBlock).build();
+
+        when(connectionManager.getLastVerifiedBlock(blockNodeConfig)).thenReturn(lastVerifiedBlockNumber);
+        // Act
+        connectionSpy.onNext(response);
+
+        // Assert connection restarts after the last verified block number
+        // verify(connectionSpy).endStreamAndRestartAtBlock(resendBlock.blockNumber() + 1L);
+
+        // Verify log messages for resend block
+        final String expectedLog = "Received ResendBlock from block node " + TEST_CONNECTION_DESCRIPTOR + " for block "
+                + TEST_BLOCK_NUMBER;
+        assertTrue(
+                logCaptor.debugLogs().stream().anyMatch(log -> log.contains(expectedLog)),
+                "Expected log message not found: " + expectedLog);
+        final String expectedLogForDifferentResendBlock = "Received ResendBlock for block " + TEST_BLOCK_NUMBER
+                + " but last verified block is " + lastVerifiedBlockNumber;
+        assertTrue(
+                logCaptor.warnLogs().stream().anyMatch(log -> log.contains(expectedLogForDifferentResendBlock)),
+                "Expected log message not found: " + expectedLogForDifferentResendBlock);
+    }
+
+    /**
+     * Tests the onNext method handling a PublishStreamResponse
+     * with a ResendBlock for already acknowledged block.
+     */
+    @Test
+    void testOnNext_WithResendBlockForAlreadyAcknowledgedBlock() {
+        // Arrange
+        final BlockNodeConnection connectionSpy = spy(connection);
+        final PublishStreamResponse.ResendBlock resendBlock = PublishStreamResponse.ResendBlock.newBuilder()
+                .blockNumber(TEST_BLOCK_NUMBER)
+                .build();
+        final PublishStreamResponse response =
+                PublishStreamResponse.newBuilder().resendBlock(resendBlock).build();
+
+        when(connectionManager.isBlockAlreadyAcknowledged(TEST_BLOCK_NUMBER)).thenReturn(true);
+        // Act
+        connectionSpy.onNext(response);
+
+        // Assert connection restarts after the last verified block number
+        // verify(connectionSpy).endStreamAndRestartAtBlock(resendBlock.blockNumber() + 1L);
+
+        // Verify log messages for resend block
+        final String expectedLog = "Received ResendBlock from block node " + TEST_CONNECTION_DESCRIPTOR + " for block "
+                + TEST_BLOCK_NUMBER;
+        assertTrue(
+                logCaptor.debugLogs().stream().anyMatch(log -> log.contains(expectedLog)),
+                "Expected log message not found: " + expectedLog);
+        final String expectedLogForResendBlockAlreadyAcknowledged = "Block " + TEST_BLOCK_NUMBER
+                + " already acknowledged, skipping resend for block node " + TEST_CONNECTION_DESCRIPTOR;
+        assertTrue(
+                logCaptor.debugLogs().stream()
+                        .anyMatch(log -> log.contains(expectedLogForResendBlockAlreadyAcknowledged)),
+                "Expected log message not found: " + expectedLogForResendBlockAlreadyAcknowledged);
     }
 
     /**


### PR DESCRIPTION
**Description**:
The PR implements the handling of `ResendBlock`'s responses from Block Nodes. In those cases, the consensus node should restart the stream and try resending the specified block in the message or it might choose to end the stream if the specified block in `ResendBlock` message has already been acknowledged by any other connection.

**Related issue(s)**:

Fixes #18254 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
