### PR TITLE
chore: Moved StaleEventDetectorTests to event-creator module

### DIFF
--- a/platform-sdk/consensus-event-creator-impl/build.gradle.kts
+++ b/platform-sdk/consensus-event-creator-impl/build.gradle.kts
@@ -14,6 +14,7 @@ testModuleInfo {
     requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.config.extensions.test.fixtures")
     requires("org.hiero.base.utility.test.fixtures")
+    requires("org.hiero.consensus.model.test.fixtures")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.mockito")

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/stale/StaleEventDetectorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/stale/StaleEventDetectorTests.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.event.stale;
+package org.hiero.consensus.event.creator.impl.stale;
 
 import static org.hiero.consensus.model.event.AncientMode.BIRTH_ROUND_THRESHOLD;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,8 +21,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.hiero.consensus.config.EventConfig_;
-import org.hiero.consensus.event.creator.impl.stale.DefaultStaleEventDetector;
-import org.hiero.consensus.event.creator.impl.stale.StaleEventDetector;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.event.StaleEventDetectorOutput;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;


### PR DESCRIPTION
**Description**:

This PR moves the `StaleEventDetectorTests` to the tests of the `consensus-event-creator-impl` module.

**Related issue(s)**:

Part of #18422 