### PR TITLE
chore: 12987 more code coverage for CryptoTransferHandler

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
@@ -18,6 +18,7 @@ import static com.hedera.node.app.service.token.impl.test.handlers.transfer.Acco
 import static com.hedera.node.app.service.token.impl.test.handlers.transfer.AccountAmountUtils.nftTransferWith;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -650,6 +651,73 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(ACCOUNT_REPEATED_IN_ACCOUNT_AMOUNTS));
     }
+
+    @Test
+    void checkCalculateFeesHandlesExceptionInternally() {
+        // need to set up a transaction that fails because of insufficient payer balance for custom fee
+        config = defaultConfig().getOrCreateConfig();
+        // setup all of the standard stores
+        givenStoresAndConfig(handleContext);
+        // make txn with owner sending 1000 w/ allowances to unknown aliased id
+        // and token transfer of FT from owner 1000 w/ allowances to unknown aliased id
+        // and one NFT from owner to unknown aliased ID
+        givenTxnWithAllowances();
+        ensureAliasesStep = new EnsureAliasesStep(body);
+        replaceAliasesWithIDsInOp = new ReplaceAliasesWithIDsInOp();
+        associateTokenRecepientsStep = new AssociateTokenRecipientsStep(body);
+
+        CryptoCreateStreamBuilder cryptoCreateRecordBuilder = mock(CryptoCreateStreamBuilder.class);
+
+        given(handleContext.dispatch(
+                argThat(options -> CryptoCreateStreamBuilder.class.equals(options.streamBuilderType())
+                        && spenderId.equals(options.payerId()))))
+                .will((invocation) -> {
+                    final var copy =
+                            account.copyBuilder().accountId(hbarReceiverId).build();
+                    writableAccountStore.put(copy);
+                    writableAliases.put(ecKeyAlias, asAccount(0L, 0L, hbarReceiver));
+                    return cryptoCreateRecordBuilder;
+                })
+                .will((invocation) -> {
+                    final var copy =
+                            account.copyBuilder().accountId(tokenReceiverId).build();
+                    writableAccountStore.put(copy);
+                    writableAliases.put(edKeyAlias, asAccount(0L, 0L, tokenReceiver));
+                    writableTokenRelStore.put(fungibleTokenRelation
+                            .copyBuilder()
+                            .kycGranted(true)
+                            .accountId(tokenReceiverId)
+                            .build());
+                    return cryptoCreateRecordBuilder;
+                });
+
+        when(handleContext.dispatchMetadata()).thenReturn(mock(DispatchMetadata.class));
+
+        FeeContext feeContext = mock(DispatchHandleContext.class);
+        FeeCalculatorFactory feeCalculatorFactory = mock(FeeCalculatorFactory.class);
+        FeeCalculator feeCalculator = mock(FeeCalculator.class);
+        Fees fees = mock(Fees.class);
+        when(feeContext.body())
+                .thenReturn(TransactionBody.newBuilder()
+                        .transactionID(TransactionID.newBuilder().accountID(ACCOUNT_ID_3333))
+                        .cryptoTransfer(body)
+                        .build());
+        when(feeContext.configuration()).thenReturn(config);
+        when(feeContext.readableStore(ReadableTokenStore.class)).thenReturn(readableTokenStore);
+        when(feeContext.readableStore(ReadableTokenRelationStore.class)).thenReturn(readableTokenRelStore);
+        when(feeContext.readableStore(ReadableAccountStore.class)).thenReturn(readableAccountStore);
+        when(feeContext.feeCalculatorFactory()).thenReturn(feeCalculatorFactory);
+        when(feeCalculatorFactory.feeCalculator(any())).thenReturn(feeCalculator);
+        when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
+        when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
+        when(feeCalculator.calculate()).thenReturn(fees);
+
+
+        // this confirms that the exception thrown by customFeeAssessor.assessNumberOfCustomFees() is
+        // handled properly by calculateFees()
+        assertThatNoException().isThrownBy(() -> subject.calculateFees(feeContext));
+    }
+
 
     @Mock(strictness = LENIENT)
     protected PreHandleContext preHandleContext;

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/CryptoTransferHandlerTest.java
@@ -669,8 +669,8 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
         CryptoCreateStreamBuilder cryptoCreateRecordBuilder = mock(CryptoCreateStreamBuilder.class);
 
         given(handleContext.dispatch(
-                argThat(options -> CryptoCreateStreamBuilder.class.equals(options.streamBuilderType())
-                        && spenderId.equals(options.payerId()))))
+                        argThat(options -> CryptoCreateStreamBuilder.class.equals(options.streamBuilderType())
+                                && spenderId.equals(options.payerId()))))
                 .will((invocation) -> {
                     final var copy =
                             account.copyBuilder().accountId(hbarReceiverId).build();
@@ -711,7 +711,6 @@ class CryptoTransferHandlerTest extends CryptoTransferHandlerTestBase {
         when(feeCalculator.addBytesPerTransaction(anyLong())).thenReturn(feeCalculator);
         when(feeCalculator.addRamByteSeconds(anyLong())).thenReturn(feeCalculator);
         when(feeCalculator.calculate()).thenReturn(fees);
-
 
         // this confirms that the exception thrown by customFeeAssessor.assessNumberOfCustomFees() is
         // handled properly by calculateFees()


### PR DESCRIPTION

**Description**:
Adds a check to make sure that CryptoTransferHandler. calculateFees actually handles exceptions thrown by the CustomFeeAssessor

**Related issue(s)**:

Fixes partially fixes #12987

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
