### PR TITLE
fix: Flaky Jumbo transactions tests

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
@@ -166,7 +166,6 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
             return positiveBoundariesTestCases.flatMap(test -> {
                 var payload = new byte[test.txnSize];
                 return hapiTest(
-                        prepareFakeUpgrade(),
                         logIt("Valid Jumbo Txn | Size: " + (test.txnSize / 1024) + "KB | Type: " + test.type
                                 + " | GasLimit: " + test.gasLimit + " | ExpectedGas: " + test.expectedGas),
                         newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),


### PR DESCRIPTION
**Description**:
The `prepareFakeUpgrade` was left when the jumbo transaction was disabled, but we do not need it anymore. The fake upgrade operation sometimes fails (flaky) since it cannot find the `0.0.150` file, thus we need to remove it to fix the pipeline.