### PR TITLE
build: add exports/opens to run tests on Module Path (foundation)

### DIFF
--- a/platform-sdk/swirlds-base/build.gradle.kts
+++ b/platform-sdk/swirlds-base/build.gradle.kts
@@ -14,6 +14,7 @@ tasks.withType<JavaCompile>().configureEach {
 }
 
 testModuleInfo {
+    requires("com.swirlds.base.test.fixtures")
     requires("org.junit.jupiter.api")
     requires("org.assertj.core")
     requires("org.mockito")

--- a/platform-sdk/swirlds-base/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-base/src/main/java/module-info.java
@@ -16,7 +16,6 @@ module com.swirlds.base {
             com.swirlds.config.api,
             com.swirlds.config.api.test.fixtures,
             com.swirlds.config.impl,
-            com.swirlds.config.exceptions,
             com.swirlds.config.extensions.test.fixtures,
             com.swirlds.logging,
             com.swirlds.logging.test.fixtures,
@@ -27,12 +26,13 @@ module com.swirlds.base {
             com.swirlds.common,
             com.swirlds.config.api,
             com.swirlds.config.api.test.fixtures,
-            com.swirlds.config.exceptions,
             com.swirlds.config.extensions.test.fixtures,
             com.swirlds.config.impl,
             com.swirlds.logging,
             com.swirlds.logging.test.fixtures,
             com.swirlds.metrics.api;
+    exports com.swirlds.base.time.internal to
+            org.hiero.consensus.event.creator.impl; // used in TransactionPoolNexusTest
 
     requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-base/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/module-info.java
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 open module com.swirlds.base.test.fixtures {
+    exports com.swirlds.base.test.fixtures.assertions;
     exports com.swirlds.base.test.fixtures.context;
     exports com.swirlds.base.test.fixtures.time;
     exports com.swirlds.base.test.fixtures.io;
     exports com.swirlds.base.test.fixtures.util;
     exports com.swirlds.base.test.fixtures.concurrent;
+    exports com.swirlds.base.test.fixtures.concurrent.internal;
 
     requires transitive com.swirlds.base;
     requires transitive org.junit.jupiter.api;

--- a/platform-sdk/swirlds-config-extensions/build.gradle.kts
+++ b/platform-sdk/swirlds-config-extensions/build.gradle.kts
@@ -7,6 +7,9 @@ plugins {
 
 testModuleInfo {
     runtimeOnly("com.swirlds.config.impl")
+    requires("com.swirlds.config.extensions.test.fixtures")
     requires("org.junit.jupiter.api")
     requires("org.assertj.core")
+
+    exportsTo("com.swirlds.config.impl") // for ConfigExportTest
 }

--- a/platform-sdk/swirlds-config-impl/build.gradle.kts
+++ b/platform-sdk/swirlds-config-impl/build.gradle.kts
@@ -12,6 +12,8 @@ testModuleInfo {
     requires("org.junit.jupiter.params")
     requires("com.swirlds.common")
     runtimeOnly("com.swirlds.platform.core")
+
+    exportsTo("com.swirlds.config.extensions")
 }
 
 jmhModuleInfo {

--- a/platform-sdk/swirlds-logging/build.gradle.kts
+++ b/platform-sdk/swirlds-logging/build.gradle.kts
@@ -28,6 +28,8 @@ testModuleInfo {
     requires("com.swirlds.base.test.fixtures")
     requires("com.swirlds.common.test.fixtures")
     requires("jakarta.inject")
+
+    opensTo("com.swirlds.base.test.fixtures") // injection via reflection
 }
 
 timingSensitiveModuleInfo {
@@ -38,6 +40,8 @@ timingSensitiveModuleInfo {
     requires("org.assertj.core")
     requires("org.junit.jupiter.api")
     runtimeOnly("com.swirlds.common.test.fixtures")
+
+    opensTo("com.swirlds.base.test.fixtures") // injection via reflection
 }
 
 jmhModuleInfo {

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/api/internal/format/StackTracePrinter.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/api/internal/format/StackTracePrinter.java
@@ -51,10 +51,15 @@ public class StackTracePrinter {
             for (int i = 0; i <= m; i++) {
                 final StackTraceElement stackTraceElement = stackTrace[i];
                 final String moduleName = stackTraceElement.getModuleName();
+                final String moduleVersion = stackTraceElement.getModuleVersion();
                 final String fileName = stackTraceElement.getFileName();
                 writer.append("\tat ");
                 if (moduleName != null) {
                     writer.append(moduleName);
+                    if (moduleVersion != null && !JDK_MODULES.contains(moduleName)) {
+                        writer.append("@");
+                        writer.append(moduleVersion);
+                    }
                     writer.append("/");
                 }
                 writer.append(stackTraceElement.getClassName());
@@ -94,4 +99,68 @@ public class StackTracePrinter {
             }
         }
     }
+
+    private static final Set<String> JDK_MODULES = Set.of(
+            "java.base",
+            "java.compiler",
+            "java.datatransfer",
+            "java.desktop",
+            "java.instrument",
+            "java.logging",
+            "java.management",
+            "java.management.rmi",
+            "java.naming",
+            "java.net.http",
+            "java.prefs",
+            "java.rmi",
+            "java.scripting",
+            "java.se",
+            "java.security.jgss",
+            "java.security.sasl",
+            "java.smartcardio",
+            "java.sql",
+            "java.sql.rowset",
+            "java.transaction.xa",
+            "java.xml",
+            "java.xml.crypto",
+            "jdk.accessibility",
+            "jdk.attach",
+            "jdk.charsets",
+            "jdk.compiler",
+            "jdk.crypto.cryptoki",
+            "jdk.crypto.ec",
+            "jdk.dynalink",
+            "jdk.editpad",
+            "jdk.hotspot.agent",
+            "jdk.httpserver",
+            "jdk.incubator.foreign",
+            "jdk.incubator.vector",
+            "jdk.jartool",
+            "jdk.javadoc",
+            "jdk.jcmd",
+            "jdk.jconsole",
+            "jdk.jdeps",
+            "jdk.jdi",
+            "jdk.jdwp.agent",
+            "jdk.jfr",
+            "jdk.jlink",
+            "jdk.jpackage",
+            "jdk.jshell",
+            "jdk.jsobject",
+            "jdk.jstatd",
+            "jdk.localedata",
+            "jdk.management",
+            "jdk.management.agent",
+            "jdk.management.jfr",
+            "jdk.naming.dns",
+            "jdk.naming.rmi",
+            "jdk.net",
+            "jdk.nio.mapmode",
+            "jdk.sctp",
+            "jdk.security.auth",
+            "jdk.security.jgss",
+            "jdk.unsupported",
+            "jdk.unsupported.desktop",
+            "jdk.xml.dom",
+            "jdk.zipfs");
 }

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/api/internal/format/StackTracePrinter.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/api/internal/format/StackTracePrinter.java
@@ -56,7 +56,7 @@ public class StackTracePrinter {
                 writer.append("\tat ");
                 if (moduleName != null) {
                     writer.append(moduleName);
-                    if (moduleVersion != null && !JDK_MODULES.contains(moduleName)) {
+                    if (moduleVersion != null) {
                         writer.append("@");
                         writer.append(moduleVersion);
                     }
@@ -99,68 +99,4 @@ public class StackTracePrinter {
             }
         }
     }
-
-    private static final Set<String> JDK_MODULES = Set.of(
-            "java.base",
-            "java.compiler",
-            "java.datatransfer",
-            "java.desktop",
-            "java.instrument",
-            "java.logging",
-            "java.management",
-            "java.management.rmi",
-            "java.naming",
-            "java.net.http",
-            "java.prefs",
-            "java.rmi",
-            "java.scripting",
-            "java.se",
-            "java.security.jgss",
-            "java.security.sasl",
-            "java.smartcardio",
-            "java.sql",
-            "java.sql.rowset",
-            "java.transaction.xa",
-            "java.xml",
-            "java.xml.crypto",
-            "jdk.accessibility",
-            "jdk.attach",
-            "jdk.charsets",
-            "jdk.compiler",
-            "jdk.crypto.cryptoki",
-            "jdk.crypto.ec",
-            "jdk.dynalink",
-            "jdk.editpad",
-            "jdk.hotspot.agent",
-            "jdk.httpserver",
-            "jdk.incubator.foreign",
-            "jdk.incubator.vector",
-            "jdk.jartool",
-            "jdk.javadoc",
-            "jdk.jcmd",
-            "jdk.jconsole",
-            "jdk.jdeps",
-            "jdk.jdi",
-            "jdk.jdwp.agent",
-            "jdk.jfr",
-            "jdk.jlink",
-            "jdk.jpackage",
-            "jdk.jshell",
-            "jdk.jsobject",
-            "jdk.jstatd",
-            "jdk.localedata",
-            "jdk.management",
-            "jdk.management.agent",
-            "jdk.management.jfr",
-            "jdk.naming.dns",
-            "jdk.naming.rmi",
-            "jdk.net",
-            "jdk.nio.mapmode",
-            "jdk.sctp",
-            "jdk.security.auth",
-            "jdk.security.jgss",
-            "jdk.unsupported",
-            "jdk.unsupported.desktop",
-            "jdk.xml.dom",
-            "jdk.zipfs");
 }

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/api/internal/format/StackTracePrinterTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/api/internal/format/StackTracePrinterTest.java
@@ -37,7 +37,7 @@ class StackTracePrinterTest {
         // Then
         final StringWriter stringWriter = new StringWriter();
         deepThrowable.printStackTrace(new PrintWriter(stringWriter));
-        assertEquals(stringWriter.toString(), writer.toString());
+        assertEquals(stringWriter.toString(), removeJavaBaseVersion(writer.toString()));
     }
 
     @Test
@@ -57,7 +57,7 @@ class StackTracePrinterTest {
         // Then
         final StringWriter stringWriter = new StringWriter();
         deepThrowable3.printStackTrace(new PrintWriter(stringWriter));
-        assertEquals(stringWriter.toString(), writer.toString());
+        assertEquals(stringWriter.toString(), removeJavaBaseVersion(writer.toString()));
     }
 
     @Test
@@ -84,5 +84,11 @@ class StackTracePrinterTest {
             count++;
         }
         return count;
+    }
+
+    private String removeJavaBaseVersion(String trace) {
+        // Java's printStackTrace() skips the versions of JDK core modules (like java.base).
+        // We don't to avoid special handling of them in StackTracePrinter.
+        return trace.replaceAll("java.base@[0-9.]+/", "java.base/");
     }
 }

--- a/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/internal/FilteredLoggingMirrorTest.java
+++ b/platform-sdk/swirlds-logging/src/test/java/com/swirlds/logging/test/internal/FilteredLoggingMirrorTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.logging.test.fixtures.internal;
+package com.swirlds.logging.test.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/platform-sdk/swirlds-logging/src/testFixtures/java/com/swirlds/logging/test/fixtures/util/Throwables.java
+++ b/platform-sdk/swirlds-logging/src/testFixtures/java/com/swirlds/logging/test/fixtures/util/Throwables.java
@@ -6,12 +6,38 @@ package com.swirlds.logging.test.fixtures.util;
  */
 public class Throwables {
 
-    public static final String METHOD_SIGNATURE_PATTERN =
-            "\\tat " + Throwables.class.getName().replace(".", "\\.") + "\\.createThrowableWithDeepCause\\("
-                    + Throwables.class.getSimpleName() + "\\.java:\\d+\\)";
-    public static final String CAUSE_METHOD_SIGNATURE_PATTERN =
-            "\\tat " + Throwables.class.getName().replace(".", "\\.") + "\\.createDeepThrowable\\("
-                    + Throwables.class.getSimpleName() + "\\.java:\\d+\\)";
+    private static String methodSignaturePatternModulePath() {
+        return "\\tat " + Throwables.class.getModule().getName() + "@"
+                + Throwables.class.getModule().getDescriptor().version().orElseThrow() + "/"
+                + Throwables.class.getName().replace(".", "\\.") + "\\.createThrowableWithDeepCause\\("
+                + Throwables.class.getSimpleName() + "\\.java:\\d+\\)";
+    }
+
+    private static String methodSignaturePatternClasspath() {
+        return "\\tat " + Throwables.class.getName().replace(".", "\\.") + "\\.createThrowableWithDeepCause\\("
+                + Throwables.class.getSimpleName() + "\\.java:\\d+\\)";
+    }
+
+    private static String causeMethodSignaturePatternModulePath() {
+        return "\\tat " + Throwables.class.getModule().getName() + "@"
+                + Throwables.class.getModule().getDescriptor().version().orElseThrow() + "/"
+                + Throwables.class.getName().replace(".", "\\.") + "\\.createDeepThrowable\\("
+                + Throwables.class.getSimpleName() + "\\.java:\\d+\\)";
+    }
+
+    private static String causeMethodSignaturePatternClasspath() {
+        return "\\tat " + Throwables.class.getName().replace(".", "\\.") + "\\.createDeepThrowable\\("
+                + Throwables.class.getSimpleName() + "\\.java:\\d+\\)";
+    }
+
+    public static String METHOD_SIGNATURE_PATTERN = Throwables.class.getModule().isNamed()
+            ? methodSignaturePatternModulePath()
+            : methodSignaturePatternClasspath();
+
+    public static String CAUSE_METHOD_SIGNATURE_PATTERN =
+            Throwables.class.getModule().isNamed()
+                    ? causeMethodSignaturePatternModulePath()
+                    : causeMethodSignaturePatternClasspath();
 
     private Throwables() {}
 

--- a/platform-sdk/swirlds-logging/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-logging/src/testFixtures/java/module-info.java
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 open module com.swirlds.logging.test.fixtures {
     exports com.swirlds.logging.test.fixtures;
+    exports com.swirlds.logging.test.fixtures.util;
+    exports com.swirlds.logging.test.fixtures.internal to
+            com.swirlds.logging; // for testing the fixture itself
 
     requires transitive com.swirlds.config.api;
+    requires transitive com.swirlds.config.extensions.test.fixtures;
     requires transitive com.swirlds.logging;
     requires transitive org.junit.jupiter.api;
     requires com.swirlds.base.test.fixtures;
-    requires com.swirlds.config.extensions.test.fixtures;
     requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-merkle/build.gradle.kts
+++ b/platform-sdk/swirlds-merkle/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
 testModuleInfo {
     requires("com.swirlds.base")
     requires("com.swirlds.common.test.fixtures")
+    requires("com.swirlds.merkle.test.fixtures")
     requires("org.hiero.base.concurrent")
     requires("org.hiero.base.crypto.test.fixtures")
     requires("org.hiero.base.utility.test.fixtures")

--- a/platform-sdk/swirlds-merkle/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-merkle/src/testFixtures/java/module-info.java
@@ -4,12 +4,17 @@
  */
 open module com.swirlds.merkle.test.fixtures {
     exports com.swirlds.merkle.test.fixtures;
+    exports com.swirlds.merkle.test.fixtures.map.benchmark;
+    exports com.swirlds.merkle.test.fixtures.map.benchmark.operations;
+    exports com.swirlds.merkle.test.fixtures.map.dummy;
     exports com.swirlds.merkle.test.fixtures.map.lifecycle;
     exports com.swirlds.merkle.test.fixtures.map.pta;
     exports com.swirlds.merkle.test.fixtures.map.util;
 
     requires transitive com.swirlds.common.test.fixtures;
     requires transitive com.swirlds.common;
+    requires transitive com.swirlds.fchashmap;
+    requires transitive com.swirlds.fcqueue;
     requires transitive com.swirlds.merkle;
     requires transitive org.hiero.base.crypto;
     requires transitive org.hiero.base.utility;
@@ -18,8 +23,6 @@ open module com.swirlds.merkle.test.fixtures {
     requires transitive com.fasterxml.jackson.databind;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.base;
-    requires com.swirlds.fchashmap;
-    requires com.swirlds.fcqueue;
     requires com.swirlds.logging;
     requires org.hiero.base.utility.test.fixtures;
     requires org.apache.logging.log4j.core;

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSerializationTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSerializationTests.java
@@ -22,7 +22,6 @@ import com.swirlds.common.merkle.MerkleInternal;
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.common.merkle.route.MerkleRouteFactory;
 import com.swirlds.common.merkle.utility.MerkleLong;
-import com.swirlds.common.test.fixtures.io.ResourceLoader;
 import com.swirlds.common.test.fixtures.merkle.TestMerkleCryptoFactory;
 import com.swirlds.common.test.fixtures.merkle.dummy.DummyMerkleInternal;
 import com.swirlds.common.test.fixtures.merkle.dummy.DummyMerkleLeaf;
@@ -169,7 +168,7 @@ class MerkleSerializationTests {
         final Path dir = getFile("merkle/serialized-tree-v3");
 
         final MerkleDataInputStream dataStream = new MerkleDataInputStream(
-                ResourceLoader.loadFileAsStream("merkle/serialized-tree-v3/serialized-tree-v3.dat"));
+                getClass().getResourceAsStream("/merkle/serialized-tree-v3/serialized-tree-v3.dat"));
         dataStream.readProtocolVersion();
         final DummyMerkleNode tree = dataStream.readMerkleTree(dir, Integer.MAX_VALUE);
         assertTrue(
@@ -240,7 +239,7 @@ class MerkleSerializationTests {
     void testHashFromFile() throws IOException {
         //		writeTreeToFile(MerkleTestUtils.buildLessSimpleTree(), "hashed-tree-merkle-v1.dat");
         final DataInputStream dataStream =
-                new DataInputStream(ResourceLoader.loadFileAsStream("merkle/hashed-tree-merkle-v1.dat"));
+                new DataInputStream(getClass().getResourceAsStream("/merkle/hashed-tree-merkle-v1.dat"));
 
         final Hash oldHash = new Hash(dataStream.readAllBytes(), DigestType.SHA_384);
         final MerkleNode tree = buildLessSimpleTree();

--- a/platform-sdk/swirlds-merkledb/build.gradle.kts
+++ b/platform-sdk/swirlds-merkledb/build.gradle.kts
@@ -21,6 +21,7 @@ jmhModuleInfo { requires("jmh.core") }
 testModuleInfo {
     requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.config.extensions.test.fixtures")
+    requires("com.swirlds.merkledb.test.fixtures")
     requires("org.hiero.base.utility.test.fixtures")
     requires("org.hiero.consensus.model")
     requires("org.junit.jupiter.api")

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/module-info.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 module com.swirlds.merkledb.test.fixtures {
     exports com.swirlds.merkledb.test.fixtures;
+    exports com.swirlds.merkledb.test.fixtures.files;
 
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.common;

--- a/platform-sdk/swirlds-state-impl/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/module-info.java
@@ -6,6 +6,10 @@ module com.swirlds.state.impl {
     exports com.swirlds.state.merkle.disk;
     exports com.swirlds.state.merkle;
 
+    // allow reflective access for tests
+    opens com.swirlds.state.merkle.disk to
+            com.hedera.node.app;
+
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.base;
     requires transitive com.swirlds.common;

--- a/platform-sdk/swirlds-virtualmap/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/module-info.java
@@ -13,19 +13,24 @@ open module com.swirlds.virtualmap {
 
     // Testing-only exports
     exports com.swirlds.virtualmap.internal to
+            com.swirlds.merkle,
+            com.swirlds.merkledb,
             com.swirlds.virtualmap.test.fixtures;
+    exports com.swirlds.virtualmap.internal.pipeline to
+            com.swirlds.merkle;
     exports com.swirlds.virtualmap.internal.cache to
+            com.swirlds.merkledb,
             com.swirlds.virtualmap.test.fixtures,
             com.swirlds.platform.core.test.fixtures;
 
     requires transitive com.hedera.pbj.runtime;
+    requires transitive com.swirlds.base;
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;
     requires transitive org.hiero.base.concurrent;
     requires transitive org.hiero.base.crypto;
     requires transitive org.hiero.base.utility;
-    requires com.swirlds.base;
     requires com.swirlds.config.extensions;
     requires com.swirlds.logging;
     requires java.management; // Test dependency

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/module-info.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/module-info.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-module com.swirlds.virtualmap.test.fixtures {
+open module com.swirlds.virtualmap.test.fixtures {
     exports com.swirlds.virtualmap.test.fixtures;
 
     requires transitive com.hedera.pbj.runtime;


### PR DESCRIPTION
**Description**:

The goal of this PR (together with #18924 and #18922) is to enable running tests on the Java Module Path (as opposed to the Classpath which is used now). This is the first step towards resolving #11573 to eventually fully use the Java Module System at runtime.

To allow the tests to use the Module Path, we will use the so-called [_Whitebox Testing_ approach for Java Modules](https://github.com/gradlex-org/java-module-testing#whitebox-test-suites). It uses Java's module patching mechanisms so that tests of a certain module are still allowed to access internals of that module at test time, but for all other Modules, the module restrictions are still enforced. Therefore, we need to allow some more cross-module visibility which this PR is adding. This makes relationships across modules that where previously hidden visible.

Note: This PR adds the required visibility for a set of modules in this repository. It does not yet turn on the _Module Path Testing_ which will be done for the complete repository in a follow up step.

**Follow ups**
- Switch on running normal tests on module path
- Switch on running hapi tests on module path
- Successively update all places that start applications/services (for real and in examples) to use the Module Path 

**Related issue(s)**:
- #11573
- #5275
- https://github.com/hiero-ledger/hiero-gradle-conventions/pull/170