### PR TITLE
chore: Remove the migration code for setting declineReward=true for all nodes on upgrade

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
@@ -378,23 +378,6 @@ public class SystemTransactions {
         if (autoNodeAdminKeyUpdates.tryIfPresent(adminConfig.upgradeSysFilesLoc(), systemContext)) {
             dispatch.stack().commitFullStack();
         }
-        // (FUTURE) Remove this 0.61 and 0.62 -specific code initiating all system node accounts to decline rewards
-        final var nodeStore = dispatch.handleContext().storeFactory().readableStore(ReadableNodeStore.class);
-        for (int i = 0; i < nodeStore.sizeOfState(); i++) {
-            final var node = nodeStore.get(i);
-            final var nodeInfo = networkInfo.nodeInfo(i);
-            if (nodeInfo != null && node != null && !node.deleted()) {
-                log.info(
-                        "Updating node{} with system node account {} to decline rewards",
-                        nodeInfo.nodeId(),
-                        nodeInfo.accountId());
-                systemContext.dispatchAdmin(b -> b.nodeUpdate(NodeUpdateTransactionBody.newBuilder()
-                        .nodeId(nodeInfo.nodeId())
-                        .declineReward(true)
-                        .build()));
-            }
-        }
-        dispatch.stack().commitFullStack();
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemTransactionsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemTransactionsTest.java
@@ -174,7 +174,7 @@ class SystemTransactionsTest {
         verifyUpdateDispatch(filesConfig.hapiPermissions(), serializedPermissionOverrides());
         verifyUpdateDispatch(filesConfig.throttleDefinitions(), serializedThrottleOverrides());
         verifyUpdateDispatch(filesConfig.feeSchedules(), serializedFeeSchedules());
-        verify(stack, times(6)).commitFullStack();
+        verify(stack, times(5)).commitFullStack();
     }
 
     @Test
@@ -192,7 +192,7 @@ class SystemTransactionsTest {
         subject.doPostUpgradeSetup(dispatch);
 
         verify(fileService).updateAddressBookAndNodeDetailsAfterFreeze(any(SystemContext.class), eq(readableNodeStore));
-        verify(stack, times(2)).commitFullStack();
+        verify(stack, times(1)).commitFullStack();
 
         final var infoLogs = logCaptor.infoLogs();
         assertThat(infoLogs.size()).isEqualTo(5);
@@ -223,7 +223,7 @@ class SystemTransactionsTest {
         subject.doPostUpgradeSetup(dispatch);
 
         verify(fileService).updateAddressBookAndNodeDetailsAfterFreeze(any(SystemContext.class), eq(readableNodeStore));
-        verify(stack, times(2)).commitFullStack();
+        verify(stack, times(1)).commitFullStack();
 
         final var errorLogs = logCaptor.errorLogs();
         assertThat(errorLogs.size()).isEqualTo(4);


### PR DESCRIPTION
Remove the migration code for setting declineReward=true for all nodes on upgrade

Cherry-pick https://github.com/hiero-ledger/hiero-consensus-node/pull/19338