### PR TITLE
chore: 12987 more code coverage for CryptoUpdateHandler

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/CryptoUpdateHandler.java
@@ -369,7 +369,12 @@ public class CryptoUpdateHandler extends BaseCryptoHandler implements Transactio
      * @return the calculated bytes
      */
     private static int currentNonBaseBytes(final Account account) {
-        return account.memo().getBytes(StandardCharsets.UTF_8).length
+        // TODO: should this part be a new utility method so we don't repeat it over and over?
+        final var accountMemoSize = (account == null || account.memo() == null)
+                ? 0
+                : account.memo().getBytes(StandardCharsets.UTF_8).length;
+
+        return accountMemoSize
                 + getAccountKeyStorageSize(CommonPbjConverters.fromPbj(account.keyOrElse(Key.DEFAULT)))
                 + (account.maxAutoAssociations() == 0 ? 0 : INT_SIZE);
     }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -19,6 +19,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.STAKING_NOT_ENABLED;
 import static com.hedera.node.app.service.token.impl.test.handlers.util.StateBuilderUtil.ACCOUNTS;
 import static com.hedera.node.app.spi.fixtures.Assertions.assertThrowsPreCheck;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThatNoException;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -786,6 +787,96 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(212L);
         inOrder.verify(feeCalculator, times(2)).addRamByteSeconds(0L);
         inOrder.verify(feeCalculator, times(1)).calculate();
+    }
+
+    @Test
+    void testNullMemo() {
+        // mock the account memo to return null. calculateFees should not crash
+        FeeContext feeContext = mock(FeeContext.class);
+        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
+        FeeCalculator feeCalculator = mock(FeeCalculator.class);
+        final var config = HederaTestConfigBuilder.create()
+                .getOrCreateConfig();
+
+        account = mock(Account.class);
+        given(account.keyOrElse(Key.DEFAULT)).willReturn(Key.DEFAULT);
+        given(account.memo()).willReturn(null);
+        updateReadableAccountStore(Map.of(accountNum, account));
+
+        TransactionBody cryptoUpdateTransaction = new CryptoUpdateBuilder()
+                .withPayer(id)
+                .withAutoRenewPeriod(account.autoRenewSeconds())
+                .withReceiverSigReq(account.receiverSigRequired())
+                .withDeclineReward(account.declineReward())
+                .withStakedNodeId(account.stakedNodeId())
+                .withStakedAccountId(
+                        account.stakedAccountId() == null
+                                ? 0L
+                                : account.stakedAccountId().accountNum())
+                .withExpiration(account.expirationSecond())
+                .withMaxAutoAssociations(account.maxAutoAssociations())
+                .withKey(account.key())
+                .withTarget(id)
+                .build();
+
+        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableStore);
+        when(feeContext.body()).thenReturn(cryptoUpdateTransaction);
+        when(feeContext.configuration()).thenReturn(config);
+        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
+        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
+        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
+        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
+        when(feeCalculator.calculate()).thenReturn(Fees.FREE);
+
+
+        assertThatNoException().isThrownBy(() -> subject.calculateFees(feeContext));
+    }
+
+    @Test
+    void testUnlimitedAutoAssociationsDisabled() {
+        // disable unlimited auto associations
+        // and set a new max of 30
+        FeeContext feeContext = mock(FeeContext.class);
+        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
+        FeeCalculator feeCalculator = mock(FeeCalculator.class);
+        final var config = HederaTestConfigBuilder.create()
+                .withValue("entities.unlimitedAutoAssociationsEnabled", false)
+                .getOrCreateConfig();
+
+        TransactionBody cryptoUpdateTransaction = new CryptoUpdateBuilder()
+                .withPayer(id)
+                .withAutoRenewPeriod(account.autoRenewSeconds())
+                .withReceiverSigReq(account.receiverSigRequired())
+                .withDeclineReward(account.declineReward())
+                .withStakedNodeId(account.stakedNodeId())
+                .withStakedAccountId(
+                        account.stakedAccountId() == null
+                                ? 0L
+                                : account.stakedAccountId().accountNum())
+                .withExpiration(account.expirationSecond())
+                .withMaxAutoAssociations(30) // set new max to 30
+                .withKey(account.key())
+                .withTarget(id)
+                .build();
+
+        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableStore);
+        when(feeContext.body()).thenReturn(cryptoUpdateTransaction);
+        when(feeContext.configuration()).thenReturn(config);
+        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
+        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
+        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
+        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
+        when(feeCalculator.calculate()).thenReturn(Fees.FREE);
+
+        subject.calculateFees(feeContext);
+
+        InOrder inOrder = inOrder(feeCalculator);
+        inOrder.verify(feeCalculator, times(1)).addBytesPerTransaction(212L);
+        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(0L);
+        // slots increases, so we have a new fee
+        inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(3732480000000L);
+        inOrder.verify(feeCalculator, times(1)).calculate();
+
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoUpdateHandlerTest.java
@@ -795,12 +795,11 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         FeeContext feeContext = mock(FeeContext.class);
         FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
         FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        final var config = HederaTestConfigBuilder.create()
-                .getOrCreateConfig();
+        final var config = HederaTestConfigBuilder.create().getOrCreateConfig();
 
         // put a null account into the readable store
         final var emptyStateBuilder = emptyReadableAccountStateBuilder();
-        emptyStateBuilder.value(account.accountId(),null);
+        emptyStateBuilder.value(account.accountId(), null);
         readableAccounts = emptyStateBuilder.build();
         given(readableStates.<AccountID, Account>get(ACCOUNTS)).willReturn(readableAccounts);
         readableStore = new ReadableAccountStoreImpl(readableStates, readableEntityCounters);
@@ -830,7 +829,6 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
         when(feeCalculator.calculate()).thenReturn(Fees.FREE);
 
-
         assertThatNoException().isThrownBy(() -> subject.calculateFees(feeContext));
 
         InOrder inOrder = inOrder(feeCalculator);
@@ -845,8 +843,7 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         FeeContext feeContext = mock(FeeContext.class);
         FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
         FeeCalculator feeCalculator = mock(FeeCalculator.class);
-        final var config = HederaTestConfigBuilder.create()
-                .getOrCreateConfig();
+        final var config = HederaTestConfigBuilder.create().getOrCreateConfig();
 
         account = mock(Account.class);
         given(account.keyOrElse(Key.DEFAULT)).willReturn(Key.DEFAULT);
@@ -877,7 +874,6 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
         when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
         when(feeCalculator.calculate()).thenReturn(Fees.FREE);
-
 
         assertThatNoException().isThrownBy(() -> subject.calculateFees(feeContext));
     }
@@ -926,7 +922,6 @@ class CryptoUpdateHandlerTest extends CryptoHandlerTestBase {
         // slots increases, so we have a new fee
         inOrder.verify(feeCalculator, times(1)).addRamByteSeconds(3732480000000L);
         inOrder.verify(feeCalculator, times(1)).calculate();
-
     }
 
     /**


### PR DESCRIPTION
**Description**:
Adds additional unit tests for CryptoUpdateHandler, specifically the cases where account is null, account.memo is null, and when unlimitedAutoAssociations are disabled and the max auto associations are different than before.

**Related issue(s)**:

Partially fixes #12987

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
