### PR TITLE
fix: 19107 Corrected classId of `BenchmarkMerkleInternal` to prevent `classId` conflict.

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/BenchmarkMerkleInternal.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/reconnect/BenchmarkMerkleInternal.java
@@ -11,7 +11,7 @@ public class BenchmarkMerkleInternal extends PartialNaryMerkleInternal implement
 
     private final String value;
 
-    private static final long CLASS_ID = 0x86753092L;
+    private static final long CLASS_ID = 0x86753093L;
 
     public static final int CLASS_VERSION = 1;
 


### PR DESCRIPTION
**Description**:

This PR fixes `classId` conflict between `BenchmarkMerkleInternal` and `DummyMerkleInternal`


Fixes #19107

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
