### PR TITLE
chore: Fix static initialization, delay submitted freeze time

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -51,6 +51,8 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
 
     private static final Logger log = LogManager.getLogger(TurtleNetwork.class);
 
+    private static final Duration FREEZE_DELAY = Duration.ofSeconds(10);
+
     private enum State {
         INIT,
         RUNNING,
@@ -174,8 +176,8 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
         log.info("Preparing upgrade...");
 
         log.debug("Sending TurtleFreezeTransaction transaction...");
-        final TurtleTransaction freezeTransaction =
-                TransactionFactory.createFreezeTransaction(timeManager.time().now());
+        final TurtleTransaction freezeTransaction = TransactionFactory.createFreezeTransaction(
+                timeManager.time().now().plus(FREEZE_DELAY));
         nodes.getFirst().submitTransaction(freezeTransaction.toByteArray());
 
         log.debug("Waiting for nodes to freeze...");

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -63,10 +63,12 @@ public class TurtleTestEnvironment implements TestEnvironment {
 
         final FakeTime time = new FakeTime(randotron.nextInstant(), Duration.ZERO);
 
+        RuntimeObjectRegistry.reset();
         RuntimeObjectRegistry.initialize(time);
 
         try {
             final ConstructableRegistry registry = ConstructableRegistry.getInstance();
+            registry.reset();
             registry.registerConstructables("");
             registerMerkleStateRootClassIds();
         } catch (final ConstructableRegistryException e) {
@@ -197,5 +199,7 @@ public class TurtleTestEnvironment implements TestEnvironment {
     public void destroy() throws InterruptedException {
         generator.stop();
         network.destroy();
+        ConstructableRegistry.getInstance().reset();
+        RuntimeObjectRegistry.reset();
     }
 }


### PR DESCRIPTION
**Description**:

This PR resets the static registries at the beginning and cleans them up afterwards to ensure the environment is consistent. Also added a delay for the freeze time as this caused issues in some tests.

**Related issue(s)**:

Fixes #19253 