### PR TITLE
chore: Generate list of PR checks that can and cannot be run by forked PRs

### DIFF
--- a/.github/workflows/docs/forked_prs.md
+++ b/.github/workflows/docs/forked_prs.md
@@ -1,15 +1,15 @@
 # Forked PRs README.md
 
 In the `hiero-consensus-node` project there are several workflow jobs that must run
-prior to merging a pull request. These jobs are defined in the `.github/workflows` 
-directory and have rulesets associated at the `hiero-consensus-repository` github 
+prior to merging a pull request. These jobs are defined in the `.github/workflows`
+directory and have rulesets associated at the `hiero-consensus-repository` github
 repository level.
 
 Several of these jobs are required to run on pull requests that are opened against the
 `hiero-consensus-node` repository. Some of these jobs must access repository or organization
 github secrets and variables.
 
-Github limits access to repository secrets in order to 
+Github limits access to repository secrets in order to
 [prevent pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).
 The only secret that is passed to a forked PR is the GITHUB_TOKEN, which is the default token for the PR.
 All other secrets are not passed to the forked PR which means that these jobs require either an override
@@ -20,4 +20,4 @@ they are sourced from a forked PR.
 
 ## Workflows with forked PR checks
 
-See the file required_checks to see which jobs can run on forked PRs and which jobs cannot.
+See the file [required_checks.md](required_checks.md) to see which jobs can run on forked PRs and which jobs cannot.

--- a/.github/workflows/docs/forked_prs.md
+++ b/.github/workflows/docs/forked_prs.md
@@ -1,0 +1,23 @@
+# Forked PRs README.md
+
+In the `hiero-consensus-node` project there are several workflow jobs that must run
+prior to merging a pull request. These jobs are defined in the `.github/workflows` 
+directory and have rulesets associated at the `hiero-consensus-repository` github 
+repository level.
+
+Several of these jobs are required to run on pull requests that are opened against the
+`hiero-consensus-node` repository. Some of these jobs must access repository or organization
+github secrets and variables.
+
+Github limits access to repository secrets in order to 
+[prevent pwn requests](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).
+The only secret that is passed to a forked PR is the GITHUB_TOKEN, which is the default token for the PR.
+All other secrets are not passed to the forked PR which means that these jobs require either an override
+from a known user or a different method of running the jobs.
+
+By default, the `hiero-consensus-node` repository will not run any jobs that require access to secrets if
+they are sourced from a forked PR.
+
+## Workflows with forked PR checks
+
+See the file required_checks to see which jobs can run on forked PRs and which jobs cannot.

--- a/.github/workflows/docs/required_checks.md
+++ b/.github/workflows/docs/required_checks.md
@@ -25,5 +25,7 @@
 - Milestone Check - :tada:
 - Assignee Check - :tada:
 
-:x: - cannot run on a forked PR
-:tada: - can run on a forked PR
+## Legend
+
+- :x: - cannot run on a forked PR
+- :tada: - can run on a forked PR

--- a/.github/workflows/docs/required_checks.md
+++ b/.github/workflows/docs/required_checks.md
@@ -24,3 +24,6 @@
 - Spotless / Check - :tada:
 - Milestone Check - :tada:
 - Assignee Check - :tada:
+
+:x: - cannot run on a forked PR
+:tada: - can run on a forked PR

--- a/.github/workflows/docs/required_checks.md
+++ b/.github/workflows/docs/required_checks.md
@@ -3,7 +3,7 @@
 - Dependency (Module Info) / Check - :tada:
 - Unit Tests / Standard - :x:
 - Snyk Scan / Standard - :x:
-- Gradle Determinism / Generate Baseline - :x: 
+- Gradle Determinism / Generate Baseline - :x:
 - Gradle Determinism / Verify Artifacts (windows-2019) - :x:
 - Gradle Determinism / Verify Artifacts (windows-2022) - :x:
 - Gradle Determinism / Verify Artifacts (ubuntu-22.04) - :x:

--- a/.github/workflows/docs/required_checks.md
+++ b/.github/workflows/docs/required_checks.md
@@ -1,0 +1,26 @@
+# Required Status checks for hiero-ledger/hiero-consensus-node
+
+- Dependency (Module Info) / Check - :tada:
+- Unit Tests / Standard - :x:
+- Snyk Scan / Standard - :x:
+- Gradle Determinism / Generate Baseline - :x: 
+- Gradle Determinism / Verify Artifacts (windows-2019) - :x:
+- Gradle Determinism / Verify Artifacts (windows-2022) - :x:
+- Gradle Determinism / Verify Artifacts (ubuntu-22.04) - :x:
+- Gradle Determinism / Verify Artifacts (hiero-network-node-linux-large) - :x:
+- Gradle Determinism / Verify Artifacts (hiero-network-node-linux-medium) - :x:
+- Gradle Determinism / Verify Artifacts (ubuntu-24.04) - :x:
+- Docker Determinism / Generate Baseline - :x:
+- Docker Determinism / Verify Artifacts (hiero-network-node-linux-large) - :x:
+- Docker Determinism / Verify Artifacts (hiero-network-node-linux-medium) - :x:
+- HAPI Tests (Crypto) / Standard - :tada:
+- HAPI Tests (Misc) / Standard - :tada:
+- HAPI Tests (Node Death Reconnect) / Standard - :tada:
+- HAPI Tests (Smart Contract) / Standard - :tada:
+- HAPI Tests (Token) / Standard - :tada:
+- HAPI Tests (Restart) / Standard - :tada:
+- HAPI Tests (ISS) / Standard - :tada:
+- Title Check - :tada:
+- Spotless / Check - :tada:
+- Milestone Check - :tada:
+- Assignee Check - :tada:


### PR DESCRIPTION
**Description**:

Adds documentation to `.github/workflows/docs` about PR checks that can be run on forked PRs.

**Related issue(s)**:

closes #18966 

