### PR TITLE
feat: Implement feature flag for gRPC web proxy endpoint

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1756,7 +1756,8 @@ enum ResponseCodeEnum {
     AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN = 398;
 
     /**
-     * GRPC web proxy is not supported for this transaction
+     * The GRPC proxy endpoint is set in the NodeCreate or NodeUpdate transaction,
+     * which the network does not support.
      */
     GRPC_WEB_PROXY_NOT_SUPPORTED = 399;
 }

--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1754,4 +1754,9 @@ enum ResponseCodeEnum {
      * Token airdrop transactions can not contain multiple senders for a single token.
      */
     AIRDROP_CONTAINS_MULTIPLE_SENDERS_FOR_A_TOKEN = 398;
+
+    /**
+     * GRPC web proxy is not supported for this transaction
+     */
+    GRPC_WEB_PROXY_NOT_SUPPORTED = 399;
 }

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeCreateHandler.java
@@ -26,7 +26,6 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
-import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.PureChecksContext;
@@ -97,11 +96,8 @@ public class NodeCreateHandler implements TransactionHandler {
         addressBookValidator.validateGossipEndpoint(op.gossipEndpoint(), nodeConfig);
         addressBookValidator.validateServiceEndpoint(op.serviceEndpoint(), nodeConfig);
         if (op.hasGrpcProxyEndpoint()) {
-            if (nodeConfig.webProxyEndpointsEnabled()) {
-                addressBookValidator.validateEndpoint(op.grpcProxyEndpoint(), nodeConfig);
-            } else {
-                throw new HandleException(GRPC_WEB_PROXY_NOT_SUPPORTED);
-            }
+            validateTrue(nodeConfig.webProxyEndpointsEnabled(), GRPC_WEB_PROXY_NOT_SUPPORTED);
+            addressBookValidator.validateEndpoint(op.grpcProxyEndpoint(), nodeConfig);
         }
         handleContext.attributeValidator().validateKey(op.adminKeyOrThrow(), INVALID_ADMIN_KEY);
 
@@ -114,7 +110,7 @@ public class NodeCreateHandler implements TransactionHandler {
                 .grpcCertificateHash(op.grpcCertificateHash())
                 .declineReward(op.declineReward())
                 .adminKey(op.adminKey());
-        if (nodeConfig.webProxyEndpointsEnabled() && op.hasGrpcProxyEndpoint()) {
+        if (op.hasGrpcProxyEndpoint()) {
             nodeBuilder.grpcProxyEndpoint(op.grpcProxyEndpoint());
         }
 

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
@@ -26,7 +26,6 @@ import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.app.spi.fees.FeeContext;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
-import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.PureChecksContext;
@@ -119,11 +118,8 @@ public class NodeUpdateHandler implements TransactionHandler {
             addressBookValidator.validateServiceEndpoint(op.serviceEndpoint(), nodeConfig);
         }
         if (op.hasGrpcProxyEndpoint()) {
-            if (nodeConfig.webProxyEndpointsEnabled()) {
-                addressBookValidator.validateEndpoint(op.grpcProxyEndpoint(), nodeConfig);
-            } else {
-                throw new HandleException(GRPC_WEB_PROXY_NOT_SUPPORTED);
-            }
+            validateTrue(nodeConfig.webProxyEndpointsEnabled(), GRPC_WEB_PROXY_NOT_SUPPORTED);
+            addressBookValidator.validateEndpoint(op.grpcProxyEndpoint(), nodeConfig);
         }
 
         final var nodeBuilder = updateNode(op, existingNode, nodeConfig);
@@ -175,7 +171,7 @@ public class NodeUpdateHandler implements TransactionHandler {
         if (op.hasDeclineReward()) {
             nodeBuilder.declineReward(op.declineReward());
         }
-        if (nodeConfig.webProxyEndpointsEnabled() && op.hasGrpcProxyEndpoint()) {
+        if (op.hasGrpcProxyEndpoint()) {
             nodeBuilder.grpcProxyEndpoint(op.grpcProxyEndpoint());
         }
         return nodeBuilder;

--- a/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/main/java/com/hedera/node/app/service/addressbook/impl/handlers/NodeUpdateHandler.java
@@ -122,7 +122,7 @@ public class NodeUpdateHandler implements TransactionHandler {
             addressBookValidator.validateEndpoint(op.grpcProxyEndpoint(), nodeConfig);
         }
 
-        final var nodeBuilder = updateNode(op, existingNode, nodeConfig);
+        final var nodeBuilder = updateNode(op, existingNode);
         nodeStore.put(nodeBuilder.build());
     }
 
@@ -139,10 +139,7 @@ public class NodeUpdateHandler implements TransactionHandler {
         return calculator.calculate();
     }
 
-    private Node.Builder updateNode(
-            @NonNull final NodeUpdateTransactionBody op,
-            @NonNull final Node node,
-            @NonNull final NodesConfig nodeConfig) {
+    private Node.Builder updateNode(@NonNull final NodeUpdateTransactionBody op, @NonNull final Node node) {
         requireNonNull(op);
         requireNonNull(node);
 

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
@@ -514,6 +514,7 @@ class NodeCreateHandlerTest extends AddressBookTestBase {
                 .withValue("nodes.maxGossipEndpoint", 2)
                 .withValue("nodes.maxServiceEndpoint", 2)
                 .withValue("nodes.maxFqdnSize", 100)
+				.withValue("nodes.webProxyEndpointsEnabled", true)
                 .getOrCreateConfig();
         given(handleContext.configuration()).willReturn(config);
         given(handleContext.attributeValidator()).willReturn(validator);
@@ -542,6 +543,7 @@ class NodeCreateHandlerTest extends AddressBookTestBase {
                 .withValue("nodes.nodeMaxDescriptionUtf8Bytes", 12)
                 .withValue("nodes.maxGossipEndpoint", 4)
                 .withValue("nodes.maxServiceEndpoint", 3)
+				.withValue("nodes.webProxyEndpointsEnabled", true)
                 .getOrCreateConfig();
         given(handleContext.configuration()).willReturn(config);
         given(handleContext.storeFactory()).willReturn(storeFactory);

--- a/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
+++ b/hedera-node/hedera-addressbook-service-impl/src/test/java/com/hedera/node/app/service/addressbook/impl/test/handlers/NodeCreateHandlerTest.java
@@ -514,7 +514,7 @@ class NodeCreateHandlerTest extends AddressBookTestBase {
                 .withValue("nodes.maxGossipEndpoint", 2)
                 .withValue("nodes.maxServiceEndpoint", 2)
                 .withValue("nodes.maxFqdnSize", 100)
-				.withValue("nodes.webProxyEndpointsEnabled", true)
+                .withValue("nodes.webProxyEndpointsEnabled", true)
                 .getOrCreateConfig();
         given(handleContext.configuration()).willReturn(config);
         given(handleContext.attributeValidator()).willReturn(validator);
@@ -543,7 +543,7 @@ class NodeCreateHandlerTest extends AddressBookTestBase {
                 .withValue("nodes.nodeMaxDescriptionUtf8Bytes", 12)
                 .withValue("nodes.maxGossipEndpoint", 4)
                 .withValue("nodes.maxServiceEndpoint", 3)
-				.withValue("nodes.webProxyEndpointsEnabled", true)
+                .withValue("nodes.webProxyEndpointsEnabled", true)
                 .getOrCreateConfig();
         given(handleContext.configuration()).willReturn(config);
         given(handleContext.storeFactory()).willReturn(storeFactory);

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NodesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NodesConfig.java
@@ -40,4 +40,5 @@ public record NodesConfig(
         @ConfigProperty(defaultValue = "100000000000000") @NetworkProperty long minNodeRewardBalance,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean adjustNodeFees,
         @ConfigProperty(defaultValue = "10") @NetworkProperty int activeRoundsPercent,
-        @ConfigProperty(defaultValue = "true") @NetworkProperty boolean preserveMinNodeRewardBalance) {}
+        @ConfigProperty(defaultValue = "true") @NetworkProperty boolean preserveMinNodeRewardBalance,
+        @ConfigProperty(defaultValue = "false") @NetworkProperty boolean webProxyEndpointsEnabled) {}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/node/HapiNodeCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/node/HapiNodeCreate.java
@@ -52,7 +52,7 @@ public class HapiNodeCreate extends HapiTxnOp<HapiNodeCreate> {
             Arrays.asList(endpointFor("192.168.1.200", 123), endpointFor("192.168.1.201", 123));
     private List<ServiceEndpoint> grpcEndpoints = List.of(
             ServiceEndpoint.newBuilder().setDomainName("test.com").setPort(123).build());
-    private ServiceEndpoint grpcWebProxyEndpoint = endpointFor("grpc.web.proxy.com", 123);
+    private Optional<ServiceEndpoint> grpcWebProxyEndpoint = Optional.of(endpointFor("grpc.web.proxy.com", 123));
     private Optional<byte[]> gossipCaCertificate = Optional.empty();
     private Optional<byte[]> grpcCertificateHash = Optional.empty();
     private Optional<String> adminKeyName = Optional.empty();
@@ -120,8 +120,12 @@ public class HapiNodeCreate extends HapiTxnOp<HapiNodeCreate> {
     }
 
     public HapiNodeCreate grpcWebProxyEndpoint(final ServiceEndpoint grpcWebProxyEndpoint) {
-        this.grpcWebProxyEndpoint = grpcWebProxyEndpoint;
+        this.grpcWebProxyEndpoint = Optional.ofNullable(grpcWebProxyEndpoint);
         return this;
+    }
+
+    public HapiNodeCreate withNoWebProxyEndpoint() {
+        return this.grpcWebProxyEndpoint(null);
     }
 
     public HapiNodeCreate gossipCaCertificate(@NonNull final Bytes cert) {
@@ -194,7 +198,7 @@ public class HapiNodeCreate extends HapiTxnOp<HapiNodeCreate> {
                             builder.setAdminKey(adminKey);
                             builder.clearGossipEndpoint().addAllGossipEndpoint(gossipEndpoints);
                             builder.clearServiceEndpoint().addAllServiceEndpoint(grpcEndpoints);
-                            builder.setGrpcProxyEndpoint(grpcWebProxyEndpoint);
+                            grpcWebProxyEndpoint.ifPresent(builder::setGrpcProxyEndpoint);
                             gossipCaCertificate.ifPresent(s -> builder.setGossipCaCertificate(ByteString.copyFrom(s)));
                             grpcCertificateHash.ifPresent(s -> builder.setGrpcCertificateHash(ByteString.copyFrom(s)));
                             declineReward.ifPresent(builder::setDeclineReward);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/node/HapiNodeCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/node/HapiNodeCreate.java
@@ -52,7 +52,10 @@ public class HapiNodeCreate extends HapiTxnOp<HapiNodeCreate> {
             Arrays.asList(endpointFor("192.168.1.200", 123), endpointFor("192.168.1.201", 123));
     private List<ServiceEndpoint> grpcEndpoints = List.of(
             ServiceEndpoint.newBuilder().setDomainName("test.com").setPort(123).build());
-    private Optional<ServiceEndpoint> grpcWebProxyEndpoint = Optional.of(endpointFor("grpc.web.proxy.com", 123));
+    // (FUTURE) Since the introduction of a flag to explicitly enable the web proxy endpoint functionality, a non-empty
+    // default here causes some tests to fail with GRPC_WEB_PROXY_NOT_SUPPORTED. Once we can enable
+    // nodes.webProxyEndpointsEnabled permanently, we can restore the non-null default.
+    private Optional<ServiceEndpoint> grpcWebProxyEndpoint = Optional.empty();
     private Optional<byte[]> gossipCaCertificate = Optional.empty();
     private Optional<byte[]> grpcCertificateHash = Optional.empty();
     private Optional<String> adminKeyName = Optional.empty();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
@@ -15,6 +15,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeCreate;
 import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.viewNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsdWithin;
 import static com.hedera.services.bdd.suites.HapiSuite.ADDRESS_BOOK_CONTROL;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
@@ -25,6 +26,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.SYSTEM_ADMIN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GOSSIP_ENDPOINTS_EXCEEDED_LIMIT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GOSSIP_ENDPOINT_CANNOT_HAVE_FQDN;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.GRPC_WEB_PROXY_NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ENDPOINT;
@@ -42,6 +44,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.EmbeddedHapiTest;
@@ -50,6 +53,8 @@ import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.transactions.node.HapiNodeCreate;
+import com.hedera.services.bdd.spec.utilops.embedded.ViewNodeOp;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ServiceEndpoint;
 import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
@@ -71,17 +76,18 @@ import org.junit.jupiter.api.DynamicTest;
 public class NodeCreateTest {
 
     public static final String ED_25519_KEY = "ed25519Alias";
-    public static List<ServiceEndpoint> GOSSIP_ENDPOINTS = Arrays.asList(
+    public static List<ServiceEndpoint> GOSSIP_ENDPOINTS_FQDNS = Arrays.asList(
             ServiceEndpoint.newBuilder().setDomainName("test.com").setPort(123).build(),
             ServiceEndpoint.newBuilder().setDomainName("test2.com").setPort(123).build());
-    public static List<ServiceEndpoint> SERVICES_ENDPOINTS = List.of(ServiceEndpoint.newBuilder()
+    public static List<ServiceEndpoint> SERVICES_ENDPOINTS_FQDNS = List.of(ServiceEndpoint.newBuilder()
             .setDomainName("service.com")
             .setPort(234)
             .build());
-    private static final ServiceEndpoint GRPC_PROXY_ENDPOINT = endpointFor("grpc.web.proxy.com", 123);
+    public static final ServiceEndpoint GRPC_PROXY_ENDPOINT_FQDN = endpointFor("grpc.web.proxy.com", 123);
     public static List<ServiceEndpoint> GOSSIP_ENDPOINTS_IPS =
             Arrays.asList(endpointFor("192.168.1.200", 123), endpointFor("192.168.1.201", 123));
     public static List<ServiceEndpoint> SERVICES_ENDPOINTS_IPS = List.of(endpointFor("192.168.1.205", 234));
+    public static final ServiceEndpoint GRPC_PROXY_ENDPOINT_IP = endpointFor("192.168.1.255", 123);
     private static List<X509Certificate> gossipCertificates;
 
     @BeforeAll
@@ -283,40 +289,23 @@ public class NodeCreateTest {
      * Check that node creation succeeds with gossip and service endpoints using ips and all optional fields are recorded.
      * @see <a href="https://github.com/hashgraph/hedera-improvement-proposal/blob/main/HIP/hip-869.md#specification">HIP-869</a>
      */
-    @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
+    @LeakyEmbeddedHapiTest(
+            reason = NEEDS_STATE_ACCESS,
+            overrides = {"nodes.webProxyEndpointsEnabled"})
     final Stream<DynamicTest> allFieldsSetHappyCaseForIps() throws CertificateEncodingException {
+        final var nodeCreate = canonicalNodeCreate()
+                .gossipEndpoint(GOSSIP_ENDPOINTS_IPS)
+                .serviceEndpoint(SERVICES_ENDPOINTS_IPS)
+                .grpcWebProxyEndpoint(GRPC_PROXY_ENDPOINT_IP);
         return hapiTest(
+                overriding("nodes.webProxyEndpointsEnabled", "true"),
                 newKeyNamed(ED_25519_KEY).shape(KeyShape.ED25519),
-                nodeCreate("nodeCreate")
-                        .description("hello")
-                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded())
-                        .grpcCertificateHash("hash".getBytes())
-                        .accountId(asAccount(asEntityString(100)))
-                        .gossipEndpoint(GOSSIP_ENDPOINTS_IPS)
-                        .serviceEndpoint(SERVICES_ENDPOINTS_IPS)
-                        .adminKey(ED_25519_KEY)
-                        .hasPrecheck(OK)
-                        .hasKnownStatus(SUCCESS),
+                nodeCreate,
+                verifyCanonicalCreate(nodeCreate),
                 viewNode("nodeCreate", node -> {
-                    assertEquals("hello", node.description(), "Description invalid");
-                    try {
-                        assertEquals(
-                                ByteString.copyFrom(
-                                        gossipCertificates.getFirst().getEncoded()),
-                                ByteString.copyFrom(node.gossipCaCertificate().toByteArray()),
-                                "Gossip CA invalid");
-                    } catch (CertificateEncodingException e) {
-                        throw new RuntimeException(e);
-                    }
-
-                    assertEquals(
-                            ByteString.copyFrom("hash".getBytes()),
-                            ByteString.copyFrom(node.grpcCertificateHash().toByteArray()),
-                            "GRPC hash invalid");
-                    assertEquals(100, node.accountId().accountNum(), "Account ID invalid");
                     assertEqualServiceEndpoints(GOSSIP_ENDPOINTS_IPS, node.gossipEndpoint());
                     assertEqualServiceEndpoints(SERVICES_ENDPOINTS_IPS, node.serviceEndpoint());
-                    assertNotNull(node.adminKey(), "Admin key invalid");
+                    assertEqualServiceEndpoint(GRPC_PROXY_ENDPOINT_IP, node.grpcProxyEndpoint());
                 }));
     }
 
@@ -326,45 +315,82 @@ public class NodeCreateTest {
      */
     @LeakyEmbeddedHapiTest(
             reason = NEEDS_STATE_ACCESS,
-            overrides = {"nodes.gossipFqdnRestricted"})
+            overrides = {"nodes.gossipFqdnRestricted", "nodes.webProxyEndpointsEnabled"})
     final Stream<DynamicTest> allFieldsSetHappyCaseForDomains() throws CertificateEncodingException {
-        final var nodeCreate = nodeCreate("nodeCreate")
+        final var nodeCreate = canonicalNodeCreate();
+        return hapiTest(
+                overridingTwo("nodes.gossipFqdnRestricted", "false", "nodes.webProxyEndpointsEnabled", "true"),
+                newKeyNamed(ED_25519_KEY).shape(KeyShape.ED25519),
+                nodeCreate,
+                verifyCanonicalCreate(nodeCreate),
+                viewNode("nodeCreate", node -> {
+                    assertEqualServiceEndpoints(GOSSIP_ENDPOINTS_FQDNS, node.gossipEndpoint());
+                    assertEqualServiceEndpoints(SERVICES_ENDPOINTS_FQDNS, node.serviceEndpoint());
+                    assertEqualServiceEndpoint(GRPC_PROXY_ENDPOINT_FQDN, node.grpcProxyEndpoint());
+                }));
+    }
+
+    @LeakyEmbeddedHapiTest(
+            reason = NEEDS_STATE_ACCESS,
+            overrides = {"nodes.gossipFqdnRestricted"})
+    final Stream<DynamicTest> allFieldsButProxyEndpointSet() throws CertificateEncodingException {
+        final var nodeCreate = canonicalNodeCreate().withNoWebProxyEndpoint();
+        return hapiTest(
+                overriding("nodes.gossipFqdnRestricted", "false"),
+                newKeyNamed(ED_25519_KEY).shape(KeyShape.ED25519),
+                nodeCreate,
+                verifyCanonicalCreate(nodeCreate),
+                // nodes.webProxyEndpointsEnabled should default to false, resulting in a null proxy endpoint
+                viewNode("nodeCreate", node -> {
+                    assertEqualServiceEndpoints(GOSSIP_ENDPOINTS_FQDNS, node.gossipEndpoint());
+                    assertEqualServiceEndpoints(SERVICES_ENDPOINTS_FQDNS, node.serviceEndpoint());
+                    assertNull(node.grpcProxyEndpoint());
+                }));
+    }
+
+    @LeakyHapiTest(overrides = {"nodes.gossipFqdnRestricted"})
+    final Stream<DynamicTest> webProxySetWhenNotEnabledReturnsNotSupported() throws CertificateEncodingException {
+        final var nodeCreate = canonicalNodeCreate();
+        return hapiTest(
+                overriding("nodes.gossipFqdnRestricted", "false"),
+                newKeyNamed(ED_25519_KEY).shape(KeyShape.ED25519),
+                nodeCreate.hasKnownStatus(GRPC_WEB_PROXY_NOT_SUPPORTED));
+    }
+
+    private static HapiNodeCreate canonicalNodeCreate() throws CertificateEncodingException {
+        return nodeCreate("nodeCreate")
                 .description("hello")
                 .gossipCaCertificate(gossipCertificates.getFirst().getEncoded())
                 .grpcCertificateHash("hash".getBytes())
                 .accountId(asAccount(asEntityString(100)))
-                .gossipEndpoint(GOSSIP_ENDPOINTS)
-                .serviceEndpoint(SERVICES_ENDPOINTS)
-                .grpcWebProxyEndpoint(GRPC_PROXY_ENDPOINT)
+                // Defaults to FQDN's for all endpoints
+                .gossipEndpoint(GOSSIP_ENDPOINTS_FQDNS)
+                .serviceEndpoint(SERVICES_ENDPOINTS_FQDNS)
+                .grpcWebProxyEndpoint(GRPC_PROXY_ENDPOINT_FQDN)
                 .adminKey(ED_25519_KEY)
                 .hasPrecheck(OK)
                 .hasKnownStatus(SUCCESS);
-        return hapiTest(
-                newKeyNamed(ED_25519_KEY).shape(KeyShape.ED25519),
-                overriding("nodes.gossipFqdnRestricted", "false"),
-                nodeCreate,
-                viewNode("nodeCreate", node -> {
-                    assertEquals("hello", node.description(), "Description invalid");
-                    try {
-                        assertEquals(
-                                ByteString.copyFrom(
-                                        gossipCertificates.getFirst().getEncoded()),
-                                ByteString.copyFrom(node.gossipCaCertificate().toByteArray()),
-                                "Gossip CA invalid");
-                    } catch (CertificateEncodingException e) {
-                        throw new RuntimeException(e);
-                    }
-                    assertEquals(
-                            ByteString.copyFrom("hash".getBytes()),
-                            ByteString.copyFrom(node.grpcCertificateHash().toByteArray()),
-                            "GRPC hash invalid");
-                    assertEquals(100, node.accountId().accountNum(), "Account ID invalid");
-                    assertEqualServiceEndpoints(GOSSIP_ENDPOINTS, node.gossipEndpoint());
-                    assertEqualServiceEndpoints(SERVICES_ENDPOINTS, node.serviceEndpoint());
-                    assertEqualServiceEndpoints(List.of(GRPC_PROXY_ENDPOINT), List.of(node.grpcProxyEndpoint()));
-                    assertNotNull(nodeCreate.getAdminKey(), " Admin key invalid");
-                    assertEquals(toPbj(nodeCreate.getAdminKey()), node.adminKey(), "Admin key invalid");
-                }));
+    }
+
+    private static ViewNodeOp verifyCanonicalCreate(final HapiNodeCreate nodeCreate) {
+        return viewNode("nodeCreate", node -> {
+            assertEquals("hello", node.description(), "Description invalid");
+            try {
+                assertEquals(
+                        ByteString.copyFrom(gossipCertificates.getFirst().getEncoded()),
+                        ByteString.copyFrom(node.gossipCaCertificate().toByteArray()),
+                        "Gossip CA invalid");
+            } catch (CertificateEncodingException e) {
+                throw new RuntimeException(e);
+            }
+            assertEquals(
+                    ByteString.copyFrom("hash".getBytes()),
+                    ByteString.copyFrom(node.grpcCertificateHash().toByteArray()),
+                    "GRPC hash invalid");
+            assertEquals(100, node.accountId().accountNum(), "Account ID invalid");
+            assertNotNull(nodeCreate.getAdminKey(), " Admin key invalid");
+            assertEquals(toPbj(nodeCreate.getAdminKey()), node.adminKey(), "Admin key invalid");
+        });
     }
 
     /**
@@ -521,7 +547,7 @@ public class NodeCreateTest {
     @DisplayName("Check default setting, gossipEndpoint can not have domain names")
     final Stream<DynamicTest> gossipEndpointHaveDomainNameFail() throws CertificateEncodingException {
         return hapiTest(nodeCreate("testNode")
-                .gossipEndpoint(GOSSIP_ENDPOINTS)
+                .gossipEndpoint(GOSSIP_ENDPOINTS_FQDNS)
                 .gossipCaCertificate(gossipCertificates.getFirst().getEncoded())
                 .hasKnownStatus(GOSSIP_ENDPOINT_CANNOT_HAVE_FQDN));
     }
@@ -601,18 +627,31 @@ public class NodeCreateTest {
     private static void assertEqualServiceEndpoints(
             List<com.hederahashgraph.api.proto.java.ServiceEndpoint> expected,
             List<com.hedera.hapi.node.base.ServiceEndpoint> actual) {
-        assertEquals(expected.size(), actual.size(), "Service endpoints size invalid");
+        assertEquals(
+                expected.size(),
+                actual.size(),
+                "Service endpoints sizes don't match: expected " + expected.size() + " but got " + actual.size());
         for (int i = 0; i < expected.size(); i++) {
-            assertEquals(
-                    ByteString.copyFrom(expected.get(i).getIpAddressV4().toByteArray()),
-                    ByteString.copyFrom(actual.get(i).ipAddressV4().toByteArray()),
-                    "Service endpoint IP address invalid");
-            assertEquals(
-                    expected.get(i).getDomainName(),
-                    actual.get(i).domainName(),
-                    "Service endpoint domain name invalid");
-            assertEquals(expected.get(i).getPort(), actual.get(i).port(), "Service endpoint port invalid");
+            assertEqualServiceEndpoint(expected.get(i), actual.get(i));
         }
+    }
+
+    private static void assertEqualServiceEndpoint(
+            com.hederahashgraph.api.proto.java.ServiceEndpoint expected,
+            com.hedera.hapi.node.base.ServiceEndpoint actual) {
+        if (expected == null && actual == null) {
+            return;
+        }
+        if (actual == null) {
+            throw new AssertionError("Service endpoint is null when non-null was expected");
+        }
+
+        assertEquals(
+                ByteString.copyFrom(expected.getIpAddressV4().toByteArray()),
+                ByteString.copyFrom(actual.ipAddressV4().toByteArray()),
+                "Service endpoint IP address invalid");
+        assertEquals(expected.getDomainName(), actual.domainName(), "Service endpoint domain name invalid");
+        assertEquals(expected.getPort(), actual.port(), "Service endpoint port invalid");
     }
 
     public static List<X509Certificate> generateX509Certificates(final int n) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
@@ -612,9 +612,10 @@ public class NodeCreateTest {
                         .hasKnownStatus(UNAUTHORIZED));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"nodes.webProxyEndpointsEnabled"})
     final Stream<DynamicTest> createNodeWithDefaultGrpcProxyFails() throws CertificateEncodingException {
         return hapiTest(
+                overriding("nodes.webProxyEndpointsEnabled", "true"),
                 newKeyNamed("adminKey"),
                 nodeCreate("testNode")
                         .adminKey("adminKey")


### PR DESCRIPTION
**Description**:
This PR adds a feature flag–`nodes.webProxyEndpointsEnabled`–to toggle support for the gRPC web proxy endpoint added in HIP 1046's implementation. The flag's default mainnet value should be `false`; any submissions for NodeCreate or NodeUpdate transactions that populate this field, without enabling the flag, should receive a new response code–`GRPC_WEB_PROXY_NOT_SUPPORTED`. Otherwise these fields should behave as expected and tested for HIP 1046.

Closes #19046 