### PR TITLE
chore: (cherry-pick) Disable `AtomicBatch` feature

### DIFF
--- a/hedera-node/configuration/dev/api-permission.properties
+++ b/hedera-node/configuration/dev/api-permission.properties
@@ -1,4 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
+
 # Crypto
 createAccount=0-*
 cryptoTransfer=0-*
@@ -61,7 +62,7 @@ tokenFeeScheduleUpdate=0-*
 tokenPause=0-*
 tokenUnpause=0-*
 tokenGetNftInfos=0-*
-# Network 
+# Network
 getVersionInfo=0-*
 systemDelete=2-59
 systemUndelete=2-60
@@ -69,3 +70,5 @@ freeze=2-58
 uncheckedSubmit=2-50
 networkGetExecutionTime=2-50
 getAccountDetails=2-50
+# Batch
+atomicBatch=0-*

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ApiPermissionConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ApiPermissionConfig.java
@@ -198,7 +198,7 @@ public record ApiPermissionConfig(
         @ConfigProperty(defaultValue = "0-*") PermissionedAccountsRange approveAllowances,
         @ConfigProperty(defaultValue = "0-*") PermissionedAccountsRange deleteAllowances,
         @ConfigProperty(defaultValue = "0-*") PermissionedAccountsRange utilPrng,
-        @ConfigProperty(defaultValue = "0-*") PermissionedAccountsRange atomicBatch,
+        @ConfigProperty(defaultValue = "0-0") PermissionedAccountsRange atomicBatch,
         @ConfigProperty(defaultValue = "0-*") PermissionedAccountsRange createFile,
         @ConfigProperty(defaultValue = "0-*") PermissionedAccountsRange updateFile,
         @ConfigProperty(defaultValue = "0-*") PermissionedAccountsRange deleteFile,

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AtomicBatchConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AtomicBatchConfig.java
@@ -8,6 +8,6 @@ import com.swirlds.config.api.ConfigProperty;
 
 @ConfigData("atomicBatch")
 public record AtomicBatchConfig(
-        @ConfigProperty(defaultValue = "true") @NetworkProperty boolean isEnabled,
+        @ConfigProperty(defaultValue = "false") @NetworkProperty boolean isEnabled,
         @ConfigProperty(defaultValue = "50") @NetworkProperty long maxNumberOfTransactions,
         @ConfigProperty(defaultValue = "Freeze,AtomicBatch") @NetworkProperty HederaFunctionalitySet blacklist) {}

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AtomicBatchConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/AtomicBatchConfig.java
@@ -9,5 +9,5 @@ import com.swirlds.config.api.ConfigProperty;
 @ConfigData("atomicBatch")
 public record AtomicBatchConfig(
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean isEnabled,
-        @ConfigProperty(defaultValue = "50") @NetworkProperty long maxNumberOfTransactions,
+        @ConfigProperty(defaultValue = "0") @NetworkProperty long maxNumberOfTransactions,
         @ConfigProperty(defaultValue = "Freeze,AtomicBatch") @NetworkProperty HederaFunctionalitySet blacklist) {}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedNode.java
@@ -63,6 +63,12 @@ public class EmbeddedNode extends AbstractLocalNode<EmbeddedNode> implements Hed
         System.setProperty(
                 "bootstrap.nodeAdminKeys.path",
                 getExternalPath(NODE_ADMIN_KEYS_JSON).toAbsolutePath().toString());
+        System.setProperty(
+                "bootstrap.hapiPermissions.path",
+                getExternalPath(DATA_CONFIG_DIR)
+                        .resolve("api-permission.properties")
+                        .toAbsolutePath()
+                        .toString());
         System.setProperty("hedera.profiles.active", "DEV");
 
         // We get the shard/realm from the metadata account which is coming from the property file

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/MiscellaneousFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/MiscellaneousFeesSuite.java
@@ -12,6 +12,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.hapiPrng;
 import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.handleAnyRepeatableQueryPayment;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingAllOf;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
@@ -20,6 +21,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.RepeatableHapiTest;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -93,7 +95,7 @@ public class MiscellaneousFeesSuite {
                 validateChargedUsd(baseTransactionGetRecord, BASE_FEE_MISC_GET_TRX_RECORD));
     }
 
-    @HapiTest
+    @LeakyHapiTest(overrides = {"atomicBatch.isEnabled"})
     @DisplayName("USD base fee as expected for atomic batch transaction")
     public Stream<DynamicTest> validateAtomicBatchBaseUSDFee() {
         final var batchOperator = "batchOperator";
@@ -101,6 +103,7 @@ public class MiscellaneousFeesSuite {
         final var innerTxn = cryptoCreate("foo").balance(ONE_HBAR).batchKey(batchOperator);
 
         return hapiTest(
+                overriding("atomicBatch.isEnabled", "true"),
                 cryptoCreate(batchOperator).balance(ONE_HBAR),
                 atomicBatch(innerTxn).payingWith(batchOperator).via("batchTxn"),
                 validateChargedUsd("batchTxn", BASE_FEE_ATOMIC_BATCH));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/MiscellaneousFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/MiscellaneousFeesSuite.java
@@ -12,8 +12,8 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.hapiPrng;
 import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.handleAnyRepeatableQueryPayment;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingAllOf;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedUsd;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_BILLION_HBARS;
@@ -95,7 +95,7 @@ public class MiscellaneousFeesSuite {
                 validateChargedUsd(baseTransactionGetRecord, BASE_FEE_MISC_GET_TRX_RECORD));
     }
 
-    @LeakyHapiTest(overrides = {"atomicBatch.isEnabled"})
+    @LeakyHapiTest(overrides = {"atomicBatch.isEnabled", "atomicBatch.maxNumberOfTransactions"})
     @DisplayName("USD base fee as expected for atomic batch transaction")
     public Stream<DynamicTest> validateAtomicBatchBaseUSDFee() {
         final var batchOperator = "batchOperator";
@@ -103,7 +103,7 @@ public class MiscellaneousFeesSuite {
         final var innerTxn = cryptoCreate("foo").balance(ONE_HBAR).batchKey(batchOperator);
 
         return hapiTest(
-                overriding("atomicBatch.isEnabled", "true"),
+                overridingTwo("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"),
                 cryptoCreate(batchOperator).balance(ONE_HBAR),
                 atomicBatch(innerTxn).payingWith(batchOperator).via("batchTxn"),
                 validateChargedUsd("batchTxn", BASE_FEE_ATOMIC_BATCH));

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
@@ -63,15 +63,19 @@ import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.Timestamp;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -79,6 +83,11 @@ import org.junit.jupiter.api.Nested;
 
 @HapiTestLifecycle
 public class AtomicBatchNegativeTest {
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true"));
+    }
 
     @Nested
     @DisplayName("Order and Execution - NEGATIVE")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
@@ -86,7 +86,8 @@ public class AtomicBatchNegativeTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true"));
+        testLifecycle.overrideInClass(
+                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchTest.java
@@ -75,7 +75,8 @@ public class AtomicBatchTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true"));
+        testLifecycle.overrideInClass(
+                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchTest.java
@@ -58,17 +58,25 @@ import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hederahashgraph.api.proto.java.Timestamp;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 
 @HapiTestLifecycle
 public class AtomicBatchTest {
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true"));
+    }
 
     @HapiTest
     @DisplayName("Validate batch transaction passed")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/ConcurrentIntegrationTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/ConcurrentIntegrationTests.java
@@ -37,6 +37,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createHollow;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeUpgrade;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.mutateNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.prepareUpgrade;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateSpecialFile;
@@ -137,7 +138,7 @@ public class ConcurrentIntegrationTests {
             @NonFungibleToken(numPreMints = 10) SpecNonFungibleToken nftTwo) {
         final List<SortedMap<AccountID, Long>> successfulRecordFees = new ArrayList<>();
         return hapiTest(
-                overriding("atomicBatch.isEnabled", "true"),
+                overridingTwo("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"),
                 cryptoCreate("operator").maxAutomaticTokenAssociations(2),
                 nftOne.doWith(
                         token -> cryptoTransfer(movingUnique(nftOne.name(), 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/ConcurrentIntegrationTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/ConcurrentIntegrationTests.java
@@ -131,12 +131,13 @@ public class ConcurrentIntegrationTests {
                 getAccountInfo("hollowAccount").isNotHollow());
     }
 
-    @LeakyHapiTest(overrides = {"ledger.nftTransfers.maxLen"})
+    @LeakyHapiTest(overrides = {"ledger.nftTransfers.maxLen", "atomicBatch.isEnabled"})
     final Stream<DynamicTest> chargedFeesReplayedAfterBatchFailure(
             @NonFungibleToken(numPreMints = 10) SpecNonFungibleToken nftOne,
             @NonFungibleToken(numPreMints = 10) SpecNonFungibleToken nftTwo) {
         final List<SortedMap<AccountID, Long>> successfulRecordFees = new ArrayList<>();
         return hapiTest(
+                overriding("atomicBatch.isEnabled", "true"),
                 cryptoCreate("operator").maxAutomaticTokenAssociations(2),
                 nftOne.doWith(
                         token -> cryptoTransfer(movingUnique(nftOne.name(), 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip423Tests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip423Tests.java
@@ -86,6 +86,7 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingAllOf;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThrottles;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.scheduledExecutionResult;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepForSeconds;
@@ -1719,7 +1720,7 @@ public class RepeatableHip423Tests {
 
     @LeakyRepeatableHapiTest(
             value = NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION,
-            overrides = {"atomicBatch.isEnabled"})
+            overrides = {"atomicBatch.isEnabled", "atomicBatch.maxNumberOfTransactions"})
     @DisplayName("Failing batch will trigger schedule")
     // BATCH_14
     final Stream<DynamicTest> failingBatchWillTriggerSchedule() {
@@ -1728,7 +1729,7 @@ public class RepeatableHip423Tests {
         final var schedule = "scheduledXfer";
         final var batchOperator = "batchOperator";
         return hapiTest(
-                overriding("atomicBatch.isEnabled", "true"),
+                overridingTwo("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"),
                 cryptoCreate(batchOperator),
                 cryptoCreate(sender).balance(ONE_HBAR).via("createSender"),
                 cryptoCreate(receiver).balance(0L),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip423Tests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip423Tests.java
@@ -1717,7 +1717,9 @@ public class RepeatableHip423Tests {
                         .hasKnownStatus(SCHEDULE_EXPIRY_IS_BUSY));
     }
 
-    @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
+    @LeakyRepeatableHapiTest(
+            value = NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION,
+            overrides = {"atomicBatch.isEnabled"})
     @DisplayName("Failing batch will trigger schedule")
     // BATCH_14
     final Stream<DynamicTest> failingBatchWillTriggerSchedule() {
@@ -1726,6 +1728,7 @@ public class RepeatableHip423Tests {
         final var schedule = "scheduledXfer";
         final var batchOperator = "batchOperator";
         return hapiTest(
+                overriding("atomicBatch.isEnabled", "true"),
                 cryptoCreate(batchOperator),
                 cryptoCreate(sender).balance(ONE_HBAR).via("createSender"),
                 cryptoCreate(receiver).balance(0L),


### PR DESCRIPTION
Fixes #19146 

Cherry-pick 
https://github.com/hiero-ledger/hiero-consensus-node/pull/19115
https://github.com/hiero-ledger/hiero-consensus-node/pull/19130

- Disables AtomicBatch feature by default and enables only in dev environment.