### PR TITLE
test: #18574: fix threading workaround (#18885)

### DIFF
--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/map/MapTest.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/map/MapTest.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.virtual.merkle.map;
 
-import static com.swirlds.common.test.fixtures.AssertionUtils.assertEventuallyTrue;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -27,7 +27,6 @@ import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
 import com.swirlds.virtualmap.datasource.VirtualLeafRecord;
 import com.swirlds.virtualmap.internal.RecordAccessor;
 import com.swirlds.virtualmap.internal.merkle.VirtualRootNode;
-import java.time.Duration;
 import org.hiero.base.crypto.DigestType;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -36,7 +35,7 @@ import org.junit.jupiter.api.Test;
 
 final class MapTest {
 
-    private static Configuration CONFIGURATION = ConfigurationBuilder.create()
+    private static final Configuration CONFIGURATION = ConfigurationBuilder.create()
             .withConfigDataType(VirtualMapConfig.class)
             .withConfigDataType(MerkleDbConfig.class)
             .withConfigDataType(TemporaryFileConfig.class)
@@ -119,11 +118,8 @@ final class MapTest {
             // Make sure all the created virtual map copies are fully processed before this test
             // is complete, otherwise OOME can be observed in random tests run after this one
             final VirtualRootNode<TestKey, TestValue> root = map.getRight();
-            root.enableFlush();
-            final VirtualMap<TestKey, TestValue> lastCopy = map.copy();
             map.release();
-            lastCopy.release();
-            assertEventuallyTrue(root::isFlushed, Duration.ofMinutes(1), "The map must be flushed");
+            assertTrue(root.getPipeline().awaitTermination(1, MINUTES), "Pipeline termination timed out");
         }
     }
 

--- a/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
@@ -175,9 +175,9 @@ class VirtualPipelineTests {
             }
         }
 
-        if (allAreDestroyed && copies.size() > 0) {
+        if (allAreDestroyed && !copies.isEmpty()) {
             final VirtualPipeline<VirtualKey, VirtualValue> pipeline =
-                    copies.get(0).getPipeline();
+                    copies.getFirst().getPipeline();
             assertTrue(pipeline.awaitTermination(2, TimeUnit.SECONDS), "thread should stop");
         }
     }


### PR DESCRIPTION
**Description**:
Some timing sensitive tests may fail, because previous test might have created huge virtual map and copies, that have not yet been fully disposed by asinc VirtualPipeline thread, causing OOM errors. When dealing with huge virtual maps in tests, ensure in the end that map and copies have been released and wait on VirtualPipeline termination.

Fixes #18574