### PR TITLE
chore: Logging improvements

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleInstrumentedNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleInstrumentedNode.java
@@ -27,8 +27,9 @@ public class TurtleInstrumentedNode extends TurtleNode implements InstrumentedNo
             @NonNull final Roster roster,
             @NonNull final KeysAndCerts privateKey,
             @NonNull final SimulatedNetwork network,
+            @NonNull final TurtleLogging logging,
             @NonNull final Path rootOutputDirectory) {
-        super(randotron, time, nodeId, roster, privateKey, network, rootOutputDirectory);
+        super(randotron, time, nodeId, roster, privateKey, network, logging, rootOutputDirectory);
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleLogging.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleLogging.java
@@ -1,0 +1,128 @@
+package org.hiero.otter.fixtures.turtle;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.Filter.Result;
+import org.apache.logging.log4j.core.appender.ConsoleAppender;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.builder.api.AppenderComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.apache.logging.log4j.core.config.builder.api.FilterComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.KeyValuePairComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.LayoutComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.api.RootLoggerComponentBuilder;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.hiero.consensus.model.node.NodeId;
+
+/**
+ * Provides logging configurations and functionality for the Turtle framework.
+ */
+public class TurtleLogging {
+
+    private final Path globalLogFile;
+    private final Map<NodeId, Path> nodeIdConfigurations = new ConcurrentHashMap<>();
+
+    public TurtleLogging(@NonNull final Path rootOutputDirectory) {
+        globalLogFile = rootOutputDirectory.resolve("otter.log");
+        updateLogging();
+    }
+
+    public void addNodeLogging(@NonNull final NodeId nodeId, @NonNull final Path outputDirectory) {
+        nodeIdConfigurations.put(nodeId, outputDirectory);
+        updateLogging();
+    }
+
+    public void removeNodeLogging(@NonNull final NodeId nodeId) {
+        nodeIdConfigurations.remove(nodeId);
+        updateLogging();
+    }
+
+    private void updateLogging() {
+        final ConfigurationBuilder<BuiltConfiguration> configuration = ConfigurationBuilderFactory.newConfigurationBuilder();
+
+        final LayoutComponentBuilder globalLogLayout = configuration.newLayout("PatternLayout")
+                .addAttribute("pattern", "%d{yyyy-MM-dd HH:mm:ss.SSS} [%t] %notEmpty{[%marker] }%-5level %logger{36} - %msg %n");
+        final LayoutComponentBuilder nodeLogLayout = configuration.newLayout("PatternLayout")
+                .addAttribute("pattern", "%d{yyyy-MM-dd HH:mm:ss.SSS} [nodeId-%X{nodeId}] [%t] %notEmpty{[%marker] }%-5level %logger{36} - %msg %n");
+
+        final FilterComponentBuilder infoFilter = configuration.newFilter("ThresholdFilter", Result.NEUTRAL, Result.DENY)
+                .addAttribute("level", Level.INFO);
+
+        final ComponentBuilder<?> globalFilter = configuration.newComponent("filters")
+                .addComponent(infoFilter);
+
+        final RootLoggerComponentBuilder rootLogger = configuration.newRootLogger(Level.ALL);
+
+        for (final Map.Entry<NodeId, Path> entry : nodeIdConfigurations.entrySet()) {
+            final NodeId nodeId = entry.getKey();
+            final Path outputDirectory = entry.getValue();
+            final KeyValuePairComponentBuilder keyValuePair = configuration.newKeyValuePair("nodeId", nodeId.toString());
+
+            final FilterComponentBuilder excludeNodeFilter = configuration.newFilter("ThreadContextMapFilter", Result.DENY, Result.NEUTRAL)
+                    .addComponent(keyValuePair);
+            globalFilter.addComponent(excludeNodeFilter);
+
+            final FilterComponentBuilder nodeOnlyFilter = configuration.newFilter("ThreadContextMapFilter", Result.NEUTRAL, Result.DENY)
+                    .addComponent(keyValuePair);
+            final FilterComponentBuilder excludeHashStateFilter = configuration.newFilter("MarkerFilter", Result.DENY, Result.NEUTRAL)
+                    .addAttribute("marker", "STATE_HASH");
+            final FilterComponentBuilder hashStateOnlyFilter = configuration.newFilter("MarkerFilter", Result.NEUTRAL, Result.DENY)
+                    .addAttribute("marker", "STATE_HASH");
+
+            final ComponentBuilder regularNodeFilter = configuration.newComponent("filters")
+                    .addComponent(infoFilter)
+                    .addComponent(nodeOnlyFilter)
+                    .addComponent(excludeHashStateFilter);
+            final AppenderComponentBuilder regularNodeFileAppender = configuration.newAppender("FileLogger-" + nodeId, "File")
+                    .addAttribute("fileName", outputDirectory.resolve("swirlds.log").toString())
+                    .addAttribute("append", true)
+                    .add(nodeLogLayout)
+                    .addComponent(regularNodeFilter);
+
+            final ComponentBuilder hashStateNodeFilter = configuration.newComponent("filters")
+                    .addComponent(infoFilter)
+                    .addComponent(nodeOnlyFilter)
+                    .addComponent(hashStateOnlyFilter);
+            final AppenderComponentBuilder hashStateFileAppender = configuration.newAppender("HashStreamLogger-" + nodeId, "File")
+                    .addAttribute("fileName", outputDirectory.resolve("swirlds-hashstream.log").toString())
+                    .addAttribute("append", true)
+                    .add(nodeLogLayout)
+                    .addComponent(hashStateNodeFilter);
+
+            configuration.add(regularNodeFileAppender);
+            configuration.add(hashStateFileAppender);
+            rootLogger.add(configuration.newAppenderRef("FileLogger-" + nodeId));
+            rootLogger.add(configuration.newAppenderRef("HashStreamLogger-" + nodeId));
+        }
+
+        final AppenderComponentBuilder inMemoryAppender = configuration.newAppender("InMemory", "InMemoryAppender");
+        final AppenderComponentBuilder consoleAppender = configuration.newAppender("ConsoleMarker", "Console")
+                .addAttribute("target", ConsoleAppender.Target.SYSTEM_OUT)
+                .add(globalLogLayout)
+                .addComponent(globalFilter);
+        final AppenderComponentBuilder globalFileAppender = configuration.newAppender("FileLogger", "File")
+                .addAttribute("fileName", globalLogFile.toString())
+                .addAttribute("append", true)
+                .add(globalLogLayout)
+                .addComponent(globalFilter);
+
+        configuration
+                .add(inMemoryAppender)
+                .add(consoleAppender)
+                .add(globalFileAppender);
+
+        rootLogger
+                .add(configuration.newAppenderRef("InMemory"))
+                .add(configuration.newAppenderRef("ConsoleMarker"))
+                .add(configuration.newAppenderRef("FileLogger"));
+
+        configuration.add(rootLogger);
+
+        Configurator.reconfigure(configuration.build());
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -64,6 +64,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
 
     private final Randotron randotron;
     private final TurtleTimeManager timeManager;
+    private final TurtleLogging logging;
     private final Path rootOutputDirectory;
     private final List<TurtleNode> nodes = new ArrayList<>();
 
@@ -83,9 +84,11 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
     public TurtleNetwork(
             @NonNull final Randotron randotron,
             @NonNull final TurtleTimeManager timeManager,
+            @NonNull final TurtleLogging logging,
             @NonNull final Path rootOutputDirectory) {
         this.randotron = requireNonNull(randotron);
         this.timeManager = requireNonNull(timeManager);
+        this.logging = requireNonNull(logging);
         this.rootOutputDirectory = requireNonNull(rootOutputDirectory);
     }
 
@@ -126,7 +129,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
     private TurtleNode createTurtleNode(
             @NonNull final NodeId nodeId, @NonNull final Roster roster, @NonNull final KeysAndCerts privateKeys) {
         final Path outputDir = rootOutputDirectory.resolve("node-" + nodeId.id());
-        return new TurtleNode(randotron, timeManager.time(), nodeId, roster, privateKeys, simulatedNetwork, outputDir);
+        return new TurtleNode(randotron, timeManager.time(), nodeId, roster, privateKeys, simulatedNetwork, logging, outputDir);
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -15,9 +15,7 @@ import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.base.time.Time;
 import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.io.config.FileSystemManagerConfig_;
 import com.swirlds.common.io.filesystem.FileSystemManager;
-import com.swirlds.common.io.utility.FileUtils;
 import com.swirlds.common.io.utility.RecycleBin;
 import com.swirlds.common.test.fixtures.Randotron;
 import com.swirlds.common.test.fixtures.platform.TestPlatformContextBuilder;
@@ -40,8 +38,6 @@ import com.swirlds.platform.util.RandomBuilder;
 import com.swirlds.platform.wiring.PlatformWiring;
 import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.File;
-import java.io.IOException;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
@@ -95,6 +91,7 @@ public class TurtleNode implements Node, TurtleTimeManager.TimeTickReceiver {
     private final Roster roster;
     private final KeysAndCerts keysAndCerts;
     private final SimulatedNetwork network;
+    private final TurtleLogging logging;
     private final TurtleNodeConfiguration nodeConfiguration;
     private final NodeResultsCollector resultsCollector;
 
@@ -115,7 +112,9 @@ public class TurtleNode implements Node, TurtleTimeManager.TimeTickReceiver {
             @NonNull final Roster roster,
             @NonNull final KeysAndCerts keysAndCerts,
             @NonNull final SimulatedNetwork network,
+            @NonNull final TurtleLogging logging,
             @NonNull final Path outputDirectory) {
+        logging.addNodeLogging(selfId, outputDirectory);
         try {
             ThreadContext.put(THREAD_CONTEXT_NODE_ID, selfId.toString());
 
@@ -125,6 +124,7 @@ public class TurtleNode implements Node, TurtleTimeManager.TimeTickReceiver {
             this.roster = requireNonNull(roster);
             this.keysAndCerts = requireNonNull(keysAndCerts);
             this.network = requireNonNull(network);
+            this.logging = requireNonNull(logging);
             this.nodeConfiguration = new TurtleNodeConfiguration(outputDirectory);
             this.resultsCollector = new NodeResultsCollector(selfId);
             this.platformStatusChangeListener = data -> {
@@ -297,17 +297,6 @@ public class TurtleNode implements Node, TurtleTimeManager.TimeTickReceiver {
             checkLifeCycle(LifeCycle.STARTED, "Node has already been started.");
             checkLifeCycle(LifeCycle.DESTROYED, "Node has already been destroyed.");
 
-            // Clean the output directory and start the node
-            final String rootPath =
-                    nodeConfiguration.createConfiguration().getValue(FileSystemManagerConfig_.ROOT_PATH);
-            log.info("Deleting directory: {}", rootPath);
-            if (rootPath != null) {
-                try {
-                    FileUtils.deleteDirectory(new File(rootPath).toPath());
-                } catch (IOException ex) {
-                    log.warn("Failed to delete directory: {}", rootPath, ex);
-                }
-            }
             doStartNode();
 
         } finally {
@@ -325,6 +314,8 @@ public class TurtleNode implements Node, TurtleTimeManager.TimeTickReceiver {
 
             doShutdownNode();
             lifeCycle = LifeCycle.DESTROYED;
+
+            logging.removeNodeLogging(selfId);
 
         } finally {
             ThreadContext.remove(THREAD_CONTEXT_NODE_ID);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -107,7 +107,8 @@ public class TurtleTestEnvironment implements TestEnvironment {
             rootLoggerConfig.setLevel(Level.ALL);
 
             final PatternLayout layout = PatternLayout.newBuilder()
-                    .withPattern("%d{yyyy-MM-dd HH:mm:ss.SSS} [%X] [%t] [%marker] %-5level %logger{36} - %msg %n")
+                    .withPattern(
+                            "%d{yyyy-MM-dd HH:mm:ss.SSS} %notEmpty{[nodeId-%X{nodeId}] }[%t] %notEmpty{[%marker] }%-5level %logger{36} - %msg %n")
                     .withConfiguration(loggerContextConfig)
                     .build();
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.fixtures.turtle;
 
-import static com.swirlds.logging.legacy.LogMarker.STATE_HASH;
 import static com.swirlds.platform.test.fixtures.state.TestingAppStateInitializer.registerMerkleStateRootClassIds;
 
 import com.swirlds.base.test.fixtures.time.FakeTime;
@@ -13,24 +12,14 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
-import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.core.Filter.Result;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.ConsoleAppender;
-import org.apache.logging.log4j.core.appender.FileAppender;
-import org.apache.logging.log4j.core.config.Configuration;
-import org.apache.logging.log4j.core.config.LoggerConfig;
-import org.apache.logging.log4j.core.filter.MarkerFilter;
-import org.apache.logging.log4j.core.layout.PatternLayout;
 import org.hiero.base.constructable.ConstructableRegistry;
 import org.hiero.base.constructable.ConstructableRegistryException;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
 import org.hiero.otter.fixtures.TransactionGenerator;
-import org.hiero.otter.fixtures.logging.internal.InMemoryAppender;
 
 /**
  * A test environment for the Turtle framework.
@@ -57,6 +46,18 @@ public class TurtleTestEnvironment implements TestEnvironment {
      * Constructor for the {@link TurtleTestEnvironment} class.
      */
     public TurtleTestEnvironment() {
+        final Path rootOutputDirectory = Path.of("build", "turtle");
+        try {
+            if (Files.exists(rootOutputDirectory)) {
+                FileUtils.deleteDirectory(rootOutputDirectory);
+            }
+            Files.createDirectories(rootOutputDirectory);
+        } catch (IOException ex) {
+            log.warn("Failed to delete directory: {}", rootOutputDirectory, ex);
+        }
+
+        final TurtleLogging logging = new TurtleLogging(rootOutputDirectory);
+
         final Randotron randotron = Randotron.create();
 
         final FakeTime time = new FakeTime(randotron.nextInstant(), Duration.ZERO);
@@ -73,85 +74,14 @@ public class TurtleTestEnvironment implements TestEnvironment {
             throw new RuntimeException(e);
         }
 
-        final Path rootOutputDirectory = Path.of("build", "turtle");
-        try {
-            if (Files.exists(rootOutputDirectory)) {
-                FileUtils.deleteDirectory(rootOutputDirectory);
-            }
-        } catch (IOException ex) {
-            log.warn("Failed to delete directory: {}", rootOutputDirectory, ex);
-        }
-        initLogging();
-
         timeManager = new TurtleTimeManager(time, GRANULARITY);
 
-        network = new TurtleNetwork(randotron, timeManager, rootOutputDirectory);
+        network = new TurtleNetwork(randotron, timeManager, logging, rootOutputDirectory);
 
         generator = new TurtleTransactionGenerator(network, randotron);
 
         timeManager.addTimeTickReceiver(network);
         timeManager.addTimeTickReceiver(generator);
-    }
-
-    private static void initLogging() {
-        final LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
-        final Configuration loggerContextConfig = loggerContext.getConfiguration();
-
-        if (loggerContextConfig.getAppender("InMemory") == null) {
-            final InMemoryAppender inMemoryAppender = InMemoryAppender.createAppender("InMemory");
-            inMemoryAppender.start();
-            loggerContextConfig.addAppender(inMemoryAppender);
-
-            final LoggerConfig rootLoggerConfig = loggerContextConfig.getLoggerConfig(LogManager.ROOT_LOGGER_NAME);
-            rootLoggerConfig.addAppender(inMemoryAppender, null, null);
-            rootLoggerConfig.setLevel(Level.ALL);
-
-            final PatternLayout layout = PatternLayout.newBuilder()
-                    .withPattern(
-                            "%d{yyyy-MM-dd HH:mm:ss.SSS} %notEmpty{[nodeId-%X{nodeId}] }[%t] %notEmpty{[%marker] }%-5level %logger{36} - %msg %n")
-                    .withConfiguration(loggerContextConfig)
-                    .build();
-
-            final ConsoleAppender consoleAppender = ConsoleAppender.newBuilder()
-                    .setName("ConsoleMarker")
-                    .setLayout(layout)
-                    .setTarget(ConsoleAppender.Target.SYSTEM_OUT)
-                    .build();
-
-            final MarkerFilter noStateHashFilter =
-                    MarkerFilter.createFilter(STATE_HASH.name(), Result.DENY, Result.NEUTRAL);
-            consoleAppender.addFilter(noStateHashFilter);
-
-            consoleAppender.start();
-            rootLoggerConfig.addAppender(consoleAppender, Level.INFO, null);
-
-            final FileAppender fileAppender = FileAppender.newBuilder()
-                    .setName("FileLogger")
-                    .setLayout(layout)
-                    .withFileName("build/turtle/otter.log")
-                    .withAppend(true)
-                    .build();
-            fileAppender.addFilter(noStateHashFilter);
-            fileAppender.start();
-            rootLoggerConfig.addAppender(fileAppender, Level.DEBUG, null);
-
-            final FileAppender stateHashFileAppender = FileAppender.newBuilder()
-                    .setName("StateHashFileLogger")
-                    .setLayout(layout)
-                    .withFileName("build/turtle/otter-state-hash.log")
-                    .withAppend(true)
-                    .build();
-
-            // Accept only logs with marker STATE_HASH
-            final MarkerFilter onlyStateHashFilter =
-                    MarkerFilter.createFilter(STATE_HASH.name(), Result.ACCEPT, Result.DENY);
-            stateHashFileAppender.addFilter(onlyStateHashFilter);
-
-            stateHashFileAppender.start();
-            rootLoggerConfig.addAppender(stateHashFileAppender, Level.DEBUG, null);
-
-            loggerContext.updateLoggers();
-        }
     }
 
     /**


### PR DESCRIPTION
**Description**:

This PR updates the logging configuration for Otter tests running on Turtle:

- The console shows only messages that do not come from a node.
- The file `turtle/otter.log` also contains all messages that do not come from a specific node.
- We create a `swirlds.log` file in each node's folder containing all log statements except those marked with `STATE_HASH`.
We create another file, `swirlds-hashstream.log`, for each node in its folder, which contains only the `STATE_HASH `Entries of that node.

Some background-process log statements do not contain the `nodeId` and therefore appear in the wrong logs. Create an issue to fix this: #19339.

In addition, this PR changes the implementation to use `ConfigurationBuilder`, the recommended way to change the log4j-configuration programmatically.

**Related issue(s)**:

Fixes #19328 
