### PR TITLE
fixed NPE in HalfDiskHashMap

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -757,7 +757,6 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                     // update bucketIndexToBucketLocation
                     bucketIndexToBucketLocation.put(bucketIndex, bucketLocation);
                 }
-                next.send();
                 return true;
             } finally {
                 // Let the current submit task know that a bucket is fully processed, and
@@ -769,6 +768,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                     // will be called on a different submit task than the one currently running
                     currentSubmitTask.get().notifyBucketProcessed();
                 }
+                next.send();
             }
         }
 


### PR DESCRIPTION
**Description**:
The last `StoreBucketTask` invokes the resulting NotifyTask by calling next.send(). This is now done after 
it tells `currentSubmitTask` about a newly available bucket permit.

**Related issue(s)**:

Fixes #18846

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
