### PR TITLE
fix: Fix failing test in crypto-base

### DIFF
--- a/platform-sdk/base-crypto/build.gradle.kts
+++ b/platform-sdk/base-crypto/build.gradle.kts
@@ -17,6 +17,7 @@ testModuleInfo {
 }
 
 timingSensitiveModuleInfo {
+    runtimeOnly("com.swirlds.common.test.fixtures")
     requires("com.swirlds.config.api")
     requires("com.swirlds.config.extensions.test.fixtures")
     requires("org.hiero.base.crypto")


### PR DESCRIPTION
**Description**:

This PR fixes a failing test in `crypto-base` by adding a missing runtime dependency.

**Related issue(s)**:

Fixes #18887 