### PR TITLE
fix: Fix the `transactionFee` in the record for `ConsensusSubmitMessage` with custom fees

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/DispatchOptions.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/DispatchOptions.java
@@ -334,7 +334,7 @@ public record DispatchOptions<T extends StreamBuilder>(
                 ReversingBehavior.REMOVABLE,
                 transactionCustomizer,
                 metaData,
-                null);
+                NOOP_FEE_CHARGING);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/TopicCustomFeeSubmitMessageTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/TopicCustomFeeSubmitMessageTest.java
@@ -53,6 +53,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CUSTOM_FEE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_VALID_MAX_CUSTOM_FEE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.services.bdd.junit.HapiTest;
@@ -67,6 +68,7 @@ import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenID;
 import com.hederahashgraph.api.proto.java.TokenType;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -1834,6 +1836,7 @@ public class TopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                                 .hasNonStakingChildRecordCount(0)
                                 .logged();
                         allRunFor(spec, submitTxnRecord);
+                        validateTransactionFees(submitTxnRecord.getResponseRecord());
                     }),
                     // assert topic fee collector balance
                     getAccountBalance(collector).hasTokenBalance(tokenName, 1),
@@ -1841,6 +1844,14 @@ public class TopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
                     getAccountBalance(denomCollector)
                             .hasTokenBalance(denomToken, 1)
                             .hasTinyBars(ONE_HBAR)));
+        }
+
+        private void validateTransactionFees(final TransactionRecord record) {
+            final var feeCreditSum = record.getTransferList().getAccountAmountsList().stream()
+                    .filter(aa -> aa.getAccountID().getAccountNum() < 1000)
+                    .mapToInt(aa -> (int) aa.getAmount())
+                    .sum();
+            assertEquals(record.getTransactionFee(), feeCreditSum);
         }
 
         @HapiTest


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/19197

Removes extra charging of the synthetic `CryptoTransfer` to assess custom fee when a `ConsensusSubmitMessage` for a topic with custom fees is submitted. 
Also, fixes the `transactionFee` in the record to be same as the credits to fee collection accounts.