### PR TITLE
feat: add buffer size parameter to DataFileWriter

### DIFF
--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/util/DataUtils.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/util/DataUtils.java
@@ -1,0 +1,42 @@
+package com.swirlds.base.test.fixtures.util;
+
+import java.util.Random;
+import java.util.UUID;
+
+/**
+ * Utility class to generate some primitive data for testing purposes.
+ */
+public final class DataUtils {
+
+    private DataUtils() {
+        // Prevent instantiation
+    }
+
+    public static int[] shuffle(Random random, final int[] array) {
+        if (random == null) {
+            random = new Random();
+        }
+        final int count = array.length;
+        for (int i = count; i > 1; i--) {
+            swap(array, i - 1, random.nextInt(i));
+        }
+        return array;
+    }
+
+    public static void swap(final int[] array, final int i, final int j) {
+        final int temp = array[i];
+        array[i] = array[j];
+        array[j] = temp;
+    }
+
+    public static byte[] randomUtf8Bytes(final int n) {
+        final byte[] data = new byte[n];
+        int i = 0;
+        while (i < n) {
+            final byte[] rnd = UUID.randomUUID().toString().getBytes();
+            System.arraycopy(rnd, 0, data, i, Math.min(rnd.length, n - 1 - i));
+            i += rnd.length;
+        }
+        return data;
+    }
+}

--- a/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/util/DataUtils.java
+++ b/platform-sdk/swirlds-base/src/testFixtures/java/com/swirlds/base/test/fixtures/util/DataUtils.java
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.swirlds.base.test.fixtures.util;
 
 import java.util.Random;

--- a/platform-sdk/swirlds-merkledb/build.gradle.kts
+++ b/platform-sdk/swirlds-merkledb/build.gradle.kts
@@ -16,7 +16,10 @@ tasks.withType<JavaCompile>().configureEach {
 
 mainModuleInfo { annotationProcessor("com.swirlds.config.processor") }
 
-jmhModuleInfo { requires("jmh.core") }
+jmhModuleInfo {
+    requires("jmh.core")
+    requires("com.swirlds.base.test.fixtures")
+}
 
 testModuleInfo {
     requires("com.swirlds.common.test.fixtures")

--- a/platform-sdk/swirlds-merkledb/src/jmh/java/com/swirlds/benchmark/DataFileWriterBenchmark.java
+++ b/platform-sdk/swirlds-merkledb/src/jmh/java/com/swirlds/benchmark/DataFileWriterBenchmark.java
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.benchmark;
+
+import static com.swirlds.base.units.UnitConstants.MEBIBYTES_TO_BYTES;
+
+import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.swirlds.base.test.fixtures.util.DataUtils;
+import com.swirlds.common.io.utility.FileUtils;
+import com.swirlds.merkledb.files.DataFileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * This benchmarks can be used to measure performance of {@link DataFileWriter} class. <p>
+ * The following parameters are used to configure the benchmark:
+ * <ul>
+ *   <li><b>bufferSizeMb</b>: Size of the buffer in MB.</li>
+ *   <li><b>maxFileSizeMb</b>: Maximum size of the file to write in MB.</li>
+ *   <li><b>sampleSize</b>: Number of sample data items to generate.</li>
+ *   <li><b>sampleRangeBytes</b>: Range of the sample data items in bytes, chosen randomly from the sample.</li>
+ * </ul>
+ */
+@State(Scope.Benchmark)
+public class DataFileWriterBenchmark {
+
+    @Param({"16", "64", "128", "256"})
+    public int bufferSizeMb;
+
+    @Param({"50", "200", "500"})
+    public int maxFileSizeMb;
+
+    @Param({"10"})
+    public int sampleSize;
+
+    // first is test for small data items like hashes
+    @Param({"56-56", "300-1000", "1024-8192"})
+    public String sampleRangeBytes;
+
+    // Runtime variables
+    private Random random;
+    private BufferedData[] sampleData;
+    private long maxFileSize;
+
+    private Path benchmarkDir;
+    private DataFileWriter dataFileWriter;
+
+    @Setup(Level.Trial)
+    public void setupGlobal() throws IOException {
+        random = new Random(1234);
+        benchmarkDir = Files.createTempDirectory("dataFileWriterBenchmark");
+
+        maxFileSize = maxFileSizeMb * MEBIBYTES_TO_BYTES;
+
+        // Generate sample data
+        String[] range = sampleRangeBytes.split("-");
+        int sampleMinLength = Integer.parseInt(range[0]);
+        int sampleMaxLength = Integer.parseInt(range[1]);
+
+        sampleData = new BufferedData[sampleSize];
+        for (int i = 0; i < sampleSize; i++) {
+            sampleData[i] =
+                    BufferedData.wrap(DataUtils.randomUtf8Bytes(random.nextInt(sampleMinLength, sampleMaxLength + 1)));
+        }
+
+        System.out.println("Sample data sizes in bytes: "
+                + Arrays.toString(Arrays.stream(sampleData)
+                        .mapToLong(BufferedData::length)
+                        .toArray()));
+    }
+
+    @TearDown(Level.Trial)
+    public void tearDownGlobal() throws IOException {
+        if (benchmarkDir != null) {
+            FileUtils.deleteDirectory(benchmarkDir);
+        }
+    }
+
+    @Setup(Level.Invocation)
+    public void setup() throws IOException {
+        dataFileWriter =
+                new DataFileWriter("test", benchmarkDir, 1, Instant.now(), 1, bufferSizeMb * MEBIBYTES_TO_BYTES);
+    }
+
+    @TearDown(Level.Invocation)
+    public void tearDown() throws IOException {
+        dataFileWriter.finishWriting();
+    }
+
+    @Benchmark
+    @BenchmarkMode(Mode.AverageTime)
+    @Measurement(iterations = 1, time = 3, timeUnit = TimeUnit.SECONDS)
+    @OutputTimeUnit(TimeUnit.MILLISECONDS)
+    @Fork(value = 1, warmups = 0)
+    @Warmup(iterations = 0)
+    public void writeInFile() throws IOException {
+        long fileSize = 0;
+        BufferedData data;
+
+        while (true) {
+            data = getRandomData();
+            fileSize += data.length();
+            if (fileSize > maxFileSize) {
+                break;
+            }
+
+            dataFileWriter.storeDataItem(data);
+            data.flip();
+        }
+    }
+
+    private BufferedData getRandomData() {
+        return sampleData[random.nextInt(sampleSize)];
+    }
+}

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileWriter.java
@@ -35,6 +35,11 @@ import java.util.function.Consumer;
 public final class DataFileWriter {
 
     /**
+     * Default buffer size for writing into the file is 268 Mb
+     */
+    private static final int DEFAULT_BUF_SIZE = PAGE_SIZE * KIBIBYTES_TO_BYTES * 64;
+
+    /**
      * The current mapped byte buffer used for writing. When overflowed, it is released, and another
      * buffer is mapped from the file channel.
      */
@@ -72,8 +77,7 @@ public final class DataFileWriter {
             final Instant creationTime,
             final int compactionLevel)
             throws IOException {
-        // TODO maybe we can use 128Mb buffer size (see DataFileWriterBenchmark)
-        this(filePrefix, dataFileDir, index, creationTime, compactionLevel, PAGE_SIZE * KIBIBYTES_TO_BYTES * 64);
+        this(filePrefix, dataFileDir, index, creationTime, compactionLevel, DEFAULT_BUF_SIZE);
     }
 
     /**
@@ -97,8 +101,7 @@ public final class DataFileWriter {
             final long dataBufferSize)
             throws IOException {
         this.dataBufferSize = dataBufferSize;
-        path = createDataFilePath(filePrefix, dataFileDir, index, creationTime, DataFileCommon.FILE_EXTENSION);
-
+        this.path = createDataFilePath(filePrefix, dataFileDir, index, creationTime, DataFileCommon.FILE_EXTENSION);
         metadata = new DataFileMetadata(
                 0, // data item count will be updated later in finishWriting()
                 index,


### PR DESCRIPTION
**Description**:
- Add a constructor parameter to configure the buffer size for `DataFileWriter`
- Add `DataFileWriterBenchmark`

**Related issue(s)**: #19041

**Notes for reviewer**:
- `com.swirlds.benchmark.DataFileWriterBenchmark#sampleRangeBytes` - What are good data size patterns to use? We have hashes, which are covered by a 56-byte length option - anything else particular?
- `com.swirlds.benchmark.DataFileWriterBenchmark#sampleSize` - I'm using sample to pre-generate data and avoid spending time on generation during test (and also possible GC). Is 10 a good number for the sample data, or should it be 100?
