### PR TITLE
fix: Change default `decline_reward` to true for nodes created during genesis

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
@@ -251,8 +251,6 @@ public class DiskStartupNetworks implements StartupNetworks {
                             final var legacyGossipEndpoints = List.of(
                                     rosterEntry.gossipEndpoint().getLast(),
                                     rosterEntry.gossipEndpoint().getFirst());
-                            final var declineReward =
-                                    nodeAccountId.accountNumOrThrow() <= ledgerConfig.numSystemAccounts();
                             return NodeMetadata.newBuilder()
                                     .rosterEntry(rosterEntry)
                                     .node(Node.newBuilder()
@@ -265,7 +263,7 @@ public class DiskStartupNetworks implements StartupNetworks {
                                             .grpcCertificateHash(Bytes.EMPTY)
                                             .weight(rosterEntry.weight())
                                             .deleted(false)
-                                            .declineReward(declineReward)
+                                            .declineReward(true)
                                             .adminKey(Key.DEFAULT)
                                             .build())
                                     .build();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
@@ -378,8 +378,7 @@ public class SystemTransactions {
         if (autoNodeAdminKeyUpdates.tryIfPresent(adminConfig.upgradeSysFilesLoc(), systemContext)) {
             dispatch.stack().commitFullStack();
         }
-        // (FUTURE) Remove this 0.61-specific code initiating all system node accounts to decline rewards
-        final var ledgerConfig = config.getConfigData(LedgerConfig.class);
+        // (FUTURE) Remove this 0.61 and 0.62 -specific code initiating all system node accounts to decline rewards
         final var nodeStore = dispatch.handleContext().storeFactory().readableStore(ReadableNodeStore.class);
         for (int i = 0; i < nodeStore.sizeOfState(); i++) {
             final var node = nodeStore.get(i);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
@@ -80,7 +80,6 @@ import com.swirlds.state.lifecycle.EntityIdFactory;
 import com.swirlds.state.lifecycle.info.NetworkInfo;
 import com.swirlds.state.lifecycle.info.NodeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -97,7 +96,6 @@ import java.util.function.Function;
 import java.util.stream.LongStream;
 import javax.inject.Inject;
 import javax.inject.Singleton;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -120,8 +118,7 @@ public class SystemTransactions {
 
     private static final EnumSet<ResponseCodeEnum> SUCCESSES =
             EnumSet.of(SUCCESS, SUCCESS_BUT_MISSING_EXPECTED_OPERATION);
-    private static final Consumer<Dispatch> DEFAULT_DISPATCH_ON_SUCCESS = dispatch -> {
-    };
+    private static final Consumer<Dispatch> DEFAULT_DISPATCH_ON_SUCCESS = dispatch -> {};
 
     private final InitTrigger initTrigger;
     private final BlocklistParser blocklistParser = new BlocklistParser();
@@ -428,8 +425,7 @@ public class SystemTransactions {
         requireNonNull(now);
         requireNonNull(activeNodeIds);
         requireNonNull(nodeRewardsAccountId);
-        final var systemContext = newSystemContext(now, state, dispatch -> {
-        }, false);
+        final var systemContext = newSystemContext(now, state, dispatch -> {}, false);
         final var activeNodeAccountIds = activeNodeIds.stream()
                 .map(id -> systemContext.networkInfo().nodeInfo(id))
                 .filter(nodeInfo -> nodeInfo != null && !nodeInfo.declineReward())
@@ -690,8 +686,8 @@ public class SystemTransactions {
         try {
             final var controlledNum = (nextEntityNum != 0)
                     ? dispatch.stack()
-                    .getWritableStates(EntityIdService.NAME)
-                    .<EntityNumber>getSingleton(ENTITY_ID_STATE_KEY)
+                            .getWritableStates(EntityIdService.NAME)
+                            .<EntityNumber>getSingleton(ENTITY_ID_STATE_KEY)
                     : null;
             if (controlledNum != null) {
                 controlledNum.put(new EntityNumber(nextEntityNum - 1));

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/DiskStartupNetworksTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/info/DiskStartupNetworksTest.java
@@ -171,6 +171,7 @@ class DiskStartupNetworksTest {
             assertThat(rosterEntry.gossipEndpoint().getFirst().ipAddressV4())
                     .isEqualTo(Bytes.wrap(new byte[] {127, 0, 0, 1}));
             assertThat(rosterEntry.gossipEndpoint().getLast().domainName()).isEqualTo("localhost");
+            assertThat(network.nodeMetadata().get(i).node().declineReward()).isTrue();
         }
     }
 


### PR DESCRIPTION
Fixes #19075 

Change default `decline_reward` to true for nodes created during genesis