### PR TITLE
build: run tests on module path

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -13,8 +13,6 @@ mainModuleInfo {
     runtimeOnly("org.junit.platform.launcher")
 }
 
-testModuleInfo { runtimeOnly("org.junit.jupiter.api") }
-
 sourceSets {
     create("rcdiff")
     create("yahcli")
@@ -65,9 +63,6 @@ tasks.test {
     // Limit heap and number of processors
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
-
-    // Do not yet run things on the '--module-path'
-    modularity.inferModulePath.set(false)
 }
 
 val prCheckTags =
@@ -195,9 +190,6 @@ tasks.register<Test>("testSubprocessWithBlockNodeSimulator") {
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
     maxParallelForks = 1
-
-    // Do not yet run things on the '--module-path'
-    modularity.inferModulePath.set(false)
 }
 
 tasks.register<Test>("testSubprocess") {
@@ -297,9 +289,6 @@ tasks.register<Test>("testSubprocess") {
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
     maxParallelForks = 1
-
-    // Do not yet run things on the '--module-path'
-    modularity.inferModulePath.set(false)
 }
 
 tasks.register<Test>("testRemote") {
@@ -363,9 +352,6 @@ tasks.register<Test>("testRemote") {
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
     maxParallelForks = 1
-
-    // Do not yet run things on the '--module-path'
-    modularity.inferModulePath.set(false)
 }
 
 val prEmbeddedCheckTags = mapOf("hapiEmbeddedMisc" to "EMBEDDED")
@@ -414,9 +400,6 @@ tasks.register<Test>("testEmbedded") {
     // Limit heap and number of processors
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
-
-    // Do not yet run things on the '--module-path'
-    modularity.inferModulePath.set(false)
 }
 
 val prRepeatableCheckTags = mapOf("hapiRepeatableMisc" to "REPEATABLE")
@@ -460,9 +443,6 @@ tasks.register<Test>("testRepeatable") {
     // Limit heap and number of processors
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
-
-    // Do not yet run things on the '--module-path'
-    modularity.inferModulePath.set(false)
 }
 
 application.mainClass = "com.hedera.services.bdd.suites.SuiteRunner"

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -24,7 +24,7 @@ tasks.register<JavaExec>("runTestClient") {
     group = "build"
     description = "Run a test client via -PtestClient=<Class>"
 
-    classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar)) + files(tasks.jar)
+    classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
     mainClass = providers.gradleProperty("testClient")
 }
 

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -26,7 +26,7 @@ tasks.register<JavaExec>("runTestClient") {
     group = "build"
     description = "Run a test client via -PtestClient=<Class>"
 
-    classpath = sourceSets.main.get().runtimeClasspath + files(tasks.jar)
+    classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar)) + files(tasks.jar)
     mainClass = providers.gradleProperty("testClient")
 }
 
@@ -41,7 +41,7 @@ tasks.jacocoTestReport {
 
 tasks.test {
     testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = sourceSets.main.get().runtimeClasspath
+    classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
 
     // Unlike other tests, these intentionally corrupt embedded state to test FAIL_INVALID
     // code paths; hence we do not run LOG_VALIDATION after the test suite finishes
@@ -133,7 +133,7 @@ tasks {
 
 tasks.register<Test>("testSubprocessWithBlockNodeSimulator") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = sourceSets.main.get().runtimeClasspath
+    classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
 
     // Choose a different initial port for each test task if running as PR check
     val initialPort =
@@ -202,7 +202,7 @@ tasks.register<Test>("testSubprocessWithBlockNodeSimulator") {
 
 tasks.register<Test>("testSubprocess") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = sourceSets.main.get().runtimeClasspath
+    classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
 
     val ciTagExpression =
         gradle.startParameter.taskNames
@@ -304,7 +304,7 @@ tasks.register<Test>("testSubprocess") {
 
 tasks.register<Test>("testRemote") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = sourceSets.main.get().runtimeClasspath
+    classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
 
     systemProperty("hapi.spec.remote", "true")
     // Support overriding a single remote target network for all executing specs
@@ -379,7 +379,7 @@ tasks {
 // Runs tests against an embedded network that supports concurrent tests
 tasks.register<Test>("testEmbedded") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = sourceSets.main.get().runtimeClasspath
+    classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
 
     val ciTagExpression =
         gradle.startParameter.taskNames
@@ -431,7 +431,7 @@ tasks {
 // single thread
 tasks.register<Test>("testRepeatable") {
     testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = sourceSets.main.get().runtimeClasspath
+    classpath = configurations.runtimeClasspath.get().plus(files(tasks.jar))
 
     val ciTagExpression =
         gradle.startParameter.taskNames

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/ProcessUtils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/ProcessUtils.java
@@ -14,6 +14,7 @@ import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import com.hedera.services.bdd.junit.hedera.HederaNode;
 import com.hedera.services.bdd.junit.hedera.NodeMetadata;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -172,15 +173,16 @@ public class ProcessUtils {
                     + (FIRST_AGENT_PORT + metadata.nodeId()));
         }
         commandLine.addAll(List.of(
-                "-classpath",
-                // Use the same classpath that started this process, excluding test-clients
-                currentNonTestClientClasspath(),
+                "--module-path",
+                // Use the same module path that started this process, excluding test-clients
+                currentNonTestClientModulePath(),
                 // JVM system
                 "-Dfile.encoding=UTF-8",
                 "-Dprometheus.endpointPortNumber=" + metadata.prometheusPort(),
                 "-Dhedera.recordStream.logDir=" + DATA_DIR + "/" + RECORD_STREAMS_DIR,
                 "-Dhedera.profiles.active=DEV",
-                "com.hedera.node.app.ServicesMain",
+                "--module",
+                "com.hedera.node.app/com.hedera.node.app.ServicesMain",
                 "-local",
                 Long.toString(metadata.nodeId())));
         return commandLine;
@@ -239,33 +241,34 @@ public class ProcessUtils {
                 EXECUTOR);
     }
 
-    private static String currentNonTestClientClasspath() {
-        // Could have been launched with -cp, or -classpath, or @/path/to/classpathFile.txt, or maybe module path?
+    private static String currentNonTestClientModulePath() {
+        // When started through Gradle, this was launched with @/path/to/pathFile.txt.
+        // This also works when launched with --module-path, -cp, or -classpath.
         final var args = ProcessHandle.current().info().arguments().orElse(EMPTY_STRING_ARRAY);
 
-        String classpath = "";
+        String moduleOrClassPath = "";
         for (int i = 0; i < args.length; i++) {
             final var arg = args[i];
             if (arg.startsWith("@")) {
                 try {
                     final var fileContents = Files.readString(Path.of(arg.substring(1)));
-                    classpath = fileContents.substring(fileContents.indexOf('/'));
+                    moduleOrClassPath = fileContents.substring(fileContents.indexOf('/'));
                     break;
                 } catch (IOException e) {
                     throw new UncheckedIOException(e);
                 }
-            } else if (arg.equals("-cp") || arg.equals("-classpath")) {
-                classpath = args[i + 1];
+            } else if (arg.equals("--module-path") || arg.equals("-cp") || arg.equals("-classpath")) {
+                moduleOrClassPath = args[i + 1];
                 break;
             }
         }
-        if (classpath.isBlank()) {
-            throw new IllegalStateException("Cannot discover the classpath. Was --module-path used instead?");
+        if (moduleOrClassPath.isBlank()) {
+            throw new IllegalStateException("Cannot discover module path or classpath.");
         }
-        return Arrays.stream(classpath.split(":"))
-                .map(String::trim) // may have picked up a '\n' in the original classpath String
+        return Arrays.stream(moduleOrClassPath.split(File.pathSeparator))
+                .map(String::trim) // may have picked up a '\n' in the original path String
                 .filter(s -> !s.contains("test-clients"))
-                .collect(Collectors.joining(":"));
+                .collect(Collectors.joining(File.pathSeparator));
     }
 
     private static boolean endsWith(final String[] args, final String lastArg) {

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -77,10 +77,8 @@ dependencies.constraints {
     api("info.picocli:picocli:4.7.6") { because("info.picocli") }
     api("io.github.classgraph:classgraph:4.8.179") { because("io.github.classgraph") }
     api("io.perfmark:perfmark-api:0.27.0") { because("io.perfmark") }
-    api("io.prometheus:simpleclient:0.16.0") { because("io.prometheus.simpleclient") }
-    api("io.prometheus:simpleclient_httpserver:0.16.0") {
-        because("io.prometheus.simpleclient.httpserver")
-    }
+    api("io.prometheus:simpleclient:0.16.0") { because("simpleclient") }
+    api("io.prometheus:simpleclient_httpserver:0.16.0") { because("simpleclient.httpserver") }
     api("jakarta.inject:jakarta.inject-api:2.0.1") { because("jakarta.inject") }
     api("javax.inject:javax.inject:1") { because("javax.inject") }
     api("com.goterl:lazysodium-java:5.1.4") { because("lazysodium.java") }

--- a/platform-sdk/consensus-event-creator-impl/build.gradle.kts
+++ b/platform-sdk/consensus-event-creator-impl/build.gradle.kts
@@ -12,6 +12,7 @@ testModuleInfo {
     requires("com.swirlds.base.test.fixtures")
     requires("com.swirlds.common.test.fixtures")
     requires("com.swirlds.config.extensions.test.fixtures")
+    requires("com.swirlds.platform.core")
     requires("com.swirlds.platform.core.test.fixtures")
     requires("org.hiero.base.crypto.test.fixtures")
     requires("org.hiero.base.utility.test.fixtures")

--- a/platform-sdk/swirlds-common/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-common/src/main/java/module-info.java
@@ -102,15 +102,15 @@ module com.swirlds.common {
     requires transitive org.hiero.consensus.model;
     requires transitive com.fasterxml.jackson.core;
     requires transitive com.fasterxml.jackson.databind;
-    requires transitive io.prometheus.simpleclient;
     requires transitive org.apache.logging.log4j;
+    requires transitive simpleclient;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.logging;
-    requires io.prometheus.simpleclient.httpserver;
     requires java.desktop;
     requires jdk.httpserver;
     requires jdk.management;
     requires org.apache.logging.log4j.core;
     requires org.bouncycastle.provider;
+    requires simpleclient.httpserver;
     requires static transitive com.github.spotbugs.annotations;
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.3.10" }
+plugins { id("org.hiero.gradle.build") version "0.4.0" }
 
 javaModules {
     // This "intermediate parent project" should be removed


### PR DESCRIPTION
**Description**:

- Activates running unit tests on module path (by updating plugins to `0.4.0`)
- Activates running hapi tests on module path by doing the corresponding updates in the `test-client` project

**Related issue(s)**:
Follow up to #18922
Fixes #5275