### PR TITLE
fix: Fix the transactionFee in the record for ConsensusSubmitMessage with custom fees

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/DispatchOptions.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/DispatchOptions.java
@@ -334,7 +334,7 @@ public record DispatchOptions<T extends StreamBuilder>(
                 ReversingBehavior.REMOVABLE,
                 transactionCustomizer,
                 metaData,
-                null);
+                NOOP_FEE_CHARGING);
     }
 
     /**


### PR DESCRIPTION
Cherry-pick https://github.com/hiero-ledger/hiero-consensus-node/pull/19195

Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/19197

Removes extra charging of the synthetic `CryptoTransfer` to assess custom fee when a `ConsensusSubmitMessage` for a topic with custom fees is submitted. 
Also, fixes the `transactionFee` in the record to be same as the credits to fee collection accounts.