### PR TITLE
fix: Correctly populate sysfiles with node info

### DIFF
--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/validators/AddressBookValidator.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/validators/AddressBookValidator.java
@@ -93,9 +93,6 @@ public class AddressBookValidator {
 
         validateFalse(endpointList == null || endpointList.isEmpty(), INVALID_GOSSIP_ENDPOINT);
         validateFalse(endpointList.size() > nodesConfig.maxGossipEndpoint(), GOSSIP_ENDPOINTS_EXCEEDED_LIMIT);
-        // for phase 2: The first in the list is used as the Internal IP address in config.txt,
-        // the second in the list is used as the External IP address in config.txt
-        validateFalse(endpointList.size() < 2, INVALID_GOSSIP_ENDPOINT);
 
         for (final var endpoint : endpointList) {
             validateFalse(

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
@@ -327,18 +327,6 @@ class NodeCreateHandlerTest extends AddressBookTestBase {
     }
 
     @Test
-    void failsWhenGossipEndpointTooSmall() {
-        txn = new NodeCreateBuilder()
-                .withAccountId(accountId)
-                .withGossipEndpoint(List.of(endpoint1))
-                .build(payerId);
-        setupHandle();
-
-        final var msg = assertThrows(HandleException.class, () -> subject.handle(handleContext));
-        assertEquals(ResponseCodeEnum.INVALID_GOSSIP_ENDPOINT, msg.getStatus());
-    }
-
-    @Test
     void failsWhenGossipEndpointHaveIPAndFQDN() {
         txn = new NodeCreateBuilder()
                 .withAccountId(accountId)

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeUpdateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeUpdateHandlerTest.java
@@ -238,19 +238,6 @@ class NodeUpdateHandlerTest extends AddressBookTestBase {
     }
 
     @Test
-    void failsWhenGossipEndpointTooSmall() {
-        txn = new NodeUpdateBuilder()
-                .withNodeId(1L)
-                .withAccountId(accountId)
-                .withGossipEndpoint(List.of(endpoint1))
-                .build();
-        setupHandle();
-
-        final var msg = assertThrows(HandleException.class, () -> subject.handle(handleContext));
-        assertEquals(ResponseCodeEnum.INVALID_GOSSIP_ENDPOINT, msg.getStatus());
-    }
-
-    @Test
     void failsWhenGossipEndpointHaveIPAndFQDN() {
         txn = new NodeUpdateBuilder()
                 .withNodeId(1L)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
@@ -118,6 +118,7 @@ public class SystemTransactions {
 
     private static final EnumSet<ResponseCodeEnum> SUCCESSES =
             EnumSet.of(SUCCESS, SUCCESS_BUT_MISSING_EXPECTED_OPERATION);
+    private static final Consumer<Dispatch> DEFAULT_DISPATCH_ON_SUCCESS = dispatch -> {};
 
     private final InitTrigger initTrigger;
     private final BlocklistParser blocklistParser = new BlocklistParser();
@@ -187,7 +188,7 @@ public class SystemTransactions {
     public void doGenesisSetup(@NonNull final Instant now, @NonNull final State state) {
         requireNonNull(now);
         requireNonNull(state);
-        final AtomicReference<Consumer<Dispatch>> onSuccess = new AtomicReference<>(dispatch -> {});
+        final AtomicReference<Consumer<Dispatch>> onSuccess = new AtomicReference<>(DEFAULT_DISPATCH_ON_SUCCESS);
         final var systemContext =
                 newSystemContext(now, state, dispatch -> onSuccess.get().accept(dispatch), true);
 
@@ -275,21 +276,25 @@ public class SystemTransactions {
                     nodeInfo.hapiEndpoints().isEmpty() ? UNKNOWN_HAPI_ENDPOINT : nodeInfo.hapiEndpoints();
             onSuccess.set(dispatch -> {
                 final var stack = dispatch.stack();
-                final var writableNodeStore = new WritableStakingInfoStore(
+                final var writableStakingInfoStore = new WritableStakingInfoStore(
                         stack.getWritableStates(TokenService.NAME),
                         new WritableEntityIdStore(stack.getWritableStates(EntityIdService.NAME)));
-                final var rewardSumHistory = new Long[numStoredPeriods + 1];
-                Arrays.fill(rewardSumHistory, 0L);
-                writableNodeStore.putAndIncrementCount(
-                        nodeInfo.nodeId(),
-                        StakingNodeInfo.newBuilder()
-                                .nodeNumber(nodeInfo.nodeId())
-                                .maxStake(stakingConfig.maxStake())
-                                .minStake(stakingConfig.minStake())
-                                .rewardSumHistory(Arrays.asList(rewardSumHistory))
-                                .weight(DEFAULT_GENESIS_WEIGHT)
-                                .build());
-                stack.commitFullStack();
+                // Writing genesis staking info to state after the node create dispatch is only necessary if the created
+                // node's staking info isn't already present in state
+                if (writableStakingInfoStore.get(nodeInfo.nodeId()) == null) {
+                    final var rewardSumHistory = new Long[numStoredPeriods + 1];
+                    Arrays.fill(rewardSumHistory, 0L);
+                    writableStakingInfoStore.putAndIncrementCount(
+                            nodeInfo.nodeId(),
+                            StakingNodeInfo.newBuilder()
+                                    .nodeNumber(nodeInfo.nodeId())
+                                    .maxStake(stakingConfig.maxStake())
+                                    .minStake(stakingConfig.minStake())
+                                    .rewardSumHistory(Arrays.asList(rewardSumHistory))
+                                    .weight(DEFAULT_GENESIS_WEIGHT)
+                                    .build());
+                    stack.commitFullStack();
+                }
             });
             systemContext.dispatchAdmin(b -> {
                 final var isSystemAccount = nodeInfo.nodeId() <= ledgerConfig.numSystemAccounts();
@@ -306,6 +311,10 @@ public class SystemTransactions {
             });
         }
         networkInfo.updateFrom(state);
+
+        // Now that the onSuccess callback has executed for all the node create transactions, set the callback back to
+        // its benign, do-nothing default
+        onSuccess.set(DEFAULT_DISPATCH_ON_SUCCESS);
 
         // Now that the node metadata is correct, create the system files
         final var nodeStore = new ReadableStoreFactory(state).getStore(ReadableNodeStore.class);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
@@ -212,9 +212,6 @@ public class SystemTransactions {
                             .build(),
                     i);
         }
-        // For a slightly more intuitive stream, now create the system files (which come next numerically)
-        final var nodeStore = new ReadableStoreFactory(state).getStore(ReadableNodeStore.class);
-        fileService.createSystemEntities(systemContext, nodeStore);
         // Create the treasury clones
         for (long i : LongStream.rangeClosed(FIRST_POST_SYSTEM_FILE_ENTITY, ledgerConfig.numReservedSystemEntities())
                 .filter(j -> j < FIRST_RESERVED_SYSTEM_CONTRACT || j > LAST_RESERVED_SYSTEM_CONTRACT)
@@ -309,6 +306,10 @@ public class SystemTransactions {
             });
         }
         networkInfo.updateFrom(state);
+
+        // Now that the node metadata is correct, create the system files
+        final var nodeStore = new ReadableStoreFactory(state).getStore(ReadableNodeStore.class);
+        fileService.createSystemEntities(systemContext, nodeStore);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeUpdateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeUpdateTest.java
@@ -28,7 +28,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GOSSIP_ENDPOIN
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GOSSIP_ENDPOINT_CANNOT_HAVE_FQDN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_GOSSIP_CA_CERTIFICATE;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_GOSSIP_ENDPOINT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_IPV4_ADDRESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_DESCRIPTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ID;
@@ -128,10 +127,6 @@ public class NodeUpdateTest {
                 nodeCreate("testNode")
                         .adminKey("adminKey")
                         .gossipCaCertificate(gossipCertificates.getFirst().getEncoded()),
-                nodeUpdate("testNode")
-                        .adminKey("adminKey")
-                        .gossipEndpoint(List.of(asServiceEndpoint("127.0.0.1:80")))
-                        .hasKnownStatus(INVALID_GOSSIP_ENDPOINT),
                 nodeUpdate("testNode")
                         .adminKey("adminKey")
                         .gossipEndpoint(List.of(asServiceEndpoint("127.0.0.2:60"), invalidServiceEndpoint()))


### PR DESCRIPTION
**Description**:

We discovered that there is a genesis case where sys files 101 and 102 were empty. This PR fixes the problem by only creating sys files after the node metadata has been synthetically populated.

This PR also removes the deprecated requirement to include 'internal IP address' in gossip endpoints.

Fixes #18551 