### PR TITLE
test: Scope shard/realm first to target network, system properties

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -122,7 +122,12 @@ val prCheckNetSizeOverrides =
     )
 
 tasks {
-    prCheckTags.forEach { (taskName, _) -> register(taskName) { dependsOn("testSubprocess") } }
+    prCheckTags.forEach { (taskName, _) ->
+        register(taskName) {
+            getByName(taskName).group = "hapi-test"
+            dependsOn("testSubprocess")
+        }
+    }
     remoteCheckTags.forEach { (taskName, _) -> register(taskName) { dependsOn("testRemote") } }
 }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/AddressBookUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/utils/AddressBookUtils.java
@@ -2,7 +2,6 @@
 package com.hedera.services.bdd.junit.hedera.utils;
 
 import static com.hedera.services.bdd.junit.hedera.utils.WorkingDirUtils.workingDirFor;
-import static com.hedera.services.bdd.spec.HapiPropertySourceStaticInitializer.SHARD_AND_REALM;
 import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.toMap;
 
@@ -115,6 +114,9 @@ public class AddressBookUtils {
                 .append("app, HederaNode.jar\n\n#The following nodes make up this network\n");
         var maxNodeId = 0L;
         for (final var node : nodes) {
+            final var accountId = node.getAccountId();
+            final var fqAccId =
+                    String.format("%d.%d.%d", accountId.shardNum(), accountId.realmNum(), accountId.accountNum());
             sb.append("address, ")
                     .append(node.getNodeId())
                     .append(", ")
@@ -129,8 +131,7 @@ public class AddressBookUtils {
                     .append(", 127.0.0.1, ")
                     .append(nextExternalGossipPort + (node.getNodeId() * 2))
                     .append(", ")
-                    .append(SHARD_AND_REALM)
-                    .append(node.getAccountId().accountNumOrThrow())
+                    .append(fqAccId)
                     .append('\n');
             maxNodeId = Math.max(node.getNodeId(), maxNodeId);
         }
@@ -163,15 +164,17 @@ public class AddressBookUtils {
             final boolean nextNodeOperatorPortEnabled,
             final int nextGossipPort,
             final int nextGossipTlsPort,
-            final int nextPrometheusPort) {
+            final int nextPrometheusPort,
+            final long shard,
+            final long realm) {
         requireNonNull(host);
         requireNonNull(networkName);
         return new NodeMetadata(
                 nodeId,
                 CLASSIC_NODE_NAMES[nodeId],
                 AccountID.newBuilder()
-                        .shardNum(Long.parseLong(SHARD))
-                        .realmNum(Long.parseLong(REALM))
+                        .shardNum(shard)
+                        .realmNum(realm)
                         .accountNum(CLASSIC_FIRST_NODE_ACCOUNT_NUM + nodeId)
                         .build(),
                 host,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/RecordStreamValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/RecordStreamValidator.java
@@ -24,4 +24,8 @@ public interface RecordStreamValidator {
     default void validateRecordsAndSidecars(List<RecordWithSidecars> records) {
         // No-op
     }
+
+    default void validateRecordsAndSidecars(List<RecordWithSidecars> records, long shard, long realm) {
+        // No-op
+    }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/BalanceReconciliationValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/BalanceReconciliationValidator.java
@@ -32,12 +32,12 @@ public class BalanceReconciliationValidator implements RecordStreamValidator {
 
     @Override
     @SuppressWarnings("java:S106")
-    public void validateRecordsAndSidecars(final List<RecordWithSidecars> recordsWithSidecars) {
+    public void validateRecordsAndSidecars(final List<RecordWithSidecars> recordsWithSidecars, long shard, long realm) {
         getExpectedBalanceFrom(recordsWithSidecars);
         System.out.println("Expected balances: " + expectedBalances);
 
         final var validationSpecs = TestBase.extractContextualizedSpecsFrom(
-                List.of(() -> new BalanceValidation(expectedBalances, accountClassifier)),
+                List.of(() -> new BalanceValidation(expectedBalances, accountClassifier, shard, realm)),
                 TestBase::contextualizedSpecsFromConcurrent);
         concurrentExecutionOf(validationSpecs);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
@@ -38,6 +38,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 import org.hiero.base.utility.CommonUtils;
@@ -93,7 +95,7 @@ public interface HapiPropertySource {
 
     default FileID getFile(String property) {
         try {
-            return asFile(get("default.shard"), get("default.realm"), get(property));
+            return asFile(getShard(), getRealm(), Long.parseLong(get(property)));
         } catch (Exception ignore) {
         }
         return FileID.getDefaultInstance();
@@ -111,7 +113,7 @@ public interface HapiPropertySource {
         }
 
         try {
-            return asAccount(get("default.shard"), get("default.realm"), get(property));
+            return asAccount(getShard(), getRealm(), Long.parseLong(value));
         } catch (Exception ignore) {
         }
 
@@ -145,12 +147,26 @@ public interface HapiPropertySource {
         return ContractID.getDefaultInstance();
     }
 
+    @Deprecated
     default RealmID getRealm(String property) {
         return RealmID.newBuilder().setRealmNum(Long.parseLong(get(property))).build();
     }
 
+    default long getRealm() {
+        return Optional.ofNullable(get("hapi.spec.default.realm"))
+                .map(Long::parseLong)
+                .orElse(realm);
+    }
+
+    @Deprecated
     default ShardID getShard(String property) {
         return ShardID.newBuilder().setShardNum(Long.parseLong(get(property))).build();
+    }
+
+    default long getShard() {
+        return Optional.ofNullable(get("hapi.spec.default.shard"))
+                .map(Long::parseLong)
+                .orElse((long) shard);
     }
 
     default TimeUnit getTimeUnit(String property) {
@@ -221,6 +237,7 @@ public interface HapiPropertySource {
 
     static HapiPropertySource[] asSources(Object... sources) {
         return Stream.of(sources)
+                .filter(Objects::nonNull)
                 .map(s -> (s instanceof HapiPropertySource)
                         ? s
                         : ((s instanceof Map) ? new MapPropertySource((Map) s) : new JutilPropertySource((String) s)))
@@ -250,10 +267,14 @@ public interface HapiPropertySource {
     }
 
     static AccountID asAccount(String shard, String realm, String num) {
+        return asAccount(Long.parseLong(shard), Long.parseLong(realm), Long.parseLong(num));
+    }
+
+    static AccountID asAccount(long shard, long realm, long num) {
         return AccountID.newBuilder()
-                .setShardNum(Long.parseLong(shard))
-                .setRealmNum(Long.parseLong(realm))
-                .setAccountNum(Long.parseLong(num))
+                .setShardNum(shard)
+                .setRealmNum(realm)
+                .setAccountNum(num)
                 .build();
     }
 
@@ -266,10 +287,14 @@ public interface HapiPropertySource {
     }
 
     static FileID asFile(String shard, String realm, String num) {
+        return asFile(Long.parseLong(shard), Long.parseLong(realm), Long.parseLong(num));
+    }
+
+    static FileID asFile(long shard, long realm, long num) {
         return FileID.newBuilder()
-                .setShardNum(Long.parseLong(shard))
-                .setRealmNum(Long.parseLong(realm))
-                .setFileNum(Long.parseLong(num))
+                .setShardNum(shard)
+                .setRealmNum(realm)
+                .setFileNum(num)
                 .build();
     }
 
@@ -452,6 +477,14 @@ public interface HapiPropertySource {
     static long[] asDotDelimitedLongArray(String s) {
         String[] parts = s.split("[.]");
         return Stream.of(parts).mapToLong(Long::valueOf).toArray();
+    }
+
+    static ShardID asShard(long v) {
+        return ShardID.newBuilder().setShardNum(v).build();
+    }
+
+    static RealmID asRealm(long v) {
+        return RealmID.newBuilder().setRealmNum(v).build();
     }
 
     static byte[] asSolidityAddress(final AccountID accountId) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
@@ -562,6 +562,14 @@ public interface HapiPropertySource {
                 .build());
     }
 
+    static String asEntityString(final long shard, final long realm, final long num) {
+        return String.format(ENTITY_STRING, shard, realm, num);
+    }
+
+    static String asEntityString(final long shard, final long realm, final String num) {
+        return String.format("%d.%d.%s", shard, realm, num);
+    }
+
     static String asEntityString(final long num) {
         return String.format(ENTITY_STRING, shard, realm, num);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -1391,6 +1391,7 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
 
     private record ShardRealm(long shard, long realm) {}
 
+	// (FUTURE) Refactor to a more intuitive location
     private static ShardRealm determineShardRealm(@NonNull final HederaNetwork targetNetwork) {
         var shard = targetNetwork.shard();
         if (shard < 0) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -10,8 +10,6 @@ import static com.hedera.services.bdd.junit.extensions.NetworkTargetingExtension
 import static com.hedera.services.bdd.junit.extensions.NetworkTargetingExtension.SHARED_NETWORK;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.RECORD_STREAMS_DIR;
 import static com.hedera.services.bdd.junit.support.StreamFileAccess.STREAM_FILE_ACCESS;
-import static com.hedera.services.bdd.spec.HapiPropertySourceStaticInitializer.REALM;
-import static com.hedera.services.bdd.spec.HapiPropertySourceStaticInitializer.SHARD;
 import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.ERROR;
 import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.FAILED;
 import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.FAILED_AS_EXPECTED;
@@ -43,6 +41,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.MoreObjects;
+import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.TimestampSeconds;
 import com.hedera.hapi.node.state.addressbook.Node;
 import com.hedera.hapi.node.state.common.EntityNumber;
@@ -319,6 +318,18 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
 
     public static ThreadPoolExecutor getCommonThreadPool() {
         return THREAD_POOL;
+    }
+
+    public long shard() {
+        return anyNodeAccountId().shardNum();
+    }
+
+    public long realm() {
+        return anyNodeAccountId().realmNum();
+    }
+
+    private AccountID anyNodeAccountId() {
+        return getNetworkNodes().getFirst().getAccountId();
     }
 
     public void adhocIncrement() {
@@ -1083,8 +1094,12 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
 
             dynamicNodes = Arrays.stream(dynamicNodes.split(","))
                     .map(NodeConnectInfo::new)
-                    .map(info -> info.uri() + ":" + SHARD + "." + REALM + "."
-                            + info.getAccount().getAccountNum())
+                    .map(info -> {
+                        final var acct = info.getAccount();
+                        return info.uri() + ":"
+                                + String.format(
+                                        "%d.%d.%d", acct.getShardNum(), acct.getRealmNum(), acct.getAccountNum());
+                    })
                     .collect(Collectors.joining(","));
 
             ciPropsSource.put("nodes", dynamicNodes);
@@ -1189,6 +1204,8 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
                 name,
                 targeted(new HapiSpec(
                         name,
+                        // Defined with only the default property source initially, but subsequent methods may add
+                        // overrides
                         HapiSpecSetup.setupFrom(HapiSpecSetup.getDefaultPropertySource()),
                         new SpecOperation[0],
                         new SpecOperation[0],
@@ -1222,22 +1239,35 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
         // (FUTURE) Remove this override by initializing the HapiClients for a remote network
         // directly from the network's HederaNode instances instead of this "nodes" property
         final var specNodes = targetNetwork.nodes().stream()
-                .map(n -> n.hapiSpecInfo(
-                        spec.setup().defaultShard().getShardNum(),
-                        spec.setup().defaultRealm().getRealmNum()))
+                .map(n -> n.hapiSpecInfo(targetNetwork.shard(), targetNetwork.realm()))
                 .collect(joining(","));
-        spec.addOverrideProperties(Map.of("nodes", specNodes, "memo.useSpecName", "true"));
+        final var overrides = new HashMap<String, String>() {
+            {
+                put("nodes", specNodes);
+                put("memo.useSpecName", "true");
+            }
+        };
+
+        // We only need to set shard/realm if they aren't the default values (zero)
+        final var shardRealm = determineShardRealm(targetNetwork);
+        if (shardRealm.shard() > 0) {
+            overrides.put("hapi.spec.default.shard", Long.toString(shardRealm.shard()));
+        }
+        if (shardRealm.realm() > 0) {
+            overrides.put("hapi.spec.default.realm", Long.toString(shardRealm.realm()));
+        }
+        spec.addOverrideProperties(overrides);
 
         if (targetNetwork instanceof EmbeddedNetwork embeddedNetwork) {
-            final Map<String, String> overrides;
+            final Map<String, String> embeddedOverrides;
             if (embeddedNetwork.inRepeatableMode()) {
                 // Statuses are immediately available in repeatable mode because ingest is synchronous;
                 // ECDSA signatures are inherently random, so use only ED25519 in repeatable mode
-                overrides = Map.of("status.wait.sleep.ms", "0", "default.keyAlgorithm", "ED25519");
+                embeddedOverrides = Map.of("status.wait.sleep.ms", "0", "default.keyAlgorithm", "ED25519");
             } else {
-                overrides = Map.of("status.wait.sleep.ms", "" + CONCURRENT_EMBEDDED_STATUS_WAIT_SLEEP_MS);
+                embeddedOverrides = Map.of("status.wait.sleep.ms", "" + CONCURRENT_EMBEDDED_STATUS_WAIT_SLEEP_MS);
             }
-            spec.addOverrideProperties(overrides);
+            spec.addOverrideProperties(embeddedOverrides);
             final var embeddedHedera = embeddedNetwork.embeddedHederaOrThrow();
             spec.setNextValidStart(embeddedHedera::nextValidStart);
             if (embeddedNetwork.inRepeatableMode()) {
@@ -1357,5 +1387,46 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
                 throw new IllegalArgumentException();
             }
         }
+    }
+
+    private record ShardRealm(long shard, long realm) {}
+
+    private static ShardRealm determineShardRealm(@NonNull final HederaNetwork targetNetwork) {
+        var shard = targetNetwork.shard();
+        if (shard < 0) {
+            throw new IllegalArgumentException("Shard must be >= 0");
+        }
+        var realm = targetNetwork.realm();
+        if (realm < 0) {
+            throw new IllegalArgumentException("Realm must be >= 0");
+        }
+
+        if (shard == 0) {
+            // No shard specified in the target network
+            var sysShard = System.getProperty("hapi.spec.default.shard");
+
+            try {
+                var parsedShard = Long.parseLong(sysShard);
+                if (parsedShard > 0) {
+                    shard = parsedShard;
+                }
+            } catch (Exception ignore) {
+            }
+        }
+
+        if (realm == 0) {
+            // No realm specified in the target network
+            var sysRealm = System.getProperty("hapi.spec.default.realm");
+
+            try {
+                var parsedRealm = Long.parseLong(sysRealm);
+                if (parsedRealm > 0) {
+                    realm = parsedRealm;
+                }
+            } catch (Exception ignore) {
+            }
+        }
+
+        return new ShardRealm(shard, realm);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -1391,7 +1391,7 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
 
     private record ShardRealm(long shard, long realm) {}
 
-	// (FUTURE) Refactor to a more intuitive location
+    // (FUTURE) Refactor to a more intuitive location
     private static ShardRealm determineShardRealm(@NonNull final HederaNetwork targetNetwork) {
         var shard = targetNetwork.shard();
         if (shard < 0) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecSetup.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecSetup.java
@@ -324,6 +324,9 @@ public class HapiSpecSetup {
         return props.get("default.payer.name");
     }
 
+    // (FUTURE) Don't distinguish between default and custom shard/realm in the public contract. Encapsulate each as an
+    // implementation detail instead
+    @Deprecated
     public RealmID defaultRealm() {
         return props.getRealm("default.realm");
     }
@@ -351,6 +354,9 @@ public class HapiSpecSetup {
         return props.getBoolean("default.receiverSigRequired");
     }
 
+    // (FUTURE) Don't distinguish between default and custom shard/realm in the public contract. Encapsulate as an
+    // implementation detail instead
+    @Deprecated
     public ShardID defaultShard() {
         return props.getShard("default.shard");
     }
@@ -534,16 +540,24 @@ public class HapiSpecSetup {
         return props.getLong("status.wait.timeout.ms");
     }
 
+    public long shard() {
+        return props.getShard();
+    }
+
+    public long realm() {
+        return props.getRealm();
+    }
+
     public AccountID nodeRewardAccount() {
-        return asAccount(props.get("default.shard"), props.get("default.realm"), "801");
+        return asAccount(shard(), realm(), 801L);
     }
 
     public AccountID stakingRewardAccount() {
-        return asAccount(props.get("default.shard"), props.get("default.realm"), "800");
+        return asAccount(shard(), realm(), 800);
     }
 
     public AccountID feeCollectorAccount() {
-        return asAccount(props.get("default.shard"), props.get("default.realm"), "802");
+        return asAccount(shard(), realm(), 802);
     }
 
     public String nodeRewardAccountName() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/AccountInfoAsserts.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.spec.assertions;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.explicitFromHeadlong;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asAccount;
 import static com.hedera.services.bdd.suites.HapiSuite.EMPTY_KEY;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
@@ -13,7 +14,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.google.protobuf.ByteString;
-import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.queries.crypto.ExpectedTokenRel;
 import com.hederahashgraph.api.proto.java.AccountID;
@@ -86,9 +86,9 @@ public class AccountInfoAsserts extends BaseErroringAssertsProvider<AccountInfo>
         return this;
     }
 
-    public AccountInfoAsserts stakedAccountId(String idLiteral) {
+    public AccountInfoAsserts stakedAccountId(String acctNum) {
         registerProvider((spec, o) -> assertEquals(
-                HapiPropertySource.asAccount(idLiteral),
+                asAccount(spec.shard(), spec.realm(), Long.parseLong(acctNum)),
                 ((AccountInfo) o).getStakingInfo().getStakedAccountId(),
                 "Bad stakedAccountId id!"));
         return this;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/NodeConnectInfo.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/props/NodeConnectInfo.java
@@ -2,8 +2,6 @@
 package com.hedera.services.bdd.spec.props;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
-import static com.hedera.services.bdd.spec.HapiPropertySource.realm;
-import static com.hedera.services.bdd.spec.HapiPropertySource.shard;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.isIdLiteral;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.isNumericLiteral;
 
@@ -48,11 +46,6 @@ public class NodeConnectInfo {
         account = Stream.of(aspects)
                 .filter(TxnUtils::isIdLiteral)
                 .map(HapiPropertySource::asAccount)
-                .map(a -> AccountID.newBuilder()
-                        .setShardNum(shard)
-                        .setRealmNum(realm)
-                        .setAccountNum(a.getAccountNum())
-                        .build())
                 .findAny()
                 .orElse(HapiPropertySource.asAccount(asEntityString(NEXT_DEFAULT_ACCOUNT_NUM++)));
         host = Stream.of(aspects)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/crypto/HapiGetAccountBalance.java
@@ -1,9 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.queries.crypto;
 
-import static com.hedera.services.bdd.spec.HapiPropertySourceStaticInitializer.REALM;
-import static com.hedera.services.bdd.spec.HapiPropertySourceStaticInitializer.SHARD;
-import static com.hedera.services.bdd.spec.HapiPropertySourceStaticInitializer.SHARD_AND_REALM;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerCostHeader;
 import static com.hedera.services.bdd.spec.queries.QueryUtils.answerHeader;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asTokenId;
@@ -94,7 +91,7 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
             repr = "KeyAlias(" + aliasKeySource + ")";
         } else if (type == ReferenceType.HEXED_CONTRACT_ALIAS) {
             literalHexedAlias = reference;
-            repr = SHARD_AND_REALM + reference;
+            repr = reference;
         } else {
             account = reference;
             repr = account;
@@ -244,7 +241,8 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
                             String.format("Wrong balance for token '%s'!", HapiPropertySource.asTokenString(tokenId)));
                 } catch (AssertionError e) {
                     if (includeTokenMemoOnError) {
-                        final var lookup = QueryVerbs.getTokenInfo(SHARD_AND_REALM + tokenId.getTokenNum());
+                        final var lookup = QueryVerbs.getTokenInfo(
+                                tokenId.getShardNum() + "." + tokenId.getRealmNum() + "." + tokenId.getTokenNum());
                         allRunFor(spec, lookup);
                         final var memo = lookup.getResponse()
                                 .getTokenGetInfo()
@@ -319,8 +317,8 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
             config = b -> b.setContractID(TxnUtils.asContractId(account, spec));
         } else if (referenceType == ReferenceType.HEXED_CONTRACT_ALIAS) {
             final var cid = ContractID.newBuilder()
-                    .setShardNum(SHARD)
-                    .setRealmNum(REALM)
+                    .setShardNum(spec.shard())
+                    .setRealmNum(spec.realm())
                     .setEvmAddress(ByteString.copyFrom(CommonUtils.unhex(literalHexedAlias)))
                     .build();
             config = b -> b.setContractID(cid);
@@ -330,8 +328,8 @@ public class HapiGetAccountBalance extends HapiQueryOp<HapiGetAccountBalance> {
                 id = TxnUtils.asId(account, spec);
             } else if (referenceType == ReferenceType.LITERAL_ACCOUNT_ALIAS) {
                 id = AccountID.newBuilder()
-                        .setShardNum(SHARD)
-                        .setRealmNum(REALM)
+                        .setShardNum(spec.shard())
+                        .setRealmNum(spec.realm())
                         .setAlias(rawAlias)
                         .build();
             } else {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnFactory.java
@@ -35,9 +35,11 @@ import com.hederahashgraph.api.proto.java.FreezeTransactionBody;
 import com.hederahashgraph.api.proto.java.NodeCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.NodeDeleteTransactionBody;
 import com.hederahashgraph.api.proto.java.NodeUpdateTransactionBody;
+import com.hederahashgraph.api.proto.java.RealmID;
 import com.hederahashgraph.api.proto.java.ScheduleCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ScheduleDeleteTransactionBody;
 import com.hederahashgraph.api.proto.java.ScheduleSignTransactionBody;
+import com.hederahashgraph.api.proto.java.ShardID;
 import com.hederahashgraph.api.proto.java.SystemDeleteTransactionBody;
 import com.hederahashgraph.api.proto.java.SystemUndeleteTransactionBody;
 import com.hederahashgraph.api.proto.java.Timestamp;
@@ -313,13 +315,13 @@ public class TxnFactory {
                 .setGas(setup.defaultCreateGas())
                 .setInitialBalance(setup.defaultContractBalance())
                 .setMemo(setup.defaultMemo())
-                .setShardID(setup.defaultShard())
-                .setRealmID(setup.defaultRealm());
+                .setShardID(shardID())
+                .setRealmID(realmID());
     }
 
     public Consumer<FileCreateTransactionBody.Builder> defaultDefFileCreateTransactionBody() {
-        return builder -> builder.setRealmID(setup.defaultRealm())
-                .setShardID(setup.defaultShard())
+        return builder -> builder.setRealmID(realmID())
+                .setShardID(shardID())
                 .setContents(ByteString.copyFrom(setup.defaultFileContents()));
     }
 
@@ -460,5 +462,13 @@ public class TxnFactory {
 
     public Consumer<AtomicBatchTransactionBody.Builder> defaultDefAtomicBatchTransactionBody() {
         return builder -> {};
+    }
+
+    private ShardID shardID() {
+        return ShardID.newBuilder().setShardNum(setup.shard()).build();
+    }
+
+    private RealmID realmID() {
+        return RealmID.newBuilder().setRealmNum(setup.realm()).build();
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnUtils.java
@@ -308,8 +308,8 @@ public class TxnUtils {
         final var effS = s.startsWith("0x") ? s.substring(2) : s;
         if (effS.length() == HapiContractCall.HEXED_EVM_ADDRESS_LEN) {
             return ContractID.newBuilder()
-                    .setShardNum(shard)
-                    .setRealmNum(realm)
+                    .setShardNum(lookupSpec.shard())
+                    .setRealmNum(lookupSpec.realm())
                     .setEvmAddress(ByteString.copyFrom(CommonUtils.unhex(effS)))
                     .build();
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.transactions.crypto;
 
+import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.*;
@@ -170,7 +171,9 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
         AccountID id;
 
         if (referenceType == ReferenceType.REGISTRY_NAME) {
-            id = TxnUtils.asId(account, spec);
+            final var maybeFqAcct =
+                    (account.matches("\\d+")) ? asEntityString(spec.shard(), spec.realm(), account) : account;
+            id = TxnUtils.asId(maybeFqAcct, spec);
         } else {
             id = asIdForKeyLookUp(aliasKeySource, spec);
             account = asAccountString(id);
@@ -206,7 +209,11 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
                                     p -> builder.setMaxAutomaticTokenAssociations(Int32Value.of(p)));
 
                             if (newStakee.isPresent()) {
-                                builder.setStakedAccountId(TxnUtils.asId(newStakee.get(), spec));
+                                var newStakeeId = newStakee.get();
+                                if (!isIdLiteral(newStakeeId)) {
+                                    newStakeeId = asEntityString(spec.shard(), spec.realm(), newStakeeId);
+                                }
+                                builder.setStakedAccountId(TxnUtils.asId(newStakeeId, spec));
                             } else if (newStakedNodeId.isPresent()) {
                                 builder.setStakedNodeId(newStakedNodeId.get());
                             }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -210,7 +210,7 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
 
                             if (newStakee.isPresent()) {
                                 var newStakeeId = newStakee.get();
-                                if (!isIdLiteral(newStakeeId)) {
+                                if (!isIdLiteral(newStakeeId) && newStakeeId.matches("\\d+")) {
                                     newStakeeId = asEntityString(spec.shard(), spec.realm(), newStakeeId);
                                 }
                                 builder.setStakedAccountId(TxnUtils.asId(newStakeeId, spec));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -231,7 +231,9 @@ public class CryptoCreateSuite {
                 cryptoCreate("invalidStakedAccount")
                         .balance(ONE_HUNDRED_HBARS)
                         .declinedReward(false)
-                        .stakedAccountId("0.0.0")
+                        .shardId(ShardID.newBuilder().setShardNum(0).build())
+                        .realmId(RealmID.newBuilder().setRealmNum(0).build())
+                        .stakedAccountId("0")
                         .hasPrecheck(INVALID_STAKING_ID),
                 cryptoCreate("invalidStakedNode")
                         .balance(ONE_HUNDRED_HBARS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoCreateSuite.java
@@ -3,7 +3,6 @@ package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
-import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
@@ -90,8 +89,8 @@ public class CryptoCreateSuite {
     public static final String ACCOUNT = "account";
     public static final String ANOTHER_ACCOUNT = "anotherAccount";
     public static final String ED_25519_KEY = "ed25519Alias";
-    public static final String ACCOUNT_ID = asEntityString(10);
-    public static final String STAKED_ACCOUNT_ID = asEntityString(3);
+    public static final String ACCOUNT_ID = "10";
+    public static final String STAKED_ACCOUNT_ID = "3";
     public static final String CIVILIAN = "civilian";
     public static final String NO_KEYS = "noKeys";
     public static final String SHORT_KEY = "shortKey";
@@ -228,7 +227,7 @@ public class CryptoCreateSuite {
                                 .isDeclinedReward(false)
                                 .noStakingNodeId()
                                 .stakedAccountId(ACCOUNT_ID)),
-                /* --- sentiel values throw */
+                /* --- sentinel values throw */
                 cryptoCreate("invalidStakedAccount")
                         .balance(ONE_HUNDRED_HBARS)
                         .declinedReward(false)
@@ -309,15 +308,11 @@ public class CryptoCreateSuite {
     final Stream<DynamicTest> createAnAccountEmptyKeyList() {
         KeyShape shape = listOf(0);
         long initialBalance = 10_000L;
-        ShardID shardID = ShardID.newBuilder().build();
-        RealmID realmID = RealmID.newBuilder().build();
 
         return hapiTest(
                 cryptoCreate(NO_KEYS)
                         .keyShape(shape)
                         .balance(initialBalance)
-                        .shardId(shardID)
-                        .realmId(realmID)
                         .logged()
                         .hasPrecheck(KEY_REQUIRED)
                 // In modular code this error is thrown in handle, but it is fixed using dynamic property
@@ -1031,6 +1026,7 @@ public class CryptoCreateSuite {
                         .balance(1L)
                         .shardId(ShardID.newBuilder().setShardNum(1).build())
                         .hasKnownStatus(INVALID_ACCOUNT_ID),
+                // expected realm is 2
                 cryptoCreate("differentRealm")
                         .key(key)
                         .balance(1L)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetInfoRegression.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoGetInfoRegression.java
@@ -2,7 +2,6 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
-import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
@@ -162,7 +161,7 @@ public class CryptoGetInfoRegression {
                 cryptoCreate("targetWithStakedAccountId")
                         .key("misc")
                         .balance(balance)
-                        .stakedAccountId(asEntityString(20)),
+                        .stakedAccountId("20"),
                 getAccountInfo("noStakingTarget")
                         .has(accountWith()
                                 .accountId("noStakingTarget")
@@ -182,7 +181,7 @@ public class CryptoGetInfoRegression {
                 getAccountInfo("targetWithStakedAccountId")
                         .has(accountWith()
                                 .accountId("targetWithStakedAccountId")
-                                .stakedAccountId(asEntityString(20))
+                                .stakedAccountId("20")
                                 .key("misc")
                                 .balance(balance))
                         .logged());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -2,7 +2,6 @@
 package com.hedera.services.bdd.suites.crypto;
 
 import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
-import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
@@ -130,9 +129,9 @@ public class CryptoUpdateSuite {
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {
         return hapiTest(
-                cryptoCreate("user").stakedAccountId(asEntityString(20)).declinedReward(true),
+                cryptoCreate("user").stakedAccountId("20").declinedReward(true),
                 submitModified(withSuccessivelyVariedBodyIds(), () -> cryptoUpdate("user")
-                        .newStakedAccountId(asEntityString(21))));
+                        .newStakedAccountId("21")));
     }
 
     private static final UnaryOperator<String> ROTATION_TXN = account -> account + "KeyRotation";
@@ -236,13 +235,10 @@ public class CryptoUpdateSuite {
     final Stream<DynamicTest> updateStakingFieldsWorks() {
         return hapiTest(
                 newKeyNamed(ADMIN_KEY),
-                cryptoCreate("user")
-                        .key(ADMIN_KEY)
-                        .stakedAccountId(asEntityString(20))
-                        .declinedReward(true),
+                cryptoCreate("user").key(ADMIN_KEY).stakedAccountId("20").declinedReward(true),
                 getAccountInfo("user")
                         .has(accountWith()
-                                .stakedAccountId(asEntityString(20))
+                                .stakedAccountId("20")
                                 .noStakingNodeId()
                                 .isDeclinedReward(true)),
                 cryptoUpdate("user").newStakedNodeId(0L).newDeclinedReward(false),
@@ -252,13 +248,10 @@ public class CryptoUpdateSuite {
                 cryptoUpdate("user").newStakedNodeId(-25L).hasKnownStatus(INVALID_STAKING_ID),
                 getAccountInfo("user")
                         .has(accountWith().noStakedAccountId().noStakingNodeId().isDeclinedReward(false)),
-                cryptoUpdate("user")
-                        .key(ADMIN_KEY)
-                        .newStakedAccountId(asEntityString(20))
-                        .newDeclinedReward(true),
+                cryptoUpdate("user").key(ADMIN_KEY).newStakedAccountId("20").newDeclinedReward(true),
                 getAccountInfo("user")
                         .has(accountWith()
-                                .stakedAccountId(asEntityString(20))
+                                .stakedAccountId("20")
                                 .noStakingNodeId()
                                 .isDeclinedReward(true))
                         .logged(),
@@ -373,7 +366,7 @@ public class CryptoUpdateSuite {
 
     @HapiTest
     final Stream<DynamicTest> sysAccountKeyUpdateBySpecialWontNeedNewKeyTxnSign() {
-        String sysAccount = asEntityString(99);
+        String sysAccount = "99";
         String randomAccount = "randomAccount";
         String firstKey = "firstKey";
         String secondKey = "secondKey";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StartStaking.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StartStaking.java
@@ -212,7 +212,7 @@ public class StartStaking extends HapiSuite {
         final var to = chooseRandomExistingStaker();
         log.info("Choosing to stake to num {}", to);
         return cryptoCreate(STAKER_NAME + RANDOM.nextLong(Long.MAX_VALUE))
-                .stakedAccountId("0.0." + to)
+                .stakedAccountId(String.valueOf(to))
                 .balance(balance)
                 .key(DEFAULT_PAYER)
                 .exposingCreatedIdTo(id -> trackStaker(id.getAccountNum(), StakerMeta.newToAccount(balance, to)));


### PR DESCRIPTION
### **Background**

In order to effectively support intuitive configuration of nonzero shard/realm in hapi test networks, an extension of the hapi test framework that doesn't rely on a test scenario's specific use case is required. Therefore, this PR is the beginning of work needed to scope a configurable shard/realm to a hapi test network (specifically, the `HederaNetwork` interface). 

### **Implementation**

Two underlying ideas govern the majority of this change set: first, that the `HederaNetwork`–if not set to the default values of (0,0)–is the primary source of truth for determining what a test network's shard/realm should be, as well as the target for any test clients instantiated as part of any related process; second, that the `hapi.spec.default.shard` and `hapi.spec.default.shard` system properties serve as the secondary source for any bootstrap cases not covered by the primary source. The most notable changes are in `HapiSpec#doTargetSpec`, which serves as a multi-faceted entrypoint for many other test entrypoints. 

It's worth noting that _this PR does not contain the complete code delta_ required to facilitate nonzero shard/realm across all hapi tests; in particular, these changes are intended to be made in a way that we can iteratively switch hapi tests over to using the correct config sources, without breaking swathes of other hapi tests in the process. However, this change set should be a decent starting point, both to unblock ongoing downstream work and to parallelize further nonzero shard/realm hapi test efforts.

It's also worth noting that the minor changes to the `build.gradle.kts` file are not related to the shard/realm efforts; it just creates a convenient new grouping of `hapiTest<X>` gradle tasks.

Part of #18881 (and #18953); related to #18812
