### PR TITLE
feat: Support accepting/declining rewards in yahcli DAB transactions

### DIFF
--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/CreateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/CreateCommand.java
@@ -78,6 +78,14 @@ public class CreateCommand implements Callable<Integer> {
             paramLabel = "path to the admin key to use")
     String adminKeyPath;
 
+    @CommandLine.Option(
+            names = "--declineRewards",
+            paramLabel = "trigger indicating the node should decline reward payments; false otherwise",
+            arity = "0..1",
+            defaultValue = "true",
+            fallbackValue = "true")
+    Boolean declineRewards;
+
     @Override
     public Integer call() throws Exception {
         final var yahcli = nodesCommand.getYahcli();
@@ -96,6 +104,7 @@ public class CreateCommand implements Callable<Integer> {
                 gossipCaCertificatePath, gossipCaCertificatePfxPath, gossipCaCertificatePfxAlias, yahcli);
         // Throws if the cert is not valid
         validatedX509Cert(hapiCertificatePath, null, null, yahcli);
+        final boolean parsedDeclineRewards = declineRewards == null || declineRewards;
         final var delegate = new CreateNodeSuite(
                 config,
                 accountId,
@@ -105,7 +114,8 @@ public class CreateCommand implements Callable<Integer> {
                 gossipCert,
                 noThrowSha384HashOf(allBytesAt(Paths.get(hapiCertificatePath))),
                 adminKeyPath,
-                maybeFeeAccountKeyPath);
+                maybeFeeAccountKeyPath,
+                parsedDeclineRewards);
         delegate.runSuiteSync();
 
         if (delegate.getFinalSpecs().getFirst().getStatus() == HapiSpec.SpecStatus.PASSED) {

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/UpdateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/UpdateCommand.java
@@ -88,6 +88,16 @@ public class UpdateCommand implements Callable<Integer> {
             paramLabel = "path to the updated admin key to use")
     String newAdminKeyPath;
 
+    @CommandLine.Option(
+            names = {"--stop-declining-rewards", "--stopDecliningRewards"},
+            paramLabel = "triggers a node to begin accepting reward payments")
+    Boolean stopDecliningRewards;
+
+    @CommandLine.Option(
+            names = {"--start-declining-rewards", "--startDecliningRewards"},
+            paramLabel = "triggers a node to begin declining reward payments")
+    Boolean startDecliningRewards;
+
     @Override
     public Integer call() throws Exception {
         final var yahcli = nodesCommand.getYahcli();
@@ -145,6 +155,12 @@ public class UpdateCommand implements Callable<Integer> {
         } else {
             newHapiCertificateHash = null;
         }
+        Boolean declineReward = null;
+        if (startDecliningRewards != null) {
+            declineReward = Boolean.TRUE;
+        } else if (stopDecliningRewards != null) {
+            declineReward = Boolean.FALSE;
+        }
         final var delegate = new UpdateNodeSuite(
                 config,
                 targetNodeId,
@@ -156,7 +172,8 @@ public class UpdateCommand implements Callable<Integer> {
                 newGossipEndpoints,
                 newHapiEndpoints,
                 newGossipCaCertificate,
-                newHapiCertificateHash);
+                newHapiCertificateHash,
+                declineReward);
         delegate.runSuiteSync();
 
         if (delegate.getFinalSpecs().getFirst().getStatus() == HapiSpec.SpecStatus.PASSED) {

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/domain/NetConfig.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/domain/NetConfig.java
@@ -96,7 +96,7 @@ public class NetConfig {
     public String toString() {
         return MoreObjects.toStringHelper(this)
                 .add("defaultPayer", defaultPayer)
-                .add("defaultNodeAccount", asEntityString(shard, realm, defaultNodeAccount))
+                .add("defaultNodeAccount", asEntityString(getShard(), getRealm(), defaultNodeAccount))
                 .add("nodes", nodes)
                 .add("allowedReceiverAccountIds", allowedReceiverAccountIds)
                 .add("shard", shard)

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/CreateNodeSuite.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/CreateNodeSuite.java
@@ -34,6 +34,8 @@ public class CreateNodeSuite extends HapiSuite {
     @Nullable
     private final String feeAccountKeyLoc;
 
+    private final boolean declineRewards;
+
     private final List<ServiceEndpoint> gossipEndpoints;
     private final List<ServiceEndpoint> serviceEndpoints;
     private final byte[] gossipCaCertificate;
@@ -51,7 +53,8 @@ public class CreateNodeSuite extends HapiSuite {
             @NonNull final byte[] gossipCaCertificate,
             @NonNull final byte[] grpcCertificateHash,
             @NonNull final String adminKeyLoc,
-            @Nullable final String feeAccountKeyLoc) {
+            @Nullable final String feeAccountKeyLoc,
+            final boolean declineRewards) {
         this.configManager = requireNonNull(configManager);
         this.accountId = accountId;
         this.description = requireNonNull(description);
@@ -61,6 +64,7 @@ public class CreateNodeSuite extends HapiSuite {
         this.grpcCertificateHash = requireNonNull(grpcCertificateHash);
         this.adminKeyLoc = requireNonNull(adminKeyLoc);
         this.feeAccountKeyLoc = feeAccountKeyLoc;
+        this.declineRewards = declineRewards;
     }
 
     public long createdIdOrThrow() {
@@ -93,6 +97,7 @@ public class CreateNodeSuite extends HapiSuite {
                             .gossipCaCertificate(gossipCaCertificate)
                             .grpcCertificateHash(grpcCertificateHash)
                             .adminKey(adminKey)
+                            .declineReward(declineRewards)
                             .advertisingCreation()
                             .exposingCreatedIdTo(createdId -> this.createdId = createdId)
                 });

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/UpdateNodeSuite.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/UpdateNodeSuite.java
@@ -58,6 +58,8 @@ public class UpdateNodeSuite extends HapiSuite {
     @Nullable
     private final byte[] hapiCertificateHash;
 
+    private final Boolean declineRewards;
+
     public UpdateNodeSuite(
             @NonNull final ConfigManager configManager,
             final long nodeId,
@@ -69,7 +71,8 @@ public class UpdateNodeSuite extends HapiSuite {
             @Nullable final List<ServiceEndpoint> gossipEndpoints,
             @Nullable final List<ServiceEndpoint> hapiEndpoints,
             @Nullable final byte[] gossipCaCertificate,
-            @Nullable final byte[] hapiCertificateHash) {
+            @Nullable final byte[] hapiCertificateHash,
+            @Nullable final Boolean declineRewards) {
         this.configManager = requireNonNull(configManager);
         this.nodeId = nodeId;
         this.accountId = accountId;
@@ -81,6 +84,7 @@ public class UpdateNodeSuite extends HapiSuite {
         this.hapiEndpoints = hapiEndpoints;
         this.gossipCaCertificate = gossipCaCertificate;
         this.hapiCertificateHash = hapiCertificateHash;
+        this.declineRewards = declineRewards;
     }
 
     @Override
@@ -130,6 +134,9 @@ public class UpdateNodeSuite extends HapiSuite {
         }
         if (hapiCertificateHash != null) {
             op.grpcCertificateHash(hapiCertificateHash);
+        }
+        if (declineRewards != null) {
+            op.declineReward(declineRewards);
         }
         return op.signedBy(availableSigners());
     }

--- a/hedera-node/test-clients/yahcli/README.md
+++ b/hedera-node/test-clients/yahcli/README.md
@@ -786,6 +786,10 @@ $ docker run -it -v $(pwd):/launch gcr.io/hedera-registry/yahcli:0.4.8 -n localh
   --adminKey adminKey.pem
 ```
 
+Independent of the gossip CA certificate format, the `--declineRewards` option can be used to indicate that the
+new node should decline reward payments. Use `--declineRewards` to decline rewards, or `--declineRewards false`
+to accept rewards. This value defaults to `true` (declines the rewards) if not specified.
+
 :warning: If the payer and admin keys do not meet the signing requirements of the new node's fee collection account,
 there must be a key in the target network's _keys/_ directory for that account.
 
@@ -853,3 +857,7 @@ Targeting localhost, paying with 0.0.2
 .!. No key on disk for account 0.0.42, payer and admin key signatures must meet its signing requirements
 .i. SUCCESS - node1 has been updated
 ```
+
+A node can also be updated to begin declining or accepting reward payments. Use `--startDecliningRewards` to
+begin accepting reward payments, or `--stopDecliningRewards` to stop accepting reward payments. These params have
+no default values.

--- a/hedera-node/test-clients/yahcli/run/build.sh
+++ b/hedera-node/test-clients/yahcli/run/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.7.5'}
+TAG=${1:-'0.7.6'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""

--- a/hedera-node/test-clients/yahcli/run/publish.sh
+++ b/hedera-node/test-clients/yahcli/run/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.7.5'}
+TAG=${1:-'0.7.6'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""


### PR DESCRIPTION
**Description**:

This version of yahcli adds support for defining node rewards behavior in the dynamic address book. For yahcli node create commands, the new `--declineRewards` flag indicates such to the consensus node, while a value of `--declineRewards false` indicates the intent to accept rewards. The node update command, keeping with the format of the staking command, now has two additional parameters: `--startDecliningRewards` and `stopDecliningRewards`, where of course 'stop declining rewards' means 'start accepting rewards.' 

Closes #19247 