### PR TITLE
fix: flaky `completedHollowAccountOperationsFuzzing` test

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/providers/ops/token/RandomTokenUpdate.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.spec.infrastructure.providers.ops.token;
 
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.randomUppercase;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenUpdate;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_AUTORENEW_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FREEZE_KEY;
@@ -80,7 +81,8 @@ public class RandomTokenUpdate implements OpProvider {
             INVALID_RENEWAL_PERIOD,
             NO_REMAINING_AUTOMATIC_ASSOCIATIONS,
             INVALID_AUTORENEW_ACCOUNT,
-            INVALID_TREASURY_ACCOUNT_FOR_TOKEN);
+            INVALID_TREASURY_ACCOUNT_FOR_TOKEN,
+            AUTORENEW_DURATION_NOT_IN_RANGE);
 
     public RandomTokenUpdate(
             EntityNameProvider keys,


### PR DESCRIPTION
**Description**:
- Fixing a flaky test

**Related issue(s)**:

Fixes #18800

**Notes for reviewer**:
[Here](https://github.com/hiero-ledger/hiero-consensus-node/pull/18698/files#diff-f3dd7dace03e4f3e95b382d56d49c1f46781902d5d8e8f1639ca6396c38263e7L131) an old logic from mono was deleted. Because of that, when we have an `autorenew_duration` lower than **now**, we are now throwing `AUTORENEW_DURATION_NOT_IN_RANGE` instead of `INVALID_RENEWAL_PERIOD`.

The `completedHollowAccountOperationsFuzzing` test is doing a lot of **random** operations with **random** populated fields in them.
One of them is `RandomTokenUpdate`. In `RandomTokenUpdate.get` there is this line:
`randomUpdates.forEach(o -> o.accept(op));` 
It populates the operation with random keys, name, etc. One of the random populations, `randomAutoRenewPeriodUpdate`, is sometimes* adding an invalid `autorenew_period`. This is when the operation throws `INVALID_RENEWAL_PERIOD` and we don't expect that.

Since we are now throwing `AUTORENEW_DURATION_NOT_IN_RANGE` we need to add it to the `permissibleOutcomes` and that fixes the flakyness.

\* when a random double from 0 to 1 is less than 0.5 and the random long is less than the current time(now)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
