### PR TITLE
refactor: Tipset.merge() method to support an empty list 

### DIFF
--- a/platform-sdk/consensus-event-creator-impl/build.gradle.kts
+++ b/platform-sdk/consensus-event-creator-impl/build.gradle.kts
@@ -14,6 +14,7 @@ testModuleInfo {
     requires("com.swirlds.config.extensions.test.fixtures")
     requires("com.swirlds.platform.core")
     requires("com.swirlds.platform.core.test.fixtures")
+    requires("com.google.common")
     requires("org.hiero.base.crypto.test.fixtures")
     requires("org.hiero.base.utility.test.fixtures")
     requires("org.hiero.consensus.model.test.fixtures")
@@ -22,5 +23,6 @@ testModuleInfo {
     requires("org.junit.jupiter.params")
     requires("org.mockito")
     requires("org.hiero.junit.extensions")
+    opensTo("org.hiero.junit.extensions")
     opensTo("org.hiero.junit.extensions")
 }

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -177,4 +177,26 @@ public class Tipset {
         sb.append(")");
         return sb.toString();
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public final boolean equals(final Object o) {
+        if (!(o instanceof final Tipset tipset)) {
+            return false;
+        }
+
+        return roster.equals(tipset.roster) && Arrays.equals(tips, tipset.tips);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        int result = roster.hashCode();
+        result = 31 * result + Arrays.hashCode(tips);
+        return result;
+    }
 }

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -57,6 +57,7 @@ public class Tipset {
      *
      * @param tipsets the tipsets to merge, must be non-empty, tipsets must be constructed from the same address book or
      *                else this method has undefined behavior
+     * @param roster the roster to use for the tipset if the tipsets list is empty
      * @return a new tipset
      */
     public static @NonNull Tipset merge(@NonNull final List<Tipset> tipsets, @NonNull final Roster roster) {

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -59,10 +59,9 @@ public class Tipset {
      *                else this method has undefined behavior
      * @return a new tipset
      */
-    public static @NonNull Tipset merge(@NonNull final List<Tipset> tipsets) {
-        Objects.requireNonNull(tipsets, "tipsets must not be null");
+    public static @NonNull Tipset merge(@NonNull final List<Tipset> tipsets, @NonNull final Roster roster) {
         if (tipsets.isEmpty()) {
-            throw new IllegalArgumentException("Cannot merge an empty list of tipsets");
+            return new Tipset(roster);
         }
 
         final int length = tipsets.get(0).tips.length;

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -57,10 +57,9 @@ public class Tipset {
      *
      * @param tipsets the tipsets to merge, must be non-empty, tipsets must be constructed from the same address book or
      *                else this method has undefined behavior
-     * @param roster the roster to use for the tipset if the tipsets list is empty
      * @return a new tipset
      */
-    public static @NonNull Tipset merge(@NonNull final List<Tipset> tipsets, @NonNull final Roster roster) {
+    public @NonNull Tipset merge(@NonNull final List<Tipset> tipsets) {
         if (tipsets.isEmpty()) {
             return new Tipset(roster);
         }

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -65,8 +65,8 @@ public class Tipset {
             return new Tipset(roster);
         }
 
-        final int length = tipsets.getFirst().tips.length;
-        final Tipset newTipset = buildEmptyTipset(tipsets.getFirst());
+        final int length = this.tips.length;
+        final Tipset newTipset = buildEmptyTipset(this);
 
         for (int index = 0; index < length; index++) {
             long max = this.tips[index];

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -4,6 +4,7 @@ package org.hiero.consensus.event.creator.impl.tipset;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -54,22 +55,25 @@ public class Tipset {
      * <p>
      * The generation for each node ID will be equal to the maximum generation found for that node ID from all source
      * tipsets.
+     * In the case of empty list, a new Tipset instance with the current roster will be returned.
      *
-     * @param tipsets the tipsets to merge, must be non-empty, tipsets must be constructed from the same address book or
+     * @param tipsets the tipsets to merge, tipsets must be constructed from the same roster or
      *                else this method has undefined behavior
      * @return a new tipset
      */
     public @NonNull Tipset merge(@NonNull final List<Tipset> tipsets) {
         if (tipsets.isEmpty()) {
-            return this;
+            return new Tipset(roster);
         }
 
+        final List<Tipset> allTipsets = new ArrayList<>(tipsets);
+        allTipsets.add(this);
         final int length = tipsets.get(0).tips.length;
         final Tipset newTipset = buildEmptyTipset(tipsets.get(0));
 
         for (int index = 0; index < length; index++) {
             long max = NonDeterministicGeneration.GENERATION_UNDEFINED;
-            for (final Tipset tipSet : tipsets) {
+            for (final Tipset tipSet : allTipsets) {
                 max = Math.max(max, tipSet.tips[index]);
             }
             newTipset.tips[index] = max;

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -61,7 +61,7 @@ public class Tipset {
      */
     public @NonNull Tipset merge(@NonNull final List<Tipset> tipsets) {
         if (tipsets.isEmpty()) {
-            return new Tipset(roster);
+            return this;
         }
 
         final int length = tipsets.get(0).tips.length;

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -4,7 +4,6 @@ package org.hiero.consensus.event.creator.impl.tipset;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -66,14 +65,12 @@ public class Tipset {
             return new Tipset(roster);
         }
 
-        final List<Tipset> allTipsets = new ArrayList<>(tipsets);
-        allTipsets.add(this);
-        final int length = tipsets.get(0).tips.length;
-        final Tipset newTipset = buildEmptyTipset(tipsets.get(0));
+        final int length = tipsets.getFirst().tips.length;
+        final Tipset newTipset = buildEmptyTipset(tipsets.getFirst());
 
         for (int index = 0; index < length; index++) {
-            long max = NonDeterministicGeneration.GENERATION_UNDEFINED;
-            for (final Tipset tipSet : allTipsets) {
+            long max = this.tips[index];
+            for (final Tipset tipSet : tipsets) {
                 max = Math.max(max, tipSet.tips[index]);
             }
             newTipset.tips[index] = max;

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTracker.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTracker.java
@@ -119,12 +119,7 @@ public class TipsetTracker {
         // will be assigned by the orphan buffer later. Furthermore, we do not want to assign it
         // here because the orphan buffer might disagree about the value given that event windows
         // are process asynchronously.
-        final Tipset eventTipset;
-        if (parentTipsets.isEmpty()) {
-            eventTipset = new Tipset(roster);
-        } else {
-            eventTipset = merge(parentTipsets);
-        }
+        final Tipset eventTipset = merge(parentTipsets, roster);
 
         tipsets.put(selfEventDesc, eventTipset);
 
@@ -144,12 +139,7 @@ public class TipsetTracker {
 
         final List<Tipset> parentTipsets = getParentTipsets(event.getAllParents());
 
-        final Tipset eventTipset;
-        if (parentTipsets.isEmpty()) {
-            eventTipset = new Tipset(roster).advance(event.getCreatorId(), event.getNGen());
-        } else {
-            eventTipset = merge(parentTipsets).advance(event.getCreatorId(), event.getNGen());
-        }
+        final Tipset eventTipset = merge(parentTipsets, roster).advance(event.getCreatorId(), event.getNGen());
 
         tipsets.put(event.getDescriptor(), eventTipset);
         latestGenerations = latestGenerations.advance(event.getCreatorId(), event.getNGen());

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTracker.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTracker.java
@@ -2,7 +2,6 @@
 package org.hiero.consensus.event.creator.impl.tipset;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
-import static org.hiero.consensus.event.creator.impl.tipset.Tipset.merge;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.time.Time;
@@ -119,7 +118,7 @@ public class TipsetTracker {
         // will be assigned by the orphan buffer later. Furthermore, we do not want to assign it
         // here because the orphan buffer might disagree about the value given that event windows
         // are process asynchronously.
-        final Tipset eventTipset = merge(parentTipsets, roster);
+        final Tipset eventTipset = new Tipset(roster).merge(parentTipsets);
 
         tipsets.put(selfEventDesc, eventTipset);
 
@@ -139,7 +138,8 @@ public class TipsetTracker {
 
         final List<Tipset> parentTipsets = getParentTipsets(event.getAllParents());
 
-        final Tipset eventTipset = merge(parentTipsets, roster).advance(event.getCreatorId(), event.getNGen());
+        final Tipset eventTipset =
+                new Tipset(roster).merge(parentTipsets).advance(event.getCreatorId(), event.getNGen());
 
         tipsets.put(event.getDescriptor(), eventTipset);
         latestGenerations = latestGenerations.advance(event.getCreatorId(), event.getNGen());

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculator.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculator.java
@@ -238,7 +238,7 @@ public class TipsetWeightCalculator {
 
         // Don't bother advancing the self generation in this theoretical tipset,
         // since self advancement doesn't contribute to tipset advancement weight.
-        final Tipset newTipset = Tipset.merge(parentTipsets);
+        final Tipset newTipset = Tipset.merge(parentTipsets, roster);
 
         return snapshot.getTipAdvancementWeight(selfId, newTipset).minus(previousAdvancementWeight);
     }

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculator.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculator.java
@@ -238,7 +238,7 @@ public class TipsetWeightCalculator {
 
         // Don't bother advancing the self generation in this theoretical tipset,
         // since self advancement doesn't contribute to tipset advancement weight.
-        final Tipset newTipset = Tipset.merge(parentTipsets, roster);
+        final Tipset newTipset = new Tipset(roster).merge(parentTipsets);
 
         return snapshot.getTipAdvancementWeight(selfId, newTipset).minus(previousAdvancementWeight);
     }

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
@@ -73,11 +73,10 @@ class TipsetTests {
 
         for (var entry : roster.rosterEntries()) {
             maxTipset.advance(NodeId.of(entry.nodeId()), Long.MAX_VALUE);
-            final long generation = random.nextLong();
-            biggerTipset.advance(
-                    NodeId.of(entry.nodeId()), generation == Long.MAX_VALUE ? Long.MAX_VALUE : generation + 1);
+            final long generation = random.nextLong(1, Long.MAX_VALUE - 1);
+            biggerTipset.advance(NodeId.of(entry.nodeId()), generation + 1);
             randomTipset.advance(NodeId.of(entry.nodeId()), generation);
-            smallerTipset.advance(NodeId.of(entry.nodeId()), generation == 0 ? 0 : generation - 1);
+            smallerTipset.advance(NodeId.of(entry.nodeId()), generation - 1);
         }
 
         // verify that an empty tipset merged against any other the result is the other

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
@@ -4,11 +4,11 @@ package org.hiero.consensus.event.creator.impl.tipset;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
 
+import com.google.common.collect.Collections2;
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.common.test.fixtures.WeightGenerators;
 import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,24 +64,72 @@ class TipsetTests {
         final Roster roster =
                 RandomRosterBuilder.create(random).withSize(nodeCount).build();
 
-        for (int count = 0; count < 10; count++) {
-            final List<Tipset> tipsets = new ArrayList<>();
-            final Map<NodeId, Long> expected = new HashMap<>();
+        // Given:
+        final Tipset emptyTipset = new Tipset(roster);
+        final Tipset maxTipset = new Tipset(roster);
+        final Tipset randomTipset = new Tipset(roster);
+        final Tipset biggerTipset = new Tipset(roster);
+        final Tipset smallerTipset = new Tipset(roster);
 
-            for (int tipsetIndex = 0; tipsetIndex < 10; tipsetIndex++) {
-                final Tipset tipset = new Tipset(roster);
-                for (int creator = 0; creator < nodeCount; creator++) {
-                    final NodeId creatorId =
-                            NodeId.of(roster.rosterEntries().get(creator).nodeId());
-                    final long generation = random.nextLong(1, 100);
-                    tipset.advance(creatorId, generation);
-                    expected.put(creatorId, Math.max(generation, expected.getOrDefault(creatorId, 0L)));
-                }
-                tipsets.add(tipset);
+        for (var entry : roster.rosterEntries()) {
+            maxTipset.advance(NodeId.of(entry.nodeId()), Long.MAX_VALUE);
+            final long generation = random.nextLong();
+            biggerTipset.advance(
+                    NodeId.of(entry.nodeId()), generation == Long.MAX_VALUE ? Long.MAX_VALUE : generation + 1);
+            randomTipset.advance(NodeId.of(entry.nodeId()), generation);
+            smallerTipset.advance(NodeId.of(entry.nodeId()), generation == 0 ? 0 : generation - 1);
+        }
+
+        // verify that an empty tipset merged against any other the result is the other
+        assertThat(emptyTipset.merge(List.of(emptyTipset))).isEqualTo(emptyTipset);
+        assertThat(emptyTipset.merge(List.of(maxTipset))).isEqualTo(maxTipset);
+        assertThat(emptyTipset.merge(List.of(randomTipset))).isEqualTo(randomTipset);
+
+        // verify that a maxed-out tipset merged against any other is equals to itself
+        assertThat(maxTipset.merge(List.of(maxTipset))).isEqualTo(maxTipset);
+        assertThat(maxTipset.merge(List.of(emptyTipset))).isEqualTo(maxTipset);
+        assertThat(maxTipset.merge(List.of(randomTipset))).isEqualTo(maxTipset);
+
+        // verify that a random tipset merged against a) itself b) an empty tipset c) a smaller tipset, is equals to
+        // itself
+        assertThat(randomTipset.merge(List.of(randomTipset))).isEqualTo(randomTipset);
+        assertThat(randomTipset.merge(List.of(emptyTipset))).isEqualTo(randomTipset);
+        assertThat(randomTipset.merge(List.of(smallerTipset))).isEqualTo(randomTipset);
+
+        // verify that a random tipset merged against a) a maxed-out b) a bigger tipset, is equals to the other
+        assertThat(randomTipset.merge(List.of(maxTipset))).isEqualTo(maxTipset);
+        assertThat(randomTipset.merge(List.of(biggerTipset))).isEqualTo(biggerTipset);
+
+        // verify that a random tipset merged against a) a maxed-out b) a bigger tipset, is equals to the other
+        assertThat(smallerTipset.merge(List.of(randomTipset))).isEqualTo(randomTipset);
+        assertThat(biggerTipset.merge(List.of(randomTipset))).isEqualTo(biggerTipset);
+
+        // verify that an empty tipset merged a list of tipsets, is equals to the biggest in the list
+        assertThat(emptyTipset.merge(List.of(randomTipset, biggerTipset, smallerTipset)))
+                .isEqualTo(biggerTipset);
+
+        // verify that tipsets being merged to a list of tiptsets returns the biggest in the list regardless of
+        // the position the tipset being merged to occupies in the list
+        for (var listOfTipsets : Collections2.permutations(List.of(randomTipset, biggerTipset, smallerTipset))) {
+            assertThat(emptyTipset.merge(listOfTipsets)).isEqualTo(biggerTipset);
+        }
+
+        for (var listOfTipsets :
+                Collections2.permutations(List.of(randomTipset, maxTipset, biggerTipset, smallerTipset))) {
+            assertThat(emptyTipset.merge(listOfTipsets)).isEqualTo(maxTipset);
+        }
+
+        for (var listOfTipsets : Collections2.permutations(List.of(emptyTipset, biggerTipset, randomTipset))) {
+            assertThat(smallerTipset.merge(listOfTipsets)).isEqualTo(biggerTipset);
+        }
+
+        // verify that tipsets being merged to a list of tiptsets containing itself still produces the expected result
+        // regardless of the position the tipset being merged to occupies in the list
+        final List<Tipset> exaustiveList = List.of(emptyTipset, biggerTipset, randomTipset, smallerTipset);
+        for (var selected : exaustiveList) {
+            for (var listOfTipsets : Collections2.permutations(exaustiveList)) {
+                assertThat(selected.merge(listOfTipsets)).isEqualTo(biggerTipset);
             }
-
-            final Tipset merged = new Tipset(roster).merge(tipsets);
-            validateTipset(merged, expected);
         }
     }
 

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
@@ -80,7 +80,7 @@ class TipsetTests {
                 tipsets.add(tipset);
             }
 
-            final Tipset merged = Tipset.merge(tipsets);
+            final Tipset merged = Tipset.merge(tipsets, roster);
             validateTipset(merged, expected);
         }
     }
@@ -109,7 +109,7 @@ class TipsetTests {
         }
 
         // Merging the tipset with itself will result in a copy
-        final Tipset comparisonTipset = Tipset.merge(List.of(initialTipset));
+        final Tipset comparisonTipset = Tipset.merge(List.of(initialTipset), roster);
         assertThat(comparisonTipset.size()).isEqualTo(initialTipset.size());
         for (int creator = 0; creator < 100; creator++) {
             final NodeId creatorId =
@@ -169,7 +169,7 @@ class TipsetTests {
         }
 
         // Merging the tipset with itself will result in a copy
-        final Tipset comparisonTipset = Tipset.merge(List.of(initialTipset));
+        final Tipset comparisonTipset = Tipset.merge(List.of(initialTipset), roster);
         assertThat(comparisonTipset.size()).isEqualTo(initialTipset.size());
         for (int creator = 0; creator < 100; creator++) {
             final NodeId creatorId =

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
@@ -80,7 +80,7 @@ class TipsetTests {
                 tipsets.add(tipset);
             }
 
-            final Tipset merged = Tipset.merge(tipsets, roster);
+            final Tipset merged = new Tipset(roster).merge(tipsets);
             validateTipset(merged, expected);
         }
     }
@@ -109,7 +109,7 @@ class TipsetTests {
         }
 
         // Merging the tipset with itself will result in a copy
-        final Tipset comparisonTipset = Tipset.merge(List.of(initialTipset), roster);
+        final Tipset comparisonTipset = new Tipset(roster).merge(List.of(initialTipset));
         assertThat(comparisonTipset.size()).isEqualTo(initialTipset.size());
         for (int creator = 0; creator < 100; creator++) {
             final NodeId creatorId =
@@ -169,7 +169,7 @@ class TipsetTests {
         }
 
         // Merging the tipset with itself will result in a copy
-        final Tipset comparisonTipset = Tipset.merge(List.of(initialTipset), roster);
+        final Tipset comparisonTipset = new Tipset(roster).merge(List.of(initialTipset));
         assertThat(comparisonTipset.size()).isEqualTo(initialTipset.size());
         for (int creator = 0; creator < 100; creator++) {
             final NodeId creatorId =

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
@@ -146,12 +146,7 @@ class TipsetTrackerTests {
                 parentTipsets.add(expectedTipsets.get(event.getSelfParent()));
             }
 
-            final Tipset expectedTipset;
-            if (parentTipsets.isEmpty()) {
-                expectedTipset = new Tipset(roster);
-            } else {
-                expectedTipset = merge(parentTipsets);
-            }
+            final Tipset expectedTipset = merge(parentTipsets, roster);
 
             if (!creator.equals(selfId)) {
                 expectedTipset.advance(creator, nGen);

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
@@ -3,7 +3,6 @@ package org.hiero.consensus.event.creator.impl.tipset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
-import static org.hiero.consensus.event.creator.impl.tipset.Tipset.merge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -146,7 +145,7 @@ class TipsetTrackerTests {
                 parentTipsets.add(expectedTipsets.get(event.getSelfParent()));
             }
 
-            final Tipset expectedTipset = merge(parentTipsets, roster);
+            final Tipset expectedTipset = new Tipset(roster).merge(parentTipsets);
 
             if (!creator.equals(selfId)) {
                 expectedTipset.advance(creator, nGen);

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
@@ -171,12 +171,7 @@ class TipsetWeightCalculatorTests {
                 parentTipsets.add(tipsetTracker.getTipset(parent));
             }
 
-            final Tipset newTipset;
-            if (parentTipsets.isEmpty()) {
-                newTipset = new Tipset(roster);
-            } else {
-                newTipset = merge(parentTipsets);
-            }
+            final Tipset newTipset = merge(parentTipsets, roster);
 
             final TipsetAdvancementWeight expectedAdvancementScoreChange =
                     previousSnapshot.getTipAdvancementWeight(selfId, newTipset).minus(runningAdvancementScore);

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
@@ -3,7 +3,6 @@ package org.hiero.consensus.event.creator.impl.tipset;
 
 import static com.swirlds.common.utility.Threshold.SUPER_MAJORITY;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
-import static org.hiero.consensus.event.creator.impl.tipset.Tipset.merge;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetAdvancementWeight.ZERO_ADVANCEMENT_WEIGHT;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -171,7 +170,7 @@ class TipsetWeightCalculatorTests {
                 parentTipsets.add(tipsetTracker.getTipset(parent));
             }
 
-            final Tipset newTipset = merge(parentTipsets, roster);
+            final Tipset newTipset = new Tipset(roster).merge(parentTipsets);
 
             final TipsetAdvancementWeight expectedAdvancementScoreChange =
                     previousSnapshot.getTipAdvancementWeight(selfId, newTipset).minus(runningAdvancementScore);


### PR DESCRIPTION
**Description**:

Update the Tipset.merge() method to support an empty list 

**Related issue(s)**:

Fixes #18832 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
