### PR TITLE
fix: Assign nGen for GUI generated events

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiEventStorage.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gui/GuiEventStorage.java
@@ -99,6 +99,7 @@ public class GuiEventStorage {
         if (eventImpl == null) {
             return;
         }
+        eventImpl.getBaseEvent().setNGen(event.getNGen());
 
         final List<ConsensusRound> rounds = consensus.addEvent(eventImpl);
 


### PR DESCRIPTION
**Description**:

Since introduction of non-deterministic generation, GUI consensus testing tool was not working, as it was not generating nGens for local events and it was creating local copies of events without copying over nGen.

**Related issue(s)**:
Fixes #18939 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
