### PR TITLE
fix: Update Roster Schema isUpgrade check

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.VersionConfig;
 import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.service.schemas.V0540RosterBaseSchema;
@@ -104,8 +105,13 @@ public class V0540RosterSchema extends Schema implements RosterTransplantSchema 
                 final var currentRoster =
                         RosterUtils.rosterFrom(startupNetworks.migrationNetworkOrThrow(ctx.platformConfig()));
                 rosterStore.putActiveRoster(currentRoster, activeRoundNumber);
-            } else if (ctx.isUpgrade(
-                    ctx.appConfig().getConfigData(VersionConfig.class).servicesVersion())) {
+            } else if (ctx.isUpgrade(ctx.appConfig()
+                    .getConfigData(VersionConfig.class)
+                    .servicesVersion()
+                    .copyBuilder()
+                    .build(""
+                            + ctx.appConfig().getConfigData(HederaConfig.class).configVersion())
+                    .build())) {
                 final var candidateRoster = rosterStore.getCandidateRoster();
                 if (candidateRoster == null) {
                     log.info("No candidate roster to adopt in round {}", activeRoundNumber);


### PR DESCRIPTION
**Description**:
In V0540RosterSchema::restart, the isUpgrade check was changed to use SemanticVersion, however the hedera.config.version is not put into the build of the SemanticVersion for comparison. Therefore this branch of code is not being executed when for example Solo bumps the hedera.config.version to perform a software upgrade. This results in the candidate roster not being adopted.
**Related issue(s)**:

Fixes #19005 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
