### PR TITLE
chore: Introduced CryptoUtils

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
@@ -117,7 +117,7 @@ import java.util.Spliterators;
 import java.util.function.Function;
 import java.util.stream.StreamSupport;
 import org.apache.tuweni.bytes.Bytes32;
-import org.hiero.base.crypto.internal.CryptoUtils;
+import org.hiero.base.crypto.internal.DetRandomProvider;
 import org.hiero.consensus.model.node.NodeId;
 import org.hyperledger.besu.evm.EVM;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -582,7 +582,7 @@ public class TransactionExecutorsTest {
 
     public static X509Certificate randomX509Certificate() {
         try {
-            final SecureRandom secureRandom = CryptoUtils.getDetRandom();
+            final SecureRandom secureRandom = DetRandomProvider.getDetRandom();
 
             final KeyPairGenerator rsaKeyGen = KeyPairGenerator.getInstance("RSA");
             rsaKeyGen.initialize(3072, secureRandom);

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/CryptoUtils.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/CryptoUtils.java
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.base.crypto;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.cert.Certificate;
+import java.security.cert.CertificateEncodingException;
+
+/**
+ * Utility class for cryptographic operations.
+ */
+public class CryptoUtils {
+
+    private CryptoUtils() {}
+
+    /**
+     * Check if a certificate is valid.  A certificate is valid if it is not null, has a public key, and can be encoded.
+     *
+     * @param certificate the certificate to check
+     * @return true if the certificate is valid, false otherwise
+     */
+    public static boolean checkCertificate(@Nullable final Certificate certificate) {
+        if (certificate == null) {
+            return false;
+        }
+        if (certificate.getPublicKey() == null) {
+            return false;
+        }
+        try {
+            if (certificate.getEncoded().length == 0) {
+                return false;
+            }
+        } catch (final CertificateEncodingException e) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/DetRandomProvider.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/DetRandomProvider.java
@@ -1,26 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.crypto.internal;
 
-import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.security.SecureRandom;
 
-public abstract class CryptoUtils {
-    /** the type of hash to use */
-    private static final String HASH_TYPE = "SHA-384";
+public class DetRandomProvider {
 
     private static final String PRNG_TYPE = "SHA1PRNG";
     private static final String PRNG_PROVIDER = "SUN";
 
-    // return the MessageDigest for the type of hash function used throughout the code
-    public static MessageDigest getMessageDigest() {
-        try {
-            return MessageDigest.getInstance(HASH_TYPE);
-        } catch (NoSuchAlgorithmException e) {
-            throw new RuntimeException(e);
-        }
-    }
+    private DetRandomProvider() {}
 
     /**
      * Create an instance of the default deterministic {@link SecureRandom}

--- a/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/SerializablePublicKeyTests.java
+++ b/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/SerializablePublicKeyTests.java
@@ -10,7 +10,7 @@ import java.security.KeyPairGenerator;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
 import java.util.stream.Stream;
-import org.hiero.base.crypto.internal.CryptoUtils;
+import org.hiero.base.crypto.internal.DetRandomProvider;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -26,7 +26,7 @@ class SerializablePublicKeyTests {
     void serializeDeserialize(String keyType, int keySize, boolean writeClassId)
             throws NoSuchAlgorithmException, NoSuchProviderException, IOException {
         KeyPairGenerator keyGen = KeyPairGenerator.getInstance(keyType);
-        keyGen.initialize(keySize, CryptoUtils.getDetRandom());
+        keyGen.initialize(keySize, DetRandomProvider.getDetRandom());
         KeyPair keyPair = keyGen.generateKeyPair();
 
         SerializablePublicKey original = new SerializablePublicKey(keyPair.getPublic());

--- a/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/StreamFileSigner.java
+++ b/platform-sdk/swirlds-common/src/testFixtures/java/com/swirlds/common/test/fixtures/stream/StreamFileSigner.java
@@ -2,7 +2,7 @@
 package com.swirlds.common.test.fixtures.stream;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
-import static org.hiero.base.crypto.internal.CryptoUtils.getDetRandom;
+import static org.hiero.base.crypto.internal.DetRandomProvider.getDetRandom;
 import static org.hiero.base.utility.CommonUtils.hex;
 
 import com.swirlds.common.stream.Signer;

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Utilities.java
@@ -4,7 +4,6 @@ package com.swirlds.platform;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.internal.Deserializer;
 import com.swirlds.platform.internal.Serializer;
 import com.swirlds.platform.network.PeerInfo;
@@ -19,6 +18,7 @@ import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hiero.base.crypto.CryptoUtils;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
 import org.hiero.consensus.model.node.NodeId;
@@ -364,7 +364,7 @@ public final class Utilities {
                 .filter(entry -> entry.nodeId() != selfId.id())
                 // Only include peers with valid gossip certificates
                 // https://github.com/hashgraph/hedera-services/issues/16648
-                .filter(entry -> CryptoStatic.checkCertificate((RosterUtils.fetchGossipCaCertificate(entry))))
+                .filter(entry -> CryptoUtils.checkCertificate((RosterUtils.fetchGossipCaCertificate(entry))))
                 .map(Utilities::toPeerInfo)
                 .toList();
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -57,6 +57,7 @@ import java.util.function.Function;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.concurrent.ExecutorFactory;
+import org.hiero.base.crypto.CryptoUtils;
 import org.hiero.base.crypto.Signature;
 import org.hiero.consensus.config.EventConfig;
 import org.hiero.consensus.event.creator.impl.pool.TransactionPoolNexus;
@@ -318,7 +319,7 @@ public final class PlatformBuilder {
         this.keysAndCerts = Objects.requireNonNull(keysAndCerts);
         // Ensure that the platform has a valid signing cert that matches the signing private key.
         // https://github.com/hashgraph/hedera-services/issues/16648
-        if (!CryptoStatic.checkCertificate(keysAndCerts.sigCert())) {
+        if (!CryptoUtils.checkCertificate(keysAndCerts.sigCert())) {
             throw new IllegalStateException("Starting the platform requires a signing cert.");
         }
         final PlatformSigner platformSigner = new PlatformSigner(keysAndCerts);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/CryptoStatic.java
@@ -44,7 +44,6 @@ import java.security.Signature;
 import java.security.SignatureException;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
-import java.security.cert.CertificateEncodingException;
 import java.security.cert.CertificateException;
 import java.security.cert.CertificateFactory;
 import java.security.cert.X509Certificate;
@@ -651,28 +650,5 @@ public final class CryptoStatic {
             store.setCertificateEntry(SIGNING.storeName(peer.nodeId()), sigCert);
         }
         return store;
-    }
-
-    /**
-     * Check if a certificate is valid.  A certificate is valid if it is not null, has a public key, and can be encoded.
-     *
-     * @param certificate the certificate to check
-     * @return true if the certificate is valid, false otherwise
-     */
-    public static boolean checkCertificate(@Nullable final Certificate certificate) {
-        if (certificate == null) {
-            return false;
-        }
-        if (certificate.getPublicKey() == null) {
-            return false;
-        }
-        try {
-            if (certificate.getEncoded().length == 0) {
-                return false;
-            }
-        } catch (final CertificateEncodingException e) {
-            return false;
-        }
-        return true;
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeysAndCerts.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/crypto/KeysAndCerts.java
@@ -15,7 +15,7 @@ import java.security.SecureRandom;
 import java.security.UnrecoverableKeyException;
 import java.security.cert.Certificate;
 import java.security.cert.X509Certificate;
-import org.hiero.base.crypto.internal.CryptoUtils;
+import org.hiero.base.crypto.internal.DetRandomProvider;
 import org.hiero.consensus.model.node.NodeId;
 
 /**
@@ -135,8 +135,8 @@ public record KeysAndCerts(KeyPair sigKeyPair, KeyPair agrKeyPair, X509Certifica
         sigKeyGen = KeyPairGenerator.getInstance(CryptoConstants.SIG_TYPE1, CryptoConstants.SIG_PROVIDER);
         agrKeyGen = KeyPairGenerator.getInstance(CryptoConstants.AGR_TYPE, CryptoConstants.AGR_PROVIDER);
 
-        sigDetRandom = CryptoUtils.getDetRandom(); // deterministic, not shared
-        agrDetRandom = CryptoUtils.getDetRandom(); // deterministic, not shared
+        sigDetRandom = DetRandomProvider.getDetRandom(); // deterministic, not shared
+        agrDetRandom = DetRandomProvider.getDetRandom(); // deterministic, not shared
 
         sigDetRandom.setSeed(masterKey);
         sigDetRandom.setSeed(swirldId);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossipModular.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/SyncGossipModular.java
@@ -16,7 +16,6 @@ import com.swirlds.component.framework.wires.input.BindableInputWire;
 import com.swirlds.component.framework.wires.output.StandardOutputWire;
 import com.swirlds.platform.Utilities;
 import com.swirlds.platform.config.StateConfig;
-import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.crypto.KeysAndCerts;
 import com.swirlds.platform.gossip.sync.SyncManagerImpl;
 import com.swirlds.platform.metrics.ReconnectMetrics;
@@ -55,6 +54,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hiero.base.crypto.CryptoUtils;
 import org.hiero.consensus.gossip.FallenBehindManager;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
@@ -112,7 +112,7 @@ public class SyncGossipModular implements Gossip {
         final RosterEntry selfEntry = RosterUtils.getRosterEntry(roster, selfId.id());
         final X509Certificate selfCert = RosterUtils.fetchGossipCaCertificate(selfEntry);
         final List<PeerInfo> peers;
-        if (!CryptoStatic.checkCertificate(selfCert)) {
+        if (!CryptoUtils.checkCertificate(selfCert)) {
             // Do not make peer connections if the self node does not have a valid signing certificate in the roster.
             // https://github.com/hashgraph/hedera-services/issues/16648
             logger.error(

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/Address.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/address/Address.java
@@ -4,7 +4,6 @@ package com.swirlds.platform.system.address;
 import static com.swirlds.common.utility.NonCryptographicHashing.hash32;
 
 import com.swirlds.base.utility.ToStringBuilder;
-import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.crypto.SerializableX509Certificate;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -14,6 +13,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Objects;
+import org.hiero.base.crypto.CryptoUtils;
 import org.hiero.base.crypto.SerializablePublicKey;
 import org.hiero.base.io.SelfSerializable;
 import org.hiero.base.io.streams.SerializableDataInputStream;
@@ -641,7 +641,7 @@ public class Address implements SelfSerializable {
         if (certificate == null) {
             return null;
         }
-        return CryptoStatic.checkCertificate(certificate.getCertificate()) ? certificate : null;
+        return CryptoUtils.checkCertificate(certificate.getCertificate()) ? certificate : null;
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/SerializableX509CertificateTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/crypto/SerializableX509CertificateTests.java
@@ -19,7 +19,7 @@ import java.security.SignatureException;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Random;
-import org.hiero.base.crypto.internal.CryptoUtils;
+import org.hiero.base.crypto.internal.DetRandomProvider;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -37,7 +37,7 @@ class SerializableX509CertificateTests {
         final int ecKeySize = 384;
 
         final Random nonSecureRandom = getRandomPrintSeed();
-        final SecureRandom secureRandom = CryptoUtils.getDetRandom();
+        final SecureRandom secureRandom = DetRandomProvider.getDetRandom();
         secureRandom.setSeed(nonSecureRandom.nextLong());
 
         // Render key pairs.

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/NetworkPeerIdentifierTest.java
@@ -33,7 +33,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.hiero.base.crypto.internal.CryptoUtils;
+import org.hiero.base.crypto.internal.DetRandomProvider;
 import org.hiero.consensus.model.node.NodeId;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -137,7 +137,7 @@ class NetworkPeerIdentifierTest {
     void testIdentifyTlsPeerReturnsNull()
             throws NoSuchAlgorithmException, NoSuchProviderException, KeyGeneratingException {
 
-        final SecureRandom secureRandom = CryptoUtils.getDetRandom();
+        final SecureRandom secureRandom = DetRandomProvider.getDetRandom();
 
         final KeyPairGenerator rsaKeyGen = KeyPairGenerator.getInstance("RSA");
         rsaKeyGen.initialize(3072, secureRandom);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterRetrieverTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/roster/RosterRetrieverTests.java
@@ -27,7 +27,7 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.stream.Stream;
-import org.hiero.base.crypto.internal.CryptoUtils;
+import org.hiero.base.crypto.internal.DetRandomProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -201,7 +201,7 @@ public class RosterRetrieverTests {
 
     public static X509Certificate randomX509Certificate() {
         try {
-            final SecureRandom secureRandom = CryptoUtils.getDetRandom();
+            final SecureRandom secureRandom = DetRandomProvider.getDetRandom();
 
             final KeyPairGenerator rsaKeyGen = KeyPairGenerator.getInstance("RSA");
             rsaKeyGen.initialize(3072, secureRandom);


### PR DESCRIPTION
**Description**:

This PR introduces `CryptoUtils`, a class with commonly used cryptographic functionality that is independent of the underlying domain model (unlike some of the functionality in `CryptoStatic`). This is preparatory work for moving `Address` and `AddressBook` to the `consensus-model` in the next step. Also, renamed `DetRandomProvider` to avoid confusion.

**Related issue(s)**:

Part of #18927 
