### PR TITLE
fix: 19223 `VirtualMapState` is hidden if it's the only element

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -1731,14 +1731,26 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
      **/
 
     /*
-     * Gets the number of elements in this map.
-     * Note that even freshly created instance of {@code VirtualMap} contains
-     * at least one element - an instance of {@link VirtualMapState}
+     * Gets the number of elements in this map. The map is considered as empty if it contains the state element only.
      *
      * @return The number of key/value pairs in the map.
      */
     public long size() {
+        if (state.getSize() == 1) {
+            // meaning that the map has the state element only
+            return 0;
+        }
+
         return state.getSize();
+    }
+
+    /*
+     * Gets whether this map is empty.
+     *
+     * @return True if the map is empty
+     */
+    public boolean isEmpty() {
+        return size() == 0;
     }
 
     public void remove(@NonNull final Bytes key) {

--- a/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/timingSensitive/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -120,45 +120,45 @@ class VirtualMapTests extends VirtualTestBase {
     @Tags({@Tag("VirtualMerkle"), @Tag("Fresh")})
     @DisplayName("A fresh map is mutable")
     void freshMapIsMutable() {
-        final VirtualMap fcm = createMap();
-        fcm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
-        assertEquals(2, fcm.size(), "VirtualMap size is wrong");
-        fcm.release();
+        final VirtualMap vm = createMap();
+        vm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
+        assertEquals(2, vm.size(), "VirtualMap size is wrong");
+        vm.release();
     }
 
     @Test
     @Tags({@Tag("VirtualMerkle"), @Tag("Fresh")})
     @DisplayName("A fresh map has both children")
     void freshMapHasBothChildren() {
-        final VirtualMap fcm = createMap();
-        assertEquals(2, fcm.getNumberOfChildren(), "VirtualMap size is wrong");
-        assertNotNull(fcm.getChild(0), "Unexpected null at index 0");
-        assertNull(fcm.getChild(1), "Unexpected non-null at index 1");
-        fcm.release();
+        final VirtualMap vm = createMap();
+        assertEquals(2, vm.getNumberOfChildren(), "VirtualMap size is wrong");
+        assertNotNull(vm.getChild(0), "Unexpected null at index 0");
+        assertNull(vm.getChild(1), "Unexpected non-null at index 1");
+        vm.release();
     }
 
     @Test
     @Tags({@Tag("VirtualMerkle"), @Tag("Fresh")})
     @DisplayName("A fresh map returns a non-null data source")
     void freshMapHasDataSource() {
-        final VirtualMap fcm = createMap();
-        assertNotNull(fcm.getDataSource(), "Unexpected null data source");
-        fcm.release();
+        final VirtualMap vm = createMap();
+        assertNotNull(vm.getDataSource(), "Unexpected null data source");
+        vm.release();
     }
 
     @Test
     @Tags({@Tag("VirtualMerkle"), @Tag("Fresh")})
     @DisplayName("The root node of an empty tree has no children")
     void emptyTreeRootHasOnlyStateAsChild() {
-        final VirtualMap fcm = createMap();
-        assertEquals(2, fcm.getNumberOfChildren(), "Unexpected number of children");
-        VirtualLeafNode child = fcm.getChild(0);
+        final VirtualMap vm = createMap();
+        assertEquals(2, vm.getNumberOfChildren(), "Unexpected number of children");
+        VirtualLeafNode child = vm.getChild(0);
         VirtualMapState virtualMapState = new VirtualMapState(child.getValue());
         assertEquals(-1, virtualMapState.getFirstLeafPath());
         assertEquals(-1, virtualMapState.getLastLeafPath());
 
-        assertNull(fcm.getChild(1), "Unexpected child of empty root");
-        fcm.release();
+        assertNull(vm.getChild(1), "Unexpected child of empty root");
+        vm.release();
     }
 
     /*
@@ -169,11 +169,11 @@ class VirtualMapTests extends VirtualTestBase {
     @Tags({@Tag("VirtualMerkle"), @Tag("FastCopy")})
     @DisplayName("Original after copy is immutable")
     void originalAfterCopyIsImmutable() {
-        final VirtualMap fcm = createMap();
-        final VirtualMap copy = fcm.copy();
-        assertTrue(fcm.isImmutable(), "Copied VirtualMap should have been immutable");
+        final VirtualMap vm = createMap();
+        final VirtualMap copy = vm.copy();
+        assertTrue(vm.isImmutable(), "Copied VirtualMap should have been immutable");
         assertFalse(copy.isImmutable(), "Most recent VirtualMap should have been mutable");
-        fcm.release();
+        vm.release();
         copy.release();
     }
 
@@ -181,10 +181,10 @@ class VirtualMapTests extends VirtualTestBase {
     @Tags({@Tag("VirtualMerkle"), @Tag("FastCopy")})
     @DisplayName("Cannot copy twice")
     void cannotCopyTwice() {
-        final VirtualMap fcm = createMap();
-        final VirtualMap copy = fcm.copy();
-        assertThrows(MutabilityException.class, fcm::copy, "Calling copy twice should have thrown exception");
-        fcm.release();
+        final VirtualMap vm = createMap();
+        final VirtualMap copy = vm.copy();
+        assertThrows(MutabilityException.class, vm::copy, "Calling copy twice should have thrown exception");
+        vm.release();
         copy.release();
     }
 
@@ -192,39 +192,39 @@ class VirtualMapTests extends VirtualTestBase {
     @Tags({@Tag("VirtualMerkle"), @Tag("FastCopy")})
     @DisplayName("Cannot copy a released fcm")
     void cannotCopyAReleasedMap() {
-        final VirtualMap fcm = createMap();
-        fcm.release();
-        assertThrows(ReferenceCountException.class, fcm::copy, "Calling copy after release should throw");
+        final VirtualMap vm = createMap();
+        vm.release();
+        assertThrows(ReferenceCountException.class, vm::copy, "Calling copy after release should throw");
     }
 
     @Test
     @Tags({@Tag("VirtualMerkle"), @Tag("FastCopy")})
     @DisplayName("Original is not impacted by changes to modified copy")
     void originalIsUnaffected() {
-        final VirtualMap fcm = createMap();
-        fcm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
-        fcm.put(B_KEY, BANANA, TestValueCodec.INSTANCE);
-        fcm.put(C_KEY, CHERRY, TestValueCodec.INSTANCE);
+        final VirtualMap vm = createMap();
+        vm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
+        vm.put(B_KEY, BANANA, TestValueCodec.INSTANCE);
+        vm.put(C_KEY, CHERRY, TestValueCodec.INSTANCE);
 
         // Perform some combination of add, remove, replace and leaving alone
-        final VirtualMap copy = fcm.copy();
+        final VirtualMap copy = vm.copy();
         assertNotNull(copy.get(A_KEY, TestValueCodec.INSTANCE), "Entry for A_KEY not found");
         copy.put(A_KEY, AARDVARK, TestValueCodec.INSTANCE);
         copy.remove(C_KEY, TestValueCodec.INSTANCE);
         copy.put(D_KEY, DOG, TestValueCodec.INSTANCE);
         copy.put(E_KEY, EMU, TestValueCodec.INSTANCE);
 
-        assertEquals(APPLE, fcm.get(A_KEY, TestValueCodec.INSTANCE), "Unexpected value");
-        assertEquals(BANANA, fcm.get(B_KEY, TestValueCodec.INSTANCE), "Unexpected value");
-        assertEquals(CHERRY, fcm.get(C_KEY, TestValueCodec.INSTANCE), "Unexpected value");
-        assertEquals(4, fcm.size(), "Unexpected size");
+        assertEquals(APPLE, vm.get(A_KEY, TestValueCodec.INSTANCE), "Unexpected value");
+        assertEquals(BANANA, vm.get(B_KEY, TestValueCodec.INSTANCE), "Unexpected value");
+        assertEquals(CHERRY, vm.get(C_KEY, TestValueCodec.INSTANCE), "Unexpected value");
+        assertEquals(4, vm.size(), "Unexpected size");
 
         assertEquals(AARDVARK, copy.get(A_KEY, TestValueCodec.INSTANCE), "Unexpected value");
         assertEquals(BANANA, copy.get(B_KEY, TestValueCodec.INSTANCE), "Unexpected value");
         assertEquals(DOG, copy.get(D_KEY, TestValueCodec.INSTANCE), "Unexpected value");
         assertEquals(EMU, copy.get(E_KEY, TestValueCodec.INSTANCE), "Unexpected value");
         assertEquals(5, copy.size(), "Unexpected size");
-        fcm.release();
+        vm.release();
         copy.release();
     }
 
@@ -235,124 +235,124 @@ class VirtualMapTests extends VirtualTestBase {
     @Test
     @DisplayName("Size matches number of items input")
     void sizeMatchesNumberOfItemsInput() {
-        final VirtualMap fcm = createMap();
+        final VirtualMap vm = createMap();
         // initial size of the map is one because of `VirtualMapState`
-        assertEquals(1, fcm.size(), "Unexpected size");
+        assertEquals(1, vm.size(), "Unexpected size");
 
         // Add an element
-        fcm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
-        assertEquals(2, fcm.size(), "Unexpected size");
+        vm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
+        assertEquals(2, vm.size(), "Unexpected size");
 
         // Add a couple more elements
-        fcm.put(B_KEY, BANANA, TestValueCodec.INSTANCE);
-        assertEquals(3, fcm.size(), "Unexpected size");
-        fcm.put(C_KEY, CHERRY, TestValueCodec.INSTANCE);
-        assertEquals(4, fcm.size(), "Unexpected size");
+        vm.put(B_KEY, BANANA, TestValueCodec.INSTANCE);
+        assertEquals(3, vm.size(), "Unexpected size");
+        vm.put(C_KEY, CHERRY, TestValueCodec.INSTANCE);
+        assertEquals(4, vm.size(), "Unexpected size");
 
         // replace a couple elements (out of order even!)
-        assertNotNull(fcm.get(B_KEY, TestValueCodec.INSTANCE), "Entry for B_KEY not found");
-        fcm.put(B_KEY, BEAR, TestValueCodec.INSTANCE);
-        assertNotNull(fcm.get(A_KEY, TestValueCodec.INSTANCE), "Entry for A_KEY not found");
-        fcm.put(A_KEY, AARDVARK, TestValueCodec.INSTANCE);
-        assertEquals(4, fcm.size(), "Unexpected size");
+        assertNotNull(vm.get(B_KEY, TestValueCodec.INSTANCE), "Entry for B_KEY not found");
+        vm.put(B_KEY, BEAR, TestValueCodec.INSTANCE);
+        assertNotNull(vm.get(A_KEY, TestValueCodec.INSTANCE), "Entry for A_KEY not found");
+        vm.put(A_KEY, AARDVARK, TestValueCodec.INSTANCE);
+        assertEquals(4, vm.size(), "Unexpected size");
 
         // Loop and add a million items and make sure the size is matching
         for (int i = 1000; i < 1_001_000; i++) {
-            fcm.put(TestKey.longToKey(i), new TestValue("value" + i), TestValueCodec.INSTANCE);
+            vm.put(TestKey.longToKey(i), new TestValue("value" + i), TestValueCodec.INSTANCE);
         }
 
-        assertEquals(1_000_004, fcm.size(), "Unexpected size");
-        fcm.release();
+        assertEquals(1_000_004, vm.size(), "Unexpected size");
+        vm.release();
     }
 
     @Test
     @DisplayName("Get of null key throws exception")
     void getOfNullKeyThrowsException() {
-        final VirtualMap fcm = createMap();
+        final VirtualMap vm = createMap();
         assertThrows(
-                NullPointerException.class, () -> fcm.get(null, TestValueCodec.INSTANCE), "Null keys are not allowed");
-        fcm.release();
+                NullPointerException.class, () -> vm.get(null, TestValueCodec.INSTANCE), "Null keys are not allowed");
+        vm.release();
     }
 
     @Test
     @DisplayName("Get of missing key returns null")
     void getOfMissingKeyReturnsNull() {
-        final VirtualMap fcm = createMap();
-        fcm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
-        fcm.put(B_KEY, BANANA, TestValueCodec.INSTANCE);
+        final VirtualMap vm = createMap();
+        vm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
+        vm.put(B_KEY, BANANA, TestValueCodec.INSTANCE);
 
-        assertNull(fcm.get(C_KEY, TestValueCodec.INSTANCE), "Expected no value");
-        assertNull(fcm.getBytes(C_KEY), "Expected no value");
-        fcm.release();
+        assertNull(vm.get(C_KEY, TestValueCodec.INSTANCE), "Expected no value");
+        assertNull(vm.getBytes(C_KEY), "Expected no value");
+        vm.release();
     }
 
     @Test
     @DisplayName("Get of key returns value")
     void getOfKeyReturnsValue() {
-        final VirtualMap fcm = createMap();
-        fcm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
-        fcm.put(B_KEY, BANANA, TestValueCodec.INSTANCE);
-        assertEquals(APPLE, fcm.get(A_KEY, TestValueCodec.INSTANCE), "Wrong value");
-        assertEquals(BANANA, fcm.get(B_KEY, TestValueCodec.INSTANCE), "Wrong value");
+        final VirtualMap vm = createMap();
+        vm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
+        vm.put(B_KEY, BANANA, TestValueCodec.INSTANCE);
+        assertEquals(APPLE, vm.get(A_KEY, TestValueCodec.INSTANCE), "Wrong value");
+        assertEquals(BANANA, vm.get(B_KEY, TestValueCodec.INSTANCE), "Wrong value");
 
-        fcm.put(A_KEY, AARDVARK, TestValueCodec.INSTANCE);
-        assertEquals(AARDVARK, fcm.get(A_KEY, TestValueCodec.INSTANCE), "Wrong value");
-        assertEquals(BANANA, fcm.get(B_KEY, TestValueCodec.INSTANCE), "Wrong value");
-        fcm.release();
+        vm.put(A_KEY, AARDVARK, TestValueCodec.INSTANCE);
+        assertEquals(AARDVARK, vm.get(A_KEY, TestValueCodec.INSTANCE), "Wrong value");
+        assertEquals(BANANA, vm.get(B_KEY, TestValueCodec.INSTANCE), "Wrong value");
+        vm.release();
     }
 
     @Test
     @DisplayName("Put with null key throws exception")
     void putWithNullKeyThrowsException() {
-        final VirtualMap fcm = createMap();
+        final VirtualMap vm = createMap();
         assertThrows(
                 NullPointerException.class,
-                () -> fcm.put(null, BANANA, TestValueCodec.INSTANCE),
+                () -> vm.put(null, BANANA, TestValueCodec.INSTANCE),
                 "Null keys are not allowed");
 
-        fcm.release();
+        vm.release();
     }
 
     @Test
     @DisplayName("Put with null values are allowed")
     void putWithNullValuesAreAllowed() {
-        final VirtualMap fcm = createMap();
-        fcm.put(A_KEY, null, TestValueCodec.INSTANCE);
-        assertNull(fcm.get(A_KEY, TestValueCodec.INSTANCE), "Expected null");
-        fcm.release();
+        final VirtualMap vm = createMap();
+        vm.put(A_KEY, null, TestValueCodec.INSTANCE);
+        assertNull(vm.get(A_KEY, TestValueCodec.INSTANCE), "Expected null");
+        vm.release();
     }
 
     @Test
     @DisplayName("Multiple keys can have the same value")
     void manyKeysCanHaveTheSameValue() {
-        final VirtualMap fcm = createMap();
-        fcm.put(A_KEY, null, TestValueCodec.INSTANCE);
-        fcm.put(B_KEY, null, TestValueCodec.INSTANCE);
-        fcm.put(C_KEY, CUTTLEFISH, TestValueCodec.INSTANCE);
-        fcm.put(D_KEY, CUTTLEFISH, TestValueCodec.INSTANCE);
+        final VirtualMap vm = createMap();
+        vm.put(A_KEY, null, TestValueCodec.INSTANCE);
+        vm.put(B_KEY, null, TestValueCodec.INSTANCE);
+        vm.put(C_KEY, CUTTLEFISH, TestValueCodec.INSTANCE);
+        vm.put(D_KEY, CUTTLEFISH, TestValueCodec.INSTANCE);
 
-        assertNull(fcm.get(A_KEY, TestValueCodec.INSTANCE), "Expected null");
-        assertNull(fcm.get(B_KEY, TestValueCodec.INSTANCE), "Expected null");
-        assertEquals(CUTTLEFISH, fcm.get(C_KEY, TestValueCodec.INSTANCE), "Wrong value");
-        assertEquals(CUTTLEFISH, fcm.get(D_KEY, TestValueCodec.INSTANCE), "Wrong value");
-        assertEquals(5, fcm.size(), "Wrong size");
-        fcm.release();
+        assertNull(vm.get(A_KEY, TestValueCodec.INSTANCE), "Expected null");
+        assertNull(vm.get(B_KEY, TestValueCodec.INSTANCE), "Expected null");
+        assertEquals(CUTTLEFISH, vm.get(C_KEY, TestValueCodec.INSTANCE), "Wrong value");
+        assertEquals(CUTTLEFISH, vm.get(D_KEY, TestValueCodec.INSTANCE), "Wrong value");
+        assertEquals(5, vm.size(), "Wrong size");
+        vm.release();
     }
 
     @Test
     @DisplayName("Put many and get many")
     void putManyAndGetMany() {
-        final VirtualMap fcm = createMap();
+        final VirtualMap vm = createMap();
         for (int i = 0; i < 1000; i++) {
-            fcm.put(TestKey.longToKey(i), new TestValue("value" + i), TestValueCodec.INSTANCE);
+            vm.put(TestKey.longToKey(i), new TestValue("value" + i), TestValueCodec.INSTANCE);
         }
 
         for (int i = 0; i < 1000; i++) {
             assertEquals(
-                    new TestValue("value" + i), fcm.get(TestKey.longToKey(i), TestValueCodec.INSTANCE), "Wrong value");
+                    new TestValue("value" + i), vm.get(TestKey.longToKey(i), TestValueCodec.INSTANCE), "Wrong value");
         }
 
-        fcm.release();
+        vm.release();
     }
 
     @Test
@@ -385,9 +385,34 @@ class VirtualMapTests extends VirtualTestBase {
     @Test
     @DisplayName("Remove from an empty map")
     void removeEmptyMap() {
-        final VirtualMap fcm = createMap();
-        assertNull(fcm.remove(A_KEY, TestValueCodec.INSTANCE), "Expected null");
-        fcm.release();
+        final VirtualMap vm = createMap();
+        assertNull(vm.remove(A_KEY, TestValueCodec.INSTANCE), "Expected null");
+        vm.release();
+    }
+
+    @Test
+    @DisplayName("Test of isEmpty and size")
+    void testIsEmptyAndSize() {
+        final VirtualMap vm = createMap();
+
+        assertEquals(0, vm.size());
+        assertTrue(vm.isEmpty());
+
+        vm.put(A_KEY, APPLE, TestValueCodec.INSTANCE);
+        assertEquals(2, vm.size()); // VM state is included
+        assertFalse(vm.isEmpty());
+        vm.put(B_KEY, BANANA, TestValueCodec.INSTANCE);
+        assertEquals(3, vm.size());
+        assertFalse(vm.isEmpty());
+        vm.remove(B_KEY, TestValueCodec.INSTANCE);
+        assertEquals(2, vm.size());
+        assertFalse(vm.isEmpty());
+
+        vm.remove(A_KEY, TestValueCodec.INSTANCE);
+
+        assertEquals(0, vm.size()); // VM state is hidden
+        assertTrue(vm.isEmpty());
+        vm.release();
     }
 
     // FUTURE WORK test deleting the same key two times in a row.


### PR DESCRIPTION
**Description**:

This PR returns method `isEmpty`. The method returns `true` of `VirtualMapState` is the only object in the map. 
Also, this PR updates `size` method. It returns 0 if `VirtualMapState` is the only element in the map. It returns 2, if the map contains one more elements besides `VirtualMapState`


**Related issue(s)**:

Fixes #19223 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
