### PR TITLE
fix: Update Roster Schema isUpgrade check

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/recordstreaming/RecordStreamingUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/recordstreaming/RecordStreamingUtils.java
@@ -141,6 +141,10 @@ public class RecordStreamingUtils {
         return isRelevant(file) && !file.contains(SIDECAR_ONLY_TOKEN);
     }
 
+    public static boolean isSidecarMarkerFile(final String file) {
+        return file.contains(SIDECAR_ONLY_TOKEN) && file.contains(".mf");
+    }
+
     public static boolean isSidecarFile(final String file) {
         return isRelevant(file) && file.contains(SIDECAR_ONLY_TOKEN);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/roster/schemas/V0540RosterSchema.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.VersionConfig;
 import com.swirlds.platform.roster.RosterRetriever;
 import com.swirlds.platform.roster.RosterUtils;
@@ -103,8 +104,13 @@ public class V0540RosterSchema extends Schema implements RosterTransplantSchema 
                 final var currentRoster =
                         RosterUtils.rosterFrom(startupNetworks.migrationNetworkOrThrow(ctx.platformConfig()));
                 rosterStore.putActiveRoster(currentRoster, activeRoundNumber);
-            } else if (ctx.isUpgrade(
-                    ctx.appConfig().getConfigData(VersionConfig.class).servicesVersion())) {
+            } else if (ctx.isUpgrade(ctx.appConfig()
+                    .getConfigData(VersionConfig.class)
+                    .servicesVersion()
+                    .copyBuilder()
+                    .build(""
+                            + ctx.appConfig().getConfigData(HederaConfig.class).configVersion())
+                    .build())) {
                 final var candidateRoster = rosterStore.getCandidateRoster();
                 if (candidateRoster == null) {
                     log.info("No candidate roster to adopt in round {}", activeRoundNumber);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -376,17 +376,10 @@ public class TransactionChecker {
     void checkJumboTransactionBody(TransactionInfo txInfo) throws PreCheckException {
         final var jumboTxnEnabled = jumboTransactionsConfig.isEnabled();
         final var allowedJumboHederaFunctionalities = jumboTransactionsConfig.allowedHederaFunctionalities();
-        final var maxJumboEthereumCallDataSize = jumboTransactionsConfig.ethereumMaxCallDataSize();
 
         if (jumboTxnEnabled
                 && txInfo.serializedTransaction().length() > hederaConfig.transactionMaxBytes()
                 && !allowedJumboHederaFunctionalities.contains(fromPbj(txInfo.functionality()))) {
-            throw new PreCheckException(TRANSACTION_OVERSIZE);
-        }
-
-        if (txInfo.txBody() != null
-                && txInfo.txBody().hasEthereumTransaction()
-                && txInfo.txBody().ethereumTransaction().ethereumData().length() > maxJumboEthereumCallDataSize) {
             throw new PreCheckException(TRANSACTION_OVERSIZE);
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -2,6 +2,8 @@
 package com.hedera.node.app.workflows;
 
 import static com.hedera.hapi.node.base.HederaFunctionality.CONSENSUS_SUBMIT_MESSAGE;
+import static com.hedera.hapi.node.base.HederaFunctionality.CRS_PUBLICATION;
+import static com.hedera.hapi.node.base.HederaFunctionality.HISTORY_PROOF_VOTE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
@@ -74,6 +76,9 @@ public class TransactionChecker {
     private static final int USER_TRANSACTION_NONCE = 0;
     private static final List<HederaFunctionality> FUNCTIONALITIES_WITH_MAX_CUSTOM_FEES =
             List.of(CONSENSUS_SUBMIT_MESSAGE);
+    // These are inner transactions that are not jumbo but sometimes are bigger than 6kb.
+    private static final List<HederaFunctionality> NON_JUMBO_TRANSACTIONS_BIGGER_THAN_6_KB =
+            List.of(CRS_PUBLICATION, HISTORY_PROOF_VOTE);
 
     // Metric config for keeping track of the number of deprecated transactions received
     private static final String COUNTER_DEPRECATED_TXNS_NAME = "DeprTxnsRcv";
@@ -378,8 +383,9 @@ public class TransactionChecker {
         final var allowedJumboHederaFunctionalities = jumboTransactionsConfig.allowedHederaFunctionalities();
 
         if (jumboTxnEnabled
-                && txInfo.serializedTransaction().length() > hederaConfig.transactionMaxBytes()
-                && !allowedJumboHederaFunctionalities.contains(fromPbj(txInfo.functionality()))) {
+                && txInfo.transaction().protobufSize() > hederaConfig.transactionMaxBytes()
+                && !allowedJumboHederaFunctionalities.contains(fromPbj(txInfo.functionality()))
+                && !NON_JUMBO_TRANSACTIONS_BIGGER_THAN_6_KB.contains(txInfo.functionality())) {
             throw new PreCheckException(TRANSACTION_OVERSIZE);
         }
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -423,38 +423,6 @@ final class TransactionCheckerTest extends AppTestBase {
 
             assertThrows(PreCheckException.class, () -> checker.checkJumboTransactionBody(txInfo));
         }
-
-        @Test
-        void withEthereumDataBiggerThenTheConfig() {
-            props = () -> new VersionedConfigImpl(
-                    HederaTestConfigBuilder.create()
-                            .withValue("jumboTransactions.isEnabled", true)
-                            .withValue("jumboTransactions.maxTxnSize", 1024 * 10) // 10 KB
-                            .withValue("hedera.transaction.maxBytes", 1024 * 6) // 6 KB
-                            .getOrCreateConfig(),
-                    1);
-
-            checker = new TransactionChecker(nodeSelfAccountId, props, metrics);
-
-            final var maxJumboEthereumCallDataSize = props.getConfiguration()
-                    .getConfigData(JumboTransactionsConfig.class)
-                    .ethereumMaxCallDataSize();
-
-            TransactionInfo txInfo = mock(TransactionInfo.class);
-            when(txInfo.serializedTransaction()).thenReturn(Bytes.wrap(new byte[maxJumboEthereumCallDataSize + 1]));
-            when(txInfo.functionality()).thenReturn(HederaFunctionality.ETHEREUM_TRANSACTION);
-
-            var transactionBodyMock = mock(TransactionBody.class);
-            when(txInfo.txBody()).thenReturn(transactionBodyMock);
-            when(transactionBodyMock.hasEthereumTransaction()).thenReturn(true);
-
-            var mockEthTransactionBody = mock(EthereumTransactionBody.class);
-            when(transactionBodyMock.ethereumTransaction()).thenReturn(mockEthTransactionBody);
-            when(mockEthTransactionBody.ethereumData())
-                    .thenReturn(Bytes.wrap(new byte[maxJumboEthereumCallDataSize + 1]));
-
-            assertThrows(PreCheckException.class, () -> checker.checkJumboTransactionBody(txInfo));
-        }
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -391,7 +391,10 @@ final class TransactionCheckerTest extends AppTestBase {
                     .ethereumMaxCallDataSize();
 
             TransactionInfo txInfo = mock(TransactionInfo.class);
-            when(txInfo.serializedTransaction()).thenReturn(Bytes.wrap(new byte[maxJumboEthereumCallDataSize]));
+            when(txInfo.transaction())
+                    .thenReturn(Transaction.newBuilder()
+                            .signedTransactionBytes(Bytes.wrap(new byte[maxJumboEthereumCallDataSize]))
+                            .build());
             when(txInfo.functionality()).thenReturn(HederaFunctionality.ETHEREUM_TRANSACTION);
 
             var transactionBodyMock = mock(TransactionBody.class);
@@ -418,7 +421,10 @@ final class TransactionCheckerTest extends AppTestBase {
             checker = new TransactionChecker(nodeSelfAccountId, props, metrics);
 
             TransactionInfo txInfo = mock(TransactionInfo.class);
-            when(txInfo.serializedTransaction()).thenReturn(Bytes.wrap(new byte[1024 * 7])); // 7 KB
+            when(txInfo.transaction())
+                    .thenReturn(Transaction.newBuilder()
+                            .signedTransactionBytes(Bytes.wrap(new byte[1024 * 7]))
+                            .build()); // 7 KB
             when(txInfo.functionality()).thenReturn(HederaFunctionality.TOKEN_MINT);
 
             assertThrows(PreCheckException.class, () -> checker.checkJumboTransactionBody(txInfo));

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
@@ -103,7 +103,7 @@ class IngestCheckerTest extends AppTestBase {
     private static final Fees DEFAULT_FEES = new Fees(100L, 20L, 3L);
 
     private final InstantSource instantSource = InstantSource.system();
-    private final int maxBytes = 6144;
+    private final int maxBytes = 133120;
 
     @Mock(strictness = LENIENT)
     CurrentPlatformStatus currentPlatformStatus;

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/JumboTransactionsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/JumboTransactionsConfig.java
@@ -10,7 +10,7 @@ import java.util.Set;
 
 @ConfigData("jumboTransactions")
 public record JumboTransactionsConfig(
-        @ConfigProperty(defaultValue = "false") @NetworkProperty boolean isEnabled,
+        @ConfigProperty(defaultValue = "true") @NetworkProperty boolean isEnabled,
         @ConfigProperty(defaultValue = "133120") @NetworkProperty int maxTxnSize,
         @ConfigProperty(defaultValue = "131072") @NetworkProperty int ethereumMaxCallDataSize,
         @ConfigProperty(defaultValue = "callEthereum") @NodeProperty Set<String> grpcMethodNames,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/BlockStreamAccess.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/BlockStreamAccess.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.junit.support;
 
+import static com.hedera.node.app.hapi.utils.exports.recordstreaming.RecordStreamingUtils.SIDECAR_ONLY_TOKEN;
 import static java.util.Comparator.comparing;
 
 import com.hedera.hapi.block.stream.Block;
@@ -275,6 +276,8 @@ public enum BlockStreamAccess {
      * @return true if the file is a block marker file, false otherwise
      */
     public static boolean isBlockMarkerFile(@NonNull final File file) {
-        return file.isFile() && file.getName().endsWith(".mf");
+        return file.isFile()
+                && file.getName().endsWith(".mf")
+                && !file.getName().contains(SIDECAR_ONLY_TOKEN);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -1208,12 +1208,19 @@ public class UtilVerbs {
     /* Stream validation. */
     public static EventualRecordStreamAssertion recordStreamMustIncludeNoFailuresFrom(
             @NonNull final Function<HapiSpec, RecordStreamAssertion> assertion) {
+        return EventualRecordStreamAssertion.eventuallyAssertingNoFailures(assertion)
+                .withBackgroundTraffic();
+    }
+
+    public static EventualRecordStreamAssertion recordStreamMustIncludeNoFailuresWithoutBackgroundTrafficFrom(
+            @NonNull final Function<HapiSpec, RecordStreamAssertion> assertion) {
         return EventualRecordStreamAssertion.eventuallyAssertingNoFailures(assertion);
     }
 
     public static EventualRecordStreamAssertion recordStreamMustIncludePassFrom(
             @NonNull final Function<HapiSpec, RecordStreamAssertion> assertion) {
-        return EventualRecordStreamAssertion.eventuallyAssertingExplicitPass(assertion);
+        return EventualRecordStreamAssertion.eventuallyAssertingExplicitPass(assertion)
+                .withBackgroundTraffic();
     }
 
     /**
@@ -1225,9 +1232,37 @@ public class UtilVerbs {
      */
     public static EventualRecordStreamAssertion recordStreamMustIncludePassFrom(
             @NonNull final Function<HapiSpec, RecordStreamAssertion> assertion, @NonNull final Duration timeout) {
+        return recordStreamMustIncludePassFrom(assertion, timeout, true);
+    }
+
+    /**
+     * Returns an operation that asserts that the record stream must include a pass from the given assertion
+     * before its timeout elapses, and that background traffic is running.
+     * @param assertion the assertion to apply to the record stream
+     * @param timeout the timeout for the assertion
+     * @return the operation that asserts a passing record stream
+     */
+    public static EventualRecordStreamAssertion recordStreamMustIncludePassWithoutBackgroundTrafficFrom(
+            @NonNull final Function<HapiSpec, RecordStreamAssertion> assertion, @NonNull final Duration timeout) {
+        return recordStreamMustIncludePassFrom(assertion, timeout, false);
+    }
+
+    /**
+     * Returns an operation that asserts that the record stream must include a pass from the given assertion
+     * before its timeout elapses, and if the background traffic should be running.
+     * @param assertion the assertion to apply to the record stream
+     * @param timeout the timeout for the assertion
+     * @param needsBackgroundTraffic whether background traffic should be running
+     * @return the operation that asserts a passing record stream
+     */
+    private static EventualRecordStreamAssertion recordStreamMustIncludePassFrom(
+            @NonNull final Function<HapiSpec, RecordStreamAssertion> assertion,
+            @NonNull final Duration timeout,
+            final boolean needsBackgroundTraffic) {
         requireNonNull(assertion);
         requireNonNull(timeout);
-        return EventualRecordStreamAssertion.eventuallyAssertingExplicitPass(assertion, timeout);
+        final var result = EventualRecordStreamAssertion.eventuallyAssertingExplicitPass(assertion, timeout);
+        return needsBackgroundTraffic ? result.withBackgroundTraffic() : result;
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/EventualRecordStreamAssertion.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/streams/assertions/EventualRecordStreamAssertion.java
@@ -35,6 +35,8 @@ public class EventualRecordStreamAssertion extends AbstractEventualStreamAsserti
     @Nullable
     private RecordStreamAssertion assertion;
 
+    private boolean needsBackgroundTraffic = false;
+
     /**
      * Returns an {@link EventualRecordStreamAssertion} that will pass as long as the given assertion does not
      * throw an {@link AssertionError} before its timeout.
@@ -43,7 +45,7 @@ public class EventualRecordStreamAssertion extends AbstractEventualStreamAsserti
      */
     public static EventualRecordStreamAssertion eventuallyAssertingNoFailures(
             final Function<HapiSpec, RecordStreamAssertion> assertionFactory) {
-        return new EventualRecordStreamAssertion(assertionFactory, true, false);
+        return new EventualRecordStreamAssertion(assertionFactory, true, false).withBackgroundTraffic();
     }
 
     /**
@@ -67,7 +69,21 @@ public class EventualRecordStreamAssertion extends AbstractEventualStreamAsserti
             @NonNull final Function<HapiSpec, RecordStreamAssertion> assertionFactory,
             @NonNull final Duration timeout) {
         requireNonNull(assertionFactory);
-        return new EventualRecordStreamAssertion(assertionFactory, false, timeout, true);
+        return new EventualRecordStreamAssertion(assertionFactory, false, timeout, true).withBackgroundTraffic();
+    }
+
+    @Override
+    public boolean needsBackgroundTraffic() {
+        return needsBackgroundTraffic;
+    }
+
+    /**
+     * Returns an {@link EventualRecordStreamAssertion} enabling background traffic.
+     * @return the eventual record stream assertion with background traffic
+     */
+    public EventualRecordStreamAssertion withBackgroundTraffic() {
+        this.needsBackgroundTraffic = true;
+        return this;
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
@@ -3,50 +3,60 @@ package com.hedera.services.bdd.suites.contract.ethereum;
 
 import static com.hedera.services.bdd.junit.TestTags.UPGRADE;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
-import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
+import static com.hedera.services.bdd.spec.keys.KeyShape.CONTRACT;
+import static com.hedera.services.bdd.spec.keys.KeyShape.PREDEFINED_SHAPE;
+import static com.hedera.services.bdd.spec.keys.KeyShape.sigs;
+import static com.hedera.services.bdd.spec.keys.KeyShape.threshOf;
+import static com.hedera.services.bdd.spec.keys.SigControl.SECP256K1_ON;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumContractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
-import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromToWithAlias;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.noOp;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
-import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
 import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_OVERSIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.OrderedInIsolation;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.queries.meta.AccountCreationDetails;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
 import com.hedera.services.bdd.suites.regression.system.LifecycleTest;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 
@@ -56,16 +66,39 @@ import org.junit.jupiter.api.Tag;
 @OrderedInIsolation
 public class JumboTransactionsEnabledTest implements LifecycleTest {
 
-    private static final String CONTRACT = "CalldataSize";
+    private static final String CONTRACT_CALLDATA_SIZE = "CalldataSize";
     private static final String FUNCTION = "callme";
+    private static final int SIX_KB_SIZE = 6 * 1024;
+    private static final int MAX_ALLOWED_SIZE = 127 * 1024;
+    private static final int ABOVE_MAX_SIZE = 129 * 1024;
+    private static final int OVERSIZED_TXN_SIZE = 130 * 1024;
+
+    private record TestCombination(int txnSize, EthTxData.EthTransactionType type) {}
+
+    private record TestCombinationWithGas(
+            int txnSize, EthTxData.EthTransactionType type, int gasLimit, int expectedGas) {}
+
+    private static HapiEthereumCall jumboEthCall(String contract, String function, byte[] payload) {
+        return jumboEthCall(contract, function, payload, EthTxData.EthTransactionType.EIP1559);
+    }
+
+    private static HapiEthereumCall jumboEthCall(
+            String contract, String function, byte[] payload, EthTxData.EthTransactionType type) {
+        return ethereumCall(contract, function, payload)
+                .markAsJumboTxn()
+                .type(type)
+                .signingWith(SECP_256K1_SOURCE_KEY)
+                .payingWith(RELAYER)
+                .gasLimit(1_000_000L);
+    }
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         testLifecycle.doAdhoc(
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                 cryptoCreate(RELAYER).balance(ONE_MILLION_HBARS),
-                uploadInitCode(CONTRACT),
-                contractCreate(CONTRACT));
+                uploadInitCode(CONTRACT_CALLDATA_SIZE),
+                contractCreate(CONTRACT_CALLDATA_SIZE));
     }
 
     @HapiTest
@@ -77,14 +110,19 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
         return hapiTest(
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                 cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
-                jumboEthCall(jumboPayload, RELAYER)
+                ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, jumboPayload)
+                        .payingWith(RELAYER)
+                        .signingWith(SECP_256K1_SOURCE_KEY)
+                        .markAsJumboTxn()
+                        .type(EthTxData.EthTransactionType.EIP1559)
+                        .gasLimit(1_000_000L)
                         // gRPC request terminated immediately
                         .orUnavailableStatus());
     }
 
     @HapiTest
     @Order(2)
-    @DisplayName("Update the config")
+    @DisplayName("Update the config before running Jumbo txns")
     public Stream<DynamicTest> updateTheConfig() {
         return hapiTest(
                 // The feature flag is only used once at startup (when building gRPC ServiceDefinitions),
@@ -110,233 +148,392 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
                 cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
 
-                // The feature flag is only used once at startup (when building gRPC ServiceDefinitions),
-                // so we can't toggle it via overriding(). Instead, we need to upgrade to the config version.
-                prepareFakeUpgrade(),
-                upgradeToNextConfigVersion(Map.of("jumboTransactions.isEnabled", "true"), noOp()),
-
                 // send jumbo payload to non jumbo endpoint
-                contractCall(CONTRACT, FUNCTION, jumboPayload)
+                contractCall(CONTRACT_CALLDATA_SIZE, FUNCTION, jumboPayload)
                         .gas(1_000_000L)
                         // gRPC request terminated immediately
                         .orUnavailableStatus(),
 
                 // send too big payload to jumbo endpoint
-                jumboEthCall(tooBigPayload, RELAYER)
+                ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, tooBigPayload)
+                        .payingWith(RELAYER)
+                        .signingWith(SECP_256K1_SOURCE_KEY)
+                        .markAsJumboTxn()
+                        .type(EthTxData.EthTransactionType.EIP1559)
+                        .gasLimit(1_000_000L)
                         // gRPC request terminated immediately
                         .orUnavailableStatus(),
 
                 // send jumbo payload to jumbo endpoint and assert the used gas
-                jumboEthCall(jumboPayload, RELAYER)
+                jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, jumboPayload)
                         .gasLimit(800000)
                         .exposingGasTo((s, gasUsed) -> assertEquals(640000, gasUsed)),
-                jumboEthCall(halfJumboPayload, RELAYER)
+                jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, halfJumboPayload)
                         .gasLimit(500000)
                         .exposingGasTo((s, gasUsed) -> assertEquals(400000, gasUsed)),
-                jumboEthCall(thirdJumboPayload, RELAYER)
+                jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, thirdJumboPayload)
                         .gasLimit(300000)
                         .exposingGasTo((s, gasUsed) -> assertEquals(240000, gasUsed)));
     }
 
-    @Order(3)
-    @DisplayName("Jumbo transaction gets bytes throttled at ingest")
-    @LeakyHapiTest(overrides = {"jumboTransactions.isEnabled", "jumboTransactions.maxBytesPerSec"})
-    public Stream<DynamicTest> jumboTransactionGetsThrottledAtIngest() {
-        final var payloadSize = 127 * 1024;
-        final var bytesPerSec = 130 * 1024;
-        final var payload = new byte[payloadSize];
-        return hapiTest(
-                overridingTwo(
-                        "jumboTransactions.isEnabled",
-                        "true",
-                        "jumboTransactions.maxBytesPerSec",
-                        String.valueOf(bytesPerSec)),
-                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
-                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS - 1)),
-                jumboEthCall(payload, RELAYER).noLogging(),
-                sleepFor(1_000),
-                jumboEthCall(payload, RELAYER).noLogging().deferStatusResolution(),
-                jumboEthCall(payload, RELAYER).noLogging().hasPrecheck(BUSY));
+    @Nested
+    @OrderedInIsolation
+    @DisplayName("Jumbo Ethereum Transactions Positive Tests")
+    class JumboEthereumTransactionsPositiveTests {
+
+        private final Stream<TestCombinationWithGas> positiveBoundariesTestCases = Stream.of(
+                new TestCombinationWithGas(SIX_KB_SIZE, EthTxData.EthTransactionType.LEGACY_ETHEREUM, 400_000, 320_000),
+                new TestCombinationWithGas(SIX_KB_SIZE, EthTxData.EthTransactionType.EIP2930, 400_000, 320_000),
+                new TestCombinationWithGas(SIX_KB_SIZE, EthTxData.EthTransactionType.EIP1559, 400_000, 320_000),
+                new TestCombinationWithGas(
+                        MAX_ALLOWED_SIZE, EthTxData.EthTransactionType.LEGACY_ETHEREUM, 9_000_000, 7_200_000),
+                new TestCombinationWithGas(
+                        MAX_ALLOWED_SIZE, EthTxData.EthTransactionType.EIP2930, 9_000_000, 7_200_000),
+                new TestCombinationWithGas(
+                        MAX_ALLOWED_SIZE, EthTxData.EthTransactionType.EIP1559, 9_000_000, 7_200_000));
+
+        @HapiTest
+        @Order(5)
+        @DisplayName("Jumbo Ethereum transactions should pass for valid sizes and expected gas used")
+        public Stream<DynamicTest> jumboTxnWithEthereumDataLessThanAllowedKbShouldPass() {
+            return positiveBoundariesTestCases.flatMap(test -> {
+                var payload = new byte[test.txnSize];
+                return hapiTest(
+                        prepareFakeUpgrade(),
+                        logIt("Valid Jumbo Txn | Size: " + (test.txnSize / 1024) + "KB | Type: " + test.type
+                                + " | GasLimit: " + test.gasLimit + " | ExpectedGas: " + test.expectedGas),
+                        newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                        cryptoTransfer(
+                                tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS - 1)),
+                        jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload, test.type)
+                                .gasLimit(test.gasLimit)
+                                .exposingGasTo((s, gasUsed) -> assertEquals(
+                                        test.expectedGas,
+                                        gasUsed,
+                                        "Unexpected gas used for size: " + test.txnSize + ", type: " + test.type)));
+            });
+        }
+
+        @HapiTest
+        @Order(6)
+        @DisplayName("Jumbo Ethereum txn works when alias account is updated to threshold key")
+        // JUMBO_P_13
+        public Stream<DynamicTest> jumboTxnAliasWithThresholdKeyPattern() {
+            final var cryptoKey = "cryptoKey";
+            final var thresholdKey = "thresholdKey";
+            final var aliasCreationTxn = "aliasCreation";
+            final var ethereumCallTxn = "jumboTxnFromThresholdKeyAccount";
+            final var contract = CONTRACT_CALLDATA_SIZE;
+            final var payload = new byte[127 * 1024];
+
+            final AtomicReference<byte[]> rawPublicKey = new AtomicReference<>();
+            final AtomicReference<AccountCreationDetails> creationDetails = new AtomicReference<>();
+
+            return hapiTest(
+
+                    // Create SECP key and extract raw bytes
+                    newKeyNamed(cryptoKey)
+                            .shape(SECP256K1_ON)
+                            .exposingKeyTo(
+                                    k -> rawPublicKey.set(k.getECDSASecp256K1().toByteArray())),
+
+                    // Create alias account via cryptoTransfer
+                    cryptoTransfer(tinyBarsFromToWithAlias(GENESIS, cryptoKey, 2 * ONE_HUNDRED_HBARS))
+                            .via(aliasCreationTxn),
+
+                    // Extract AccountCreationDetails for EVM address and account ID
+                    getTxnRecord(aliasCreationTxn)
+                            .exposingCreationDetailsTo(details -> creationDetails.set(details.getFirst())),
+
+                    // Create threshold key using SECP key and contract
+                    newKeyNamed(thresholdKey)
+                            .shape(threshOf(1, PREDEFINED_SHAPE, CONTRACT).signedWith(sigs(cryptoKey, contract))),
+
+                    // Update alias account to use threshold key
+                    sourcing(() -> cryptoUpdate(
+                                    asAccountString(creationDetails.get().createdId()))
+                            .key(thresholdKey)
+                            .signedBy(GENESIS, cryptoKey)),
+
+                    // Submit jumbo Ethereum txn, signed with SECP key
+                    sourcing(() -> ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .markAsJumboTxn()
+                            .nonce(0)
+                            .signingWith(cryptoKey)
+                            .payingWith(RELAYER)
+                            .gasLimit(1_000_000L)
+                            .via(ethereumCallTxn)),
+                    getTxnRecord(ethereumCallTxn).logged());
+        }
+
+        @HapiTest
+        @Order(7)
+        @DisplayName("Jumbo transaction with multiple signatures should pass")
+        // JUMBO_P_13
+        public Stream<DynamicTest> jumboTransactionWithMultipleSignaturesShouldPass() {
+            final var cryptoKey = "cryptoKey";
+            final var payload = new byte[10 * 1024];
+            return hapiTest(
+                    newKeyNamed(cryptoKey).shape(SECP_256K1_SHAPE),
+                    newKeyNamed("test").shape(SECP_256K1_SHAPE),
+                    newKeyNamed("test2").shape(SECP_256K1_SHAPE),
+                    newKeyNamed("test3").shape(SECP_256K1_SHAPE),
+                    newKeyNamed("test4").shape(SECP_256K1_SHAPE),
+                    newKeyNamed("test5").shape(SECP_256K1_SHAPE),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, cryptoKey, ONE_HUNDRED_HBARS)),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, "test", ONE_HUNDRED_HBARS)),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, "test2", ONE_HUNDRED_HBARS)),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, "test3", ONE_HUNDRED_HBARS)),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, "test4", ONE_HUNDRED_HBARS)),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, "test5", ONE_HUNDRED_HBARS)),
+                    sourcing(() -> ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .markAsJumboTxn()
+                            .signingWith(cryptoKey)
+                            .signedBy("test", "test2", "test3", "test4", "test5")
+                            .payingWith(RELAYER)
+                            .gasLimit(1_000_000L)));
+        }
     }
 
-    @Order(4)
-    @DisplayName("Privileged account is exempt from bytes throttles")
-    @LeakyHapiTest(overrides = {"jumboTransactions.isEnabled", "jumboTransactions.maxBytesPerSec"})
-    public Stream<DynamicTest> privilegedAccountIsExemptFromThrottles() {
-        final var payloadSize = 127 * 1024;
-        final var bytesPerSec = 60 * 1024;
-        final var payload = new byte[payloadSize];
-        final var initialNonce = new AtomicLong(0);
-        return hapiTest(
-                overridingTwo(
-                        "jumboTransactions.isEnabled",
-                        "true",
-                        "jumboTransactions.maxBytesPerSec",
-                        String.valueOf(bytesPerSec)),
-                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
-                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS - 1)),
-                withOpContext((spec, op) -> allRunFor(
-                        spec,
-                        getAccountInfo(DEFAULT_PAYER).exposingEthereumNonceTo(initialNonce::set),
-                        ethereumCall(CONTRACT, FUNCTION, payload)
-                                .nonce(initialNonce.get())
-                                .markAsJumboTxn()
-                                .gasLimit(1_000_000L)
-                                .noLogging())));
-    }
+    @Nested
+    @OrderedInIsolation
+    @DisplayName("Jumbo Ethereum Transactions Negative Tests")
+    class JumboEthereumTransactionsNegativeTests {
 
-    @HapiTest
-    @Order(5)
-    @DisplayName("Jumbo transaction send to the wrong gRPC endpoint")
-    public Stream<DynamicTest> sendToTheWrongGRPCEndpoint() {
-        final var sixKbPayload = new byte[6 * 1024];
-        final var moreThenSixKbPayload = new byte[6 * 1024 + 1];
-        final var limitPayload = new byte[128 * 1024];
-        final var tooBigPayload = new byte[130 * 1024];
+        private final Stream<TestCombination> oversizedCases = Stream.of(
+                new TestCombination(OVERSIZED_TXN_SIZE, EthTxData.EthTransactionType.LEGACY_ETHEREUM),
+                new TestCombination(OVERSIZED_TXN_SIZE, EthTxData.EthTransactionType.EIP2930),
+                new TestCombination(OVERSIZED_TXN_SIZE, EthTxData.EthTransactionType.EIP1559));
 
-        return hapiTest(
-                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
-                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
-                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS - 1)),
-                ethereumCall(CONTRACT, FUNCTION, sixKbPayload)
-                        .markAsJumboTxn()
-                        // Override the hedera functionality to make the framework send the request to the wrong
-                        // endpoint
-                        .withOverriddenHederaFunctionality(HederaFunctionality.TokenAirdrop)
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .gasLimit(1_000_000L)
-                        .orUnavailableStatus(),
-                ethereumCall(CONTRACT, FUNCTION, moreThenSixKbPayload)
-                        .markAsJumboTxn()
-                        // Override the hedera functionality to make the framework send the request to the wrong
-                        // endpoint
-                        .withOverriddenHederaFunctionality(HederaFunctionality.TokenAirdrop)
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .gasLimit(1_000_000L)
-                        .orUnavailableStatus(),
-                ethereumCall(CONTRACT, FUNCTION, limitPayload)
-                        .markAsJumboTxn()
-                        // Override the hedera functionality to make the framework send the request to the wrong
-                        // endpoint
-                        .withOverriddenHederaFunctionality(HederaFunctionality.TokenAirdrop)
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .gasLimit(1_000_000L)
-                        .orUnavailableStatus(),
-                ethereumCall(CONTRACT, FUNCTION, tooBigPayload)
-                        .markAsJumboTxn()
-                        // Override the hedera functionality to make the framework send the request to the wrong
-                        // endpoint
-                        .withOverriddenHederaFunctionality(HederaFunctionality.TokenAirdrop)
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .gasLimit(1_000_000L)
-                        .orUnavailableStatus());
-    }
+        private final Stream<TestCombinationWithGas> aboveMaxCases = Stream.of(
+                new TestCombinationWithGas(ABOVE_MAX_SIZE, EthTxData.EthTransactionType.LEGACY_ETHEREUM, 8_500_000, 0),
+                new TestCombinationWithGas(ABOVE_MAX_SIZE, EthTxData.EthTransactionType.EIP2930, 8_500_000, 0),
+                new TestCombinationWithGas(ABOVE_MAX_SIZE, EthTxData.EthTransactionType.EIP1559, 8_500_000, 0));
 
-    @HapiTest
-    @Order(6)
-    @DisplayName("Ethereum Call jumbo transaction with ethereum data overflow should fail")
-    public Stream<DynamicTest> ethereumCallJumboTxnWithEthereumDataOverflow() {
-        final var size = 131072 + 1; // Exceeding the limit
-        final var payload = new byte[size];
-        return hapiTest(
-                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
-                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
-                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS - 1)),
-                uploadInitCode(CONTRACT),
-                contractCreate(CONTRACT),
-                ethereumCall(CONTRACT, FUNCTION, payload)
-                        .markAsJumboTxn()
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .signingWith(SECP_256K1_SOURCE_KEY)
-                        .payingWith(RELAYER)
-                        .gasLimit(1_000_000L)
-                        .hasPrecheck(TRANSACTION_OVERSIZE));
-    }
+        private final Stream<Integer> insufficientFeeCases = Stream.of(SIX_KB_SIZE, MAX_ALLOWED_SIZE);
 
-    @HapiTest
-    @Order(7)
-    @DisplayName("Allows Ethereum jumbo contract create jumbo above max transaction size of 6kb")
-    public Stream<DynamicTest> ethereumContractCreateJumboTxnMoreThen6Kb() {
-        final var contract = "TokenCreateContract";
-        return hapiTest(
-                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
-                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
-                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
-                        .via("autoAccount"),
-                uploadInitCode(contract),
-                ethereumContractCreate(contract)
-                        .markAsJumboTxn()
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .signingWith(SECP_256K1_SOURCE_KEY)
-                        .payingWith(RELAYER)
-                        .nonce(0)
-                        .maxGasAllowance(ONE_HUNDRED_HBARS)
-                        .gasLimit(6_000_000L)
-                        .via("payTxn"));
-    }
+        private static byte[] corruptedPayload() {
+            return Arrays.copyOf("corruptedPayload".getBytes(StandardCharsets.UTF_8), 128 * 1024);
+        }
 
-    @HapiTest
-    @Order(8)
-    @DisplayName("Non-jumbo transaction bigger then 6kb should fail")
-    public Stream<DynamicTest> nonJumboTransactionBiggerThen6kb() {
-        return hapiTest(
-                cryptoCreate("receiver"),
-                cryptoTransfer(tinyBarsFromTo(GENESIS, "receiver", ONE_HUNDRED_HBARS))
-                        .memo(StringUtils.repeat("a", 6145))
-                        .hasKnownStatus(TRANSACTION_OVERSIZE)
-                        .orUnavailableStatus());
-    }
+        @HapiTest
+        @Order(8)
+        @DisplayName("Jumbo transaction send to the wrong gRPC endpoint")
+        // JUMBO_N_03, JUMBO_N_04, JUMBO_N_05, JUMBO_N_06
+        public Stream<DynamicTest> sendToTheWrongGRPCEndpoint() {
+            final var sixKbPayload = new byte[6 * 1024];
+            final var moreThenSixKbPayload = new byte[6 * 1024 + 1];
+            final var limitPayload = new byte[127 * 1024];
+            final var tooBigPayload = new byte[130 * 1024];
 
-    @HapiTest
-    @Order(9)
-    @DisplayName("Three jumbo transactions one after the other")
-    public Stream<DynamicTest> treeJumboTransactionOneAfterTheOther() {
-        final var payload = new byte[127 * 1024];
-        return hapiTest(
-                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
-                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
-                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
-                        .via("autoAccount"),
-                ethereumCall(CONTRACT, FUNCTION, payload)
-                        .markAsJumboTxn()
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .gasLimit(1_000_000L),
-                sleepFor(1000),
-                ethereumCall(CONTRACT, FUNCTION, payload)
-                        .markAsJumboTxn()
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .gasLimit(1_000_000L),
-                sleepFor(1000),
-                ethereumCall(CONTRACT, FUNCTION, payload)
-                        .markAsJumboTxn()
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .gasLimit(1_000_000L));
-    }
+            return hapiTest(
+                    newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                    cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS - 1)),
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, sixKbPayload)
+                            .markAsJumboTxn()
+                            // Override the hedera functionality to make the framework send the request to the wrong
+                            // endpoint
+                            .withOverriddenHederaFunctionality(HederaFunctionality.TokenAirdrop)
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .gasLimit(1_000_000L)
+                            .orUnavailableStatus(),
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, moreThenSixKbPayload)
+                            .markAsJumboTxn()
+                            // Override the hedera functionality to make the framework send the request to the wrong
+                            // endpoint
+                            .withOverriddenHederaFunctionality(HederaFunctionality.TokenAirdrop)
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .gasLimit(1_000_000L)
+                            .orUnavailableStatus(),
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, limitPayload)
+                            .markAsJumboTxn()
+                            // Override the hedera functionality to make the framework send the request to the wrong
+                            // endpoint
+                            .withOverriddenHederaFunctionality(HederaFunctionality.TokenAirdrop)
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .gasLimit(1_000_000L)
+                            .orUnavailableStatus(),
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, tooBigPayload)
+                            .markAsJumboTxn()
+                            // Override the hedera functionality to make the framework send the request to the wrong
+                            // endpoint
+                            .withOverriddenHederaFunctionality(HederaFunctionality.TokenAirdrop)
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .gasLimit(1_000_000L)
+                            .orUnavailableStatus());
+        }
 
-    @HapiTest
-    @Order(10)
-    @DisplayName("Mix of jumbo and non-jumbo transactions")
-    public Stream<DynamicTest> mixOfJumboAndNonJumboTransactions() {
-        final var payload = new byte[50 * 1024];
-        return hapiTest(
-                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
-                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
-                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
-                        .via("autoAccount"),
-                ethereumCall(CONTRACT, FUNCTION, payload)
-                        .markAsJumboTxn()
-                        .type(EthTxData.EthTransactionType.EIP1559)
-                        .gasLimit(1_000_000L),
-                cryptoCreate("receiver"),
-                cryptoTransfer(tinyBarsFromTo(GENESIS, "receiver", ONE_HUNDRED_HBARS)));
-    }
+        @HapiTest
+        @DisplayName("Jumbo Ethereum transactions should fail for above max size data with TRANSACTION_OVERSIZE")
+        @Order(9)
+        // JUMBO_N_01
+        public Stream<DynamicTest> jumboTxnWithAboveMaxDataShouldFail() {
+            return aboveMaxCases.flatMap(test -> {
+                var payload = new byte[test.txnSize];
+                return hapiTest(
+                        logIt("Invalid Jumbo Txn | Size: " + (test.txnSize / 1024) + "KB | Type: " + test.type
+                                + " | GasLimit: " + test.gasLimit + " | ExpectedGas: " + test.expectedGas),
+                        newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                        cryptoCreate(RELAYER).balance(ONE_HUNDRED_HBARS),
+                        jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload, test.type)
+                                .gasLimit(test.gasLimit)
+                                .noLogging()
+                                .exposingGasTo((s, gasUsed) -> assertEquals(
+                                        test.expectedGas,
+                                        gasUsed,
+                                        "Unexpected gas used for txn size " + test.txnSize + " and type " + test.type))
+                                .hasPrecheck(TRANSACTION_OVERSIZE));
+            });
+        }
 
-    private static HapiEthereumCall jumboEthCall(byte[] payload, String payer) {
-        return ethereumCall(CONTRACT, FUNCTION, payload)
-                .markAsJumboTxn()
-                .type(EthTxData.EthTransactionType.EIP1559)
-                .signingWith(SECP_256K1_SOURCE_KEY)
-                .payingWith(payer)
-                .gasLimit(1_000_000L);
+        @HapiTest
+        @DisplayName("Jumbo Ethereum transactions should fail for oversized data with grpc unavailable status")
+        @Order(10)
+        // JUMBO_N_02
+        public Stream<DynamicTest> jumboTxnWithOversizedDataShouldFail() {
+            return oversizedCases.flatMap(test -> hapiTest(
+                    logIt("Invalid Jumbo Txn with size: " + (test.txnSize / 1024) + "KB and type: " + test.type),
+                    newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                    cryptoCreate(RELAYER).balance(ONE_HUNDRED_HBARS),
+                    jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, new byte[test.txnSize], test.type)
+                            .noLogging()
+                            .orUnavailableStatus()));
+        }
+
+        @HapiTest
+        @Order(11)
+        @DisplayName("Allows Ethereum jumbo contract create jumbo above max transaction size of 6kb")
+        public Stream<DynamicTest> ethereumContractCreateJumboTxnMoreThen6Kb() {
+            final var contract = "TokenCreateContract";
+            return hapiTest(
+                    newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                    cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                            .via("autoAccount"),
+                    uploadInitCode(contract),
+                    ethereumContractCreate(contract)
+                            .markAsJumboTxn()
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .signingWith(SECP_256K1_SOURCE_KEY)
+                            .payingWith(RELAYER)
+                            .nonce(0)
+                            .maxGasAllowance(ONE_HUNDRED_HBARS)
+                            .gasLimit(6_000_000L)
+                            .via("payTxn"));
+        }
+
+        @HapiTest
+        @DisplayName("Jumbo Ethereum transactions should fail with corrupted payload")
+        @Order(12)
+        // JUMBO_N_17
+        public Stream<DynamicTest> jumboTxnWithCorruptedPayloadShouldFail() {
+            var corruptedTypes = Stream.of(
+                    EthTxData.EthTransactionType.LEGACY_ETHEREUM,
+                    EthTxData.EthTransactionType.EIP2930,
+                    EthTxData.EthTransactionType.EIP1559);
+            return corruptedTypes.flatMap(type -> hapiTest(
+                    logIt("Corrupted Jumbo Txn of size 128KB and type: " + type),
+                    newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, corruptedPayload())
+                            .markAsJumboTxn()
+                            .type(type)
+                            .payingWith(RELAYER)
+                            .signingWith(SECP_256K1_SOURCE_KEY)
+                            .gasLimit(1_000_000L)
+                            .hasPrecheck(TRANSACTION_OVERSIZE)));
+        }
+
+        @HapiTest
+        @Order(13)
+        @DisplayName("Non-jumbo transaction bigger then 6kb should fail")
+        // JUMBO_N_07
+        public Stream<DynamicTest> nonJumboTransactionBiggerThen6kb() {
+            return hapiTest(
+                    cryptoCreate("receiver"),
+                    cryptoTransfer(tinyBarsFromTo(GENESIS, "receiver", ONE_HUNDRED_HBARS))
+                            .memo(StringUtils.repeat("a", 6145))
+                            .hasKnownStatus(TRANSACTION_OVERSIZE)
+                            .orUnavailableStatus());
+        }
+
+        @HapiTest
+        @Order(14)
+        @DisplayName("Three jumbo transactions one after the other")
+        // JUMBO_N_08
+        public Stream<DynamicTest> treeJumboTransactionOneAfterTheOther() {
+            final var payload = new byte[128 * 1024 - 100];
+            return hapiTest(
+                    newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                    cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                            .via("autoAccount"),
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                            .markAsJumboTxn()
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .gasLimit(1_000_000L),
+                    sleepFor(1000),
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                            .markAsJumboTxn()
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .gasLimit(1_000_000L),
+                    sleepFor(1000),
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                            .markAsJumboTxn()
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .gasLimit(1_000_000L));
+        }
+
+        @HapiTest
+        @DisplayName("Jumbo Ethereum transactions should fail with wrong signature")
+        @Order(15)
+        // JUMBO_N_16
+        public Stream<DynamicTest> jumboTxnWithWrongSignatureShouldFail() {
+            var payload = new byte[10 * 1024];
+            return hapiTest(
+                    newKeyNamed("unrelatedKey").shape(SECP_256K1_SHAPE),
+
+                    // Submit jumbo Ethereum txn with wrong key
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                            .markAsJumboTxn()
+                            .signingWith("unrelatedKey")
+                            .payingWith(RELAYER)
+                            .gasLimit(1_000_000L)
+                            .hasPrecheck(INVALID_ACCOUNT_ID));
+        }
+
+        @HapiTest
+        @Order(16)
+        @DisplayName("Mix of jumbo and non-jumbo transactions")
+        public Stream<DynamicTest> mixOfJumboAndNonJumboTransactions() {
+            final var payload = new byte[50 * 1024];
+            return hapiTest(
+                    newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                    cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                            .via("autoAccount"),
+                    ethereumCall(CONTRACT_CALLDATA_SIZE, FUNCTION, payload)
+                            .markAsJumboTxn()
+                            .type(EthTxData.EthTransactionType.EIP1559)
+                            .gasLimit(1_000_000L),
+                    cryptoCreate("receiver"),
+                    cryptoTransfer(tinyBarsFromTo(GENESIS, "receiver", ONE_HUNDRED_HBARS)));
+        }
+
+        @HapiTest
+        @DisplayName("Jumbo Ethereum transactions should fail due to insufficient payer balance")
+        @Order(17)
+        // JUMBO_N_14
+        public Stream<DynamicTest> jumboTxnWithInsufficientPayerBalanceShouldFail() {
+            return insufficientFeeCases.flatMap(txnSize -> hapiTest(
+                    logIt("Invalid Jumbo Txn with insufficient balance and size: " + (txnSize / 1024) + "KB"),
+                    newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                    cryptoCreate(RELAYER).balance(1L),
+                    jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, new byte[txnSize])
+                            .hasPrecheck(INSUFFICIENT_PAYER_BALANCE)));
+        }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/CryptoUpdateSuite.java
@@ -36,7 +36,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doWithStartupConfig
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.recordStreamMustIncludePassFrom;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.recordStreamMustIncludePassWithoutBackgroundTrafficFrom;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.submitModified;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
@@ -158,7 +158,7 @@ public class CryptoUpdateSuite {
                 .toArray(String[]::new);
         return hapiTest(flatten(
                 cryptoTransfer(tinyBarsFromTo(GENESIS, ADDRESS_BOOK_CONTROL, 1)),
-                recordStreamMustIncludePassFrom(
+                recordStreamMustIncludePassWithoutBackgroundTrafficFrom(
                         visibleNonSyntheticItems(keyRotationsValidator(accountsToHaveKeysRotated), allTxnIds),
                         Duration.ofSeconds(15)),
                 // If the FileAlterationObserver just started the monitor, there's a chance we could miss the

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip1064TestsDisabled.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip1064TestsDisabled.java
@@ -10,7 +10,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.recordStreamMustIncludeNoFailuresFrom;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.recordStreamMustIncludeNoFailuresWithoutBackgroundTrafficFrom;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.selectedItems;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilStartOfNextStakingPeriod;
 import static com.hedera.services.bdd.suites.HapiSuite.CIVILIAN_PAYER;
@@ -51,7 +51,7 @@ public class RepeatableHip1064TestsDisabled {
     final Stream<DynamicTest> doesntPayWhenFeatureFlagDisabled() {
         final AtomicLong expectedNodeFees = new AtomicLong(0);
         return hapiTest(
-                recordStreamMustIncludeNoFailuresFrom(selectedItems(
+                recordStreamMustIncludeNoFailuresWithoutBackgroundTrafficFrom(selectedItems(
                         (spec, records) -> Assertions.fail("Should not have any records with 801 " + "being debited!"),
                         // We expect no reward payments in this test
                         1,
@@ -85,7 +85,7 @@ public class RepeatableHip1064TestsDisabled {
         final AtomicLong expectedNodeFees = new AtomicLong(0);
         return hapiTest(
                 overriding("nodes.preserveMinNodeRewardBalance", "true"),
-                recordStreamMustIncludeNoFailuresFrom(selectedItems(
+                recordStreamMustIncludeNoFailuresWithoutBackgroundTrafficFrom(selectedItems(
                         (spec, records) -> Assertions.fail("Should not have any records with 801 " + "being debited!"),
                         // We expect no reward payments in this test
                         1,


### PR DESCRIPTION
**Description**:
cherry-picks 31f78c6

In V0540RosterSchema::restart, the isUpgrade check was changed to use SemanticVersion, however the hedera.config.version is not put into the build of the SemanticVersion for comparison. Therefore this branch of code is not being executed when for example Solo bumps the hedera.config.version to perform a software upgrade. This results in the candidate roster not being adopted.


**Related issue(s)**:

Fixes #19005 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
