### PR TITLE
chore: Always register all classes in org.hiero in ConstructableRegistry

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/FileSignTool.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/FileSignTool.java
@@ -231,7 +231,7 @@ public class FileSignTool {
     public static void prepare(final StreamType streamType) throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
 
         if (streamType.getExtension().equalsIgnoreCase(RECORD_STREAM_EXTENSION)) {
             LOGGER.info(MARKER, "registering Constructables for parsing record stream files");

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/RecordBlockNumberTool.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/exports/RecordBlockNumberTool.java
@@ -48,7 +48,7 @@ public class RecordBlockNumberTool {
     public static void prepare() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
 
         LOGGER.info(MARKER, "registering Constructables for parsing record stream files");
         // if we are parsing new record stream files,

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasher.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/java/com/swirlds/demo/virtualmerkle/VirtualMerkleLeafHasher.java
@@ -139,7 +139,7 @@ public class VirtualMerkleLeafHasher<K extends VirtualKey, V extends VirtualValu
             registry.registerConstructables("com.swirlds.merkledb");
             registry.registerConstructables("com.swirlds.demo.virtualmerkle");
             registry.registerConstructables("com.swirlds.common.crypto");
-            registry.registerConstructables("org.hiero.consensus.model.crypto");
+            registry.registerConstructables("org.hiero");
         } catch (final ConstructableRegistryException e) {
             e.printStackTrace();
             return;

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/ControlActionTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/ControlActionTest.java
@@ -19,7 +19,7 @@ public class ControlActionTest {
     public static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     @Test

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/MapValueSerializableTest.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/test/java/com/swirlds/demo/platform/MapValueSerializableTest.java
@@ -65,7 +65,7 @@ class MapValueSerializableTest {
     public static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         cryptography = TestMerkleCryptoFactory.getInstance();
     }
 

--- a/platform-sdk/platform-apps/tests/PlatformTestingTool/src/timingSensitive/java/com/swirlds/demo/merkle/map/MapValueFCQTests.java
+++ b/platform-sdk/platform-apps/tests/PlatformTestingTool/src/timingSensitive/java/com/swirlds/demo/merkle/map/MapValueFCQTests.java
@@ -62,7 +62,7 @@ public class MapValueFCQTests {
     public static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         cryptography = TestMerkleCryptoFactory.getInstance();
 
         mapKey = new MapKey(0, 0, random.nextLong());

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BaseBench.java
@@ -114,7 +114,7 @@ public abstract class BaseBench {
             registry.registerConstructables("com.swirlds.benchmark");
             registry.registerConstructables("com.swirlds.common.crypto");
             registry.registerConstructables("com.swirlds.common");
-            registry.registerConstructables("org.hiero.consensus");
+            registry.registerConstructables("org.hiero");
             registry.registerConstructable(
                     new ClassConstructorPair(BenchmarkMerkleInternal.class, BenchmarkMerkleInternal::new));
             registry.registerConstructable(new ClassConstructorPair(BenchmarkKey.class, BenchmarkKey::new));

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamObjectTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamObjectTest.java
@@ -69,7 +69,7 @@ class StreamObjectTest {
     static void setUp() throws ConstructableRegistryException, IOException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.base");
+        registry.registerConstructables("org.hiero");
     }
 
     static void clearDir() throws IOException {

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamUtilitiesTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/stream/StreamUtilitiesTest.java
@@ -100,7 +100,7 @@ class StreamUtilitiesTest {
     static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.base.crypto");
+        registry.registerConstructables("org.hiero");
     }
 
     private static File getResourceFile(final String path) {

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/MerkleCopyTests.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/MerkleCopyTests.java
@@ -41,7 +41,7 @@ class MerkleCopyTests {
     public static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.*");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     /**

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/MerklePathReplacementTests.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/MerklePathReplacementTests.java
@@ -41,7 +41,7 @@ class MerklePathReplacementTests {
     public static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.*");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     /**

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MMSerializeTests.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MMSerializeTests.java
@@ -35,7 +35,7 @@ class MMSerializeTests {
     public static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         cryptography = TestMerkleCryptoFactory.getInstance();
     }
 

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MerkleMapEntryKeyTests.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MerkleMapEntryKeyTests.java
@@ -112,7 +112,7 @@ class MerkleMapEntryKeyTests {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.merkle.map");
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
 
         final MerkleMapEntryKey<SerializableLong> key = new MerkleMapEntryKey<>(new SerializableLong(1));
 

--- a/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MerkleMapEntryTests.java
+++ b/platform-sdk/swirlds-merkle/src/test/java/com/swirlds/merkle/test/map/MerkleMapEntryTests.java
@@ -157,7 +157,7 @@ class MerkleMapEntryTests {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.merkle.map");
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
 
         final MerkleMapEntry<SerializableLong, KeyedMerkleLong<SerializableLong>> entry =
                 new MerkleMapEntry<>(new SerializableLong(1), new KeyedMerkleLong<>(1));

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSerializationTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSerializationTests.java
@@ -68,7 +68,7 @@ class MerkleSerializationTests {
     static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     private void resetDirectory() throws IOException {

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSynchronizationBenchmarks.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSynchronizationBenchmarks.java
@@ -43,7 +43,7 @@ public class MerkleSynchronizationBenchmarks {
     void registerClasses() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     /**

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSynchronizationTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/MerkleSynchronizationTests.java
@@ -57,7 +57,7 @@ public class MerkleSynchronizationTests {
         loadLog4jContext();
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     /**

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/map/MerkleMapMemoryBenchmark.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/map/MerkleMapMemoryBenchmark.java
@@ -27,7 +27,7 @@ class MerkleMapMemoryBenchmark {
         registry.registerConstructables("com.swirlds.MerkleMap");
         registry.registerConstructables("com.swirlds.merkletree");
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     /**

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/map/MerkleMapMemoryTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/map/MerkleMapMemoryTests.java
@@ -33,7 +33,7 @@ class MerkleMapMemoryTests {
     static void startup() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     /**

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/map/MerkleMapTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/map/MerkleMapTests.java
@@ -85,7 +85,7 @@ class MerkleMapTests {
         MerkleMapTestUtil.loadLogging();
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         cryptography = TestMerkleCryptoFactory.getInstance();
     }
 

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/tree/MerkleBinaryTreeTests.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/merkle/test/tree/MerkleBinaryTreeTests.java
@@ -124,7 +124,7 @@ class MerkleBinaryTreeTests {
     void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     protected Stream<Arguments> buildSizeArguments() {

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
@@ -132,7 +132,7 @@ public class VirtualMapReconnectTestBase {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
 
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         registry.registerConstructables("com.swirlds.virtualmap");
         registry.registerConstructable(new ClassConstructorPair(QueryResponse.class, QueryResponse::new));
         registry.registerConstructable(new ClassConstructorPair(DummyMerkleInternal.class, DummyMerkleInternal::new));

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/VirtualMapSerializationTests.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/VirtualMapSerializationTests.java
@@ -66,7 +66,7 @@ class VirtualMapSerializationTests {
         registry.registerConstructables("com.swirlds.merkledb");
         registry.registerConstructables("com.swirlds.virtualmap");
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         ConstructableRegistry.getInstance()
                 .registerConstructable(new ClassConstructorPair(
                         MerkleDbDataSourceBuilder.class, () -> new MerkleDbDataSourceBuilder(CONFIGURATION)));

--- a/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
+++ b/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbSnapshotTest.java
@@ -70,7 +70,7 @@ class MerkleDbSnapshotTest {
     static void setup() throws Exception {
         ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         registry.registerConstructables("com.swirlds.merkledb");
         registry.registerConstructables("com.swirlds.virtualmap");
         registry.registerConstructable(new ClassConstructorPair(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/SignedStateFileReadWriteTest.java
@@ -65,7 +65,7 @@ class SignedStateFileReadWriteTest {
         final var registry = ConstructableRegistry.getInstance();
         platformVersion =
                 SemanticVersion.newBuilder().major(RandomUtils.nextInt(1, 100)).build();
-        registry.registerConstructables("org.hiero.base.crypto");
+        registry.registerConstructables("org.hiero");
         registry.registerConstructables("com.swirlds.platform");
         registry.registerConstructables("com.swirlds.state");
         registry.registerConstructables("com.swirlds.virtualmap");

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/StateFileManagerTests.java
@@ -89,7 +89,7 @@ class StateFileManagerTests {
     static void beforeAll() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.base.crypto");
+        registry.registerConstructables("org.hiero");
         registerMerkleStateRootClassIds();
     }
 

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/CesEventTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/CesEventTest.java
@@ -18,7 +18,7 @@ public class CesEventTest {
     @BeforeAll
     public static void setUp() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     @Test

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
@@ -101,7 +101,7 @@ public abstract class VirtualMapReconnectTestBase {
         loadLog4jContext();
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         registry.registerConstructable(new ClassConstructorPair(DummyMerkleInternal.class, DummyMerkleInternal::new));
         registry.registerConstructable(new ClassConstructorPair(DummyMerkleLeaf.class, DummyMerkleLeaf::new));
         registry.registerConstructable(new ClassConstructorPair(VirtualMap.class, () -> new VirtualMap(CONFIGURATION)));

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamMultiFileIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamMultiFileIteratorTest.java
@@ -47,7 +47,7 @@ class EventStreamMultiFileIteratorTest {
     static void beforeAll() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     public static void assertEventsAreEqual(final CesEvent expected, final CesEvent actual) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamPathIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamPathIteratorTest.java
@@ -43,7 +43,7 @@ class EventStreamPathIteratorTest {
     static void beforeAll() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     @Test

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamRoundIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamRoundIteratorTest.java
@@ -45,7 +45,7 @@ class EventStreamRoundIteratorTest {
     static void beforeAll() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     public static void assertEventsAreEqual(final CesEvent expected, final CesEvent actual) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamSingleFileIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/EventStreamSingleFileIteratorTest.java
@@ -39,7 +39,7 @@ class EventStreamSingleFileIteratorTest {
     static void beforeAll() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     public static void assertEventsAreEqual(final CesEvent expected, final CesEvent actual) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/ObjectStreamIteratorTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/recovery/ObjectStreamIteratorTest.java
@@ -42,7 +42,7 @@ class ObjectStreamIteratorTest {
     static void beforeAll() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     public static void assertEventsAreEqual(final CesEvent expected, final CesEvent actual) {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/scratchpad/ScratchpadTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/scratchpad/ScratchpadTests.java
@@ -67,7 +67,7 @@ class ScratchpadTests {
     static void beforeAll() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
     }
 
     @Test

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/state/signed/StartupStateUtilsTests.java
@@ -93,7 +93,7 @@ public class StartupStateUtilsTests {
     static void beforeAll() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         registry.registerConstructable(new ClassConstructorPair(TestMerkleStateRoot.class, TestMerkleStateRoot::new));
     }
 

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleTestBase.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/MerkleTestBase.java
@@ -251,7 +251,7 @@ public class MerkleTestBase extends StateTestBase {
             registry.registerConstructables("com.swirlds.virtualmap");
             registry.registerConstructables("com.swirlds.common.merkle");
             registry.registerConstructables("com.swirlds.common");
-            registry.registerConstructables("org.hiero.base.crypto");
+            registry.registerConstructables("org.hiero");
             registry.registerConstructables("com.swirlds.merkle");
             registry.registerConstructables("com.swirlds.merkle.tree");
             ConstructableRegistry.getInstance()

--- a/platform-sdk/swirlds-virtualmap/src/jmh/java/com/swirlds/virtualmap/benchmark/reconnect/VirtualMapReconnectBenchBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/jmh/java/com/swirlds/virtualmap/benchmark/reconnect/VirtualMapReconnectBenchBase.java
@@ -68,7 +68,7 @@ public abstract class VirtualMapReconnectBenchBase {
         loadLog4jContext();
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         registry.registerConstructables("com.swirlds.virtualmap");
         registry.registerConstructable(new ClassConstructorPair(QueryResponse.class, QueryResponse::new));
         registry.registerConstructable(new ClassConstructorPair(DummyMerkleInternal.class, DummyMerkleInternal::new));

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/VirtualTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/VirtualTestBase.java
@@ -114,7 +114,7 @@ public class VirtualTestBase {
         // Ensure VirtualNodeCache.release() returns clean
         System.setProperty("syncCleaningPool", "true");
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
-        registry.registerConstructables("org.hiero.base.crypto");
+        registry.registerConstructables("org.hiero");
         registry.registerConstructables("com.swirlds.virtualmap");
         registry.registerConstructables("com.swirlds.virtualmap.test.fixtures");
         registry.registerConstructable(new ClassConstructorPair(TestKey.class, () -> new TestKey(0L)));

--- a/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
@@ -104,7 +104,7 @@ public abstract class VirtualMapReconnectTestBase {
         loadLog4jContext();
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructables("com.swirlds.common");
-        registry.registerConstructables("org.hiero.consensus");
+        registry.registerConstructables("org.hiero");
         registry.registerConstructable(new ClassConstructorPair(QueryResponse.class, QueryResponse::new));
         registry.registerConstructable(new ClassConstructorPair(DummyMerkleInternal.class, DummyMerkleInternal::new));
         registry.registerConstructable(new ClassConstructorPair(DummyMerkleLeaf.class, DummyMerkleLeaf::new));


### PR DESCRIPTION
**Description**:

This PR updates all places where we register a subpackage of `org.hiero` in the `ConstructableRegistry` to use `org.hiero` instead. This ensures we do not miss classes and break tests when moving them.

**Related issue(s)**:

Fixes #19228 
