### PR TITLE
fix: Only allow creation of accounts that match the configured shard/realm

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoCreateHandler.java
@@ -119,10 +119,10 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
         validateTruePreCheck(op.hasAutoRenewPeriod(), INVALID_RENEWAL_PERIOD);
         validateTruePreCheck(op.autoRenewPeriodOrThrow().seconds() >= 0, INVALID_RENEWAL_PERIOD);
         if (op.hasShardID()) {
-            validateTruePreCheck(op.shardIDOrThrow().shardNum() == 0, INVALID_ACCOUNT_ID);
+            validateTruePreCheck(op.shardIDOrThrow().shardNum() >= 0, INVALID_ACCOUNT_ID);
         }
         if (op.hasRealmID()) {
-            validateTruePreCheck(op.realmIDOrThrow().realmNum() == 0, INVALID_ACCOUNT_ID);
+            validateTruePreCheck(op.realmIDOrThrow().realmNum() >= 0, INVALID_ACCOUNT_ID);
         }
         // HIP 904 now allows for unlimited auto-associations
         validateTruePreCheck(
@@ -312,6 +312,15 @@ public class CryptoCreateHandler extends BaseCryptoHandler implements Transactio
         final var accountConfig = context.configuration().getConfigData(AccountsConfig.class);
         final var hederaConfig = context.configuration().getConfigData(HederaConfig.class);
         final var alias = op.alias();
+
+        // Don't allow creation of accounts that don't match the configured shard and realm
+        if (op.hasShardID()) {
+            validateTrue(op.shardIDOrThrow().shardNum() == hederaConfig.shard(), INVALID_ACCOUNT_ID);
+        }
+        if (op.hasRealmID()) {
+            validateTrue(op.realmIDOrThrow().realmNum() == hederaConfig.realm(), INVALID_ACCOUNT_ID);
+        }
+
         // You can never set the alias to be an "entity num alias" (sometimes called "long-zero").
         validateFalse(isEntityNumAlias(alias, hederaConfig.shard(), hederaConfig.realm()), INVALID_ALIAS_KEY);
 

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoCreateHandlerTest.java
@@ -210,7 +210,11 @@ class CryptoCreateHandlerTest extends CryptoHandlerTestBase {
     void validateNonZeroShardAndRealm() {
         final long shard = 5;
         final long realm = 10;
-        txn = new CryptoCreateBuilder().withStakedAccountId(3).build();
+        txn = new CryptoCreateBuilder()
+                .withStakedAccountId(3)
+                .withShardId(shard)
+                .withRealmId(realm)
+                .build();
         given(handleContext.body()).willReturn(txn);
         given(pureChecksContext.body()).willReturn(txn);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -1021,7 +1021,7 @@ public class CryptoCreateSuite {
     }
 
     @HapiTest
-    final Stream<DynamicTest> accountsWith() {
+    final Stream<DynamicTest> accountsWithDifferentShardOrRealmNotCreated() {
         final String key = "key";
         return hapiTest(
                 newKeyNamed(key),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -60,6 +60,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.KEY_REQUIRED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 
 import com.esaulpaugh.headlong.abi.Address;
@@ -1017,5 +1018,23 @@ public class CryptoCreateSuite {
                     .hasPrecheck(INVALID_ALIAS_KEY);
             allRunFor(spec, op);
         }));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> accountsWith() {
+        final String key = "key";
+        return hapiTest(
+                newKeyNamed(key),
+                cryptoCreate("control").key(key).balance(1L).hasKnownStatus(SUCCESS),
+                cryptoCreate("differentShard")
+                        .key(key)
+                        .balance(1L)
+                        .shardId(ShardID.newBuilder().setShardNum(1).build())
+                        .hasKnownStatus(INVALID_ACCOUNT_ID),
+                cryptoCreate("differentRealm")
+                        .key(key)
+                        .balance(1L)
+                        .realmId(RealmID.newBuilder().setRealmNum(1).build())
+                        .hasKnownStatus(INVALID_ACCOUNT_ID));
     }
 }


### PR DESCRIPTION
**Description**:

We found a bug that only allows creation of accounts with shard/realm 0.0. This PR fixes that bug by relaxing the restriction to instead check that the account's shard/realm matches the node's configured shard/realm. 
