### PR TITLE
feat: add throttle for ops duration

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/state/throttles/throttle_usage_snapshots.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/state/throttles/throttle_usage_snapshots.proto
@@ -20,8 +20,8 @@ option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 
 /**
- * All point-in-time snapshots of throttle usage for TPS and "gas" throttle
- * values for a given point in time.
+ * All point-in-time snapshots of throttle usage for TPS, "gas" throttle
+ * values for a given point in time and evm ops duration throttle.
  *
  * > Question:
  * >> What point in time?  Should this store consensus timestamp here?
@@ -39,6 +39,11 @@ message ThrottleUsageSnapshots {
      * A single snapshot for the gas throttle.
      */
     ThrottleUsageSnapshot gas_throttle = 2;
+
+    /**
+     * A single snapshot for evm ops duration throttle.
+     */
+    ThrottleUsageSnapshot evm_ops_duration_throttle = 3;
 }
 
 /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/AppThrottleFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/AppThrottleFactory.java
@@ -56,6 +56,7 @@ public class AppThrottleFactory implements Throttle.Factory {
                 configSupplier, () -> capacitySplit, ThrottleAccumulator.ThrottleType.BACKEND_THROTTLE);
         throttleAccumulator.applyGasConfig();
         throttleAccumulator.applyBytesConfig();
+        throttleAccumulator.applyDurationConfig();
         throttleAccumulator.rebuildFor(definitionsSupplier.get());
         if (initialUsageSnapshots != null) {
             final var tpsThrottles = throttleAccumulator.allActiveThrottles();
@@ -93,7 +94,8 @@ public class AppThrottleFactory implements Throttle.Factory {
                         throttleAccumulator.allActiveThrottles().stream()
                                 .map(DeterministicThrottle::usageSnapshot)
                                 .toList(),
-                        throttleAccumulator.gasLimitThrottle().usageSnapshot());
+                        throttleAccumulator.gasLimitThrottle().usageSnapshot(),
+                        throttleAccumulator.opsDurationThrottle().usageSnapshot());
             }
         };
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -101,6 +101,7 @@ public class ThrottleAccumulator {
     private boolean lastTxnWasGasThrottled;
     private LeakyBucketDeterministicThrottle bytesThrottle;
     private LeakyBucketDeterministicThrottle gasThrottle;
+    private LeakyBucketDeterministicThrottle opsDurationThrottle;
     private List<DeterministicThrottle> activeThrottles = emptyList();
 
     @Nullable
@@ -543,15 +544,16 @@ public class ThrottleAccumulator {
             @NonNull final TransactionBody txnBody, @NonNull final HederaFunctionality function) {
         final long nominalGas =
                 switch (function) {
-                    case CONTRACT_CREATE -> txnBody.contractCreateInstanceOrThrow()
-                            .gas();
+                    case CONTRACT_CREATE ->
+                        txnBody.contractCreateInstanceOrThrow().gas();
                     case CONTRACT_CALL -> txnBody.contractCallOrThrow().gas();
-                    case ETHEREUM_TRANSACTION -> Optional.of(txnBody.ethereumTransactionOrThrow()
-                                    .ethereumData()
-                                    .toByteArray())
-                            .map(EthTxData::populateEthTxData)
-                            .map(EthTxData::gasLimit)
-                            .orElse(0L);
+                    case ETHEREUM_TRANSACTION ->
+                        Optional.of(txnBody.ethereumTransactionOrThrow()
+                                        .ethereumData()
+                                        .toByteArray())
+                                .map(EthTxData::populateEthTxData)
+                                .map(EthTxData::gasLimit)
+                                .orElse(0L);
                     default -> 0L;
                 };
         // Interpret negative gas as overflow
@@ -895,6 +897,28 @@ public class ThrottleAccumulator {
         }
     }
 
+    public void applyDurationConfig() {
+        final var configuration = configSupplier.get();
+        final var contractConfig = configuration.getConfigData(ContractsConfig.class);
+        final var maxOpsDuration = contractConfig.maxOpsDuration();
+        if (contractConfig.throttleThrottleByOpsDuration() && maxOpsDuration == 0) {
+            log.warn("{} ops duration throttles are enabled, but limited to 0 ops/sec", throttleType.name());
+        }
+        opsDurationThrottle =
+                new LeakyBucketDeterministicThrottle(maxOpsDuration, "OpsDuration", DEFAULT_BURST_SECONDS);
+        // TODO: luke do we need metrics for backend throttles?
+        //        if (throttleMetrics != null) {
+        //            throttleMetrics.setupBytesThrottleMetric(bytesThrottle, configuration);
+        //        }
+        if (verbose == Verbose.YES) {
+            log.info(
+                    "Resolved {} bytes throttle -\n {} bytes/sec (throttling {})",
+                    throttleType.name(),
+                    opsDurationThrottle.capacity(),
+                    (contractConfig.throttleThrottleByOpsDuration() ? "ON" : "OFF"));
+        }
+    }
+
     @NonNull
     private ThrottleGroup<HederaFunctionality> hapiGroupFromPbj(
             @NonNull final com.hedera.hapi.node.transaction.ThrottleGroup pbjThrottleGroup) {
@@ -937,6 +961,13 @@ public class ThrottleAccumulator {
      */
     public @NonNull LeakyBucketDeterministicThrottle bytesLimitThrottle() {
         return requireNonNull(bytesThrottle, "");
+    }
+
+    /**
+     * Gets the ops duration throttle.
+     */
+    public @NonNull LeakyBucketDeterministicThrottle opsDurationThrottle() {
+        return requireNonNull(opsDurationThrottle, "");
     }
 
     public enum ThrottleType {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleServiceManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleServiceManager.java
@@ -74,9 +74,10 @@ public class ThrottleServiceManager {
      */
     public void init(@NonNull final State state, @NonNull final Bytes throttleDefinitions) {
         requireNonNull(state);
-        // Apply configuration for gas and bytes throttles
+        // Apply configuration for gas, bytes and ops duration throttles
         applyGasConfig();
         applyBytesConfig();
+        applyOpsDurationConfig();
         // Create backend/frontend throttles from the configured system file
         rebuildThrottlesFrom(throttleDefinitions);
         // Reset multiplier expectations
@@ -116,6 +117,7 @@ public class ThrottleServiceManager {
     public void refreshThrottleConfiguration() {
         applyGasConfig();
         applyBytesConfig();
+        applyOpsDurationConfig();
         congestionMultipliers.resetExpectations();
     }
 
@@ -163,10 +165,13 @@ public class ThrottleServiceManager {
 
         final var gasThrottle = backendThrottle.gasLimitThrottle();
         final var gasThrottleSnapshot = gasThrottle.usageSnapshot();
+        final var opsDurationThrottle = backendThrottle.opsDurationThrottle();
+        final var opsDurationThrottleSnapshot = opsDurationThrottle.usageSnapshot();
 
         final WritableSingletonState<ThrottleUsageSnapshots> throttleSnapshots =
                 serviceStates.getSingleton(THROTTLE_USAGE_SNAPSHOTS_STATE_KEY);
-        throttleSnapshots.put(new ThrottleUsageSnapshots(hapiThrottleSnapshots, gasThrottleSnapshot));
+        throttleSnapshots.put(
+                new ThrottleUsageSnapshots(hapiThrottleSnapshots, gasThrottleSnapshot, opsDurationThrottleSnapshot));
     }
 
     private void saveCongestionLevelStartsTo(@NonNull final WritableStates serviceStates) {
@@ -192,6 +197,10 @@ public class ThrottleServiceManager {
 
     private void applyBytesConfig() {
         ingestThrottle.applyBytesConfig();
+    }
+
+    private void applyOpsDurationConfig() {
+        backendThrottle.applyBytesConfig();
     }
 
     private void syncFromCongestionLevelStarts(@NonNull final ReadableStates serviceStates) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/AppThrottleFactoryTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/AppThrottleFactoryTest.java
@@ -58,6 +58,7 @@ class AppThrottleFactoryTest {
             List.of(
                     new ThrottleUsageSnapshot(1L, new Timestamp(234567, 8)),
                     new ThrottleUsageSnapshot(2L, new Timestamp(345678, 9))),
+            ThrottleUsageSnapshot.DEFAULT,
             ThrottleUsageSnapshot.DEFAULT);
 
     @Mock

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleServiceManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleServiceManagerTest.java
@@ -38,7 +38,9 @@ class ThrottleServiceManagerTest {
     private static final Bytes MOCK_ENCODED_THROTTLE_DEFS = Bytes.wrap("NOPE");
     private static final ThrottleDefinitions MOCK_THROTTLE_DEFS = ThrottleDefinitions.DEFAULT;
     private static final ThrottleUsageSnapshots MOCK_THROTTLE_USAGE_SNAPSHOTS = new ThrottleUsageSnapshots(
-            List.of(new ThrottleUsageSnapshot(123L, EPOCH)), new ThrottleUsageSnapshot(456L, EPOCH));
+            List.of(new ThrottleUsageSnapshot(123L, EPOCH)),
+            new ThrottleUsageSnapshot(456L, EPOCH),
+            new ThrottleUsageSnapshot(789L, EPOCH));
     private static final CongestionLevelStarts MOCK_CONGESTION_LEVEL_STARTS =
             new CongestionLevelStarts(List.of(new Timestamp(1L, 2), EPOCH), List.of(new Timestamp(3L, 4), EPOCH));
     private static final ThrottleUsageSnapshot MOCK_USAGE_SNAPSHOT =
@@ -145,7 +147,8 @@ class ThrottleServiceManagerTest {
         subject.saveThrottleSnapshotsAndCongestionLevelStartsTo(state);
 
         verify(writableThrottleSnapshots)
-                .put(new ThrottleUsageSnapshots(List.of(MOCK_USAGE_SNAPSHOT), MOCK_USAGE_SNAPSHOT));
+                .put(new ThrottleUsageSnapshots(
+                        List.of(MOCK_USAGE_SNAPSHOT), MOCK_USAGE_SNAPSHOT, MOCK_USAGE_SNAPSHOT));
         verify(writableLevelStarts).put(MOCK_CONGESTION_LEVEL_STARTS);
     }
 

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -27,6 +27,7 @@ public record ContractsConfig(
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean enforceCreationThrottle,
         @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSec,
         @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSecBackend,
+        @ConfigProperty(defaultValue = "500000000") @NetworkProperty long maxOpsDuration,
         @ConfigProperty(defaultValue = "1") @NetworkProperty int gasThrottleBurstSeconds,
         @ConfigProperty(value = "maxKvPairs.aggregate", defaultValue = "500000000") @NetworkProperty
                 long maxKvPairsAggregate,
@@ -41,6 +42,8 @@ public record ContractsConfig(
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean sidecarValidationEnabled,
         @ConfigProperty(value = "throttle.throttleByGas", defaultValue = "true") @NetworkProperty
                 boolean throttleThrottleByGas,
+        @ConfigProperty(value = "throttle.throttleByOpsDuration", defaultValue = "false") @NetworkProperty
+                boolean throttleThrottleByOpsDuration,
         @ConfigProperty(defaultValue = "20") @NetworkProperty int maxRefundPercentOfGasLimit,
         @ConfigProperty(defaultValue = "5000000") @NetworkProperty long scheduleThrottleMaxGasLimit,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean redirectTokenCalls,


### PR DESCRIPTION
**Description**:
Add a throttle for evm ops duration.  Also includes the protobuf changes needed in order to save the associated `ThrottleUsageSnapshot` into state.

