### PR TITLE
fix: 19054: Need a way to check if a MerkleDb compaction tasks are running

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -11,12 +11,11 @@ import com.swirlds.common.threading.framework.config.ThreadConfiguration;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.files.DataFileCompactor;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.channels.ClosedByInterruptException;
+import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -36,7 +35,6 @@ import org.apache.logging.log4j.Logger;
  * The number of threads in the pool is defined by {@link MerkleDbConfig#compactionThreads()} property.
  *
  */
-@SuppressWarnings("rawtypes")
 class MerkleDbCompactionCoordinator {
 
     private static final Logger logger = LogManager.getLogger(MerkleDbCompactionCoordinator.class);
@@ -77,24 +75,13 @@ class MerkleDbCompactionCoordinator {
         return compactionExecutor;
     }
 
-    public static final String HASH_STORE_DISK_SUFFIX = "HashStoreDisk";
-    public static final String OBJECT_KEY_TO_PATH_SUFFIX = "ObjectKeyToPath";
-    public static final String PATH_TO_KEY_VALUE_SUFFIX = "PathToKeyValue";
     private final AtomicBoolean compactionEnabled = new AtomicBoolean();
-    // we need a map of exactly three elements, one per storage
-    final ConcurrentMap<String, Future<Boolean>> compactionFuturesByName = new ConcurrentHashMap<>(3);
-    private final CompactionTask objectKeyToPathTask;
-    private final CompactionTask hashesStoreDiskTask;
-    private final CompactionTask pathToKeyValueTask;
 
-    @Nullable
-    private final DataFileCompactor objectKeyToPath;
+    // A map of compactor futures by task names
+    final Map<String, Future<Boolean>> futuresByName = new ConcurrentHashMap<>(16);
 
-    @Nullable
-    private final DataFileCompactor hashesStoreDisk;
-
-    @NonNull
-    private final DataFileCompactor pathToKeyValue;
+    // A map of compactors by task names
+    final Map<String, DataFileCompactor> compactorsByName = new ConcurrentHashMap<>(16);
 
     @NonNull
     private final MerkleDbConfig merkleDbConfig;
@@ -106,62 +93,12 @@ class MerkleDbCompactionCoordinator {
     /**
      * Creates a new instance of {@link MerkleDbCompactionCoordinator}.
      * @param tableName the name of the table
-     * @param objectKeyToPath an object key to path store
-     * @param hashesStoreDisk a hash store
-     * @param pathToKeyValue a path to key-value store
      * @param merkleDbConfig platform config for MerkleDbDataSource
      */
-    public MerkleDbCompactionCoordinator(
-            @NonNull String tableName,
-            @Nullable DataFileCompactor objectKeyToPath,
-            @Nullable DataFileCompactor hashesStoreDisk,
-            @NonNull DataFileCompactor pathToKeyValue,
-            @NonNull MerkleDbConfig merkleDbConfig) {
+    public MerkleDbCompactionCoordinator(@NonNull String tableName, @NonNull MerkleDbConfig merkleDbConfig) {
         requireNonNull(tableName);
-        requireNonNull(pathToKeyValue);
         requireNonNull(merkleDbConfig);
-        this.objectKeyToPath = objectKeyToPath;
-        this.hashesStoreDisk = hashesStoreDisk;
-        this.pathToKeyValue = pathToKeyValue;
         this.merkleDbConfig = merkleDbConfig;
-        if (objectKeyToPath != null) {
-            objectKeyToPathTask = new CompactionTask(tableName + OBJECT_KEY_TO_PATH_SUFFIX, objectKeyToPath);
-        } else {
-            objectKeyToPathTask = null;
-        }
-        if (hashesStoreDisk != null) {
-            hashesStoreDiskTask = new CompactionTask(tableName + HASH_STORE_DISK_SUFFIX, hashesStoreDisk);
-        } else {
-            hashesStoreDiskTask = null;
-        }
-        this.pathToKeyValueTask = new CompactionTask(tableName + PATH_TO_KEY_VALUE_SUFFIX, pathToKeyValue);
-    }
-
-    /**
-     * Compacts the object key to path store asynchronously if it's present.
-     */
-    void compactDiskStoreForKeyToPathAsync() {
-        if (objectKeyToPathTask == null) {
-            return;
-        }
-        submitCompactionTaskForExecution(objectKeyToPathTask);
-    }
-
-    /**
-     * Compacts the hash store asynchronously if it's present.
-     */
-    void compactDiskStoreForHashesAsync() {
-        if (hashesStoreDiskTask == null) {
-            return;
-        }
-        submitCompactionTaskForExecution(hashesStoreDiskTask);
-    }
-
-    /**
-     * Compacts the path to key-value store asynchronously.
-     */
-    void compactPathToKeyValueAsync() {
-        submitCompactionTaskForExecution(pathToKeyValueTask);
     }
 
     /**
@@ -178,42 +115,32 @@ class MerkleDbCompactionCoordinator {
      * #resumeCompaction()}} is called.
      */
     public void pauseCompaction() throws IOException {
-        if (hashesStoreDisk != null) {
-            hashesStoreDisk.pauseCompaction();
-        }
-
-        pathToKeyValue.pauseCompaction();
-
-        if (objectKeyToPath != null) {
-            objectKeyToPath.pauseCompaction();
-        }
-    }
-    /** Resumes previously stopped data file collection compaction. */
-    public void resumeCompaction() throws IOException {
-        if (hashesStoreDisk != null) {
-            hashesStoreDisk.resumeCompaction();
-        }
-
-        pathToKeyValue.resumeCompaction();
-
-        if (objectKeyToPath != null) {
-            objectKeyToPath.resumeCompaction();
+        for (final DataFileCompactor compactor : compactorsByName.values()) {
+            compactor.pauseCompaction();
         }
     }
 
     /**
-     * Stops all compactions in progress and disables background compaction.
-     * All subsequent calls to compacting methods will be ignored until {@link #enableBackgroundCompaction()} is called.
+     * Resumes previously stopped data file collection compaction.
+     */
+    public void resumeCompaction() throws IOException {
+        for (final DataFileCompactor compactor : compactorsByName.values()) {
+            compactor.resumeCompaction();
+        }
+    }
+
+    /**
+     * Stops all compactions in progress and disables background compaction. All subsequent calls to
+     * compacting methods will be ignored until {@link #enableBackgroundCompaction()} is called.
      */
     void stopAndDisableBackgroundCompaction() {
         compactionEnabled.set(false);
         // Interrupt all running compaction tasks, if any
-        synchronized (compactionFuturesByName) {
-            for (var futureEntry : compactionFuturesByName.values()) {
-                futureEntry.cancel(true);
-            }
-            compactionFuturesByName.clear();
+        for (final Future<Boolean> futureEntry : futuresByName.values()) {
+            futureEntry.cancel(true);
         }
+        futuresByName.clear();
+        compactorsByName.clear();
         // Wait till all the tasks are stopped
         final long now = System.currentTimeMillis();
         try {
@@ -230,27 +157,35 @@ class MerkleDbCompactionCoordinator {
     }
 
     /**
-     * Submits a compaction task for execution. If a compaction task for the same storage type is already in progress,
+     * Submits a compaction task for execution. If a compactor with the given name is already in progress,
      * the call is effectively no op.
-     * @param task a compaction task to execute
+     *
+     * @param key Compaction task name
+     * @param compactor Compactor to run
      */
-    private void submitCompactionTaskForExecution(CompactionTask task) {
-        synchronized (compactionFuturesByName) {
-            if (!compactionEnabled.get()) {
-                return;
-            }
-            if (compactionFuturesByName.containsKey(task.id)) {
-                Future<?> future = compactionFuturesByName.get(task.id);
-                if (future.isDone()) {
-                    compactionFuturesByName.remove(task.id);
-                } else {
-                    logger.debug(MERKLE_DB.getMarker(), "Compaction for {} is already in progress", task.id);
-                    return;
-                }
-            }
-            final ExecutorService executor = getCompactionExecutor(merkleDbConfig);
-            compactionFuturesByName.put(task.id, executor.submit(task));
+    public void compactIfNotRunningYet(final String key, final DataFileCompactor compactor) {
+        if (!compactionEnabled.get()) {
+            return;
         }
+        if (futuresByName.containsKey(key)) {
+            logger.debug(MERKLE_DB.getMarker(), "Compaction for {} is already in progress", key);
+            return;
+        }
+        assert !compactorsByName.containsKey(key);
+        compactorsByName.put(key, compactor);
+        final ExecutorService executor = getCompactionExecutor(merkleDbConfig);
+        final CompactionTask task = new CompactionTask(key, compactor);
+        futuresByName.put(key, executor.submit(task));
+    }
+
+    /**
+     * Checks if a compaction task with the given name is currently in progress.
+     *
+     * @param key Compactor name
+     * @return {@code true} if compaction with this name is currently running, {@code false} otherwise
+     */
+    public boolean isCompactionRunning(final String key) {
+        return futuresByName.containsKey(key);
     }
 
     boolean isCompactionEnabled() {
@@ -279,12 +214,14 @@ class MerkleDbCompactionCoordinator {
             try {
                 return compactor.compact();
             } catch (final InterruptedException | ClosedByInterruptException e) {
-                logger.info(MERKLE_DB.getMarker(), "Interrupted while compacting, this is allowed.", e);
+                logger.info(MERKLE_DB.getMarker(), "Interrupted while compacting, this is allowed");
             } catch (Exception e) {
                 // It is important that we capture all exceptions here, otherwise a single exception
-                // will stop all  future merges from happening.
+                // will stop all future merges from happening
                 logger.error(EXCEPTION.getMarker(), "[{}] Compaction failed", id, e);
             } finally {
+                compactorsByName.remove(id);
+                futuresByName.remove(id);
                 tasksRunning.decrementAndGet();
             }
             return false;

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -365,50 +365,9 @@ public final class MerkleDbDataSource implements VirtualDataSource {
 
         // Stats
         statisticsUpdater = new MerkleDbStatisticsUpdater(merkleDbConfig, tableName);
-        final Runnable updateTotalStatsFunction = () -> {
-            statisticsUpdater.updateStoreFileStats(this);
-            statisticsUpdater.updateOffHeapStats(this);
-        };
 
-        // Compactors
-        final DataFileCompactor hashStoreDiskFileCompactor;
-        if (hasDiskStoreForHashes) {
-            hashStoreDiskFileCompactor = new DataFileCompactor(
-                    merkleDbConfig,
-                    hashStoreDiskStoreName,
-                    hashStoreDisk.getFileCollection(),
-                    pathToDiskLocationInternalNodes,
-                    statisticsUpdater::setHashesStoreCompactionTimeMs,
-                    statisticsUpdater::setHashesStoreCompactionSavedSpaceMb,
-                    statisticsUpdater::setHashesStoreFileSizeByLevelMb,
-                    updateTotalStatsFunction);
-        } else {
-            hashStoreDiskFileCompactor = null;
-        }
-        final DataFileCompactor pathToKeyValueFileCompactor = new DataFileCompactor(
-                merkleDbConfig,
-                pathToKeyValueStoreName,
-                pathToKeyValue.getFileCollection(),
-                pathToDiskLocationLeafNodes,
-                statisticsUpdater::setLeavesStoreCompactionTimeMs,
-                statisticsUpdater::setLeavesStoreCompactionSavedSpaceMb,
-                statisticsUpdater::setLeavesStoreFileSizeByLevelMb,
-                updateTotalStatsFunction);
-        final DataFileCompactor keyToPathFileCompactor = new DataFileCompactor(
-                merkleDbConfig,
-                keyToPathStoreName,
-                keyToPath.getFileCollection(),
-                keyToPath.getBucketIndexToBucketLocation(),
-                statisticsUpdater::setLeafKeysStoreCompactionTimeMs,
-                statisticsUpdater::setLeafKeysStoreCompactionSavedSpaceMb,
-                statisticsUpdater::setLeafKeysStoreFileSizeByLevelMb,
-                updateTotalStatsFunction);
-        compactionCoordinator = new MerkleDbCompactionCoordinator(
-                tableName,
-                keyToPathFileCompactor,
-                hashStoreDiskFileCompactor,
-                pathToKeyValueFileCompactor,
-                merkleDbConfig);
+        // File compactions
+        compactionCoordinator = new MerkleDbCompactionCoordinator(tableName, merkleDbConfig);
         if (compactionEnabled) {
             enableBackgroundCompaction();
         }
@@ -1152,7 +1111,8 @@ public final class MerkleDbDataSource implements VirtualDataSource {
         if (hasDiskStoreForHashes) {
             final DataFileReader newHashesFile = hashStoreDisk.endWriting();
             statisticsUpdater.setFlushHashesStoreFileSize(newHashesFile);
-            compactionCoordinator.compactDiskStoreForHashesAsync();
+            compactionCoordinator.compactIfNotRunningYet(
+                    DataFileCompactor.HASH_STORE_DISK, newHashStoreDiskCompactor());
         }
     }
 
@@ -1239,10 +1199,64 @@ public final class MerkleDbDataSource implements VirtualDataSource {
         // end writing
         final DataFileReader pathToKeyValueReader = pathToKeyValue.endWriting();
         statisticsUpdater.setFlushLeavesStoreFileSize(pathToKeyValueReader);
-        compactionCoordinator.compactPathToKeyValueAsync();
+        compactionCoordinator.compactIfNotRunningYet(DataFileCompactor.PATH_TO_KEY_VALUE, newPathToKeyValueCompactor());
         final DataFileReader keyToPathReader = keyToPath.endWriting();
         statisticsUpdater.setFlushLeafKeysStoreFileSize(keyToPathReader);
-        compactionCoordinator.compactDiskStoreForKeyToPathAsync();
+        compactionCoordinator.compactIfNotRunningYet(DataFileCompactor.OBJECT_KEY_TO_PATH, newKeyToPathCompactor());
+    }
+
+    /**
+     * Creates a new data file compactor for hashStoreDisk file collection.
+     */
+    DataFileCompactor newHashStoreDiskCompactor() {
+        return new DataFileCompactor(
+                database.getConfiguration().getConfigData(MerkleDbConfig.class),
+                tableName + "_" + DataFileCompactor.HASH_STORE_DISK,
+                hashStoreDisk.getFileCollection(),
+                pathToDiskLocationInternalNodes,
+                statisticsUpdater::setHashesStoreCompactionTimeMs,
+                statisticsUpdater::setHashesStoreCompactionSavedSpaceMb,
+                statisticsUpdater::setHashesStoreFileSizeByLevelMb,
+                () -> {
+                    statisticsUpdater.updateStoreFileStats(this);
+                    statisticsUpdater.updateOffHeapStats(this);
+                });
+    }
+
+    /**
+     * Creates a new data file compactor for pathToKeyValue file collection.
+     */
+    DataFileCompactor newPathToKeyValueCompactor() {
+        return new DataFileCompactor(
+                database.getConfiguration().getConfigData(MerkleDbConfig.class),
+                tableName + "_" + DataFileCompactor.PATH_TO_KEY_VALUE,
+                pathToKeyValue.getFileCollection(),
+                pathToDiskLocationLeafNodes,
+                statisticsUpdater::setLeavesStoreCompactionTimeMs,
+                statisticsUpdater::setLeavesStoreCompactionSavedSpaceMb,
+                statisticsUpdater::setLeavesStoreFileSizeByLevelMb,
+                () -> {
+                    statisticsUpdater.updateStoreFileStats(this);
+                    statisticsUpdater.updateOffHeapStats(this);
+                });
+    }
+
+    /**
+     * Creates a new data file compactor for keyToPath file collection.
+     */
+    DataFileCompactor newKeyToPathCompactor() {
+        return new DataFileCompactor(
+                database.getConfiguration().getConfigData(MerkleDbConfig.class),
+                tableName + "_" + DataFileCompactor.OBJECT_KEY_TO_PATH,
+                keyToPath.getFileCollection(),
+                keyToPath.getBucketIndexToBucketLocation(),
+                statisticsUpdater::setLeafKeysStoreCompactionTimeMs,
+                statisticsUpdater::setLeafKeysStoreCompactionSavedSpaceMb,
+                statisticsUpdater::setLeafKeysStoreFileSizeByLevelMb,
+                () -> {
+                    statisticsUpdater.updateStoreFileStats(this);
+                    statisticsUpdater.updateOffHeapStats(this);
+                });
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
@@ -40,6 +40,10 @@ public class DataFileCompactor {
 
     private static final Logger logger = LogManager.getLogger(DataFileCompactor.class);
 
+    public static final String HASH_STORE_DISK = "HashStoreDisk";
+    public static final String OBJECT_KEY_TO_PATH = "ObjectKeyToPath";
+    public static final String PATH_TO_KEY_VALUE = "PathToKeyValue";
+
     /**
      * This is the compaction level that non-compacted files have.
      */
@@ -48,25 +52,28 @@ public class DataFileCompactor {
     private final MerkleDbConfig dbConfig;
 
     /**
-     * Name of the file store to compact.
+     * Name of the file store to compact. This is used for logging and metrics.
      */
     private final String storeName;
+
     /**
-     * The data file collection to compact
+     * The data file collection to compact.
      */
     private final DataFileCollection dataFileCollection;
 
     /**
-     * Index to update during compaction
+     * Index to update during compaction.
      */
     private final CASableLongIndex index;
+
     /**
-     * A function that will be called to report the duration of the compaction
+     * A function that will be called to report the duration of the compaction.
      */
     @Nullable
     private final BiConsumer<Integer, Long> reportDurationMetricFunction;
+
     /**
-     * A function that will be called to report the amount of space saved by the compaction
+     * A function that will be called to report the amount of space saved by the compaction.
      */
     @Nullable
     private final BiConsumer<Integer, Double> reportSavedSpaceMetricFunction;
@@ -74,7 +81,7 @@ public class DataFileCompactor {
     private final BiConsumer<Integer, Double> reportFileSizeByLevelMetricFunction;
 
     /**
-     * A function that updates statistics of total usage of disk space and off-heap space
+     * A function that updates statistics of total usage of disk space and off-heap space.
      */
     @Nullable
     private final Runnable updateTotalStatsFunction;
@@ -133,7 +140,7 @@ public class DataFileCompactor {
      * @param index                          index to update during compaction
      * @param reportDurationMetricFunction   function to report how long compaction took, in ms
      * @param reportSavedSpaceMetricFunction function to report how much space was compacted, in Mb
-     * @param reportFileSizeByLevelMetricFunction function to report how much spaсе is used by the store by compaction level, in Mb
+     * @param reportFileSizeByLevelMetricFunction function to report how much space is used by the store by compaction level, in Mb
      * @param updateTotalStatsFunction       A function that updates statistics of total usage of disk space and off-heap space
      */
     public DataFileCompactor(
@@ -481,7 +488,7 @@ public class DataFileCompactor {
      * then this level and the levels above it are not included in the plan.
      * @return filter creating a compaction plan
      */
-    static <D> List<DataFileReader> compactionPlan(
+    static List<DataFileReader> compactionPlan(
             List<DataFileReader> dataFileReaders, int minNumberOfFilesToCompact, int maxCompactionLevel) {
         if (dataFileReaders.isEmpty()) {
             return dataFileReaders;

--- a/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
+++ b/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
@@ -182,12 +182,15 @@ class MerkleDbDataSourceSnapshotMergeTest {
                         e.printStackTrace();
                     }
                 } else { // thread 1 initiates compaction and waits for its completion
-                    dataSource.compactionCoordinator.compactPathToKeyValueAsync();
-                    dataSource.compactionCoordinator.compactDiskStoreForKeyToPathAsync();
-                    dataSource.compactionCoordinator.compactPathToKeyValueAsync();
+                    dataSource.compactionCoordinator.compactIfNotRunningYet(
+                            "hashStoreDisk", dataSource.newHashStoreDiskCompactor());
+                    dataSource.compactionCoordinator.compactIfNotRunningYet(
+                            "objectKeyToPath", dataSource.newKeyToPathCompactor());
+                    dataSource.compactionCoordinator.compactIfNotRunningYet(
+                            "pathToKeyValue", dataSource.newPathToKeyValueCompactor());
 
                     assertEventuallyTrue(
-                            dataSource.compactionCoordinator.compactionFuturesByName::isEmpty,
+                            dataSource.compactionCoordinator.futuresByName::isEmpty,
                             Duration.ofSeconds(1),
                             "compaction tasks should have been completed");
 


### PR DESCRIPTION
Fix summary:

* `MerkleDbCompactionCoordinator` no longer contains a fixed set of compaction tasks. Instead, it accepts arbitrary tasks in its `compactIfNotRunningYet()` method
* Every time a compaction is started after flush, new compaction tasks are submitted to the coordinator. This is essential for #8841 
* Minor typos are fixed
* All synchronized blocks in `MerkleDbCompactionCoordinator` are removed, they are redundant

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/19054
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
