### PR TITLE
build: swirlds-platform-core tests opensTo org.hiero.junit.extensions

### DIFF
--- a/platform-sdk/swirlds-platform-core/build.gradle.kts
+++ b/platform-sdk/swirlds-platform-core/build.gradle.kts
@@ -51,6 +51,7 @@ testModuleInfo {
     requires("org.hiero.junit.extensions")
 
     opensTo("com.swirlds.base.test.fixtures") // injection via reflection
+    opensTo("org.hiero.junit.extensions")
 }
 
 timingSensitiveModuleInfo {


### PR DESCRIPTION
**Description**:

This is missing. It was not added in #18811 because #19059 was not integrated yet. The PRs overlapped.