### PR TITLE
fix: 19319: Improve MerkleDb reconnect / compaction synchronization

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -13,16 +13,13 @@ import com.swirlds.merkledb.files.DataFileCompactor;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.channels.ClosedByInterruptException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -75,20 +72,14 @@ class MerkleDbCompactionCoordinator {
         return compactionExecutor;
     }
 
-    private final AtomicBoolean compactionEnabled = new AtomicBoolean();
+    // Synchronized on this
+    private boolean compactionEnabled = false;
 
-    // A map of compactor futures by task names
-    final Map<String, Future<Boolean>> futuresByName = new ConcurrentHashMap<>(16);
-
-    // A map of compactors by task names
-    final Map<String, DataFileCompactor> compactorsByName = new ConcurrentHashMap<>(16);
+    // A map of compactors by task names. Synchronized on this
+    final Map<String, DataFileCompactor> compactorsByName = new HashMap<>(16);
 
     @NonNull
     private final MerkleDbConfig merkleDbConfig;
-
-    // Number of compaction tasks currently running. Checked during shutdown to make sure all
-    // tasks are stopped
-    private final AtomicInteger tasksRunning = new AtomicInteger(0);
 
     /**
      * Creates a new instance of {@link MerkleDbCompactionCoordinator}.
@@ -104,8 +95,8 @@ class MerkleDbCompactionCoordinator {
     /**
      * Enables background compaction.
      */
-    void enableBackgroundCompaction() {
-        compactionEnabled.set(true);
+    synchronized void enableBackgroundCompaction() {
+        compactionEnabled = true;
     }
 
     /**
@@ -114,7 +105,7 @@ class MerkleDbCompactionCoordinator {
      * critical for snapshots (e.g. update an index), it will be stopped until {@link
      * #resumeCompaction()}} is called.
      */
-    public void pauseCompaction() throws IOException {
+    public synchronized void pauseCompaction() throws IOException {
         for (final DataFileCompactor compactor : compactorsByName.values()) {
             compactor.pauseCompaction();
         }
@@ -123,7 +114,7 @@ class MerkleDbCompactionCoordinator {
     /**
      * Resumes previously stopped data file collection compaction.
      */
-    public void resumeCompaction() throws IOException {
+    public synchronized void resumeCompaction() throws IOException {
         for (final DataFileCompactor compactor : compactorsByName.values()) {
             compactor.resumeCompaction();
         }
@@ -133,26 +124,24 @@ class MerkleDbCompactionCoordinator {
      * Stops all compactions in progress and disables background compaction. All subsequent calls to
      * compacting methods will be ignored until {@link #enableBackgroundCompaction()} is called.
      */
-    void stopAndDisableBackgroundCompaction() {
-        compactionEnabled.set(false);
+    synchronized void stopAndDisableBackgroundCompaction() {
+        // Make sure no new compaction tasks are scheduled
+        compactionEnabled = false;
         // Interrupt all running compaction tasks, if any
-        for (final Future<Boolean> futureEntry : futuresByName.values()) {
-            futureEntry.cancel(true);
+        for (final DataFileCompactor compactor : compactorsByName.values()) {
+            compactor.interruptCompaction();
         }
-        futuresByName.clear();
-        compactorsByName.clear();
         // Wait till all the tasks are stopped
-        final long now = System.currentTimeMillis();
         try {
-            while ((tasksRunning.get() != 0) && (System.currentTimeMillis() - now < SHUTDOWN_TIMEOUT_MILLIS)) {
-                Thread.sleep(1);
+            while (!compactorsByName.isEmpty()) {
+                wait(SHUTDOWN_TIMEOUT_MILLIS);
             }
         } catch (final InterruptedException e) {
             logger.warn(MERKLE_DB.getMarker(), "Interrupted while waiting for compaction tasks to complete", e);
         }
         // If some tasks are still running, there is nothing else to than to log it
-        if (tasksRunning.get() != 0) {
-            logger.error(MERKLE_DB.getMarker(), "Failed to stop all compactions tasks");
+        if (!compactorsByName.isEmpty()) {
+            logger.warn(MERKLE_DB.getMarker(), "Timed out waiting to stop all compactions tasks");
         }
     }
 
@@ -163,19 +152,18 @@ class MerkleDbCompactionCoordinator {
      * @param key Compaction task name
      * @param compactor Compactor to run
      */
-    public void compactIfNotRunningYet(final String key, final DataFileCompactor compactor) {
-        if (!compactionEnabled.get()) {
+    public synchronized void compactIfNotRunningYet(final String key, final DataFileCompactor compactor) {
+        if (!compactionEnabled) {
             return;
         }
-        if (futuresByName.containsKey(key)) {
+        if (compactorsByName.containsKey(key)) {
             logger.debug(MERKLE_DB.getMarker(), "Compaction for {} is already in progress", key);
             return;
         }
-        assert !compactorsByName.containsKey(key);
         compactorsByName.put(key, compactor);
         final ExecutorService executor = getCompactionExecutor(merkleDbConfig);
         final CompactionTask task = new CompactionTask(key, compactor);
-        futuresByName.put(key, executor.submit(task));
+        executor.submit(task);
     }
 
     /**
@@ -185,11 +173,11 @@ class MerkleDbCompactionCoordinator {
      * @return {@code true} if compaction with this name is currently running, {@code false} otherwise
      */
     public boolean isCompactionRunning(final String key) {
-        return futuresByName.containsKey(key);
+        return compactorsByName.containsKey(key);
     }
 
-    boolean isCompactionEnabled() {
-        return compactionEnabled.get();
+    synchronized boolean isCompactionEnabled() {
+        return compactionEnabled;
     }
 
     /**
@@ -210,7 +198,6 @@ class MerkleDbCompactionCoordinator {
 
         @Override
         public Boolean call() {
-            tasksRunning.incrementAndGet();
             try {
                 return compactor.compact();
             } catch (final InterruptedException | ClosedByInterruptException e) {
@@ -220,9 +207,10 @@ class MerkleDbCompactionCoordinator {
                 // will stop all future merges from happening
                 logger.error(EXCEPTION.getMarker(), "[{}] Compaction failed", id, e);
             } finally {
-                compactorsByName.remove(id);
-                futuresByName.remove(id);
-                tasksRunning.decrementAndGet();
+                synchronized (MerkleDbCompactionCoordinator.this) {
+                    compactorsByName.remove(id);
+                    MerkleDbCompactionCoordinator.this.notifyAll();
+                }
             }
             return false;
         }

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -105,7 +105,7 @@ class MerkleDbCompactionCoordinator {
      * critical for snapshots (e.g. update an index), it will be stopped until {@link
      * #resumeCompaction()}} is called.
      */
-    public synchronized void pauseCompaction() throws IOException {
+    synchronized void pauseCompaction() throws IOException {
         for (final DataFileCompactor compactor : compactorsByName.values()) {
             compactor.pauseCompaction();
         }
@@ -114,7 +114,7 @@ class MerkleDbCompactionCoordinator {
     /**
      * Resumes previously stopped data file collection compaction.
      */
-    public synchronized void resumeCompaction() throws IOException {
+    synchronized void resumeCompaction() throws IOException {
         for (final DataFileCompactor compactor : compactorsByName.values()) {
             compactor.resumeCompaction();
         }
@@ -172,7 +172,7 @@ class MerkleDbCompactionCoordinator {
      * @param key Compactor name
      * @return {@code true} if compaction with this name is currently running, {@code false} otherwise
      */
-    public boolean isCompactionRunning(final String key) {
+    synchronized boolean isCompactionRunning(final String key) {
         return compactorsByName.containsKey(key);
     }
 

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
@@ -799,11 +799,9 @@ public abstract class AbstractLongList<C> implements LongList {
             return true;
         }
         Objects.requireNonNull(action);
+        final BooleanSupplier condition = cond != null ? cond : () -> true;
         long i = minValidIndex.get();
-        for (; i <= max; i++) {
-            if ((cond != null) && !cond.getAsBoolean()) {
-                break;
-            }
+        for (; (i <= max) && condition.getAsBoolean(); i++) {
             final long value = get(i);
             if (value != IMPERMISSIBLE_VALUE) {
                 action.handle(i, value);

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/AbstractLongList.java
@@ -12,6 +12,7 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.utilities.MerkleDbFileUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
@@ -20,8 +21,10 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.BooleanSupplier;
 import java.util.stream.LongStream;
 import java.util.stream.StreamSupport;
 
@@ -781,20 +784,32 @@ public abstract class AbstractLongList<C> implements LongList {
         }
     }
 
-    /** {@inheritDoc} */
+    /**
+     * {@inheritDoc}
+     *
+     * <p>This long list implementation checks the condition (if not null) before every list
+     * item is processed.
+     */
     @Override
-    public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
+    public <T extends Throwable> boolean forEach(
+            @NonNull final LongAction<T> action, @Nullable final BooleanSupplier cond) throws InterruptedException, T {
         final long max = maxValidIndex.get();
         if (max < 0) {
             // Empty list, nothing to do
-            return;
+            return true;
         }
-        for (long i = minValidIndex.get(); i <= max; i++) {
+        Objects.requireNonNull(action);
+        long i = minValidIndex.get();
+        for (; i <= max; i++) {
+            if ((cond != null) && !cond.getAsBoolean()) {
+                break;
+            }
             final long value = get(i);
             if (value != IMPERMISSIBLE_VALUE) {
                 action.handle(i, value);
             }
         }
+        return i == max + 1;
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/CASableLongIndex.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/CASableLongIndex.java
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkledb.collections;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.function.BooleanSupplier;
+
 /**
  * An interface for classes that provide long index functionality. Such long indices must
  * support Compare-And-Swap operations and iterations over all valid index entries.
@@ -33,17 +37,25 @@ public interface CASableLongIndex {
     /**
      * Iterates over all valid index entries and calls the specified action for each of them.
      *
-     * @param action Action to call.
+     * <p>If a condition to check is provided, implementations should do their best checking it,
+     * but there is no guarantee it is checked before each entry in the list, or checked at all.
+     * If the condition is {@code false}, no more index entries are iterated over, and this
+     * method returns.
+     *
      * @param <T> Type of throwables allowed to throw by this method
+     * @param action Action to call
+     * @param whileCondition Optional condition to check if this method should be stopped
+     * @return {@code true} if all index items have been processed by this method
      * @throws InterruptedException If the thread running the method is interrupted
      * @throws T If an error occurs
      */
-    <T extends Throwable> void forEach(LongAction<T> action) throws InterruptedException, T;
+    <T extends Throwable> boolean forEach(@NonNull LongAction<T> action, @Nullable BooleanSupplier whileCondition)
+            throws InterruptedException, T;
 
     /**
-     * Action interface to use in {@link #forEach(LongAction)}. It could be a standard Java API
-     * interface like BiFunction, but all these APIs work with boxed Long type instead of
-     * primitive longs, which adds unnecessary load on GC. So let's use something more simple
+     * Action interface to use in {@link #forEach(LongAction, BooleanSupplier)}. It could be a standard Java
+     * API interface like BiFunction, but all these APIs work with boxed Long type instead of primitive
+     * longs, which adds unnecessary load on GC. So let's use something more simple
      *
      * @param <T> Type of throwable allowed to throw by the action
      */

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
@@ -181,7 +181,7 @@ public class DataFileCompactor {
      * @throws IOException          If there was a problem with the compaction
      * @throws InterruptedException If the compaction thread was interrupted
      */
-    synchronized List<Path> compactFiles(
+    List<Path> compactFiles(
             final CASableLongIndex index,
             final List<? extends DataFileReader> filesToCompact,
             final int targetCompactionLevel)

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
@@ -138,7 +138,7 @@ public class DataFileCompactor {
      * This flag is set in {@link #interruptCompaction()} and checked periodically in the main
      * compaction loop.
      */
-    private final AtomicBoolean interruptFlag = new AtomicBoolean(false);
+    private volatile boolean interruptFlag = false;
 
     /**
      * @param dbConfig                       MerkleDb config
@@ -192,7 +192,7 @@ public class DataFileCompactor {
             return Collections.emptyList();
         }
 
-        interruptFlag.set(false);
+        interruptFlag = false;
 
         // create a merge time stamp, this timestamp is the newest time of the set of files we are
         // merging
@@ -407,12 +407,12 @@ public class DataFileCompactor {
      * after this method is called, but it's stopped in reasonable time.
      */
     public void interruptCompaction() {
-        interruptFlag.set(true);
+        interruptFlag = true;
     }
 
     // A helper method to avoid using a lambda in compactFiles()
     public boolean notInterrupted() {
-        return !interruptFlag.get();
+        return !interruptFlag;
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
@@ -510,12 +510,14 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
             // Count valid entries and collect their indices
             final AtomicLong count = new AtomicLong(0);
             final Set<Long> keysInForEach = new HashSet<>();
-            longList.forEach((path, location) -> {
-                count.incrementAndGet();
-                keysInForEach.add(path);
+            longList.forEach(
+                    (path, location) -> {
+                        count.incrementAndGet();
+                        keysInForEach.add(path);
 
-                assertEquals(path + 100, location, "Mismatch in value for index " + path);
-            });
+                        assertEquals(path + 100, location, "Mismatch in value for index " + path);
+                    },
+                    null);
 
             // Ensure the number of valid indices matches the expected range
             assertEquals(
@@ -622,6 +624,40 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 Files.delete(tmpFile);
                 Files.delete(tmpDir);
             }
+        }
+    }
+
+    @Test
+    void forEachWhileTest() throws Exception {
+        try (final LongList list = createLongList(10, 100, 0)) {
+            list.updateValidRange(0, 99);
+            for (int i = 0; i < 100; i++) {
+                list.put(i, i + 1000);
+            }
+            final AtomicInteger counter = new AtomicInteger(0);
+            list.forEach(
+                    (l, v) -> {
+                        counter.incrementAndGet();
+                    },
+                    () -> counter.get() < 42);
+            assertEquals(42, counter.get());
+        }
+    }
+
+    @Test
+    void forEachWhileNullCondTest() throws Exception {
+        try (final LongList list = createLongList(10, 100, 0)) {
+            list.updateValidRange(0, 99);
+            for (int i = 0; i < 100; i++) {
+                list.put(i, i + 1000);
+            }
+            final AtomicInteger counter = new AtomicInteger(0);
+            list.forEach(
+                    (l, v) -> {
+                        counter.incrementAndGet();
+                    },
+                    null);
+            assertEquals(100, counter.get());
         }
     }
 

--- a/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
+++ b/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/MerkleDbDataSourceSnapshotMergeTest.java
@@ -190,8 +190,12 @@ class MerkleDbDataSourceSnapshotMergeTest {
                             "pathToKeyValue", dataSource.newPathToKeyValueCompactor());
 
                     assertEventuallyTrue(
-                            dataSource.compactionCoordinator.futuresByName::isEmpty,
-                            Duration.ofSeconds(1),
+                            () -> {
+                                synchronized (dataSource.compactionCoordinator) {
+                                    return dataSource.compactionCoordinator.compactorsByName.isEmpty();
+                                }
+                            },
+                            Duration.ofSeconds(4),
                             "compaction tasks should have been completed");
 
                     compacting.set(false);

--- a/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -116,10 +117,12 @@ class DataFileCollectionCompactionTest {
                 return false;
             }
 
-            public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
+            public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
+                    throws InterruptedException, T {
                 for (final Map.Entry<Long, Long> e : index.entrySet()) {
                     action.handle(e.getKey(), e.getValue());
                 }
+                return true;
             }
         };
         final var compactor =
@@ -208,11 +211,12 @@ class DataFileCollectionCompactionTest {
                             return true;
                         }
 
-                        public <T extends Throwable> void forEach(final LongAction<T> action)
+                        public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
                                 throws InterruptedException, T {
                             for (int i = 0; i < MAXKEYS; i++) {
                                 action.handle(i, index[i]);
                             }
+                            return true;
                         }
                     };
 
@@ -265,10 +269,12 @@ class DataFileCollectionCompactionTest {
                     return true;
                 }
 
-                public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
+                public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
+                        throws InterruptedException, T {
                     for (int i = 0; i < MAXKEYS; i++) {
                         action.handle(i, index[i]);
                     }
+                    return true;
                 }
             };
 
@@ -323,11 +329,12 @@ class DataFileCollectionCompactionTest {
                         return index.compareAndSet((int) key, oldValue, newValue);
                     }
 
-                    public <T extends Throwable> void forEach(final LongAction<T> action)
+                    public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
                             throws InterruptedException, T {
                         for (int i = 0; i < index.length(); i++) {
                             action.handle(i, index.get(i));
                         }
+                        return true;
                     }
                 };
 
@@ -396,11 +403,12 @@ class DataFileCollectionCompactionTest {
                         return index.compareAndSet((int) key, oldValue, newValue);
                     }
 
-                    public <T extends Throwable> void forEach(final LongAction<T> action)
+                    public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
                             throws InterruptedException, T {
                         for (int i = 0; i < index.length(); i++) {
                             action.handle(i, index.get(i));
                         }
+                        return true;
                     }
                 };
 
@@ -615,8 +623,9 @@ class DataFileCollectionCompactionTest {
                 return true;
             }
 
-            public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
-                index.forEach(action);
+            public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
+                    throws InterruptedException, T {
+                return index.forEach(action, cond);
             }
         };
 
@@ -647,8 +656,9 @@ class DataFileCollectionCompactionTest {
                 return true;
             }
 
-            public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
-                index2.forEach(action);
+            public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
+                    throws InterruptedException, T {
+                return index2.forEach(action, cond);
             }
         };
 


### PR DESCRIPTION
Fix summary:

* `DataFileCompactor.snapshotCompactionLock` is changed from `Semaphore` to `ReentrantLock`
* `MerkleDbCompactionCoordinator` synchronization is reworked, now it has most methods synchronized
* Busy loop in `MerkleDbCompactionCoordinator.stopAndDisableBackgroundCompaction()` is reworked with `wait()`
* `CASableLongIndex.forEach()` is changed to return boolean (if all entries are processed) and it now accepts a boolean supplier to check whether iteration over all list entries should be stopped (gracefully)
* To interrupt data compaction tasks, `Thread.interrupt()` is no longer used. Instead, a new method is introduced to `DataFileCompactor` to interrupt the task explicitly. This method sets a flag, which is checked periodically in `compactFiles()`, so this method can return gracefully

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/19319
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
