### PR TITLE
fix: Move sort before `filterLikelyDuplicates`

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowgraphSynchronizer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowgraphSynchronizer.java
@@ -341,6 +341,8 @@ public class ShadowgraphSynchronizer {
         final List<PlatformEvent> eventsTheyMayNeed =
                 sendSet.stream().map(ShadowEvent::getEvent).collect(Collectors.toCollection(ArrayList::new));
 
+        SyncUtils.sort(eventsTheyMayNeed);
+
         List<PlatformEvent> sendList;
         if (filterLikelyDuplicates) {
             final long startFilterTime = time.nanoTime();
@@ -350,8 +352,6 @@ public class ShadowgraphSynchronizer {
         } else {
             sendList = eventsTheyMayNeed;
         }
-
-        SyncUtils.sort(eventsTheyMayNeed);
 
         if (maximumEventsPerSync > 0 && sendList.size() > maximumEventsPerSync) {
             sendList = sendList.subList(0, maximumEventsPerSync);


### PR DESCRIPTION
**Description**:
Moves the sorting of events prior to sending in a sync to the original location.

**Related issue(s)**:

Fixes #18721