### PR TITLE
ci: let Dependabot find updates for org.hiero.gradle.build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
 version: 2
 updates:
+  - package-ecosystem: "gradle"
+    directory: "/" # for 'plugins { }' in 'settings.gradle.kts'
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 10
   - package-ecosystem: "gradle"
     directory: "/hiero-dependency-versions"
     schedule:


### PR DESCRIPTION
**Description**:

With this change, Dependabot will observe our own `org.hiero.gradle.build` (hiero-gradle-conventions) plugin and suggest updates when available.

For reference, see the similar configuration here:
https://github.com/hiero-ledger/hiero-sdk-java/blob/main/.github/dependabot.yml#L4-L12
