### PR TITLE
test: reduce gas sent in ContractMintHTSV2SecurityModelSuite

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSV2SecurityModelSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/ContractMintHTSV2SecurityModelSuite.java
@@ -52,7 +52,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 @SuppressWarnings("java:S1192") // "string literal should not be duplicated" - this rule makes test suites worse
 public class ContractMintHTSV2SecurityModelSuite {
-    private static final long GAS_TO_OFFER = 4_000_000L;
+    private static final long GAS_TO_OFFER = 2_000_000L;
     private static final String TOKEN_TREASURY = "treasury";
     private static final KeyShape TRESHOLD_KEY_SHAPE = KeyShape.threshOf(1, ED25519, CONTRACT);
     private static final String CONTRACT_KEY = "ContractKey";


### PR DESCRIPTION
**Description**:
The `ContractMintHTSV2SecurityModelSuite` has become flaky.  One explanation is that because each `ContractCall` takes 4M gas and the gas needed for `ContractCreate` has recently been increased, we are running into the gas throttle.  This pr is an attempt to reduce the flakiness of this test by reducing the gas sent with each `ContractCall`