### PR TITLE
chore: unify resource-from-module/class-path-loading in V0490FileSchema

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BootstrapConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BootstrapConfig.java
@@ -9,7 +9,7 @@ import com.swirlds.config.api.ConfigProperty;
 
 @ConfigData("bootstrap")
 public record BootstrapConfig(
-        @ConfigProperty(value = "feeSchedulesJson.resource", defaultValue = "/genesis/feeSchedules.json")
+        @ConfigProperty(value = "feeSchedulesJson.resource", defaultValue = "genesis/feeSchedules.json")
                 @NetworkProperty
                 String feeSchedulesJsonResource,
         @ConfigProperty(

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/V0490FileSchema.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/V0490FileSchema.java
@@ -50,6 +50,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.StringReader;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -89,7 +90,7 @@ public class V0490FileSchema extends Schema {
      * The default throttle definitions resource. Used as the ultimate fallback if the configured file and resource is
      * not found.
      */
-    private static final String DEFAULT_THROTTLES_RESOURCE = "/genesis/throttles.json";
+    private static final String DEFAULT_THROTTLES_RESOURCE = "genesis/throttles.json";
 
     /**
      * A hint to the database system of the maximum number of files we will store. This MUST NOT BE CHANGED. If it is
@@ -274,7 +275,7 @@ public class V0490FileSchema extends Schema {
      */
     public Bytes genesisFeeSchedules(@NonNull final Configuration config) {
         final var resourceName = config.getConfigData(BootstrapConfig.class).feeSchedulesJsonResource();
-        try (final var in = V0490FileSchema.class.getResourceAsStream(resourceName)) {
+        try (final var in = loadResourceInPackage(resourceName)) {
             final var feeScheduleJsonBytes = requireNonNull(in).readAllBytes();
             final var feeSchedule = parseFeeSchedules(feeScheduleJsonBytes);
             return CurrentAndNextFeeSchedule.PROTOBUF.toBytes(feeSchedule);
@@ -480,7 +481,7 @@ public class V0490FileSchema extends Schema {
         // Otherwise, load from the classpath. If that cannot be done, we have a totally broken build.
         if (apiPermissionsContent == null) {
             final var resourceName = "api-permission.properties";
-            try (final var in = Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName)) {
+            try (final var in = loadResourceInRoot(resourceName)) {
                 apiPermissionsContent = new String(requireNonNull(in).readAllBytes(), UTF_8);
                 logger.info("API Permissions loaded from classpath resource {}", resourceName);
             } catch (IOException | NullPointerException e) {
@@ -574,8 +575,7 @@ public class V0490FileSchema extends Schema {
 
         // Otherwise, load from the classpath. If that cannot be done, we have a totally broken build.
         if (throttleDefinitionsContent == null) {
-            try (final var in =
-                    Thread.currentThread().getContextClassLoader().getResourceAsStream(throttleDefinitionsResource)) {
+            try (final var in = loadResourceInPackage(throttleDefinitionsResource)) {
                 throttleDefinitionsContent = new String(requireNonNull(in).readAllBytes(), UTF_8);
                 logger.info("Throttle definitions loaded from classpath resource {}", throttleDefinitionsResource);
             } catch (IOException | NullPointerException e) {
@@ -587,7 +587,7 @@ public class V0490FileSchema extends Schema {
 
         if (throttleDefinitionsContent == null) {
             // Load the default throttle definitions resource
-            try (final var in = V0490FileSchema.class.getResourceAsStream(DEFAULT_THROTTLES_RESOURCE)) {
+            try (final var in = loadResourceInPackage(DEFAULT_THROTTLES_RESOURCE)) {
                 throttleDefinitionsContent = new String(requireNonNull(in).readAllBytes(), UTF_8);
                 logger.info(
                         "Throttle definitions loaded from default fallback classpath resource {}",
@@ -682,5 +682,19 @@ public class V0490FileSchema extends Schema {
                 .shardNum(hederaConfig.shard())
                 .fileNum(fileNum)
                 .build();
+    }
+
+    /**
+     * Loads a resource from within a package. The package must be within the loading Module or exported/opened.
+     */
+    private static InputStream loadResourceInPackage(String resourcePath) {
+        return V0490FileSchema.class.getResourceAsStream("/" + resourcePath);
+    }
+
+    /**
+     * Loads a resource from the root of any Jar file (not inside a package).
+     */
+    private static InputStream loadResourceInRoot(String resourceName) {
+        return Thread.currentThread().getContextClassLoader().getResourceAsStream(resourceName);
     }
 }


### PR DESCRIPTION
**Description**:

Follow up to #18922.

There are more cases in `V0490FileSchema` that I missed in #18922. I only discovered those by running HAPI tests on module path. This is a more consistent and complete solution.