### PR TITLE
chore: Node account id shard realm

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -124,8 +124,7 @@ public abstract class HapiSpecOperation implements SpecOperation {
     protected Optional<String> metadata = Optional.empty();
     protected Optional<String> payer = Optional.empty();
     protected Optional<Boolean> genRecord = Optional.empty();
-    protected Optional<AccountID> node = Optional.empty();
-    protected Optional<String> nodeNum = Optional.empty();
+    protected Optional<String> node = Optional.empty();
     protected Optional<Supplier<AccountID>> nodeSupplier = Optional.empty();
     protected OptionalDouble usdFee = OptionalDouble.empty();
     protected Optional<Integer> retryLimits = Optional.empty();
@@ -170,8 +169,7 @@ public abstract class HapiSpecOperation implements SpecOperation {
     }
 
     protected AccountID targetNodeFor(final HapiSpec spec) {
-        fixNodeFor(spec);
-        return node.get();
+        return fixNodeFor(spec);
     }
 
     protected void configureTlsFor(final HapiSpec spec) {
@@ -184,18 +182,17 @@ public abstract class HapiSpecOperation implements SpecOperation {
                 : spec.setup().txnProtoStructure();
     }
 
-    protected void fixNodeFor(final HapiSpec spec) {
-        nodeNum.ifPresent(s -> node = Optional.of(asId(s, spec)));
+    protected AccountID fixNodeFor(final HapiSpec spec) {
         if (node.isPresent()) {
-            return;
+            return asId(node.get(), spec);
         }
         if (nodeSupplier.isPresent()) {
-            node = Optional.of(nodeSupplier.get().get());
+            return nodeSupplier.get().get();
         } else {
             if (spec.setup().nodeSelector() == HapiSpecSetup.NodeSelection.RANDOM) {
-                node = Optional.of(randomNodeFrom(spec));
+                return randomNodeFrom(spec);
             } else {
-                node = Optional.of(spec.setup().defaultNode());
+                return spec.setup().defaultNode();
             }
         }
     }
@@ -275,7 +272,7 @@ public abstract class HapiSpecOperation implements SpecOperation {
             if (omitNodeAccount) {
                 builder.clearNodeAccountID();
             } else {
-                node.ifPresent(builder::setNodeAccountID);
+                node.ifPresent((s) -> builder.setNodeAccountID(fixNodeFor(spec)));
             }
             validDurationSecs.ifPresent(s -> builder.setTransactionValidDuration(
                     Duration.newBuilder().setSeconds(s).build()));
@@ -452,7 +449,7 @@ public abstract class HapiSpecOperation implements SpecOperation {
             helper.add("sigs", FeeBuilder.getSignatureCount(txnSubmitted));
         }
         payer.ifPresent(a -> helper.add("payer", a));
-        node.ifPresent(id -> helper.add("node", HapiPropertySource.asAccountString(id)));
+        node.ifPresent(id -> helper.add("node", id));
         return helper;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/queries/HapiQueryOp.java
@@ -173,7 +173,6 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
 
     @Override
     protected boolean submitOp(HapiSpec spec) throws Throwable {
-        fixNodeFor(spec);
         configureTlsFor(spec);
 
         Transaction payment = Transaction.getDefaultInstance();
@@ -434,7 +433,7 @@ public abstract class HapiQueryOp<T extends HapiQueryOp<T>> extends HapiSpecOper
     }
 
     public T setNode(String accountNum) {
-        nodeNum = Optional.of(accountNum);
+        node = Optional.of(accountNum);
         return self();
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -182,7 +182,6 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
 
     @Override
     protected boolean submitOp(HapiSpec spec) throws Throwable {
-        fixNodeFor(spec);
         configureTlsFor(spec);
         int retryCount = 1;
         while (true) {
@@ -783,18 +782,13 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
         return self();
     }
 
-    public T setNodeId(AccountID account) {
-        node = Optional.of(account);
-        return self();
-    }
-
     public T setNode(String accountNum) {
-        nodeNum = Optional.of(accountNum);
+        node = Optional.of(accountNum);
         return self();
     }
 
     public T setNode(long accountNum) {
-        nodeNum = Optional.of(Long.toString(accountNum));
+        node = Optional.of(Long.toString(accountNum));
         return self();
     }
 
@@ -895,11 +889,7 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
         return self();
     }
 
-    public Optional<AccountID> getNode() {
+    public Optional<String> getNode() {
         return node;
-    }
-
-    public Optional<String> getNodeNum() {
-        return nodeNum;
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
@@ -18,7 +18,6 @@ import com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts;
 import com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts;
 import com.hedera.services.bdd.spec.infrastructure.meta.ActionableContractCall;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCallTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
@@ -238,10 +237,6 @@ public class HapiContractCall extends HapiBaseCall<HapiContractCall> {
 
     public Optional<String> getCustomTxnId() {
         return customTxnId;
-    }
-
-    public Optional<AccountID> getNode() {
-        return node;
     }
 
     public OptionalDouble getUsdFee() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCreate.java
@@ -17,7 +17,6 @@ import com.hedera.services.bdd.spec.infrastructure.HapiSpecRegistry;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
-import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractCreateTransactionBody;
 import com.hederahashgraph.api.proto.java.ContractGetInfoResponse;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -451,10 +450,6 @@ public class HapiContractCreate extends HapiBaseContractCreate<HapiContractCreat
 
     public Optional<String> getCustomTxnId() {
         return customTxnId;
-    }
-
-    public Optional<AccountID> getNode() {
-        return node;
     }
 
     public OptionalDouble getUsdFee() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/network/HapiUncheckedSubmit.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/network/HapiUncheckedSubmit.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.transactions.network;
 
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.UncheckedSubmit;
 
 import com.google.common.base.MoreObjects;
@@ -39,9 +38,6 @@ public class HapiUncheckedSubmit<T extends HapiTxnOp<T>> extends HapiTxnOp<HapiU
 
     @Override
     protected Consumer<TransactionBody.Builder> opBodyDef(final HapiSpec spec) throws Throwable {
-        if (subOp.getNodeNum().isPresent()) {
-            subOp.setNodeId(asId(subOp.getNodeNum().get(), spec));
-        }
         final var subOpBytes = subOp.serializeSignedTxnFor(spec);
         if (verboseLoggingOn) {
             log.info("Submitting unchecked: {}", CommonUtils.extractTransactionBody(Transaction.parseFrom(subOpBytes)));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/util/HapiAtomicBatch.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/util/HapiAtomicBatch.java
@@ -2,7 +2,6 @@
 package com.hedera.services.bdd.spec.transactions.util;
 
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.extractTxnId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.txnToString;
@@ -78,8 +77,10 @@ public class HapiAtomicBatch extends HapiTxnOp<HapiAtomicBatch> {
                         AtomicBatchTransactionBody.class, b -> {
                             for (HapiTxnOp<?> op : operationsToBatch) {
                                 try {
-                                    // If the node num is not set, set the ID to 0.0.0
-                                    setInnerTxnNodeID(spec, op);
+                                    // set node account id to 0.0.0 if not set
+                                    if (op.getNode().isEmpty()) {
+                                        op.setNode(DEFAULT_NODE_ACCOUNT_ID);
+                                    }
                                     // create a transaction for each operation
                                     final var transaction = op.signedTxnFor(spec);
                                     if (!loggingOff) {
@@ -171,17 +172,6 @@ public class HapiAtomicBatch extends HapiTxnOp<HapiAtomicBatch> {
             if (consensus2.getNanos() <= consensus1.getNanos()) {
                 throw new IllegalArgumentException("Invalid execution order");
             }
-        }
-    }
-
-    private void setInnerTxnNodeID(HapiSpec spec, HapiTxnOp<?> op) {
-        // Set node ID for inner transactions
-        if (op.getNodeNum().isPresent()) {
-            op.setNodeId(asId(op.getNodeNum().get(), spec));
-        }
-        // set node account id to 0.0.0 if not set
-        if (op.getNode().isEmpty()) {
-            op.setNodeId(asId(DEFAULT_NODE_ACCOUNT_ID, spec));
         }
     }
 }


### PR DESCRIPTION

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
Refactor `HapiSpecOperation` :
* Remove `protected Optional<String> nodeNum = Optional.empty();`
* Update `protected Optional<String> node = Optional.empty();` so any operation can set node as string. This way we can pass ID literals, account number literal or spec registry key.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
