### PR TITLE
chore: Replace usage of address book with roster

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -14,7 +14,7 @@ import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.initLo
 import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.setupGlobalMetrics;
 import static com.swirlds.platform.config.internal.PlatformConfigUtils.checkConfiguration;
 import static com.swirlds.platform.crypto.CryptoStatic.initNodeSecurity;
-import static com.swirlds.platform.state.signed.StartupStateUtils.copyInitialSignedState;
+import static com.swirlds.platform.state.signed.StartupStateUtils.loadInitialState;
 import static com.swirlds.platform.system.InitTrigger.GENESIS;
 import static com.swirlds.platform.system.InitTrigger.RESTART;
 import static com.swirlds.platform.system.SystemExitCode.NODE_ADDRESS_MISMATCH;
@@ -54,7 +54,6 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.SystemEnvironmentConfigSource;
 import com.swirlds.config.extensions.sources.SystemPropertiesConfigSource;
-import com.swirlds.logging.legacy.payload.SavedStateLoadedPayload;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.Browser;
 import com.swirlds.platform.CommandLineArgs;
@@ -64,14 +63,11 @@ import com.swirlds.platform.config.BasicConfig;
 import com.swirlds.platform.config.legacy.ConfigurationException;
 import com.swirlds.platform.config.legacy.LegacyConfigProperties;
 import com.swirlds.platform.config.legacy.LegacyConfigPropertiesLoader;
-import com.swirlds.platform.crypto.CryptoStatic;
 import com.swirlds.platform.state.ConsensusStateEventHandler;
 import com.swirlds.platform.state.MerkleNodeState;
 import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.HashedReservedSignedState;
 import com.swirlds.platform.state.signed.ReservedSignedState;
-import com.swirlds.platform.state.signed.SignedState;
-import com.swirlds.platform.state.signed.StartupStateUtils;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.SwirldMain;
@@ -296,7 +292,6 @@ public class ServicesMain implements SwirldMain<MerkleNodeState> {
                 merkleCryptography);
         final Optional<AddressBook> maybeDiskAddressBook = loadLegacyAddressBook();
         final HashedReservedSignedState reservedState = loadInitialState(
-                platformConfig,
                 recycleBin,
                 version,
                 () -> {
@@ -512,58 +507,6 @@ public class ServicesMain implements SwirldMain<MerkleNodeState> {
             return Optional.of(props.getAddressBook());
         } catch (final Exception ignore) {
             return Optional.empty();
-        }
-    }
-
-    /**
-     * Get the initial state to be used by this node. May return a state loaded from disk, or may return a genesis state
-     * if no valid state is found on disk.
-     *
-     * @param configuration      the configuration for this node
-     * @param softwareVersion     the software version of the app
-     * @param stateRootSupplier a supplier that can build a genesis state
-     * @param mainClassName       the name of the app's SwirldMain class
-     * @param swirldName          the name of this swirld
-     * @param selfId              the node id of this node
-     * @param platformStateFacade an object to access the platform state
-     * @return the initial state to be used by this node
-     */
-    @NonNull
-    private static HashedReservedSignedState loadInitialState(
-            @NonNull final Configuration configuration,
-            @NonNull final RecycleBin recycleBin,
-            @NonNull final SemanticVersion softwareVersion,
-            @NonNull final Supplier<MerkleNodeState> stateRootSupplier,
-            @NonNull final String mainClassName,
-            @NonNull final String swirldName,
-            @NonNull final NodeId selfId,
-            @NonNull final PlatformStateFacade platformStateFacade,
-            @NonNull final PlatformContext platformContext) {
-        final var loadedState = StartupStateUtils.loadStateFile(
-                recycleBin, selfId, mainClassName, swirldName, softwareVersion, platformStateFacade, platformContext);
-        try (loadedState) {
-            if (loadedState.isNotNull()) {
-                logger.info(
-                        STARTUP.getMarker(),
-                        new SavedStateLoadedPayload(
-                                loadedState.get().getRound(), loadedState.get().getConsensusTimestamp()));
-                return copyInitialSignedState(loadedState.get(), platformStateFacade, platformContext);
-            }
-        }
-        final var stateRoot = stateRootSupplier.get();
-        final var signedState = new SignedState(
-                configuration,
-                CryptoStatic::verifySignature,
-                stateRoot,
-                "genesis state",
-                false,
-                false,
-                false,
-                platformStateFacade);
-        signedState.init(platformContext);
-        final var reservedSignedState = signedState.reserve("initial reservation on genesis state");
-        try (reservedSignedState) {
-            return copyInitialSignedState(reservedSignedState.get(), platformStateFacade, platformContext);
         }
     }
 

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/node/NodeId.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/node/NodeId.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.model.node;
 
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.Objects;
@@ -49,18 +48,6 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
      */
     public static NodeId of(final long id) {
         return NodeIdCache.getOrCreate(id);
-    }
-
-    /**
-     * Return a potentially cached NodeId instance for a given {@link RosterEntry}.
-     * The caller MUST NOT mutate the returned object even though the NodeId class is technically mutable.
-     * If the caller needs to mutate the instance, then it must use the regular NodeId(long) constructor instead.
-     *
-     * @param rosterEntry a {@code RosterEntry}
-     * @return a NodeId instance
-     */
-    public static NodeId of(@NonNull final RosterEntry rosterEntry) {
-        return NodeId.of(rosterEntry.nodeId());
     }
 
     /**

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/node/NodeId.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/node/NodeId.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.model.node;
 
+import com.hedera.hapi.node.state.roster.RosterEntry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.Objects;
@@ -48,6 +49,18 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
      */
     public static NodeId of(final long id) {
         return NodeIdCache.getOrCreate(id);
+    }
+
+    /**
+     * Return a potentially cached NodeId instance for a given {@link RosterEntry}.
+     * The caller MUST NOT mutate the returned object even though the NodeId class is technically mutable.
+     * If the caller needs to mutate the instance, then it must use the regular NodeId(long) constructor instead.
+     *
+     * @param rosterEntry a {@code RosterEntry}
+     * @return a NodeId instance
+     */
+    public static NodeId of(@NonNull final RosterEntry rosterEntry) {
+        return NodeId.of(rosterEntry.nodeId());
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleInstrumentedNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleInstrumentedNode.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.fixtures.turtle;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.platform.test.fixtures.turtle.gossip.SimulatedNetwork;
@@ -10,7 +11,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
-import org.hiero.consensus.model.roster.AddressBook;
 import org.hiero.otter.fixtures.InstrumentedNode;
 
 /**
@@ -20,26 +20,15 @@ public class TurtleInstrumentedNode extends TurtleNode implements InstrumentedNo
 
     private final Logger log = LogManager.getLogger(TurtleInstrumentedNode.class);
 
-    /**
-     * Constructor for TurtleInstrumentedNode.
-     *
-     * @param randotron
-     * @param time
-     * @param nodeId
-     * @param addressBook
-     * @param privateKey
-     * @param network
-     * @param rootOutputDirectory
-     */
     public TurtleInstrumentedNode(
             @NonNull final Randotron randotron,
             @NonNull final Time time,
             @NonNull final NodeId nodeId,
-            @NonNull final AddressBook addressBook,
+            @NonNull final Roster roster,
             @NonNull final KeysAndCerts privateKey,
             @NonNull final SimulatedNetwork network,
             @NonNull final Path rootOutputDirectory) {
-        super(randotron, time, nodeId, addressBook, privateKey, network, rootOutputDirectory);
+        super(randotron, time, nodeId, roster, privateKey, network, rootOutputDirectory);
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -27,6 +27,7 @@ import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.status.PlatformStatus;
+import org.hiero.consensus.roster.RosterUtils;
 import org.hiero.otter.fixtures.InstrumentedNode;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.Node;
@@ -100,7 +101,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
                 new SimulatedNetwork(randotron, roster, AVERAGE_NETWORK_DELAY, STANDARD_DEVIATION_NETWORK_DELAY);
 
         final List<TurtleNode> nodeList = roster.rosterEntries().stream()
-                .map(NodeId::of)
+                .map(RosterUtils::getNodeId)
                 .sorted()
                 .map(nodeId -> createTurtleNode(nodeId, roster, rosterBuilder.getPrivateKeys(nodeId)))
                 .toList();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -8,8 +8,9 @@ import static org.hiero.consensus.model.status.PlatformStatus.FREEZE_COMPLETE;
 import static org.hiero.otter.fixtures.turtle.TurtleTestEnvironment.AVERAGE_NETWORK_DELAY;
 import static org.hiero.otter.fixtures.turtle.TurtleTestEnvironment.STANDARD_DEVIATION_NETWORK_DELAY;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.common.test.fixtures.Randotron;
-import com.swirlds.platform.test.fixtures.addressbook.RandomAddressBookBuilder;
+import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import com.swirlds.platform.test.fixtures.turtle.gossip.SimulatedNetwork;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Path;
@@ -25,7 +26,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
-import org.hiero.consensus.model.roster.AddressBook;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.otter.fixtures.InstrumentedNode;
 import org.hiero.otter.fixtures.Network;
@@ -39,7 +39,6 @@ import org.hiero.otter.fixtures.turtle.app.TurtleTransaction;
 /**
  * An implementation of {@link Network} that is based on the Turtle framework.
  */
-@SuppressWarnings("removal")
 public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceiver {
 
     private static final Logger log = LogManager.getLogger(TurtleNetwork.class);
@@ -93,16 +92,17 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
         executorService = Executors.newFixedThreadPool(
                 Math.min(count, Runtime.getRuntime().availableProcessors()));
 
-        final RandomAddressBookBuilder addressBookBuilder =
-                RandomAddressBookBuilder.create(randotron).withSize(count).withRealKeysEnabled(true);
-        final AddressBook addressBook = addressBookBuilder.build();
+        final RandomRosterBuilder rosterBuilder =
+                RandomRosterBuilder.create(randotron).withSize(count).withRealKeysEnabled(true);
+        final Roster roster = rosterBuilder.build();
 
         simulatedNetwork =
-                new SimulatedNetwork(randotron, addressBook, AVERAGE_NETWORK_DELAY, STANDARD_DEVIATION_NETWORK_DELAY);
+                new SimulatedNetwork(randotron, roster, AVERAGE_NETWORK_DELAY, STANDARD_DEVIATION_NETWORK_DELAY);
 
-        final List<TurtleNode> nodeList = addressBook.getNodeIdSet().stream()
+        final List<TurtleNode> nodeList = roster.rosterEntries().stream()
+                .map(NodeId::of)
                 .sorted()
-                .map(nodeId -> createTurtleNode(nodeId, addressBook, addressBookBuilder.getPrivateKeys(nodeId)))
+                .map(nodeId -> createTurtleNode(nodeId, roster, rosterBuilder.getPrivateKeys(nodeId)))
                 .toList();
         nodes.addAll(nodeList);
 
@@ -111,12 +111,9 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
     }
 
     private TurtleNode createTurtleNode(
-            @NonNull final NodeId nodeId,
-            @NonNull final AddressBook addressBook,
-            @NonNull final KeysAndCerts privateKeys) {
+            @NonNull final NodeId nodeId, @NonNull final Roster roster, @NonNull final KeysAndCerts privateKeys) {
         final Path outputDir = rootOutputDirectory.resolve("node-" + nodeId.id());
-        return new TurtleNode(
-                randotron, timeManager.time(), nodeId, addressBook, privateKeys, simulatedNetwork, outputDir);
+        return new TurtleNode(randotron, timeManager.time(), nodeId, roster, privateKeys, simulatedNetwork, outputDir);
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNodeConfiguration.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNodeConfiguration.java
@@ -77,6 +77,7 @@ public class TurtleNodeConfiguration implements NodeConfiguration<TurtleNodeConf
                 .withValue(StateCommonConfig_.SAVED_STATE_DIRECTORY, outputDirectory)
                 .withValue(FileSystemManagerConfig_.ROOT_PATH, outputDirectory)
                 .withValue(PathsConfig_.SETTINGS_USED_DIR, outputDirectory)
-                .withValue(PcesConfig_.LIMIT_REPLAY_FREQUENCY, false);
+                .withValue(PcesConfig_.LIMIT_REPLAY_FREQUENCY, false)
+                .withValue(SOFTWARE_VERSION, "1.0.0");
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/app/TurtleAppState.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/app/TurtleAppState.java
@@ -23,6 +23,9 @@ public class TurtleAppState extends MerkleStateRoot<TurtleAppState> implements M
     /**
      * Creates an initialized {@code TurtleAppState}.
      *
+     * @param configuration the configuration used during initialization
+     * @param roster the initial roster stored in the state
+     * @param version the software version to set in the state
      * @return merkle tree root
      */
     @NonNull

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/app/TurtleAppState.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/app/TurtleAppState.java
@@ -1,19 +1,41 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.fixtures.turtle.app;
 
+import static com.swirlds.platform.state.service.PlatformStateFacade.DEFAULT_PLATFORM_STATE_FACADE;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.platform.state.MerkleNodeState;
 import com.swirlds.platform.test.fixtures.state.TestingAppStateInitializer;
 import com.swirlds.state.merkle.MerkleStateRoot;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import org.hiero.consensus.roster.RosterUtils;
 
 public class TurtleAppState extends MerkleStateRoot<TurtleAppState> implements MerkleNodeState {
 
     private static final long CLASS_ID = 0x107F552E92071390L;
 
     private static final class ClassVersion {
-
         public static final int ORIGINAL = 1;
+    }
+
+    /**
+     * Creates an initialized {@code TurtleAppState}.
+     *
+     * @return merkle tree root
+     */
+    @NonNull
+    public static TurtleAppState createGenesisState(
+            @NonNull final Configuration configuration,
+            @NonNull final Roster roster,
+            @NonNull final SemanticVersion version) {
+        final TestingAppStateInitializer initializer = new TestingAppStateInitializer(configuration);
+        final TurtleAppState state = new TurtleAppState();
+        initializer.initStates(state);
+        RosterUtils.setActiveRoster(state, roster, 0L);
+        DEFAULT_PLATFORM_STATE_FACADE.setCreationSoftwareVersionTo(state, version);
+        return state;
     }
 
     long state;
@@ -59,24 +81,17 @@ public class TurtleAppState extends MerkleStateRoot<TurtleAppState> implements M
         return new TurtleAppState(this);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     protected TurtleAppState copyingConstructor() {
         return new TurtleAppState(this);
     }
 
     /**
-     * Creates a merkle node to act as a state tree root.
-     *
-     * @return merkle tree root
+     * {@inheritDoc}
      */
-    @NonNull
-    public static MerkleNodeState getStateRootNode(@NonNull final Configuration configuration) {
-        final TestingAppStateInitializer initializer = new TestingAppStateInitializer(configuration);
-        final MerkleNodeState state = new TurtleAppState();
-        initializer.initStates(state);
-        return state;
-    }
-
     @Override
     public int getMinimumSupportedVersion() {
         return ClassVersion.ORIGINAL;

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/roster/RosterUtils.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/roster/RosterUtils.java
@@ -295,9 +295,9 @@ public final class RosterUtils {
      */
     @NonNull
     public static RosterHistory createRosterHistory(@NonNull final ReadableRosterStore rosterStore) {
-        final var roundRosterPairs = rosterStore.getRosterHistory();
+        final List<RoundRosterPair> roundRosterPairs = rosterStore.getRosterHistory();
         final Map<Bytes, Roster> rosterMap = new HashMap<>();
-        for (final var pair : roundRosterPairs) {
+        for (final RoundRosterPair pair : roundRosterPairs) {
             rosterMap.put(pair.activeRosterHash(), Objects.requireNonNull(rosterStore.get(pair.activeRosterHash())));
         }
         return new RosterHistory(roundRosterPairs, rosterMap);

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/roster/RosterUtils.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/roster/RosterUtils.java
@@ -222,6 +222,18 @@ public final class RosterUtils {
     }
 
     /**
+     * Return a potentially cached NodeId instance for a given {@link RosterEntry}.
+     * The caller MUST NOT mutate the returned object even though the NodeId class is technically mutable.
+     * If the caller needs to mutate the instance, then it must use the regular NodeId(long) constructor instead.
+     *
+     * @param rosterEntry a {@code RosterEntry}
+     * @return a NodeId instance
+     */
+    public static NodeId of(@NonNull final RosterEntry rosterEntry) {
+        return NodeId.of(rosterEntry.nodeId());
+    }
+
+    /**
      * Retrieves the roster entry that matches the specified node ID, returning null if one does not exist.
      * <p>
      * Useful for one-off look-ups. If code needs to look up multiple entries by NodeId, then the code should use the

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/roster/RosterUtils.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/roster/RosterUtils.java
@@ -229,7 +229,7 @@ public final class RosterUtils {
      * @param rosterEntry a {@code RosterEntry}
      * @return a NodeId instance
      */
-    public static NodeId of(@NonNull final RosterEntry rosterEntry) {
+    public static NodeId getNodeId(@NonNull final RosterEntry rosterEntry) {
         return NodeId.of(rosterEntry.nodeId());
     }
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -372,7 +372,7 @@ public final class StartupStateUtils {
     }
 
     /**
-     * Get the initial state to be used by this node. May return a state loaded from disk, or may return a genesis state
+     * Get the initial state to be used by a node. May return a state loaded from disk, or may return a genesis state
      * if no valid state is found on disk.
      *
      * @param recycleBin          the recycle bin to use

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/state/signed/StartupStateUtils.java
@@ -141,9 +141,8 @@ public final class StartupStateUtils {
             return createNullReservation();
         }
 
-        final ReservedSignedState state = loadLatestState(
+        return loadLatestState(
                 recycleBin, currentSoftwareVersion, savedStateFiles, platformStateFacade, platformContext);
-        return state;
     }
 
     /**
@@ -370,5 +369,57 @@ public final class StartupStateUtils {
         });
 
         RosterUtils.setActiveRoster(state, RosterRetriever.buildRoster(addressBook), round);
+    }
+
+    /**
+     * Get the initial state to be used by this node. May return a state loaded from disk, or may return a genesis state
+     * if no valid state is found on disk.
+     *
+     * @param recycleBin          the recycle bin to use
+     * @param softwareVersion     the software version of the app
+     * @param stateRootSupplier   a supplier that can build a genesis state
+     * @param mainClassName       the name of the app's SwirldMain class
+     * @param swirldName          the name of this swirld
+     * @param selfId              the node id of this node
+     * @param platformStateFacade an object to access the platform state
+     * @param platformContext     the platform context
+     * @return the initial state to be used by this node
+     */
+    @NonNull
+    public static HashedReservedSignedState loadInitialState(
+            @NonNull final RecycleBin recycleBin,
+            @NonNull final SemanticVersion softwareVersion,
+            @NonNull final Supplier<MerkleNodeState> stateRootSupplier,
+            @NonNull final String mainClassName,
+            @NonNull final String swirldName,
+            @NonNull final NodeId selfId,
+            @NonNull final PlatformStateFacade platformStateFacade,
+            @NonNull final PlatformContext platformContext) {
+        final var loadedState = loadStateFile(
+                recycleBin, selfId, mainClassName, swirldName, softwareVersion, platformStateFacade, platformContext);
+        try (loadedState) {
+            if (loadedState.isNotNull()) {
+                logger.info(
+                        STARTUP.getMarker(),
+                        new SavedStateLoadedPayload(
+                                loadedState.get().getRound(), loadedState.get().getConsensusTimestamp()));
+                return copyInitialSignedState(loadedState.get(), platformStateFacade, platformContext);
+            }
+        }
+        final var stateRoot = stateRootSupplier.get();
+        final var signedState = new SignedState(
+                platformContext.getConfiguration(),
+                CryptoStatic::verifySignature,
+                stateRoot,
+                "genesis state",
+                false,
+                false,
+                false,
+                platformStateFacade);
+        signedState.init(platformContext);
+        final var reservedSignedState = signedState.reserve("initial reservation on genesis state");
+        try (reservedSignedState) {
+            return copyInitialSignedState(reservedSignedState.get(), platformStateFacade, platformContext);
+        }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/gossip/SimulatedNetwork.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/gossip/SimulatedNetwork.java
@@ -16,6 +16,7 @@ import java.util.Random;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.roster.AddressBook;
+import org.hiero.consensus.roster.RosterUtils;
 
 /**
  * Connects {@link SimulatedGossip} peers in a simulated network.
@@ -76,7 +77,10 @@ public class SimulatedNetwork {
             @NonNull final Duration standardDeviationDelay) {
         this(
                 random,
-                roster.rosterEntries().stream().map(NodeId::of).sorted().toList(),
+                roster.rosterEntries().stream()
+                        .map(RosterUtils::getNodeId)
+                        .sorted()
+                        .toList(),
                 averageDelay,
                 standardDeviationDelay);
     }

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/gossip/SimulatedNetwork.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/gossip/SimulatedNetwork.java
@@ -74,7 +74,11 @@ public class SimulatedNetwork {
             @NonNull final Roster roster,
             @NonNull final Duration averageDelay,
             @NonNull final Duration standardDeviationDelay) {
-        this(random, roster.rosterEntries().stream().map(NodeId::of).toList(), averageDelay, standardDeviationDelay);
+        this(
+                random,
+                roster.rosterEntries().stream().map(NodeId::of).sorted().toList(),
+                averageDelay,
+                standardDeviationDelay);
     }
 
     /**
@@ -92,14 +96,7 @@ public class SimulatedNetwork {
             @NonNull final Duration standardDeviationDelay) {
         this(random, addressBook.getNodeIdSet().stream().sorted().toList(), averageDelay, standardDeviationDelay);
     }
-    /**
-     * Constructor.
-     *
-     * @param random                 the random number generator to use for simulating network delays
-     * @param nodeIds                the nodeIds of the network
-     * @param averageDelay           the average delay for events to travel between nodes
-     * @param standardDeviationDelay the standard deviation of the delay for events to travel between nodes
-     */
+
     private SimulatedNetwork(
             @NonNull final Random random,
             @NonNull final List<NodeId> nodeIds,

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/gossip/SimulatedNetwork.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/turtle/gossip/SimulatedNetwork.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.test.fixtures.turtle.gossip;
 
+import com.hedera.hapi.node.state.roster.Roster;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.time.Instant;
@@ -64,6 +65,22 @@ public class SimulatedNetwork {
      * Constructor.
      *
      * @param random                 the random number generator to use for simulating network delays
+     * @param roster                 the roster of the network
+     * @param averageDelay           the average delay for events to travel between nodes
+     * @param standardDeviationDelay the standard deviation of the delay for events to travel between nodes
+     */
+    public SimulatedNetwork(
+            @NonNull final Random random,
+            @NonNull final Roster roster,
+            @NonNull final Duration averageDelay,
+            @NonNull final Duration standardDeviationDelay) {
+        this(random, roster.rosterEntries().stream().map(NodeId::of).toList(), averageDelay, standardDeviationDelay);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param random                 the random number generator to use for simulating network delays
      * @param addressBook            the address book of the network
      * @param averageDelay           the average delay for events to travel between nodes
      * @param standardDeviationDelay the standard deviation of the delay for events to travel between nodes
@@ -73,10 +90,25 @@ public class SimulatedNetwork {
             @NonNull final AddressBook addressBook,
             @NonNull final Duration averageDelay,
             @NonNull final Duration standardDeviationDelay) {
+        this(random, addressBook.getNodeIdSet().stream().sorted().toList(), averageDelay, standardDeviationDelay);
+    }
+    /**
+     * Constructor.
+     *
+     * @param random                 the random number generator to use for simulating network delays
+     * @param nodeIds                the nodeIds of the network
+     * @param averageDelay           the average delay for events to travel between nodes
+     * @param standardDeviationDelay the standard deviation of the delay for events to travel between nodes
+     */
+    private SimulatedNetwork(
+            @NonNull final Random random,
+            @NonNull final List<NodeId> nodeIds,
+            @NonNull final Duration averageDelay,
+            @NonNull final Duration standardDeviationDelay) {
 
         this.random = Objects.requireNonNull(random);
 
-        for (final NodeId nodeId : addressBook.getNodeIdSet().stream().sorted().toList()) {
+        for (final NodeId nodeId : nodeIds) {
             newlySubmittedEvents.put(nodeId, new ArrayList<>());
             sortedNodeIds.add(nodeId);
             eventsInTransit.put(nodeId, new PriorityQueue<>());


### PR DESCRIPTION
**Description**:

This PR replaces the address book with the roster in the Otter framework. Also, moved `loadInitialState()` from `ServicesMain` to `StartupStateUtils` to make it generally available.

**Related issue(s)**:

Fixes #18934 