### PR TITLE
fix: 18771: Backport fixes for 18593, 18795, 18844, and 18903 to release 0.61

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDb.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDb.java
@@ -443,7 +443,7 @@ public final class MerkleDb {
             final int tableId,
             final String tableName,
             final boolean dbCompactionEnabled,
-            final boolean useDiskIndices)
+            final boolean offlineUse)
             throws IOException {
         final MerkleDbTableConfig tableConfig = getTableConfig(tableId);
         if (tableConfig == null) {
@@ -456,7 +456,7 @@ public final class MerkleDb {
             }
             try {
                 return new MerkleDbDataSource(
-                        this, config, tableName, tableId, tableConfig, dbCompactionEnabled, useDiskIndices);
+                        this, config, tableName, tableId, tableConfig, dbCompactionEnabled, offlineUse);
             } catch (final IOException z) {
                 rethrowIO.set(z);
                 return null;

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDb.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDb.java
@@ -353,7 +353,7 @@ public final class MerkleDb {
         final int tableId = getNextTableId();
         tableConfigs.set(tableId, new TableMetadata(tableId, label, tableConfig));
         final MerkleDbDataSource dataSource =
-                new MerkleDbDataSource(this, label, tableId, tableConfig, dbCompactionEnabled, false);
+                new MerkleDbDataSource(this, configuration, label, tableId, tableConfig, dbCompactionEnabled, false);
         dataSources.set(tableId, dataSource);
         // New tables are always primary
         primaryTables.add(tableId);
@@ -383,7 +383,7 @@ public final class MerkleDb {
         final String label = dataSource.getTableName();
         final int tableId = getNextTableId();
         importDataSource(dataSource, tableId, !makeCopyPrimary, makeCopyPrimary); // import to itself == copy
-        return getDataSource(tableId, label, makeCopyPrimary, offlineUse);
+        return getDataSource(configuration, tableId, label, makeCopyPrimary, offlineUse);
     }
 
     private void importDataSource(
@@ -414,6 +414,10 @@ public final class MerkleDb {
         storeMetadata();
     }
 
+    public MerkleDbDataSource getDataSource(final String name, final boolean dbCompactionEnabled) throws IOException {
+        return getDataSource(configuration, name, dbCompactionEnabled);
+    }
+
     /**
      * Returns a data source with the given name. If the data source isn't opened yet (e.g. on
      * restore from a snapshot), opens it first. If there is no table configuration for the given
@@ -424,17 +428,22 @@ public final class MerkleDb {
      *     data source. If the data source was previously opened, this flag is ignored
      * @return The datasource
      */
-    public MerkleDbDataSource getDataSource(final String name, final boolean dbCompactionEnabled) throws IOException {
+    public MerkleDbDataSource getDataSource(
+            final Configuration config, final String name, final boolean dbCompactionEnabled) throws IOException {
         final TableMetadata metadata = getTableMetadata(name);
         if (metadata == null) {
             throw new IllegalStateException("Unknown table: " + name);
         }
         final int tableId = metadata.getTableId();
-        return getDataSource(tableId, name, dbCompactionEnabled, false);
+        return getDataSource(config, tableId, name, dbCompactionEnabled, false);
     }
 
     private MerkleDbDataSource getDataSource(
-            final int tableId, final String tableName, final boolean dbCompactionEnabled, final boolean useDiskIndices)
+            final Configuration config,
+            final int tableId,
+            final String tableName,
+            final boolean dbCompactionEnabled,
+            final boolean useDiskIndices)
             throws IOException {
         final MerkleDbTableConfig tableConfig = getTableConfig(tableId);
         if (tableConfig == null) {
@@ -447,7 +456,7 @@ public final class MerkleDb {
             }
             try {
                 return new MerkleDbDataSource(
-                        this, tableName, tableId, tableConfig, dbCompactionEnabled, useDiskIndices);
+                        this, config, tableName, tableId, tableConfig, dbCompactionEnabled, useDiskIndices);
             } catch (final IOException z) {
                 rethrowIO.set(z);
                 return null;

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -48,6 +48,7 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.Objects;
@@ -170,6 +171,7 @@ public final class MerkleDbDataSource implements VirtualDataSource {
 
     public MerkleDbDataSource(
             final MerkleDb database,
+            final Configuration config,
             final String tableName,
             final int tableId,
             final MerkleDbTableConfig tableConfig,
@@ -182,7 +184,6 @@ public final class MerkleDbDataSource implements VirtualDataSource {
         this.tableConfig = tableConfig;
         this.preferDiskBasedIndices = preferDiskBasedIndices;
 
-        final Configuration config = database.getConfiguration();
         final MerkleDbConfig merkleDbConfig = config.getConfigData(MerkleDbConfig.class);
 
         // create thread group with label
@@ -241,7 +242,7 @@ public final class MerkleDbDataSource implements VirtualDataSource {
         final long pathIndexCapacity = virtualSize * 2;
 
         final boolean forceIndexRebuilding = merkleDbConfig.indexRebuildingEnforced();
-        // path to disk location index, hashes
+        // Path to disk location index, hashes
         final Path pathToHashLocationFile = dbPaths.pathToDiskLocationInternalNodesFile;
         if (Files.exists(pathToHashLocationFile) && !forceIndexRebuilding) {
             pathToDiskLocationInternalNodes = preferDiskBasedIndices
@@ -252,7 +253,7 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                     ? new LongListDisk(pathIndexCapacity, config)
                     : new LongListOffHeap(pathIndexCapacity, config);
         }
-        // path to disk location index, leaf nodes
+        // Path to disk location index, leaf nodes
         final Path pathToLeafLocationFile = dbPaths.pathToDiskLocationLeafNodesFile;
         if (Files.exists(pathToLeafLocationFile) && !forceIndexRebuilding) {
             pathToDiskLocationLeafNodes = preferDiskBasedIndices
@@ -264,7 +265,7 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                     : new LongListOffHeap(pathIndexCapacity, config);
         }
 
-        // internal node hashes store, RAM
+        // Hashes store, RAM
         final long hashesRamToDiskThreshold = tableConfig.getHashesRamToDiskThreshold();
         if (hashesRamToDiskThreshold > 0) {
             if (Files.exists(dbPaths.hashStoreRamFile)) {
@@ -276,16 +277,9 @@ public final class MerkleDbDataSource implements VirtualDataSource {
             hashStoreRam = null;
         }
 
-        statisticsUpdater = new MerkleDbStatisticsUpdater(merkleDbConfig, tableName);
-
-        final Runnable updateTotalStatsFunction = () -> {
-            statisticsUpdater.updateStoreFileStats(this);
-            statisticsUpdater.updateOffHeapStats(this);
-        };
-
-        // internal node hashes store, on disk
+        // Hashes store, on disk (paths to hashes)
+        final String hashStoreDiskStoreName = tableName + "_internalhashes";
         hasDiskStoreForHashes = tableConfig.getHashesRamToDiskThreshold() < Long.MAX_VALUE;
-        final DataFileCompactor hashStoreDiskFileCompactor;
         if (hasDiskStoreForHashes) {
             final boolean needRestorePathToDiskLocationInternalNodes = pathToDiskLocationInternalNodes.size() == 0;
             final LoadedDataCallback hashRecordLoadedCallback;
@@ -304,49 +298,18 @@ public final class MerkleDbDataSource implements VirtualDataSource {
             } else {
                 hashRecordLoadedCallback = null;
             }
-            final String storeName = tableName + "_internalhashes";
             hashStoreDisk = new MemoryIndexDiskKeyValueStore(
                     merkleDbConfig,
                     dbPaths.hashStoreDiskDirectory,
-                    storeName,
+                    hashStoreDiskStoreName,
                     tableName + ":internalHashes",
                     hashRecordLoadedCallback,
                     pathToDiskLocationInternalNodes);
-            hashStoreDiskFileCompactor = new DataFileCompactor(
-                    merkleDbConfig,
-                    storeName,
-                    hashStoreDisk.getFileCollection(),
-                    pathToDiskLocationInternalNodes,
-                    statisticsUpdater::setHashesStoreCompactionTimeMs,
-                    statisticsUpdater::setHashesStoreCompactionSavedSpaceMb,
-                    statisticsUpdater::setHashesStoreFileSizeByLevelMb,
-                    updateTotalStatsFunction);
         } else {
             hashStoreDisk = null;
-            hashStoreDiskFileCompactor = null;
         }
 
-        final DataFileCompactor keyToPathFileCompactor;
-        // key to path store
-        String keyToPathStoreName = tableName + "_objectkeytopath";
-        keyToPath = new HalfDiskHashMap(
-                database.getConfiguration(),
-                tableConfig.getMaxNumberOfKeys(),
-                dbPaths.keyToPathDirectory,
-                keyToPathStoreName,
-                tableName + ":objectKeyToPath",
-                preferDiskBasedIndices);
-        keyToPathFileCompactor = new DataFileCompactor(
-                merkleDbConfig,
-                keyToPathStoreName,
-                keyToPath.getFileCollection(),
-                keyToPath.getBucketIndexToBucketLocation(),
-                statisticsUpdater::setLeafKeysStoreCompactionTimeMs,
-                statisticsUpdater::setLeafKeysStoreCompactionSavedSpaceMb,
-                statisticsUpdater::setLeafKeysStoreFileSizeByLevelMb,
-                updateTotalStatsFunction);
-        keyToPath.printStats();
-
+        // Leaves store (path to KV)
         final LoadedDataCallback leafRecordLoadedCallback;
         final boolean needRestorePathToDiskLocationLeafNodes =
                 (pathToDiskLocationLeafNodes.size() == 0) && (validLeafPathRange.getMinValidKey() > 0);
@@ -366,7 +329,6 @@ public final class MerkleDbDataSource implements VirtualDataSource {
         } else {
             leafRecordLoadedCallback = null;
         }
-        // Create path to key/value store, this will create new or load if files exist
         final String pathToKeyValueStoreName = tableName + "_pathtohashkeyvalue";
         pathToKeyValue = new MemoryIndexDiskKeyValueStore(
                 merkleDbConfig,
@@ -375,6 +337,51 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                 tableName + ":pathToHashKeyValue",
                 leafRecordLoadedCallback,
                 pathToDiskLocationLeafNodes);
+
+        // Keys (keys to paths)
+        String keyToPathStoreName = tableName + "_objectkeytopath";
+        keyToPath = new HalfDiskHashMap(
+                config,
+                tableConfig.getMaxNumberOfKeys(),
+                dbPaths.keyToPathDirectory,
+                keyToPathStoreName,
+                tableName + ":objectKeyToPath",
+                preferDiskBasedIndices);
+        keyToPath.printStats();
+        final String tablesToRepairHdhmConfig = merkleDbConfig.tablesToRepairHdhm();
+        if (tablesToRepairHdhmConfig != null) {
+            final String[] tableNames = tablesToRepairHdhmConfig.split(",");
+            if (Arrays.stream(tableNames).filter(s -> !s.isBlank()).anyMatch(tableName::equals)) {
+                keyToPath.repair(getFirstLeafPath(), getLastLeafPath(), pathToKeyValue);
+            }
+        }
+
+        // Leaf records cache
+        leafRecordCacheSize = merkleDbConfig.leafRecordCacheSize();
+        leafRecordCache = (leafRecordCacheSize > 0) ? new VirtualLeafBytes[leafRecordCacheSize] : null;
+
+        // Stats
+        statisticsUpdater = new MerkleDbStatisticsUpdater(merkleDbConfig, tableName);
+        final Runnable updateTotalStatsFunction = () -> {
+            statisticsUpdater.updateStoreFileStats(this);
+            statisticsUpdater.updateOffHeapStats(this);
+        };
+
+        // Compactors
+        final DataFileCompactor hashStoreDiskFileCompactor;
+        if (hasDiskStoreForHashes) {
+            hashStoreDiskFileCompactor = new DataFileCompactor(
+                    merkleDbConfig,
+                    hashStoreDiskStoreName,
+                    hashStoreDisk.getFileCollection(),
+                    pathToDiskLocationInternalNodes,
+                    statisticsUpdater::setHashesStoreCompactionTimeMs,
+                    statisticsUpdater::setHashesStoreCompactionSavedSpaceMb,
+                    statisticsUpdater::setHashesStoreFileSizeByLevelMb,
+                    updateTotalStatsFunction);
+        } else {
+            hashStoreDiskFileCompactor = null;
+        }
         final DataFileCompactor pathToKeyValueFileCompactor = new DataFileCompactor(
                 merkleDbConfig,
                 pathToKeyValueStoreName,
@@ -384,10 +391,24 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                 statisticsUpdater::setLeavesStoreCompactionSavedSpaceMb,
                 statisticsUpdater::setLeavesStoreFileSizeByLevelMb,
                 updateTotalStatsFunction);
-
-        // Leaf records cache
-        leafRecordCacheSize = merkleDbConfig.leafRecordCacheSize();
-        leafRecordCache = (leafRecordCacheSize > 0) ? new VirtualLeafBytes[leafRecordCacheSize] : null;
+        final DataFileCompactor keyToPathFileCompactor = new DataFileCompactor(
+                merkleDbConfig,
+                keyToPathStoreName,
+                keyToPath.getFileCollection(),
+                keyToPath.getBucketIndexToBucketLocation(),
+                statisticsUpdater::setLeafKeysStoreCompactionTimeMs,
+                statisticsUpdater::setLeafKeysStoreCompactionSavedSpaceMb,
+                statisticsUpdater::setLeafKeysStoreFileSizeByLevelMb,
+                updateTotalStatsFunction);
+        compactionCoordinator = new MerkleDbCompactionCoordinator(
+                tableName,
+                keyToPathFileCompactor,
+                hashStoreDiskFileCompactor,
+                pathToKeyValueFileCompactor,
+                merkleDbConfig);
+        if (compactionEnabled) {
+            enableBackgroundCompaction();
+        }
 
         // Update count of open databases
         COUNT_OF_OPEN_DATABASES.increment();
@@ -399,17 +420,6 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                 storageDir,
                 tableConfig.getMaxNumberOfKeys(),
                 tableConfig.getHashesRamToDiskThreshold());
-
-        compactionCoordinator = new MerkleDbCompactionCoordinator(
-                tableName,
-                keyToPathFileCompactor,
-                hashStoreDiskFileCompactor,
-                pathToKeyValueFileCompactor,
-                merkleDbConfig);
-
-        if (compactionEnabled) {
-            enableBackgroundCompaction();
-        }
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -50,6 +50,10 @@ import com.swirlds.config.extensions.validators.DefaultConfigViolation;
  * @param indexRebuildingEnforced
  * 		Configuration used to avoid reading stored indexes from a saved state and enforce rebuilding those indexes from
  * 		data files.
+ * @param tablesToRepairHdhm
+ *      Comma-delimited list of data source names, may be empty. When a MerkleDb data source with a name from the
+ *      list is loaded from a snapshot, its key to path map will be rebuilt from path to KV data files. Note that
+ *      to rebuild the map may take very long. Don't enable it for large tables!
  * @param percentHalfDiskHashMapFlushThreads
  *      Percentage, from 0.0 to 100.0, of available processors to use for half disk hash map background flushing
  *      threads.
@@ -81,6 +85,7 @@ public record MerkleDbConfig(
         @Positive @ConfigProperty(defaultValue = "16777216") int iteratorInputBufferBytes,
         @ConfigProperty(defaultValue = "false") boolean reconnectKeyLeakMitigationEnabled,
         @ConfigProperty(defaultValue = "false") boolean indexRebuildingEnforced,
+        @ConfigProperty(defaultValue = "") String tablesToRepairHdhm,
         @ConfigProperty(defaultValue = "75.0") double percentHalfDiskHashMapFlushThreads,
         @ConfigProperty(defaultValue = "-1") int numHalfDiskHashMapFlushThreads,
         @ConfigProperty(defaultValue = "1048576") int leafRecordCacheSize,

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -87,7 +87,7 @@ public record MerkleDbConfig(
         @ConfigProperty(defaultValue = "false") boolean indexRebuildingEnforced,
         @ConfigProperty(
                         defaultValue =
-                                "ScheduleService.SCHEDULED_COUNTS,ScheduleService.SCHEDULED_ORDERS,ScheduleService.SCHEDULED_USAGES,ScheduleService.SCHEDULES_BY_ID,ScheduleService.SCHEDULE_ID_BY_EQUALITY,TokenService.PENDING_AIRDROPS")
+                                "ScheduleService.SCHEDULED_COUNTS,ScheduleService.SCHEDULED_ORDERS,ScheduleService.SCHEDULED_USAGES,ScheduleService.SCHEDULES_BY_ID,ScheduleService.SCHEDULE_ID_BY_EQUALITY")
                 String tablesToRepairHdhm,
         @ConfigProperty(defaultValue = "75.0") double percentHalfDiskHashMapFlushThreads,
         @ConfigProperty(defaultValue = "-1") int numHalfDiskHashMapFlushThreads,

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -85,7 +85,10 @@ public record MerkleDbConfig(
         @Positive @ConfigProperty(defaultValue = "16777216") int iteratorInputBufferBytes,
         @ConfigProperty(defaultValue = "false") boolean reconnectKeyLeakMitigationEnabled,
         @ConfigProperty(defaultValue = "false") boolean indexRebuildingEnforced,
-        @ConfigProperty(defaultValue = "") String tablesToRepairHdhm,
+        @ConfigProperty(
+                        defaultValue =
+                                "ScheduleService.SCHEDULED_COUNTS,ScheduleService.SCHEDULED_ORDERS,ScheduleService.SCHEDULED_USAGES,ScheduleService.SCHEDULES_BY_ID,ScheduleService.SCHEDULE_ID_BY_EQUALITY,TokenService.PENDING_AIRDROPS")
+                String tablesToRepairHdhm,
         @ConfigProperty(defaultValue = "75.0") double percentHalfDiskHashMapFlushThreads,
         @ConfigProperty(defaultValue = "-1") int numHalfDiskHashMapFlushThreads,
         @ConfigProperty(defaultValue = "1048576") int leafRecordCacheSize,

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -20,6 +20,8 @@ import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.files.DataFileCollection;
 import com.swirlds.merkledb.files.DataFileCollection.LoadedDataCallback;
 import com.swirlds.merkledb.files.DataFileReader;
+import com.swirlds.merkledb.files.MemoryIndexDiskKeyValueStore;
+import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.DataInputStream;
@@ -93,11 +95,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
      * that we can optimize and avoid the cost of doing a % to find the bucket index from hash code.
      */
     private final int numOfBuckets;
-    /**
-     * The requested max size for the map, this is the maximum number of key/values expected to be
-     * stored in this map.
-     */
-    private final long mapSize;
+
     /** The name to use for the files prefix on disk */
     private final String storeName;
 
@@ -204,7 +202,6 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
             throws IOException {
         requireNonNull(configuration);
         this.merkleDbConfig = configuration.getConfigData(MerkleDbConfig.class);
-        this.mapSize = mapSize;
         this.storeName = storeName;
         Path indexFile = storeDir.resolve(storeName + BUCKET_INDEX_FILENAME_SUFFIX);
         // create bucket pool
@@ -300,6 +297,87 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
             metaOut.writeInt(numOfBuckets);
             metaOut.flush();
         }
+    }
+
+    /**
+     * Removes all stale and unknown keys from this HalfDiskHashMap using leaf information from the
+     * provided store. This method iterates over all key to path entries in this map, gets the paths,
+     * loads leaf records by the paths, and compares to the original keys. If the key from the entry
+     * doesn't match the key from the leaf record, the entry is deleted from this map. If the key
+     * from the entry is outside the given path range, the entry is deleted, too.
+     *
+     * @param firstLeafPath The first leaf path
+     * @param lastLeafPath The last leaf path
+     * @param store Path to KV store to check the keys
+     * @throws IOException If an I/O error occurs
+     */
+    public void repair(final long firstLeafPath, final long lastLeafPath, final MemoryIndexDiskKeyValueStore store)
+            throws IOException {
+        logger.info(
+                MERKLE_DB.getMarker(),
+                "Rebuilding HDHM {}, leaf path range [{},{}]",
+                storeName,
+                firstLeafPath,
+                lastLeafPath);
+        startWriting();
+        for (int i = 0; i < numOfBuckets; i++) {
+            final long bucketId = i;
+            final long bucketDataLocation = bucketIndexToBucketLocation.get(bucketId);
+            if (bucketDataLocation <= 0) {
+                continue;
+            }
+            final BufferedData bucketData =
+                    fileCollection.readDataItemUsingIndex(bucketIndexToBucketLocation, bucketId);
+            if (bucketData == null) {
+                throw new IOException("Cannot read bucket=" + bucketId + ", data location=" + bucketDataLocation);
+            }
+            try (final ParsedBucket bucket = new ParsedBucket()) {
+                bucket.readFrom(bucketData);
+                if (bucket.getBucketIndex() != bucketId) {
+                    logger.warn(MERKLE_DB.getMarker(), "Delete stale bucket: {}", bucketId);
+                    bucketIndexToBucketLocation.remove(bucketId);
+                    continue;
+                }
+                bucket.forEachEntry(entry -> {
+                    final Bytes keyBytes = entry.getKeyBytes();
+                    final long path = entry.getValue();
+                    try {
+                        boolean removeKey = true;
+                        if ((path < firstLeafPath) || (path > lastLeafPath)) {
+                            logger.warn(
+                                    MERKLE_DB.getMarker(), "Delete key (path range): key={}, path={}", keyBytes, path);
+                        } else {
+                            final BufferedData recordBytes = store.get(path);
+                            assert recordBytes != null;
+                            final VirtualLeafBytes record = VirtualLeafBytes.parseFrom(recordBytes);
+                            if (!record.keyBytes().equals(keyBytes)) {
+                                logger.warn(
+                                        MERKLE_DB.getMarker(),
+                                        "Delete key (stale): path={}, expected={}, actual={}",
+                                        path,
+                                        record.keyBytes(),
+                                        keyBytes);
+                            } else {
+                                assert record.path() == path;
+                                removeKey = false;
+                            }
+                        }
+                        if (removeKey) {
+                            delete(keyBytes, entry.getHashCode());
+                        }
+                    } catch (final Exception e) {
+                        logger.error(
+                                MERKLE_DB.getMarker(),
+                                "Exception while processing bucket entry, bucket={}, key={} path={}",
+                                bucketId,
+                                keyBytes,
+                                path,
+                                e);
+                    }
+                });
+            }
+        }
+        endWriting();
     }
 
     /** {@inheritDoc} */
@@ -766,11 +844,9 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                 MERKLE_DB.getMarker(),
                 """
                         HalfDiskHashMap Stats {
-                        	mapSize = {}
                         	numOfBuckets = {}
                         	GOOD_AVERAGE_BUCKET_ENTRY_COUNT = {}
                         }""",
-                mapSize,
                 numOfBuckets,
                 GOOD_AVERAGE_BUCKET_ENTRY_COUNT);
     }

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -32,7 +32,9 @@ import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.LongSummaryStatistics;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -320,7 +322,9 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                 storeName,
                 firstLeafPath,
                 lastLeafPath);
-        startWriting();
+        // If no stale bucket entries are found, no need to create a new bucket data file
+        final AtomicBoolean newDataFile = new AtomicBoolean(false);
+        final AtomicLong liveEntries = new AtomicLong(0);
         for (int i = 0; i < numOfBuckets; i++) {
             final long bucketId = i;
             final long bucketDataLocation = bucketIndexToBucketLocation.get(bucketId);
@@ -330,12 +334,14 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
             final BufferedData bucketData =
                     fileCollection.readDataItemUsingIndex(bucketIndexToBucketLocation, bucketId);
             if (bucketData == null) {
-                throw new IOException("Cannot read bucket=" + bucketId + ", data location=" + bucketDataLocation);
+                logger.warn("Delete bucket (not found): {}, dataLocation={}", bucketId, bucketDataLocation);
+                bucketIndexToBucketLocation.remove(bucketId);
+                continue;
             }
             try (final ParsedBucket bucket = new ParsedBucket()) {
                 bucket.readFrom(bucketData);
                 if (bucket.getBucketIndex() != bucketId) {
-                    logger.warn(MERKLE_DB.getMarker(), "Delete stale bucket: {}", bucketId);
+                    logger.warn(MERKLE_DB.getMarker(), "Delete bucket (stale): {}", bucketId);
                     bucketIndexToBucketLocation.remove(bucketId);
                     continue;
                 }
@@ -349,7 +355,9 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                                     MERKLE_DB.getMarker(), "Delete key (path range): key={}, path={}", keyBytes, path);
                         } else {
                             final BufferedData recordBytes = store.get(path);
-                            assert recordBytes != null;
+                            if (recordBytes == null) {
+                                throw new IOException("Record not found in pathToKeyValue store, path=" + path);
+                            }
                             final VirtualLeafBytes record = VirtualLeafBytes.parseFrom(recordBytes);
                             if (!record.keyBytes().equals(keyBytes)) {
                                 logger.warn(
@@ -359,12 +367,16 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                                         record.keyBytes(),
                                         keyBytes);
                             } else {
-                                assert record.path() == path;
                                 removeKey = false;
                             }
                         }
                         if (removeKey) {
+                            if (newDataFile.compareAndSet(false, true)) {
+                                startWriting();
+                            }
                             delete(keyBytes, entry.getHashCode());
+                        } else {
+                            liveEntries.incrementAndGet();
                         }
                     } catch (final Exception e) {
                         logger.error(
@@ -378,7 +390,15 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                 });
             }
         }
-        endWriting();
+        // If a new data file is created, call endWriting()
+        if (newDataFile.get()) {
+            endWriting();
+        }
+        final long expectedEntries = lastLeafPath - firstLeafPath + 1;
+        if (liveEntries.get() != expectedEntries) {
+            throw new IOException(
+                    "HDHM repair failed, expected keys = " + expectedEntries + ", actual = " + liveEntries.get());
+        }
         logger.info(
                 MERKLE_DB.getMarker(),
                 "Rebuilding HDHM {} done, took {} ms",

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -394,7 +394,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
         if (newDataFile.get()) {
             endWriting();
         }
-        final long expectedEntries = lastLeafPath - firstLeafPath + 1;
+        final long expectedEntries = (lastLeafPath == -1) ? 0 : (lastLeafPath - firstLeafPath + 1);
         if (liveEntries.get() != expectedEntries) {
             throw new IOException(
                     "HDHM repair failed, expected keys = " + expectedEntries + ", actual = " + liveEntries.get());

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -313,6 +313,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
      */
     public void repair(final long firstLeafPath, final long lastLeafPath, final MemoryIndexDiskKeyValueStore store)
             throws IOException {
+        final long start = System.currentTimeMillis();
         logger.info(
                 MERKLE_DB.getMarker(),
                 "Rebuilding HDHM {}, leaf path range [{},{}]",
@@ -378,6 +379,11 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
             }
         }
         endWriting();
+        logger.info(
+                MERKLE_DB.getMarker(),
+                "Rebuilding HDHM {} done, took {} ms",
+                storeName,
+                System.currentTimeMillis() - start);
     }
 
     /** {@inheritDoc} */

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/ParsedBucket.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/ParsedBucket.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -145,6 +146,10 @@ public final class ParsedBucket extends Bucket {
         }
     }
 
+    public void forEachEntry(final Consumer<BucketEntry> consumer) {
+        entries.forEach(consumer);
+    }
+
     public void readFrom(final ReadableSequentialData in) {
         // defaults
         bucketIndex = 0;
@@ -225,7 +230,7 @@ public final class ParsedBucket extends Bucket {
      * in a bucket, and a bucket entry already exists for the same key, instead of creating
      * a new entry, we just update the value in the existing entry.
      */
-    private static class BucketEntry {
+    public static class BucketEntry {
 
         /** Key hash code */
         private final int hashCode;

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
@@ -5,12 +5,17 @@ import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
+import com.swirlds.merkledb.collections.LongList;
+import com.swirlds.merkledb.collections.LongListHeap;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.files.DataFileCompactor;
+import com.swirlds.merkledb.files.MemoryIndexDiskKeyValueStore;
 import com.swirlds.merkledb.test.fixtures.ExampleLongKeyFixedSize;
 import com.swirlds.merkledb.test.fixtures.files.FilesTestType;
 import com.swirlds.virtualmap.VirtualKey;
+import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Random;
@@ -35,6 +40,18 @@ class HalfDiskHashMapTest {
                 CONFIGURATION, count, tempDirPath.resolve(testType.name()), "HalfDiskHashMapTest", null, false);
         map.printStats();
         return map;
+    }
+
+    private MemoryIndexDiskKeyValueStore createNewTempKV(FilesTestType testType, int count) throws IOException {
+        final MerkleDbConfig merkleDbConfig = CONFIGURATION.getConfigData(MerkleDbConfig.class);
+        final LongList index = new LongListHeap(count, CONFIGURATION);
+        return new MemoryIndexDiskKeyValueStore(
+                merkleDbConfig,
+                tempDirPath.resolve(testType.name() + "_kv"),
+                "HalfDiskHashMapTestKV",
+                null,
+                null,
+                index);
     }
 
     private static void createSomeData(
@@ -172,6 +189,51 @@ class HalfDiskHashMapTest {
             }
             assertDoesNotThrow(map::endWriting);
         }
+    }
+
+    @Test
+    void testRebuildMap() throws Exception {
+        final FilesTestType testType = FilesTestType.variable;
+        final HalfDiskHashMap map = createNewTempMap(testType, 100);
+
+        map.startWriting();
+        final VirtualKey key1 = testType.createVirtualLongKey(1);
+        map.put(testType.keySerializer.toBytes(key1), key1.hashCode(), 1);
+        final VirtualKey key2 = testType.createVirtualLongKey(2);
+        map.put(testType.keySerializer.toBytes(key2), key2.hashCode(), 2);
+        map.endWriting();
+        map.startWriting();
+        final VirtualKey key3 = testType.createVirtualLongKey(3);
+        map.put(testType.keySerializer.toBytes(key3), key3.hashCode(), 3);
+        final VirtualKey key4 = testType.createVirtualLongKey(4);
+        map.put(testType.keySerializer.toBytes(key4), key4.hashCode(), 4);
+        map.endWriting();
+
+        assertEquals(1, map.get(testType.keySerializer.toBytes(key1), key1.hashCode(), -1));
+        assertEquals(2, map.get(testType.keySerializer.toBytes(key2), key2.hashCode(), -1));
+        assertEquals(3, map.get(testType.keySerializer.toBytes(key3), key3.hashCode(), -1));
+        assertEquals(4, map.get(testType.keySerializer.toBytes(key4), key4.hashCode(), -1));
+
+        final MemoryIndexDiskKeyValueStore kv = createNewTempKV(testType, 100);
+        kv.startWriting();
+        kv.updateValidKeyRange(2, 4);
+        final VirtualLeafBytes rec2 =
+                new VirtualLeafBytes(2, testType.keySerializer.toBytes(key2), key2.hashCode(), Bytes.wrap("12"));
+        kv.put(2, rec2::writeTo, rec2.getSizeInBytes());
+        final VirtualLeafBytes rec3 =
+                new VirtualLeafBytes(3, testType.keySerializer.toBytes(key3), key3.hashCode(), Bytes.wrap("13"));
+        kv.put(3, rec3::writeTo, rec3.getSizeInBytes());
+        final VirtualLeafBytes rec4 =
+                new VirtualLeafBytes(4, testType.keySerializer.toBytes(key4), key4.hashCode(), Bytes.wrap("14"));
+        kv.put(4, rec4::writeTo, rec4.getSizeInBytes());
+        kv.endWriting();
+
+        map.repair(2, 4, kv);
+
+        assertEquals(-1, map.get(testType.keySerializer.toBytes(key1), key1.hashCode(), -1));
+        assertEquals(2, map.get(testType.keySerializer.toBytes(key2), key2.hashCode(), -1));
+        assertEquals(3, map.get(testType.keySerializer.toBytes(key3), key3.hashCode(), -1));
+        assertEquals(4, map.get(testType.keySerializer.toBytes(key4), key4.hashCode(), -1));
     }
 
     private static void printTestUpdate(long start, long count, String msg) {

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMapTest.java
@@ -4,6 +4,7 @@ package com.swirlds.merkledb.files.hashmap;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.io.streams.SerializableDataInputStream;
@@ -234,6 +235,44 @@ class HalfDiskHashMapTest {
         assertEquals(2, map.get(testType.keySerializer.toBytes(key2), key2.hashCode(), -1));
         assertEquals(3, map.get(testType.keySerializer.toBytes(key3), key3.hashCode(), -1));
         assertEquals(4, map.get(testType.keySerializer.toBytes(key4), key4.hashCode(), -1));
+    }
+
+    @Test
+    void testRebuildIncompleteMap() throws Exception {
+        final FilesTestType testType = FilesTestType.variable;
+        final HalfDiskHashMap map = createNewTempMap(testType, 100);
+
+        map.startWriting();
+        final VirtualKey key1 = testType.createVirtualLongKey(1);
+        map.put(testType.keySerializer.toBytes(key1), key1.hashCode(), 1);
+        final VirtualKey key2 = testType.createVirtualLongKey(2);
+        map.put(testType.keySerializer.toBytes(key2), key2.hashCode(), 2);
+        final VirtualKey key3 = testType.createVirtualLongKey(3);
+        map.put(testType.keySerializer.toBytes(key3), key3.hashCode(), 3);
+        final VirtualKey key4 = testType.createVirtualLongKey(4);
+        // No entry for key 4
+        map.endWriting();
+
+        assertEquals(1, map.get(testType.keySerializer.toBytes(key1), key1.hashCode(), -1));
+        assertEquals(2, map.get(testType.keySerializer.toBytes(key2), key2.hashCode(), -1));
+        assertEquals(3, map.get(testType.keySerializer.toBytes(key3), key3.hashCode(), -1));
+
+        final MemoryIndexDiskKeyValueStore kv = createNewTempKV(testType, 100);
+        kv.startWriting();
+        kv.updateValidKeyRange(2, 4);
+        final VirtualLeafBytes rec2 =
+                new VirtualLeafBytes(2, testType.keySerializer.toBytes(key2), key2.hashCode(), Bytes.wrap("12"));
+        kv.put(2, rec2::writeTo, rec2.getSizeInBytes());
+        final VirtualLeafBytes rec3 =
+                new VirtualLeafBytes(3, testType.keySerializer.toBytes(key3), key3.hashCode(), Bytes.wrap("13"));
+        kv.put(3, rec3::writeTo, rec3.getSizeInBytes());
+        final VirtualLeafBytes rec4 =
+                new VirtualLeafBytes(4, testType.keySerializer.toBytes(key4), key4.hashCode(), Bytes.wrap("14"));
+        kv.put(4, rec4::writeTo, rec4.getSizeInBytes());
+        kv.endWriting();
+
+        // key4 is missing in the map, it cannot be restored from pathToKeyValue store
+        assertThrows(IOException.class, () -> map.repair(2, 4, kv));
     }
 
     private static void printTestUpdate(long start, long count, String msg) {

--- a/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
+++ b/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbDataSourceTest.java
@@ -16,15 +16,23 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.swirlds.base.function.CheckedConsumer;
 import com.swirlds.base.units.UnitConstants;
+import com.swirlds.common.config.StateCommonConfig;
 import com.swirlds.common.constructable.ConstructableRegistry;
 import com.swirlds.common.crypto.Hash;
+import com.swirlds.common.io.config.FileSystemManagerConfig;
+import com.swirlds.common.io.config.TemporaryFileConfig;
 import com.swirlds.common.io.utility.LegacyTemporaryFileBuilder;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
+import com.swirlds.config.extensions.sources.SimpleConfigSource;
+import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.test.fixtures.ExampleByteArrayVirtualValue;
 import com.swirlds.merkledb.test.fixtures.TestType;
 import com.swirlds.metrics.api.IntegerGauge;
 import com.swirlds.metrics.api.Metric.ValueType;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.VirtualKey;
+import com.swirlds.virtualmap.config.VirtualMapConfig;
 import com.swirlds.virtualmap.datasource.VirtualHashRecord;
 import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
@@ -702,6 +710,80 @@ class MerkleDbDataSourceTest {
                 assertEquals(values.get(i), leaf.getValue(), "Wrong value at path " + i);
             }
         });
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    @Test
+    void testRebuildHDHMIndex() throws Exception {
+        final String label = "testRebuildHDHMIndex";
+        final TestType testType = TestType.variable_variable;
+        final Path originalDbPath = testDirectory.resolve("merkledb-testRebuildHDHMIndex-" + testType);
+        final KeySerializer keySerializer = testType.dataType().getKeySerializer();
+        final ValueSerializer valueSerializer = testType.dataType().getValueSerializer();
+        final Path snapshotDbPath1 = testDirectory.resolve("merkledb-testRebuildHDHMIndex_SNAPSHOT1");
+        final Path snapshotDbPath2 = testDirectory.resolve("merkledb-testRebuildHDHMIndex_SNAPSHOT2");
+        createAndApplyDataSource(originalDbPath, label, testType, 100, 0, dataSource -> {
+            // Flush 1: leaf path range is [8,16]
+            dataSource.saveRecords(
+                    8,
+                    16,
+                    IntStream.range(0, 17).mapToObj(i -> createVirtualInternalRecord(i, 2 * i)),
+                    IntStream.range(8, 17)
+                            .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i, i, 3 * i))
+                            .map(r -> r.toBytes(keySerializer, valueSerializer)),
+                    Stream.empty());
+            // Flush 2: leaf path range is [9,18]. Note that the list of deleted leaves is empty, so one of the leaves
+            // becomes stale in the database. This is not what we have in production, but it will let test rebuilding
+            // HDHM bucket index
+            dataSource.saveRecords(
+                    9,
+                    18,
+                    IntStream.range(0, 19).mapToObj(i -> createVirtualInternalRecord(i, 2 * i)),
+                    IntStream.range(9, 19)
+                            .mapToObj(i -> testType.dataType().createVirtualLeafRecord(i, i, 3 * i))
+                            .map(r -> r.toBytes(keySerializer, valueSerializer)),
+                    Stream.empty());
+            // Create snapshots
+            dataSource.getDatabase().snapshot(snapshotDbPath1, dataSource);
+            dataSource.getDatabase().snapshot(snapshotDbPath2, dataSource);
+            // close data source
+            dataSource.close();
+        });
+
+        // Load snapshot 1 with empty tablesToRepairHdhm config. It's expected to contain a stale key
+        final Configuration config1 = ConfigurationBuilder.create()
+                .withConfigDataType(MerkleDbConfig.class)
+                .withConfigDataType(VirtualMapConfig.class)
+                .withConfigDataType(TemporaryFileConfig.class)
+                .withConfigDataType(StateCommonConfig.class)
+                .withConfigDataType(FileSystemManagerConfig.class)
+                .withSource(new SimpleConfigSource("merkleDb.tablesToRepairHdhm", ""))
+                .build();
+        final MerkleDb snapshotDb1 = MerkleDb.getInstance(snapshotDbPath1, config1);
+        final MerkleDbDataSource snapshotDataSource1 = snapshotDb1.getDataSource(label, false);
+        IntStream.range(9, 19)
+                .forEach(i ->
+                        assertLeaf(testType, keySerializer, valueSerializer, snapshotDataSource1, i, i, 2 * i, 3 * i));
+        final VirtualKey staleKey = testType.dataType().createVirtualLongKey(8);
+        assertEquals(8, snapshotDataSource1.findKey(keySerializer.toBytes(staleKey), staleKey.hashCode()));
+        snapshotDataSource1.close();
+
+        // Now load snapshot 2, but with HDHM bucket index rebuilt. There must be no stale keys there
+        final Configuration config2 = ConfigurationBuilder.create()
+                .withConfigDataType(MerkleDbConfig.class)
+                .withConfigDataType(VirtualMapConfig.class)
+                .withConfigDataType(TemporaryFileConfig.class)
+                .withConfigDataType(StateCommonConfig.class)
+                .withConfigDataType(FileSystemManagerConfig.class)
+                .withSource(new SimpleConfigSource("merkleDb.tablesToRepairHdhm", label))
+                .build();
+        final MerkleDb snapshotDb2 = MerkleDb.getInstance(snapshotDbPath2, config2);
+        final MerkleDbDataSource snapshotDataSource2 = snapshotDb2.getDataSource(config2, label, false);
+        IntStream.range(9, 19)
+                .forEach(i ->
+                        assertLeaf(testType, keySerializer, valueSerializer, snapshotDataSource2, i, i, 2 * i, 3 * i));
+        assertEquals(-1, snapshotDataSource2.findKey(keySerializer.toBytes(staleKey), staleKey.hashCode()));
+        snapshotDataSource2.close();
     }
 
     @Test

--- a/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbTest.java
+++ b/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbTest.java
@@ -167,8 +167,8 @@ public class MerkleDbTest {
         instance.createDataSource(tableName, tableConfig, false).close();
 
         // create datasource reusing existing metadata
-        MerkleDbDataSource dataSource =
-                new MerkleDbDataSource(instance, tableName, instance.getNextTableId() - 1, tableConfig, false, false);
+        MerkleDbDataSource dataSource = new MerkleDbDataSource(
+                instance, CONFIGURATION, tableName, instance.getNextTableId() - 1, tableConfig, false, false);
         // This datasource cannot be properly closed because MerkleDb instance is not aware of this.
         // Assertion error is expected
         assertThrows(AssertionError.class, dataSource::close);


### PR DESCRIPTION
Fix summary:

* Backport of https://github.com/hiero-ledger/hiero-consensus-node/pull/18625 to the `release/0.61` branch
* Also contains changes from https://github.com/hiero-ledger/hiero-consensus-node/issues/18795, since this is a follow-up for #18625 above, it makes sense to backport them together
* Also contains changes from https://github.com/hiero-ledger/hiero-consensus-node/pull/18859
* Also contains changed from https://github.com/hiero-ledger/hiero-consensus-node/pull/18906

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/18771
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
