### PR TITLE
fix(19162): Open clause for JMS runtime for junit-extensions

### DIFF
--- a/platform-sdk/junit-extensions/README.md
+++ b/platform-sdk/junit-extensions/README.md
@@ -31,7 +31,9 @@ This module contains tailored made Junit Extensions for general use.
       invokedParameters.add(new UsedParams(username, lastName, age));
   }
   ```
+
 ## Related to Java Module System at Runtime
+
 Some of the extensions will need access to the module where is being instructed to execute code on:
 Make sure to open the module to
 `opensTo("org.hiero.junit.extensions")`

--- a/platform-sdk/junit-extensions/README.md
+++ b/platform-sdk/junit-extensions/README.md
@@ -31,3 +31,7 @@ This module contains tailored made Junit Extensions for general use.
       invokedParameters.add(new UsedParams(username, lastName, age));
   }
   ```
+## Related to Java Module System at Runtime
+Some of the extensions will need access to the module where is being instructed to execute code on:
+Make sure to open the module to
+`opensTo("org.hiero.junit.extensions")`

--- a/platform-sdk/swirlds-platform-core/build.gradle.kts
+++ b/platform-sdk/swirlds-platform-core/build.gradle.kts
@@ -51,6 +51,7 @@ testModuleInfo {
     requires("org.hiero.junit.extensions")
 
     opensTo("com.swirlds.base.test.fixtures") // injection via reflection
+    opensTo("org.hiero.junit.extensions")
 }
 
 timingSensitiveModuleInfo {


### PR DESCRIPTION
**Description**:
After enabling JMS at runtime, we need to update the module information for client modules of junit-extensions to open their content to it, allowing access and execution of code on the target module.

**Related issue(s)**:

Fixes #19162 
