### PR TITLE
chore: Fix for ConsensusTests.cliqueTests()

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/ConsensusTestDefinitions.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/ConsensusTestDefinitions.java
@@ -289,7 +289,7 @@ public final class ConsensusTestDefinitions {
             cliques.put(i, 1);
         }
         for (int i = 2 * cliqueSize; i < numberOfNodes; i++) {
-            cliques.put(i, 1);
+            cliques.put(i, 2);
         }
         // There are 3 cliques
         // Each clique syncs within itself frequently, but with outsiders it syncs rarely


### PR DESCRIPTION
**Description**:

This test fixes the `Consensustests.CliqueTests()`. Checked by looking at the generated parent matrix.

**Related issue(s)**:

Fixes #18826 
