### PR TITLE
chore: Disable all examples for Otter Test Framework

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationTest.java
@@ -8,6 +8,7 @@ import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.OtterTest;
 import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
+import org.junit.jupiter.api.Disabled;
 
 class BirthRoundMigrationTest {
 
@@ -15,6 +16,7 @@ class BirthRoundMigrationTest {
     private static final Duration ONE_MINUTE = Duration.ofMinutes(1L);
 
     @OtterTest
+    @Disabled
     void testBirthRoundMigration(TestEnvironment env) throws InterruptedException {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/HappyPathTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/HappyPathTest.java
@@ -8,10 +8,12 @@ import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
 import org.hiero.otter.fixtures.Validator.Profile;
 import org.hiero.otter.fixtures.turtle.TurtleNode;
+import org.junit.jupiter.api.Disabled;
 
 public class HappyPathTest {
 
     @OtterTest
+    @Disabled
     void testHappyPath(TestEnvironment env) throws InterruptedException {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
@@ -15,6 +15,7 @@ import org.hiero.otter.fixtures.OtterTest;
 import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
 import org.hiero.otter.fixtures.Validator.Profile;
+import org.junit.jupiter.api.Disabled;
 
 public class SandboxTest {
 
@@ -23,6 +24,7 @@ public class SandboxTest {
     private static final Duration TWO_MINUTES = Duration.ofMinutes(2);
 
     @OtterTest
+    @Disabled
     void testConsistencyNDReconnect(TestEnvironment env) throws InterruptedException {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();
@@ -59,6 +61,7 @@ public class SandboxTest {
     }
 
     @OtterTest
+    @Disabled
     void testBranching(TestEnvironment env) throws InterruptedException {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();


### PR DESCRIPTION
**Description**:

This PR disables all examples for the Otter Test Framework. The framework is not ready yet and the tests are not meant to be executed right now.

**Related issue(s)**:

Part of #18630 
