### PR TITLE
refactor: introduce KeyRole enum and refactor role key management in HapiSpecRegistry

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/utils/KeyMetadata.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/utils/KeyMetadata.java
@@ -33,11 +33,14 @@ public record KeyMetadata(
         Registration registration) {
 
     public interface Registration {
-        void save(HapiSpecRegistry registry, String name, KeyRole keyRole, Key key);
+        void save(HapiSpecRegistry registry, String name, Key key);
     }
 
-    private static final Registration DEFAULT_REGISTRATION = HapiSpecRegistry::saveRoleKey;
+    private static final Registration DEFAULT_REGISTRATION = HapiSpecRegistry::saveKey;
 
+    public static Registration roleBasedRegistration(KeyRole role) {
+        return (registry, name, key) -> registry.saveRoleKey(name, role, key);
+    }
     /**
      * Constructs a {@link KeyMetadata} instance from the given protoc key and {@link HapiSpec}
      * with the default registration.
@@ -104,7 +107,7 @@ public record KeyMetadata(
     public void registerAs(@NonNull final String name, @NonNull final HapiSpec spec) {
         requireNonNull(spec);
         requireNonNull(name);
-        registration.save(spec.registry(), name, null, protoKey);
+        registration.save(spec.registry(), name, protoKey);
         spec.keys().setControl(protoKey, sigControl);
         spec.keys().addPrivateKeyMap(privateKeyMap);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/utils/KeyMetadata.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/dsl/utils/KeyMetadata.java
@@ -7,6 +7,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.infrastructure.HapiSpecRegistry;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hederahashgraph.api.proto.java.Key;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -32,10 +33,10 @@ public record KeyMetadata(
         Registration registration) {
 
     public interface Registration {
-        void save(HapiSpecRegistry registry, String name, Key key);
+        void save(HapiSpecRegistry registry, String name, KeyRole keyRole, Key key);
     }
 
-    private static final Registration DEFAULT_REGISTRATION = HapiSpecRegistry::saveKey;
+    private static final Registration DEFAULT_REGISTRATION = HapiSpecRegistry::saveRoleKey;
 
     /**
      * Constructs a {@link KeyMetadata} instance from the given protoc key and {@link HapiSpec}
@@ -103,7 +104,7 @@ public record KeyMetadata(
     public void registerAs(@NonNull final String name, @NonNull final HapiSpec spec) {
         requireNonNull(spec);
         requireNonNull(name);
-        registration.save(spec.registry(), name, protoKey);
+        registration.save(spec.registry(), name, null, protoKey);
         spec.keys().setControl(protoKey, sigControl);
         spec.keys().addPrivateKeyMap(privateKeyMap);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -776,7 +776,6 @@ public class HapiSpecRegistry {
     }
 
     private String getRoleKeyName(String tokenName, KeyRole role) {
-        final String roleKeyFormat = "%s_%s_KEY";
-        return String.format(roleKeyFormat, tokenName, role);
+        return String.format("%s_%s_KEY", tokenName, role);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/infrastructure/HapiSpecRegistry.java
@@ -17,6 +17,7 @@ import com.hedera.services.bdd.spec.infrastructure.listeners.TokenAccountRegistr
 import com.hedera.services.bdd.spec.infrastructure.meta.ActionableContractCall;
 import com.hedera.services.bdd.spec.infrastructure.meta.ActionableContractCallLocal;
 import com.hedera.services.bdd.spec.infrastructure.meta.SupportedContract;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.utilops.inventory.TypedKey;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -218,62 +219,6 @@ public class HapiSpecRegistry {
         put(name, key, Key.class);
     }
 
-    public void forgetAdminKey(String name) {
-        remove(name + "Admin", Key.class);
-    }
-
-    public void saveAdminKey(String name, Key key) {
-        put(name + "Admin", key, Key.class);
-    }
-
-    public boolean hasAdminKey(String name) {
-        return has(name + "Admin", Key.class);
-    }
-
-    public void saveFreezeKey(String name, Key key) {
-        put(name + "Freeze", key, Key.class);
-    }
-
-    public boolean hasFeeScheduleKey(String name) {
-        return has(name + "FeeSchedule", Key.class);
-    }
-
-    public void forgetFeeScheduleKey(String name) {
-        remove(name + "FeeSchedule", Key.class);
-    }
-
-    public void saveFeeScheduleKey(String name, Key key) {
-        put(name + "FeeSchedule", key, Key.class);
-    }
-
-    public Key getFeeScheduleKey(String name) {
-        return get(name + "FeeSchedule", Key.class);
-    }
-
-    public void savePauseKey(String name, Key key) {
-        put(name + "Pause", key, Key.class);
-    }
-
-    public boolean hasPauseKey(String name) {
-        return has(name + "Pause", Key.class);
-    }
-
-    public Key getPauseKey(String name) {
-        return get(name + "Pause", Key.class);
-    }
-
-    public void forgetPauseKey(String name) {
-        remove(name + "Pause", Key.class);
-    }
-
-    public boolean hasFreezeKey(String name) {
-        return has(name + "Freeze", Key.class);
-    }
-
-    public void forgetFreezeKey(String name) {
-        remove(name + "Freeze", Key.class);
-    }
-
     public void saveExpiry(String name, Long value) {
         put(name + "Expiry", value, Long.class);
     }
@@ -282,40 +227,20 @@ public class HapiSpecRegistry {
         put(name + "CreationTime", value, Timestamp.class);
     }
 
-    public void saveSupplyKey(String name, Key key) {
-        put(name + "Supply", key, Key.class);
+    public Key getRoleKey(String tokenName, KeyRole role) {
+        return getOrElse(getRoleKeyName(tokenName, role), Key.class, null);
     }
 
-    public boolean hasSupplyKey(String name) {
-        return has(name + "Supply", Key.class);
+    public void saveRoleKey(String name, KeyRole role, Key key) {
+        put(getRoleKeyName(name, role), key);
     }
 
-    public void saveWipeKey(String name, Key key) {
-        put(name + "Wipe", key, Key.class);
+    public void forgetRoleKey(String name, KeyRole role) {
+        remove(getRoleKeyName(name, role), Key.class);
     }
 
-    public boolean hasWipeKey(String name) {
-        return has(name + "Wipe", Key.class);
-    }
-
-    public void forgetWipeKey(String name) {
-        remove(name + "Wipe", Key.class);
-    }
-
-    public void forgetSupplyKey(String name) {
-        remove(name + "Supply", Key.class);
-    }
-
-    public boolean hasKycKey(String name) {
-        return has(name + "Kyc", Key.class);
-    }
-
-    public void saveKycKey(String name, Key key) {
-        put(name + "Kyc", key, Key.class);
-    }
-
-    public void forgetKycKey(String name) {
-        remove(name + "Kyc", Key.class);
+    public boolean hasRoleKey(String name, KeyRole role) {
+        return has(getRoleKeyName(name, role), Key.class);
     }
 
     public void saveSymbol(String token, String symbol) {
@@ -360,26 +285,6 @@ public class HapiSpecRegistry {
 
     public Key getKey(String name) {
         return get(name, Key.class);
-    }
-
-    public Key getAdminKey(String name) {
-        return get(name + "Admin", Key.class);
-    }
-
-    public Key getFreezeKey(String name) {
-        return get(name + "Freeze", Key.class);
-    }
-
-    public Key getSupplyKey(String name) {
-        return get(name + "Supply", Key.class);
-    }
-
-    public Key getWipeKey(String name) {
-        return get(name + "Wipe", Key.class);
-    }
-
-    public Key getKycKey(String name) {
-        return getOrElse(name + "Kyc", Key.class, null);
     }
 
     public Long getExpiry(String name) {
@@ -831,18 +736,6 @@ public class HapiSpecRegistry {
         return typeName + "-" + name;
     }
 
-    public void forgetMetadataKey(String name) {
-        remove(name + "Metadata", Key.class);
-    }
-
-    public void saveMetadataKey(String name, Key metadataKey) {
-        put(name + "Metadata", metadataKey, Key.class);
-    }
-
-    public Key getMetadataKey(String name) {
-        return get(name + "Metadata", Key.class);
-    }
-
     public void saveMetadata(String token, String metadata) {
         put(token + "Metadata", metadata, String.class);
     }
@@ -880,5 +773,10 @@ public class HapiSpecRegistry {
         builder.addAllGossipEndpoint(txn.getGossipEndpointList());
         builder.addAllServiceEndpoint(txn.getServiceEndpointList());
         put(name, builder.build());
+    }
+
+    private String getRoleKeyName(String tokenName, KeyRole role) {
+        final String roleKeyFormat = "%s_%s_KEY";
+        return String.format(roleKeyFormat, tokenName, role);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyRole.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/KeyRole.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.spec.keys;
+
+public enum KeyRole {
+    ADMIN,
+    FREEZE,
+    SUPPLY,
+    WIPE,
+    KYC,
+    PAUSE,
+    FEE_SCHEDULE,
+    METADATA;
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/schedule/HapiGetScheduleInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/schedule/HapiGetScheduleInfo.java
@@ -12,6 +12,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.infrastructure.HapiSpecRegistry;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.queries.HapiQueryOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
@@ -219,7 +220,7 @@ public class HapiGetScheduleInfo extends HapiQueryOp<HapiGetScheduleInfo> {
         assertFor(
                 actualInfo.getAdminKey(),
                 expectedAdminKey,
-                (n, r) -> r.getAdminKey(schedule),
+                (n, r) -> r.getRoleKey(schedule, KeyRole.ADMIN),
                 "Wrong schedule admin key!",
                 registry);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/token/HapiGetTokenInfo.java
@@ -11,6 +11,7 @@ import com.google.common.base.MoreObjects;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.infrastructure.HapiSpecRegistry;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.queries.HapiQueryOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.CustomFee;
@@ -476,7 +477,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getFreezeKey(),
                     expectedFreezeKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getFreezeKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getRoleKey(n, KeyRole.FREEZE),
                     "Wrong token freeze key!",
                     registry);
         }
@@ -489,7 +490,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getAdminKey(),
                     expectedAdminKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getAdminKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getRoleKey(n, KeyRole.ADMIN),
                     "Wrong token admin key!",
                     registry);
         }
@@ -502,7 +503,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getWipeKey(),
                     expectedWipeKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getWipeKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getRoleKey(n, KeyRole.WIPE),
                     "Wrong token wipe key!",
                     registry);
         }
@@ -515,7 +516,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getKycKey(),
                     expectedKycKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getKycKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getRoleKey(n, KeyRole.KYC),
                     "Wrong token KYC key!",
                     registry);
         }
@@ -528,7 +529,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getSupplyKey(),
                     expectedSupplyKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getSupplyKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getRoleKey(n, KeyRole.SUPPLY),
                     "Wrong token supply key!",
                     registry);
         }
@@ -542,7 +543,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getFeeScheduleKey(),
                     expectedFeeScheduleKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getFeeScheduleKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getRoleKey(n, KeyRole.FEE_SCHEDULE),
                     "Wrong token fee schedule key!",
                     registry);
         }
@@ -555,7 +556,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getPauseKey(),
                     expectedPauseKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getPauseKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getRoleKey(n, KeyRole.PAUSE),
                     "Wrong token pause key!",
                     registry);
         }
@@ -566,7 +567,7 @@ public class HapiGetTokenInfo extends HapiQueryOp<HapiGetTokenInfo> {
             assertFor(
                     actualInfo.getMetadataKey(),
                     expectedMetadataKey,
-                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getMetadataKey(n),
+                    (n, r) -> searchKeysGlobally ? r.getKey(n) : r.getRoleKey(n, KeyRole.METADATA),
                     "Wrong token metadata key!",
                     registry);
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractUpdate.java
@@ -14,6 +14,7 @@ import com.google.protobuf.Int32Value;
 import com.google.protobuf.StringValue;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.FeeCalculator;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -154,7 +155,7 @@ public class HapiContractUpdate extends HapiTxnOp<HapiContractUpdate> {
                     k -> spec.registry().saveKey(contract, spec.registry().getKey(k)));
         }
         if (useEmptyAdminKeyList) {
-            spec.registry().forgetAdminKey(contract);
+            spec.registry().forgetRoleKey(contract, KeyRole.ADMIN);
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleCreate.java
@@ -15,6 +15,7 @@ import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
 import com.hedera.services.bdd.spec.fees.FeeCalculator;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.suites.schedule.ScheduleUtils;
@@ -310,8 +311,8 @@ public class HapiScheduleCreate<T extends HapiTxnOp<T>> extends HapiTxnOp<HapiSc
 
         newScheduleIdObserver.ifPresent(obs -> obs.accept(scheduleId));
 
-        adminKey.ifPresent(
-                k -> registry.saveAdminKey(scheduleEntity, spec.registry().getKey(k)));
+        adminKey.ifPresent(k -> registry.saveRoleKey(
+                scheduleEntity, KeyRole.ADMIN, spec.registry().getKey(k)));
         if (saveExpectedScheduledTxnId) {
             if (verboseLoggingOn) {
                 log.info("Returned receipt for scheduled txn is {}", lastReceipt.getScheduledTransactionID());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenBurn.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenBurn.java
@@ -11,6 +11,7 @@ import com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -92,7 +93,7 @@ public class HapiTokenBurn extends HapiTxnOp<HapiTokenBurn> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getSupplyKey(token));
+                .getRoleKey(token, KeyRole.SUPPLY));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
@@ -27,7 +27,6 @@ import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.dsl.utils.KeyMetadata;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
-import com.hedera.services.bdd.spec.infrastructure.HapiSpecRegistry;
 import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
@@ -493,7 +492,7 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
         for (KeyRole role : KeyRole.values()) {
             final var key = getKeyFromOp(op, role);
             if (key != null) {
-                metadata.add(KeyMetadata.from(key, spec, HapiSpecRegistry::saveRoleKey));
+                metadata.add(KeyMetadata.from(key, spec, KeyMetadata.roleBasedRegistration(role)));
             }
         }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenCreate.java
@@ -28,6 +28,7 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.dsl.utils.KeyMetadata;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
 import com.hedera.services.bdd.spec.infrastructure.HapiSpecRegistry;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.suites.utils.contracts.precompile.TokenKeyType;
@@ -390,8 +391,8 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
                                         case SUPPLY_KEY -> b.setSupplyKey(contractKey);
                                         case WIPE_KEY -> b.setWipeKey(contractKey);
                                         case METADATA_KEY -> b.setMetadataKey(contractKey);
-                                        default -> throw new IllegalStateException(
-                                                "Unexpected tokenKeyType: " + tokenKeyType);
+                                        default ->
+                                            throw new IllegalStateException("Unexpected tokenKeyType: " + tokenKeyType);
                                     }
                                 }
                             }
@@ -461,29 +462,12 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
         final var registry = spec.registry();
         final var submittedBody = extractTransactionBodyUnchecked(txnSubmitted);
         final var op = submittedBody.getTokenCreation();
-        if (op.hasKycKey()) {
-            registry.saveKycKey(token, op.getKycKey());
-        }
-        if (op.hasWipeKey()) {
-            registry.saveWipeKey(token, op.getWipeKey());
-        }
-        if (op.hasAdminKey()) {
-            registry.saveAdminKey(token, op.getAdminKey());
-        }
-        if (op.hasSupplyKey()) {
-            registry.saveSupplyKey(token, op.getSupplyKey());
-        }
-        if (op.hasFreezeKey()) {
-            registry.saveFreezeKey(token, op.getFreezeKey());
-        }
-        if (op.hasFeeScheduleKey()) {
-            registry.saveFeeScheduleKey(token, op.getFeeScheduleKey());
-        }
-        if (op.hasPauseKey()) {
-            registry.savePauseKey(token, op.getPauseKey());
-        }
-        if (op.hasMetadataKey()) {
-            registry.saveMetadataKey(token, op.getMetadataKey());
+
+        for (KeyRole role : KeyRole.values()) {
+            final var key = getKeyFromOp(op, role);
+            if (key != null) {
+                registry.saveRoleKey(token, role, key);
+            }
         }
     }
 
@@ -505,30 +489,27 @@ public class HapiTokenCreate extends HapiTxnOp<HapiTokenCreate> {
         final List<KeyMetadata> metadata = new ArrayList<>();
         final var submittedBody = extractTransactionBodyUnchecked(txnSubmitted);
         final var op = submittedBody.getTokenCreation();
-        if (op.hasKycKey()) {
-            metadata.add(KeyMetadata.from(op.getKycKey(), spec, HapiSpecRegistry::saveKycKey));
+
+        for (KeyRole role : KeyRole.values()) {
+            final var key = getKeyFromOp(op, role);
+            if (key != null) {
+                metadata.add(KeyMetadata.from(key, spec, HapiSpecRegistry::saveRoleKey));
+            }
         }
-        if (op.hasWipeKey()) {
-            metadata.add(KeyMetadata.from(op.getWipeKey(), spec, HapiSpecRegistry::saveWipeKey));
-        }
-        if (op.hasAdminKey()) {
-            metadata.add(KeyMetadata.from(op.getAdminKey(), spec, HapiSpecRegistry::saveAdminKey));
-        }
-        if (op.hasSupplyKey()) {
-            metadata.add(KeyMetadata.from(op.getSupplyKey(), spec, HapiSpecRegistry::saveSupplyKey));
-        }
-        if (op.hasFreezeKey()) {
-            metadata.add(KeyMetadata.from(op.getFreezeKey(), spec, HapiSpecRegistry::saveFreezeKey));
-        }
-        if (op.hasFeeScheduleKey()) {
-            metadata.add(KeyMetadata.from(op.getFeeScheduleKey(), spec, HapiSpecRegistry::saveFeeScheduleKey));
-        }
-        if (op.hasPauseKey()) {
-            metadata.add(KeyMetadata.from(op.getPauseKey(), spec, HapiSpecRegistry::savePauseKey));
-        }
-        if (op.hasMetadataKey()) {
-            metadata.add(KeyMetadata.from(op.getMetadataKey(), spec, HapiSpecRegistry::saveMetadataKey));
-        }
+
         return metadata;
+    }
+
+    private Key getKeyFromOp(TokenCreateTransactionBody op, KeyRole role) {
+        return switch (role) {
+            case KYC -> op.hasKycKey() ? op.getKycKey() : null;
+            case WIPE -> op.hasWipeKey() ? op.getWipeKey() : null;
+            case ADMIN -> op.hasAdminKey() ? op.getAdminKey() : null;
+            case SUPPLY -> op.hasSupplyKey() ? op.getSupplyKey() : null;
+            case FREEZE -> op.hasFreezeKey() ? op.getFreezeKey() : null;
+            case FEE_SCHEDULE -> op.hasFeeScheduleKey() ? op.getFeeScheduleKey() : null;
+            case PAUSE -> op.hasPauseKey() ? op.getPauseKey() : null;
+            case METADATA -> op.hasMetadataKey() ? op.getMetadataKey() : null;
+        };
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenDelete.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenDelete.java
@@ -10,6 +10,8 @@ import com.hedera.node.app.hapi.fees.usage.TxnUsageEstimator;
 import com.hedera.node.app.hapi.fees.usage.token.TokenDeleteUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.infrastructure.HapiSpecRegistry;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -71,7 +73,7 @@ public class HapiTokenDelete extends HapiTxnOp<HapiTokenDelete> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getAdminKey(token));
+                .getRoleKey(token, KeyRole.ADMIN));
     }
 
     @Override
@@ -84,32 +86,20 @@ public class HapiTokenDelete extends HapiTxnOp<HapiTokenDelete> {
         registry.forgetSymbol(token);
         registry.forgetTokenId(token);
         registry.forgetTreasury(token);
-        if (registry.hasKycKey(token)) {
-            registry.forgetKycKey(token);
-        }
-        if (registry.hasWipeKey(token)) {
-            registry.forgetWipeKey(token);
-        }
-        if (registry.hasSupplyKey(token)) {
-            registry.forgetSupplyKey(token);
-        }
-        if (registry.hasAdminKey(token)) {
-            registry.forgetAdminKey(token);
-        }
-        if (registry.hasFreezeKey(token)) {
-            registry.forgetFreezeKey(token);
-        }
-        if (registry.hasFeeScheduleKey(token)) {
-            registry.forgetFeeScheduleKey(token);
-        }
-        if (registry.hasPauseKey(token)) {
-            registry.forgetPauseKey(token);
-        }
+        forgetRoleKeys(registry);
     }
 
     @Override
     protected MoreObjects.ToStringHelper toStringHelper() {
         final MoreObjects.ToStringHelper helper = super.toStringHelper().add("token", token);
         return helper;
+    }
+
+    private void forgetRoleKeys(HapiSpecRegistry registry) {
+        for (KeyRole role : KeyRole.values()) {
+            if (registry.hasRoleKey(token, role)) {
+                registry.forgetRoleKey(token, role);
+            }
+        }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFeeScheduleUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFeeScheduleUpdate.java
@@ -17,6 +17,7 @@ import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
 import com.hedera.services.bdd.spec.fees.FeeCalculator;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.queries.token.HapiGetTokenInfo;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
@@ -97,7 +98,9 @@ public class HapiTokenFeeScheduleUpdate extends HapiTxnOp<HapiTokenFeeScheduleUp
         signers.add(spec -> spec.registry().getKey(effectivePayer(spec)));
         signers.add(spec -> {
             final var registry = spec.registry();
-            return registry.hasFeeScheduleKey(token) ? registry.getFeeScheduleKey(token) : Key.getDefaultInstance();
+            return registry.hasRoleKey(token, KeyRole.FEE_SCHEDULE)
+                    ? registry.getRoleKey(token, KeyRole.FEE_SCHEDULE)
+                    : Key.getDefaultInstance();
         });
         return signers;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenFreeze.java
@@ -12,6 +12,7 @@ import com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.queries.crypto.ReferenceType;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
@@ -94,7 +95,7 @@ public class HapiTokenFreeze extends HapiTxnOp<HapiTokenFreeze> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getFreezeKey(token));
+                .getRoleKey(token, KeyRole.FREEZE));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycGrant.java
@@ -10,6 +10,7 @@ import com.hedera.node.app.hapi.fees.usage.TxnUsageEstimator;
 import com.hedera.node.app.hapi.fees.usage.token.TokenGrantKycUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.queries.crypto.ReferenceType;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
@@ -91,7 +92,7 @@ public class HapiTokenKycGrant extends HapiTxnOp<HapiTokenKycGrant> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getKycKey(token));
+                .getRoleKey(token, KeyRole.KYC));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycRevoke.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenKycRevoke.java
@@ -10,6 +10,7 @@ import com.hedera.node.app.hapi.fees.usage.TxnUsageEstimator;
 import com.hedera.node.app.hapi.fees.usage.token.TokenRevokeKycUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.queries.crypto.ReferenceType;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
@@ -92,7 +93,7 @@ public class HapiTokenKycRevoke extends HapiTxnOp<HapiTokenKycRevoke> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getKycKey(token));
+                .getRoleKey(token, KeyRole.KYC));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenMint.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenMint.java
@@ -14,6 +14,7 @@ import com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -133,7 +134,7 @@ public class HapiTokenMint extends HapiTxnOp<HapiTokenMint> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getSupplyKey(token));
+                .getRoleKey(token, KeyRole.SUPPLY));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenPause.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenPause.java
@@ -11,6 +11,7 @@ import com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -56,7 +57,7 @@ public class HapiTokenPause extends HapiTxnOp<HapiTokenPause> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getPauseKey(token));
+                .getRoleKey(token, KeyRole.PAUSE));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnfreeze.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnfreeze.java
@@ -12,6 +12,7 @@ import com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.queries.crypto.ReferenceType;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
@@ -94,7 +95,7 @@ public class HapiTokenUnfreeze extends HapiTxnOp<HapiTokenUnfreeze> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getFreezeKey(token));
+                .getRoleKey(token, KeyRole.FREEZE));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnpause.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUnpause.java
@@ -11,6 +11,7 @@ import com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -56,7 +57,7 @@ public class HapiTokenUnpause extends HapiTxnOp<HapiTokenUnpause> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getPauseKey(token));
+                .getRoleKey(token, KeyRole.PAUSE));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdateNfts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdateNfts.java
@@ -10,6 +10,7 @@ import com.hedera.node.app.hapi.fees.usage.state.UsageAccumulator;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -118,7 +119,7 @@ public class HapiTokenUpdateNfts extends HapiTxnOp<HapiTokenUpdateNfts> {
         final List<Function<HapiSpec, Key>> signers = new ArrayList<>();
         signers.add(spec -> spec.registry().getKey(effectivePayer(spec)));
         if (metadataKey.isPresent()) {
-            signers.add(spec -> spec.registry().getMetadataKey(token));
+            signers.add(spec -> spec.registry().getRoleKey(token, KeyRole.METADATA));
         }
         return signers;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenWipe.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenWipe.java
@@ -12,6 +12,7 @@ import com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
+import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.queries.crypto.ReferenceType;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
@@ -130,7 +131,7 @@ public class HapiTokenWipe extends HapiTxnOp<HapiTokenWipe> {
     @Override
     protected List<Function<HapiSpec, Key>> defaultSigners() {
         return List.of(spec -> spec.registry().getKey(effectivePayer(spec)), spec -> spec.registry()
-                .getWipeKey(token));
+                .getRoleKey(token, KeyRole.WIPE));
     }
 
     @Override


### PR DESCRIPTION
**Description**:

- Refactored HapiSpecRegistry role key management by introducing a KeyRole enum.
-  Removed the proliferation of specialized saveXKey() and getXKey() methods by using role-based key storage with standardized naming. 
- Simplified KeyMetadata to support role-aware registration without changing existing public signatures.

<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->


Fixes #
https://github.com/hiero-ledger/hiero-consensus-node/issues/13640

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
