### PR TITLE
chore: Allow the provision of a FakeTime in RuntimeObjectRegistry

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -6,6 +6,7 @@ import static com.swirlds.platform.test.fixtures.state.TestingAppStateInitialize
 import com.swirlds.base.test.fixtures.time.FakeTime;
 import com.swirlds.common.io.utility.FileUtils;
 import com.swirlds.common.test.fixtures.Randotron;
+import com.swirlds.common.utility.RuntimeObjectRegistry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -80,6 +81,10 @@ public class TurtleTestEnvironment implements TestEnvironment {
 
         final Randotron randotron = Randotron.create();
 
+        final FakeTime time = new FakeTime(randotron.nextInstant(), Duration.ZERO);
+
+        RuntimeObjectRegistry.initialize(time);
+
         try {
             final ConstructableRegistry registry = ConstructableRegistry.getInstance();
             registry.registerConstructables("");
@@ -87,8 +92,6 @@ public class TurtleTestEnvironment implements TestEnvironment {
         } catch (final ConstructableRegistryException e) {
             throw new RuntimeException(e);
         }
-
-        final FakeTime time = new FakeTime(randotron.nextInstant(), Duration.ZERO);
 
         final Path rootOutputDirectory = Path.of("build", "turtle");
         try {

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/app/TurtleApp.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/app/TurtleApp.java
@@ -65,7 +65,7 @@ public enum TurtleApp implements ConsensusStateEventHandler<TurtleAppState> {
      */
     @Override
     public boolean onSealConsensusRound(@NonNull final Round round, @NonNull final TurtleAppState state) {
-        return false;
+        return true;
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/RuntimeObjectRegistry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/utility/RuntimeObjectRegistry.java
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.common.utility;
 
+import static java.util.Objects.requireNonNull;
+
+import com.swirlds.base.time.Time;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -9,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 import org.hiero.base.constructable.RuntimeConstructable;
 
 /**
@@ -22,7 +27,28 @@ public final class RuntimeObjectRegistry {
      */
     private static final Map<Class<?>, List<RuntimeObjectRecord>> RECORDS = new ConcurrentHashMap<>();
 
+    /**
+     * The time provider. This is used to get the current time for the records.
+     *
+     * <p>We also use this field to check if the registry has already been initialized by checking if it is {code null}.
+     * An {@link AtomicReference} is used to make the check thread-safe.
+     *
+     */
+    private static final AtomicReference<Time> time = new AtomicReference<>(null);
+
     private RuntimeObjectRegistry() {}
+
+    /**
+     * Initialize the registry with a {@link Time} instance. This should be called once at the beginning of the program.
+     * The {@link Time} instance is used to get the current time for the records.
+     *
+     * @param newValue the new {@link Time} instance
+     */
+    public static void initialize(@NonNull final Time newValue) {
+        if (!RuntimeObjectRegistry.time.compareAndSet(null, requireNonNull(newValue))) {
+            throw new IllegalStateException("RuntimeObjectRegistry has already been initialized");
+        }
+    }
 
     /**
      * Create a new record for a runtime object with the specified class and add it to the records list.
@@ -49,7 +75,9 @@ public final class RuntimeObjectRegistry {
      * 		when the object is released.
      */
     public static <T> RuntimeObjectRecord createRecord(final Class<T> cls, final Object metadata) {
-        final Instant now = Instant.now();
+        // If not initialized, we use the default time provider
+        time.compareAndSet(null, Time.getCurrent());
+        final Instant now = time.get().now();
         final List<RuntimeObjectRecord> classRecords =
                 RECORDS.computeIfAbsent(cls, clsid -> Collections.synchronizedList(new ArrayList<>()));
         final RuntimeObjectRecord objectRecord = new RuntimeObjectRecord(now, classRecords::remove, metadata);
@@ -128,5 +156,6 @@ public final class RuntimeObjectRegistry {
      */
     public static void reset() {
         RECORDS.clear();
+        time.set(null);
     }
 }

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/RuntimeObjectRegistryTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/RuntimeObjectRegistryTest.java
@@ -19,19 +19,19 @@ class RuntimeObjectRegistryTest {
     }
 
     @Test
-    void testInitializingWithNullFails() {
+    void initializingWithNullFails() {
         //noinspection DataFlowIssue
         assertThatCode(() -> RuntimeObjectRegistry.initialize(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void testUninitializedRegistryUsesRealTime() {
+    void uninitializedRegistryUsesRealTime() {
         final RuntimeObjectRecord objectRecord = RuntimeObjectRegistry.createRecord(Object.class);
         assertThat(objectRecord.getAge(Instant.now())).isLessThan(Duration.ofMinutes(5));
     }
 
     @Test
-    void testInitializedRegistryUsesFakeTime() {
+    void initializedRegistryUsesFakeTime() {
         final Time fakeTime = new FakeTime();
         RuntimeObjectRegistry.initialize(fakeTime);
 
@@ -40,7 +40,7 @@ class RuntimeObjectRegistryTest {
     }
 
     @Test
-    void testAlreadyUsedRegistryCannotBeInitialized() {
+    void alreadyUsedRegistryCannotBeInitialized() {
         final Time fakeTime = new FakeTime();
 
         RuntimeObjectRegistry.createRecord(Object.class);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/RuntimeObjectRegistryTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/utility/RuntimeObjectRegistryTest.java
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.common.utility;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import com.swirlds.base.test.fixtures.time.FakeTime;
+import com.swirlds.base.time.Time;
+import java.time.Duration;
+import java.time.Instant;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+class RuntimeObjectRegistryTest {
+
+    @AfterEach
+    void cleanUp() {
+        RuntimeObjectRegistry.reset();
+    }
+
+    @Test
+    void testInitializingWithNullFails() {
+        //noinspection DataFlowIssue
+        assertThatCode(() -> RuntimeObjectRegistry.initialize(null)).isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void testUninitializedRegistryUsesRealTime() {
+        final RuntimeObjectRecord objectRecord = RuntimeObjectRegistry.createRecord(Object.class);
+        assertThat(objectRecord.getAge(Instant.now())).isLessThan(Duration.ofMinutes(5));
+    }
+
+    @Test
+    void testInitializedRegistryUsesFakeTime() {
+        final Time fakeTime = new FakeTime();
+        RuntimeObjectRegistry.initialize(fakeTime);
+
+        final RuntimeObjectRecord objectRecord = RuntimeObjectRegistry.createRecord(Object.class);
+        assertThat(objectRecord.getAge(fakeTime.now().plusSeconds(5L))).isEqualTo(Duration.ofSeconds(5L));
+    }
+
+    @Test
+    void testAlreadyUsedRegistryCannotBeInitialized() {
+        final Time fakeTime = new FakeTime();
+
+        RuntimeObjectRegistry.createRecord(Object.class);
+        assertThatCode(() -> RuntimeObjectRegistry.initialize(fakeTime)).isInstanceOf(IllegalStateException.class);
+    }
+}


### PR DESCRIPTION
**Description**:

`RuntimeObjectRegistry` uses real-time to determine an object's age. This leads to unexpected behavior in tests when we use `FakeTime`. This PR adds the possibility of setting a time provider in `RuntimeObjectRegistry`.

**Related issue(s)**:

Fixes #19111 
