### PR TITLE
chore: publish all HCN Modules in the same Maven group

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -793,14 +793,7 @@ jobs:
             gpg --output "${PUBLIC_ARCHIVE_FILE}.sha256.asc" --detach-sig "${PUBLIC_ARCHIVE_FILE}.sha256"
           echo "::endgroup::"
 
-      - name: Gradle Publish Platform to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
-        if: ${{ inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
-        env:
-          NEXUS_USERNAME: ${{ secrets.sdk-ossrh-username }}
-          NEXUS_PASSWORD: ${{ secrets.sdk-ossrh-password }}
-        run: ./gradlew release${{ inputs.release-profile }} -PpublishingPackageGroup=com.swirlds -Ps01SonatypeHost=true -PpublishSigningEnabled=true --no-configuration-cache
-
-      - name: Gradle Publish Services to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
+      - name: Gradle Publish to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
         if: ${{ inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
         env:
           NEXUS_USERNAME: ${{ secrets.svcs-ossrh-username }}

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -191,7 +191,7 @@ jobs:
 
       - name: Gradle Dependency Scopes Check
         if: ${{ inputs.enable-dependency-check && steps.gradle-build.conclusion == 'success' && !cancelled() }}
-        run: ${GRADLE_EXEC} checkAllModuleInfo validatePomFiles --continue
+        run: ${GRADLE_EXEC} checkAllModuleInfo validatePomFiles --continue --no-build-cache
 
       - name: Unit Testing
         id: gradle-test

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,7 +10,7 @@ javaModules {
 
     // The Hedera platform modules
     directory("platform-sdk") {
-        group = "com.swirlds"
+        group = "com.hedera.hashgraph"
         module("swirlds") // not actually a Module as it has no module-info.java
         module("swirlds-benchmarks") // not actually a Module as it has no module-info.java
     }
@@ -44,11 +44,11 @@ javaModules {
     }
 
     // Platform-base demo applications
-    directory("example-apps") { group = "com.swirlds" }
+    directory("example-apps") { group = "com.hedera.hashgraph" }
 
     // Platform demo applications
-    directory("platform-sdk/platform-apps/demos") { group = "com.swirlds" }
+    directory("platform-sdk/platform-apps/demos") { group = "com.hedera.hashgraph" }
 
     // Platform test applications
-    directory("platform-sdk/platform-apps/tests") { group = "com.swirlds" }
+    directory("platform-sdk/platform-apps/tests") { group = "com.hedera.hashgraph" }
 }


### PR DESCRIPTION
**Description**:

With this PR we use `com.hedera.hashgraph` as **Maven Group** for all modules published from this repository. This allow us to keep Modules that already exist in that group as they are. All other Modules – `com.swirlds` and new `org.hiero` – are moved from the `com.swirlds` group to the `com.hedera.hashgraph` group with this PR.

Publishing in then simplified and can be performed in one step (see pipeline adjustment in this PR).
**This will then allow us, as a next step, to switch to the new Maven Central Portal publishing mechanism in one go.**

This will also make it simpler to eventually move everything to the new `org.hiero` group.
