### PR TITLE
fix: ensure all Block Node Communication is behind feature flag

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -236,7 +236,10 @@ public class HandleWorkflow {
             @NonNull final Round round,
             @NonNull final Consumer<ScopedSystemTransaction<StateSignatureTransaction>> stateSignatureTxnCallback) {
         logStartRound(round);
-        BlockStreamStateManager.ensureNewBlocksPermitted();
+        final var blockStreamConfig = configProvider.getConfiguration().getConfigData(BlockStreamConfig.class);
+        if (blockStreamConfig.streamToBlockNodes()) {
+            BlockStreamStateManager.ensureNewBlocksPermitted();
+        }
         cacheWarmer.warm(state, round);
         if (streamMode != RECORDS) {
             blockStreamManager.startRound(round, state);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -12,6 +12,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.block.stream.BlockItem;
@@ -27,6 +29,7 @@ import com.hedera.node.app.blocks.BlockHashSigner;
 import com.hedera.node.app.blocks.BlockStreamManager;
 import com.hedera.node.app.blocks.impl.BoundaryStateChangeListener;
 import com.hedera.node.app.blocks.impl.KVStateChangeListener;
+import com.hedera.node.app.blocks.impl.streaming.BlockStreamStateManager;
 import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.hints.HintsService;
 import com.hedera.node.app.history.HistoryService;
@@ -47,6 +50,7 @@ import com.hedera.node.app.workflows.handle.steps.StakePeriodChanges;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.hedera.node.config.types.BlockStreamWriterMode;
 import com.hedera.node.config.types.StreamMode;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.system.InitTrigger;
@@ -69,6 +73,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -182,7 +187,7 @@ class HandleWorkflowTest {
         given(round.getConsensusTimestamp()).willReturn(Instant.ofEpochSecond(12345L));
         given(blockRecordManager.consTimeOfLastHandledTxn()).willReturn(NOW);
 
-        givenSubjectWith(RECORDS, emptyList());
+        givenSubjectWith(RECORDS, BlockStreamWriterMode.FILE, emptyList());
 
         subject.handleRound(state, round, txns -> {});
 
@@ -200,7 +205,7 @@ class HandleWorkflowTest {
         final var secondBuilder =
                 StateChanges.newBuilder().stateChanges(List.of(StateChange.DEFAULT, StateChange.DEFAULT));
         final var builders = List.of(firstBuilder, secondBuilder);
-        givenSubjectWith(BOTH, builders);
+        givenSubjectWith(BOTH, BlockStreamWriterMode.FILE, builders);
 
         subject.handleRound(state, round, txns -> {});
 
@@ -230,7 +235,7 @@ class HandleWorkflowTest {
                 .willReturn(List.<ConsensusTransaction>of().iterator());
 
         // Create subject with BLOCKS mode
-        givenSubjectWith(StreamMode.BLOCKS, List.of());
+        givenSubjectWith(StreamMode.BLOCKS, BlockStreamWriterMode.FILE, List.of());
 
         // WHEN
         subject.handleRound(state, round, txns -> {});
@@ -281,7 +286,7 @@ class HandleWorkflowTest {
         given(round.iterator()).willReturn(List.of(event).iterator());
 
         // Create subject with BLOCKS mode
-        givenSubjectWith(StreamMode.BLOCKS, List.of());
+        givenSubjectWith(StreamMode.BLOCKS, BlockStreamWriterMode.FILE, List.of());
 
         // WHEN
         subject.handleRound(state, round, txns -> {});
@@ -338,7 +343,7 @@ class HandleWorkflowTest {
         given(round.iterator()).willReturn(List.of(event).iterator());
 
         // Create subject with BLOCKS mode
-        givenSubjectWith(StreamMode.BLOCKS, List.of());
+        givenSubjectWith(StreamMode.BLOCKS, BlockStreamWriterMode.FILE, List.of());
 
         // WHEN
         subject.handleRound(state, round, txns -> {});
@@ -404,7 +409,7 @@ class HandleWorkflowTest {
         given(round.iterator()).willReturn(List.of(event).iterator());
 
         // Create subject with BLOCKS mode
-        givenSubjectWith(StreamMode.BLOCKS, List.of());
+        givenSubjectWith(StreamMode.BLOCKS, BlockStreamWriterMode.FILE, List.of());
 
         // WHEN
         subject.handleRound(state, round, txns -> {});
@@ -438,9 +443,12 @@ class HandleWorkflowTest {
     }
 
     private void givenSubjectWith(
-            @NonNull final StreamMode mode, @NonNull final List<StateChanges.Builder> migrationStateChanges) {
+            @NonNull final StreamMode mode,
+            @NonNull BlockStreamWriterMode streamWriterMode,
+            @NonNull final List<StateChanges.Builder> migrationStateChanges) {
         final var config = HederaTestConfigBuilder.create()
                 .withValue("blockStream.streamMode", "" + mode)
+                .withValue("blockStream.writerMode", "" + streamWriterMode)
                 .withValue("tss.hintsEnabled", "false")
                 .withValue("tss.historyEnabled", "false")
                 .getOrCreateConfig();
@@ -476,5 +484,61 @@ class HandleWorkflowTest {
                 blockHashSigner,
                 null,
                 nodeRewardManager);
+    }
+
+    @Test
+    void startRoundShouldCallEnsureNewBlocksPermittedWhenStreamingToBlockNodesEnabled() {
+        // Mock the round iterator and event
+        NodeId creatorId = NodeId.of(0);
+        Hash eventHash = CryptoRandomUtils.randomHash();
+        given(event.getHash()).willReturn(eventHash);
+        given(event.getCreatorId()).willReturn(creatorId);
+        given(event.getEventCore()).willReturn(EventCore.DEFAULT);
+        given(event.getSignature()).willReturn(Bytes.wrap(new byte[64]));
+        given(event.allParentsIterator())
+                .willReturn(List.<EventDescriptorWrapper>of().iterator());
+        given(networkInfo.nodeInfo(creatorId.id())).willReturn(mock(NodeInfo.class));
+        given(event.consensusTransactionIterator()).willReturn(emptyIterator());
+        given(round.iterator()).willReturn(List.of(event).iterator());
+
+        // Create subject with streamToBlockNodes enabled
+        givenSubjectWith(BOTH, BlockStreamWriterMode.FILE_AND_GRPC, emptyList());
+
+        // Use a static mock to verify the static method call
+        try (MockedStatic<BlockStreamStateManager> mockedStatic = mockStatic(BlockStreamStateManager.class)) {
+            // Execute the method
+            subject.handleRound(state, round, txn -> {});
+
+            // Verify that ensureNewBlocksPermitted was called
+            mockedStatic.verify(() -> BlockStreamStateManager.ensureNewBlocksPermitted());
+        }
+    }
+
+    @Test
+    void startRoundShouldNotCallEnsureNewBlocksPermittedWhenStreamingToBlockNodesDisabled() {
+        // Mock the round iterator and event
+        NodeId creatorId = NodeId.of(0);
+        Hash eventHash = CryptoRandomUtils.randomHash();
+        given(event.getHash()).willReturn(eventHash);
+        given(event.getCreatorId()).willReturn(creatorId);
+        given(event.getEventCore()).willReturn(EventCore.DEFAULT);
+        given(event.getSignature()).willReturn(Bytes.wrap(new byte[64]));
+        given(event.allParentsIterator())
+                .willReturn(List.<EventDescriptorWrapper>of().iterator());
+        given(networkInfo.nodeInfo(creatorId.id())).willReturn(mock(NodeInfo.class));
+        given(event.consensusTransactionIterator()).willReturn(emptyIterator());
+        given(round.iterator()).willReturn(List.of(event).iterator());
+
+        // Create subject with streamToBlockNodes disabled
+        givenSubjectWith(BOTH, BlockStreamWriterMode.FILE, emptyList());
+
+        // Use a static mock to verify the static method call
+        try (MockedStatic<BlockStreamStateManager> mockedStatic = mockStatic(BlockStreamStateManager.class)) {
+            // Execute the method
+            subject.handleRound(state, round, txn -> {});
+
+            // Verify that ensureNewBlocksPermitted was NOT called
+            mockedStatic.verify(() -> BlockStreamStateManager.ensureNewBlocksPermitted(), never());
+        }
     }
 }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

Added `blockStream.writerMode` feature flag checks in `BlockStreamStateManager` and `HandleWorkflow`.

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/19136

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
