### PR TITLE
fix: NoArgsConstructor has duplicated get() method

### DIFF
--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/constructable/ConstructableRegistry.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/constructable/ConstructableRegistry.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.constructable;
 
-import java.util.function.Supplier;
-
 /**
  * A central registry of constructors for {@link RuntimeConstructable} classes. This central registry has a set of
  * sub-registries based on the constructor type of the class.
@@ -38,7 +36,7 @@ public interface ConstructableRegistry {
      * 		and then {@link ConstructorRegistry#getConstructor(long)}
      */
     @Deprecated(forRemoval = true)
-    Supplier<RuntimeConstructable> getConstructor(final long classId);
+    NoArgsConstructor getConstructor(final long classId);
 
     /**
      * Instantiates an object of a class defined by the supplied {@code classId}. If no object is registered with this

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/constructable/NoArgsConstructor.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/constructable/NoArgsConstructor.java
@@ -8,10 +8,9 @@ import java.util.function.Supplier;
  * {@link Supplier}
  */
 @FunctionalInterface
-public interface NoArgsConstructor extends Supplier<RuntimeConstructable> {
+public interface NoArgsConstructor {
     /**
      * @return a new instance of the {@link RuntimeConstructable}
      */
-    @Override
     RuntimeConstructable get();
 }

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/constructable/internal/DefaultConstructableRegistry.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/constructable/internal/DefaultConstructableRegistry.java
@@ -4,7 +4,6 @@ package org.hiero.base.constructable.internal;
 import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Supplier;
 import org.hiero.base.constructable.ClassConstructorPair;
 import org.hiero.base.constructable.ConstructableRegistry;
 import org.hiero.base.constructable.ConstructableRegistryException;
@@ -23,14 +22,14 @@ public class DefaultConstructableRegistry implements ConstructableRegistry {
     }
 
     @Override
-    public Supplier<RuntimeConstructable> getConstructor(final long classId) {
+    public NoArgsConstructor getConstructor(final long classId) {
         return getOrCreate(NoArgsConstructor.class).getConstructor(classId);
     }
 
     @SuppressWarnings("unchecked")
     @Override
     public <T extends RuntimeConstructable> T createObject(final long classId) {
-        final Supplier<RuntimeConstructable> c = getConstructor(classId);
+        final NoArgsConstructor c = getConstructor(classId);
         if (c == null) {
             return null;
         }


### PR DESCRIPTION
**Description**:

In `GenericConstructorRegistry.getMethod(Class<?> constructorType)` [we drop duplicated constructors](https://github.com/hiero-ledger/hiero-consensus-node/blob/b4509ff0045de9f86c770bcda9ff1d714c98ff18/platform-sdk/base-utility/src/main/java/org/hiero/base/constructable/internal/GenericConstructorRegistry.java#L204). However, [we ignore the return type in the comparison](https://github.com/hiero-ledger/hiero-consensus-node/blob/b4509ff0045de9f86c770bcda9ff1d714c98ff18/platform-sdk/base-utility/src/main/java/org/hiero/base/constructable/internal/MethodWrapper.java#L20-L26). I think the return type is also the reasons why there are duplicates in the first place. It is somehow related to how Java is compiling generic types. In the case of `NoArgsConstructor` the method `get()` exists two times. One time with the return type `RuntimeConstructable` (this is what we want) a second time with `Object` (this is sneaking in from the super interface). As long as this is sorted in a way that the `RuntimeConstructable` variant comes first, things work. But if not, we get the following exception (in [GenericConstructorRegistry](https://github.com/hiero-ledger/hiero-consensus-node/blob/b4509ff0045de9f86c770bcda9ff1d714c98ff18/platform-sdk/base-utility/src/main/java/org/hiero/base/constructable/internal/GenericConstructorRegistry.java#L58)):

```
java.lang.IllegalArgumentException: The constructor return type must extend RuntimeConstructable
``` 

This is already flaky now, but does not seem to happen often (?). Maybe updating Java or moving classes to other packages has an influence on that it started to appear. In any case, the order cannot be relied on.
When switching test execution to the module path (#19059) the flakiness can be seen heavily on CI agents (e.g. https://scans.gradle.com/s/fwerfudwewqfm).

This PR proposes to solve this, by removing the `extends Supplier<RuntimeConstructable>` from `NoArgsConstructor` which does not seem to be required. It also looks to me as if this part of the code base is due to be refactored more in the future.

Current situation on main:
![s1](https://github.com/user-attachments/assets/c0181a34-dd7f-4186-b5a9-263a89d71bfd)


With this PR:
![s2](https://github.com/user-attachments/assets/1ad13b16-07ab-46b5-a264-5eca4c9d6077)



