### PR TITLE
feat: Enable Birth Rounds as Ancient Threshold

### DIFF
--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/config/EventConfig.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/config/EventConfig.java
@@ -24,7 +24,7 @@ public record EventConfig(
         @ConfigProperty(defaultValue = "5") long eventsLogPeriod,
         @ConfigProperty(defaultValue = "/opt/hgcapp/eventsStreams") String eventsLogDir,
         @ConfigProperty(defaultValue = "true") boolean enableEventStreaming,
-        @ConfigProperty(defaultValue = "false") boolean useBirthRoundAncientThreshold) {
+        @ConfigProperty(defaultValue = "true") boolean useBirthRoundAncientThreshold) {
 
     /**
      * @return the {@link AncientMode} based on useBirthRoundAncientThreshold

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/preconsensus/DefaultInlinePcesWriterTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/preconsensus/DefaultInlinePcesWriterTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.event.preconsensus;
 
+import static org.hiero.consensus.model.event.AncientMode.BIRTH_ROUND_THRESHOLD;
 import static org.hiero.consensus.model.event.AncientMode.GENERATION_THRESHOLD;
 
 import com.swirlds.base.test.fixtures.time.FakeTime;
@@ -18,6 +19,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import org.hiero.base.utility.test.fixtures.RandomUtils;
+import org.hiero.consensus.config.EventConfig_;
 import org.hiero.consensus.model.event.AncientMode;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
@@ -40,6 +42,7 @@ class DefaultInlinePcesWriterTest {
     @BeforeEach
     void beforeEach() {
         final Configuration configuration = new TestConfigBuilder()
+                .withValue(EventConfig_.USE_BIRTH_ROUND_ANCIENT_THRESHOLD, ancientMode == BIRTH_ROUND_THRESHOLD)
                 .withValue(PcesConfig_.DATABASE_DIRECTORY, tempDir.toString())
                 .getOrCreateConfig();
         platformContext = buildContext(configuration);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/ShadowGraphTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/sync/ShadowGraphTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.platform.gossip.NoOpIntakeEventCounter;
 import com.swirlds.platform.gossip.shadowgraph.ReservedEventWindow;
 import com.swirlds.platform.gossip.shadowgraph.ShadowEvent;
@@ -38,6 +39,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.utility.test.fixtures.RandomUtils;
+import org.hiero.consensus.config.EventConfig_;
 import org.hiero.consensus.model.event.EventDescriptorWrapper;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
@@ -78,8 +80,11 @@ class ShadowgraphTest {
     }
 
     private void initShadowgraph(final Random random, final int numEvents, final int numNodes) {
-        final PlatformContext platformContext =
-                TestPlatformContextBuilder.create().build();
+        final PlatformContext platformContext = TestPlatformContextBuilder.create()
+                .withConfiguration(new TestConfigBuilder()
+                        .withValue(EventConfig_.USE_BIRTH_ROUND_ANCIENT_THRESHOLD, "false")
+                        .getOrCreateConfig())
+                .build();
 
         emitter = EventEmitterBuilder.newBuilder()
                 .setRandomSeed(random.nextLong())


### PR DESCRIPTION
**Description**:
Enables birth rounds as the definition of the ancient threshold.

**Related issue(s)**:

Fixes #10023

