### PR TITLE
feat: Implement staking activation with nonzero shard/realm

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiPropertySource.java
@@ -571,7 +571,15 @@ public interface HapiPropertySource {
     }
 
     static String asEntityString(final long num) {
-        return String.format(ENTITY_STRING, shard, realm, num);
+        return asEntityString(shard, realm, num);
+    }
+
+    static String asEntityString(final String shard, final String realm, final String num) {
+        return String.format("%s.%s.%s", shard, realm, num);
+    }
+
+    static String asEntityString(final AccountID id) {
+        return asEntityString(id.getShardNum(), id.getRealmNum(), id.getAccountNum());
     }
 
     static long numberOfLongZero(@NonNull final byte[] explicit) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpec.java
@@ -17,6 +17,7 @@ import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.PASSED;
 import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.PASSED_UNEXPECTEDLY;
 import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.PENDING;
 import static com.hedera.services.bdd.spec.HapiSpec.SpecStatus.RUNNING;
+import static com.hedera.services.bdd.spec.HapiSpecSetup.getDefaultPropertySource;
 import static com.hedera.services.bdd.spec.HapiSpecSetup.setupFrom;
 import static com.hedera.services.bdd.spec.infrastructure.HapiClients.clientsFor;
 import static com.hedera.services.bdd.spec.keys.DefaultKeyGen.DEFAULT_KEY_GEN;
@@ -1282,6 +1283,16 @@ public class HapiSpec implements Runnable, Executable, LifecycleTest {
         this(
                 name,
                 setupFrom(HapiSpecSetup.getDefaultPropertySource()),
+                new SpecOperation[0],
+                new SpecOperation[0],
+                ops,
+                List.of());
+    }
+
+    public HapiSpec(String name, HapiPropertySource source, SpecOperation[] ops) {
+        this(
+                name,
+                setupFrom(source, getDefaultPropertySource()),
                 new SpecOperation[0],
                 new SpecOperation[0],
                 ops,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/remote/RemoteNetworkFactory.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/remote/RemoteNetworkFactory.java
@@ -6,11 +6,13 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.services.bdd.junit.hedera.HederaNetwork;
 import com.hedera.services.bdd.junit.hedera.remote.RemoteNetwork;
 import com.hedera.services.bdd.spec.infrastructure.HapiClients;
+import com.hedera.services.bdd.spec.props.NodeConnectInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.yaml.snakeyaml.LoaderOptions;
@@ -32,10 +34,15 @@ public class RemoteNetworkFactory {
             final RemoteNetworkSpec networkSpec = yamlIn.load(fin);
             log.info("Loaded remote network spec from {}: {}", remoteNodesYmlLoc, networkSpec);
             final var connectInfos = networkSpec.connectInfos();
-            return RemoteNetwork.newRemoteNetwork(
-                    connectInfos, new HapiClients(() -> connectInfos), networkSpec.getShard(), networkSpec.getRealm());
+            return newWithTargetFrom(networkSpec.getShard(), networkSpec.getRealm(), connectInfos);
         } catch (IOException e) {
             throw new UncheckedIOException("Failed to read remote nodes YAML file: " + remoteNodesYmlLoc, e);
         }
+    }
+
+    public static HederaNetwork newWithTargetFrom(
+            final long shard, final long realm, @NonNull final List<NodeConnectInfo> nodeInfos) {
+        requireNonNull(nodeInfos);
+        return RemoteNetwork.newRemoteNetwork(nodeInfos, new HapiClients(() -> nodeInfos), shard, realm);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/remote/RemoteNodeSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/remote/RemoteNodeSpec.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.remote;
 
+import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
+
 import com.hedera.services.bdd.spec.props.NodeConnectInfo;
 
 /**
@@ -51,6 +53,7 @@ public class RemoteNodeSpec {
      * @return a {@link NodeConnectInfo} object representing this node
      */
     public NodeConnectInfo asNodeConnectInfo(final long shard, final long realm) {
-        return new NodeConnectInfo(String.format("%s:%d:%d.%d.%d", host, port, shard, realm, accountNum));
+        final var fqAcct = asEntityString(shard, realm, accountNum);
+        return new NodeConnectInfo(String.format("%s:%d:%s", host, port, fqAcct));
     }
 }

--- a/hedera-node/test-clients/src/main/java/module-info.java
+++ b/hedera-node/test-clients/src/main/java/module-info.java
@@ -63,6 +63,8 @@ module com.hedera.node.test.clients {
     exports com.hedera.services.bdd.junit.support.validators.block;
     exports com.hedera.services.bdd.utils;
     exports com.hedera.services.bdd.junit.restart;
+    exports com.hedera.services.bdd.junit.hedera.remote;
+    exports com.hedera.services.bdd.spec.remote;
 
     requires com.hedera.node.app.hapi.fees;
     requires com.hedera.node.app.hapi.utils;

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.accounts;
 
+import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -68,7 +69,7 @@ public class StakeCommand implements Callable<Integer> {
         delegate.runSuiteSync();
 
         if (stakedAccountNum == null) {
-            stakedAccountNum = ConfigUtils.asId(config.getDefaultPayer());
+            stakedAccountNum = asEntityString(config.getDefaultPayer());
         }
         if (delegate.getFinalSpecs().get(0).getStatus() == HapiSpec.SpecStatus.PASSED) {
             final var msgSb = new StringBuilder("SUCCESS - account ")

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/ConfigManager.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/ConfigManager.java
@@ -3,10 +3,11 @@ package com.hedera.services.yahcli.config;
 
 import static com.hedera.node.app.hapi.utils.keys.Ed25519Utils.readKeyPairFrom;
 import static com.hedera.node.app.hapi.utils.keys.Secp256k1Utils.readECKeyFrom;
-import static com.hedera.services.yahcli.config.ConfigUtils.asId;
-import static com.hedera.services.yahcli.config.ConfigUtils.isLiteral;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 
 import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.props.NodeConnectInfo;
+import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.utilops.inventory.AccessoryUtils;
 import com.hedera.services.bdd.suites.utils.sysfiles.serdes.StandardSerdes;
 import com.hedera.services.bdd.suites.utils.sysfiles.serdes.ThrottlesJsonToGrpcBytes;
@@ -14,6 +15,9 @@ import com.hedera.services.yahcli.Yahcli;
 import com.hedera.services.yahcli.config.domain.GlobalConfig;
 import com.hedera.services.yahcli.config.domain.NetConfig;
 import com.hedera.services.yahcli.config.domain.NodeConfig;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.RealmID;
+import com.hederahashgraph.api.proto.java.ShardID;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,6 +56,18 @@ public class ConfigManager {
         var yamlIn = new Yaml(new Constructor(GlobalConfig.class, new LoaderOptions()));
         try (InputStream fin = Files.newInputStream(Paths.get(yamlLoc))) {
             GlobalConfig globalConfig = yamlIn.load(fin);
+
+            globalConfig.getNetworks().forEach((name, netConfig) -> {
+                netConfig.getNodes().forEach(nodeConfig -> {
+                    if (netConfig.getShard() != null) {
+                        nodeConfig.setShard(netConfig.getShard());
+                    }
+                    if (netConfig.getRealm() != null) {
+                        nodeConfig.setRealm(netConfig.getRealm());
+                    }
+                });
+            });
+
             return new ConfigManager(yahcli, globalConfig);
         }
     }
@@ -67,14 +83,18 @@ public class ConfigManager {
             specConfig.put("fees.fixedOffer", String.valueOf(useFixedFee() ? fixedFee() : "0"));
             specConfig.put("fees.useFixedOffer", "true");
         }
-        var payerId = asId(defaultPayer);
-        if (isLiteral(payerId)) {
+        var payerId = asEntityString(targetNet.getShard(), targetNet.getRealm(), Long.parseLong(defaultPayer));
+        if (TxnUtils.isIdLiteral(payerId)) {
             addPayerConfig(specConfig, payerId);
         } else {
             fail("Named accounts not yet supported!");
         }
         specConfig.put("default.node", defaultNodeAccount);
         return specConfig;
+    }
+
+    public List<NodeConnectInfo> asNodeInfos() {
+        return targetNet.toNodeInfos();
     }
 
     public boolean isAllowListEmptyOrContainsAccount(long account) {
@@ -199,8 +219,8 @@ public class ConfigManager {
     }
 
     private void assertDefaultNodeAccountIsKnown() {
-        final var configDefault = "0.0." + targetNet.getDefaultNodeAccount();
-        defaultNodeAccount = Optional.ofNullable(yahcli.getNodeAccount()).orElse(configDefault);
+        defaultNodeAccount =
+                Optional.ofNullable(yahcli.getNodeAccount()).orElse(String.valueOf(targetNet.getDefaultNodeAccount()));
     }
 
     private void assertDefaultPayerIsKnown() {
@@ -235,9 +255,8 @@ public class ConfigManager {
         targetNet = global.getNetworks().get(targetName);
         if (yahcli.getNodeIpv4Addr() != null) {
             final var ip = yahcli.getNodeIpv4Addr();
-            var nodeAccount = (yahcli.getNodeAccount() == null)
-                    ? MISSING_NODE_ACCOUNT
-                    : HapiPropertySource.asDotDelimitedLongArray(yahcli.getNodeAccount())[2];
+            var nodeAccount =
+                    (yahcli.getNodeAccount() == null) ? MISSING_NODE_ACCOUNT : Long.parseLong(yahcli.getNodeAccount());
             final var nodes = targetNet.getNodes();
             if (nodeAccount == MISSING_NODE_ACCOUNT) {
                 for (final var node : nodes) {
@@ -254,6 +273,8 @@ public class ConfigManager {
 
             final var overrideConfig = new NodeConfig();
             overrideConfig.setIpv4Addr(ip);
+            overrideConfig.setShard(targetNet.getShard());
+            overrideConfig.setRealm(targetNet.getRealm());
             overrideConfig.setAccount(nodeAccount);
             targetNet.setNodes(List.of(overrideConfig));
         }
@@ -263,11 +284,22 @@ public class ConfigManager {
         throw new CommandLine.ParameterException(yahcli.getSpec().commandLine(), msg);
     }
 
-    public String getDefaultPayer() {
-        return defaultPayer;
+    public AccountID getDefaultPayer() {
+        return HapiPropertySource.asAccount(targetNet.getShard(), targetNet.getRealm(), Long.parseLong(defaultPayer));
     }
 
     public String getTargetName() {
         return targetName;
+    }
+
+    public ShardID shard() {
+        return ShardID.newBuilder().setShardNum(targetNet.getShard()).build();
+    }
+
+    public RealmID realm() {
+        return RealmID.newBuilder()
+                .setShardNum(targetNet.getShard())
+                .setRealmNum(targetNet.getRealm())
+                .build();
     }
 }

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/domain/NetConfig.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/domain/NetConfig.java
@@ -1,20 +1,26 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.config.domain;
 
+import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
+
 import com.google.common.base.MoreObjects;
-import com.hedera.services.yahcli.output.CommonMessages;
+import com.hedera.services.bdd.spec.props.NodeConnectInfo;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+// Methods used by reflection to load java beans
+@SuppressWarnings("unused")
 public class NetConfig {
-    public static final Integer TRADITIONAL_DEFAULT_NODE_ACCOUNT = 3;
+    private static final Integer TRADITIONAL_DEFAULT_NODE_ACCOUNT = 3;
 
     private String defaultPayer;
     private Integer defaultNodeAccount = TRADITIONAL_DEFAULT_NODE_ACCOUNT;
     private List<Long> allowedReceiverAccountIds;
     private List<NodeConfig> nodes;
+    private Long shard;
+    private Long realm;
 
     public String getDefaultPayer() {
         return defaultPayer;
@@ -48,23 +54,53 @@ public class NetConfig {
         this.allowedReceiverAccountIds = allowedReceiverAccountIds;
     }
 
-    public String fqDefaultNodeAccount() {
-        return CommonMessages.COMMON_MESSAGES.fq(defaultNodeAccount);
+    public Long getShard() {
+        return shard != null ? shard : 0;
+    }
+
+    public void setShard(Long shard) {
+        this.shard = shard;
+    }
+
+    public Long getRealm() {
+        return realm != null ? realm : 0;
+    }
+
+    public void setRealm(Long realm) {
+        this.realm = realm;
     }
 
     public Map<String, String> toSpecProperties() {
         Map<String, String> customProps = new HashMap<>();
-        customProps.put("nodes", nodes.stream().map(NodeConfig::asNodesItem).collect(Collectors.joining(",")));
+        customProps.put("nodes", nodes.stream().map(NodeConfig::toString).collect(Collectors.joining(",")));
+        if (shard != null) {
+            customProps.put("hapi.spec.default.shard", String.valueOf(shard));
+        }
+        if (realm != null) {
+            customProps.put("hapi.spec.default.realm", String.valueOf(realm));
+        }
         return customProps;
+    }
+
+    public List<NodeConnectInfo> toNodeInfos() {
+        Map<String, String> nodeInfos = new HashMap<>();
+        return nodes.stream()
+                .map(NodeConfig::toString)
+                // Strip the node ID from the end of the string
+                .map(s -> s.contains("#") ? s.substring(0, s.indexOf('#')) : s)
+                .map(NodeConnectInfo::new)
+                .collect(Collectors.toList());
     }
 
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("defaultPayer", defaultPayer)
-                .add("defaultNodeAccount", "0.0." + defaultNodeAccount)
+                .add("defaultNodeAccount", asEntityString(shard, realm, defaultNodeAccount))
                 .add("nodes", nodes)
                 .add("allowedReceiverAccountIds", allowedReceiverAccountIds)
+                .add("shard", shard)
+                .add("realm", realm)
                 .omitNullValues()
                 .toString();
     }

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/domain/NodeConfig.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/domain/NodeConfig.java
@@ -5,6 +5,8 @@ public class NodeConfig {
     private int id;
     private long account;
     private String ipv4Addr;
+    private long shard;
+    private long realm;
 
     public long getAccount() {
         return account;
@@ -30,12 +32,16 @@ public class NodeConfig {
         this.id = id;
     }
 
-    @Override
-    public String toString() {
-        return String.format("%s:0.0.%d#%d", ipv4Addr, account, id);
+    public void setShard(long shard) {
+        this.shard = shard;
     }
 
-    public String asNodesItem() {
-        return String.format("%s:0.0.%d", ipv4Addr, account);
+    public void setRealm(long realm) {
+        this.realm = realm;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("%s:%d.%d.%d#%d", ipv4Addr, shard, realm, account, id);
     }
 }

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/output/CommonMessages.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/output/CommonMessages.java
@@ -3,7 +3,6 @@ package com.hedera.services.yahcli.output;
 
 import com.hedera.services.bdd.spec.queries.QueryUtils;
 import com.hedera.services.yahcli.config.ConfigManager;
-import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.Utils;
 import com.hederahashgraph.api.proto.java.FileID;
 import com.hederahashgraph.api.proto.java.Response;
@@ -21,8 +20,7 @@ public enum CommonMessages {
     }
 
     public void printGlobalInfo(ConfigManager config) {
-        var msg = String.format(
-                "Targeting %s, paying with %s", config.getTargetName(), ConfigUtils.asId(config.getDefaultPayer()));
+        var msg = String.format("Targeting %s, paying with %s", config.getTargetName(), config.getDefaultPayer());
         System.out.println(msg);
     }
 
@@ -68,9 +66,5 @@ public enum CommonMessages {
         } catch (Throwable throwable) {
             throwable.printStackTrace();
         }
-    }
-
-    public String fq(Integer num) {
-        return "0.0." + num;
     }
 }

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/StakeSetupSuite.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/StakeSetupSuite.java
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.suites;
 
+import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.SpecOperation;
+import com.hedera.services.bdd.spec.props.MapPropertySource;
+import com.hedera.services.bdd.spec.remote.RemoteNetworkFactory;
 import com.hedera.services.bdd.spec.transactions.TxnVerbs;
 import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
@@ -21,6 +25,8 @@ import org.junit.jupiter.api.DynamicTest;
 
 public class StakeSetupSuite extends HapiSuite {
     private static final Logger log = LogManager.getLogger(StakeSetupSuite.class);
+    private static final String SPEC_NAME = "StartStakingAndExportCreatedStakers";
+
     private final long stakePerNode;
     private final long stakingRewardRate;
     private final long rewardAccountBalance;
@@ -51,21 +57,22 @@ public class StakeSetupSuite extends HapiSuite {
     }
 
     final Stream<DynamicTest> startStakingAndExportCreatedStakers() {
-        return HapiSpec.customHapiSpec("StartStakingAndExportCreatedStakers")
-                .withProperties(specConfig)
-                .given(
-                        overriding("staking.perHbarRewardRate", String.valueOf(stakingRewardRate)),
-                        TxnVerbs.cryptoTransfer(HapiCryptoTransfer.tinyBarsFromTo(
-                                HapiSuite.DEFAULT_PAYER, HapiSuite.STAKING_REWARD, rewardAccountBalance)))
-                .when()
-                .then(UtilVerbs.inParallel(configManager.nodeIdsInTargetNet().stream()
-                        .map(nodeId -> TxnVerbs.cryptoCreate("stakerFor" + nodeId)
-                                .stakedNodeId(nodeId)
-                                .balance(stakePerNode)
-                                .key(HapiSuite.DEFAULT_PAYER)
-                                .exposingCreatedIdTo(
-                                        id -> accountsToStakedNodes.put("0.0." + id.getAccountNum(), nodeId)))
-                        .toArray(HapiSpecOperation[]::new)));
+        final var spec = new HapiSpec(SPEC_NAME, new MapPropertySource(specConfig), new SpecOperation[] {
+            overriding("staking.perHbarRewardRate", String.valueOf(stakingRewardRate)),
+            TxnVerbs.cryptoTransfer(HapiCryptoTransfer.tinyBarsFromTo(
+                    HapiSuite.DEFAULT_PAYER, HapiSuite.STAKING_REWARD, rewardAccountBalance)),
+            UtilVerbs.inParallel(configManager.nodeIdsInTargetNet().stream()
+                    .map(nodeId -> TxnVerbs.cryptoCreate("stakerFor" + nodeId)
+                            .stakedNodeId(nodeId)
+                            .balance(stakePerNode)
+                            .key(HapiSuite.DEFAULT_PAYER)
+                            .exposingCreatedIdTo(id -> accountsToStakedNodes.put(asEntityString(id), nodeId)))
+                    .toArray(HapiSpecOperation[]::new))
+        });
+        final var network = RemoteNetworkFactory.newWithTargetFrom(
+                configManager.shard().getShardNum(), configManager.realm().getRealmNum(), configManager.asNodeInfos());
+        spec.setTargetNetwork(network);
+        return Stream.of(DynamicTest.dynamicTest(SPEC_NAME, spec));
     }
 
     @Override


### PR DESCRIPTION
### Description

This PR reworks some of the yahcli config code to integrate a nonzero shard and realm. Since the config is already passed into each of yahcli's `Suite` classes, it then only becomes a matter of using it to construct a target network and invoking the spec with said network. The new code makes use of each configured node's 'info' string–already quite similar to the info string produced by `NodeConnectInfo`–as inputs to new `NodeConnectInfo` objects, which are then used to construct a `RemoteNetwork`. Done this way, yahcli need not worry about juggling specific local vs. remote scenarios (except for a small number of isolated locations in the code, which should be appropriately encapsulated). 

The hapi framework essentially does the rest. Each `HapiSpec` now has a `shard()` and `realm()` computed that are appropriately scoped to the spec's target network. Due to this recent convenience, re-implementation of all existing yahcli commands to support nonzero shard/realm going forward becomes almost trivial. 

I verified this command works locally, and devops has successfully used the new command in their build process. Further testing of all other commands will come individually (in separate tickets), as their implementations are redefined to utilize the remote network. 

Closes #18950 