### PR TITLE
feat: remove shard/realm negative check in asTokenId

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -114,11 +114,7 @@ public class ConversionUtils {
      */
     public static TokenID asTokenId(@NonNull final com.esaulpaugh.headlong.abi.Address address) {
         final var explicit = explicitFromHeadlong(address);
-        return TokenID.newBuilder()
-                .shardNum(shardOfLongZero(explicit))
-                .realmNum(realmOfLongZero(explicit))
-                .tokenNum(numberOfLongZero(explicit))
-                .build();
+        return TokenID.newBuilder().tokenNum(numberOfLongZero(explicit)).build();
     }
 
     /**
@@ -780,42 +776,6 @@ public class ConversionUtils {
             throw new IllegalArgumentException("Number is negative");
         }
         return number;
-    }
-
-    /**
-     * Given an explicit 20-byte addresss, returns its realm value.
-     *
-     * @param explicit the explicit 20-byte address
-     * @return its realm value
-     */
-    public static long realmOfLongZero(@NonNull final byte[] explicit) {
-        final var realm = longFrom(
-                explicit[4],
-                explicit[5],
-                explicit[6],
-                explicit[7],
-                explicit[8],
-                explicit[9],
-                explicit[10],
-                explicit[11]);
-        if (realm < 0) {
-            throw new IllegalArgumentException("Realm is negative");
-        }
-        return realm;
-    }
-
-    /**
-     * Given an explicit 20-byte addresss, returns its shard value.
-     *
-     * @param explicit the explicit 20-byte address
-     * @return its shard value
-     */
-    public static int shardOfLongZero(@NonNull final byte[] explicit) {
-        final var shard = longFrom(explicit[0], explicit[1], explicit[2], explicit[3]);
-        if (shard < 0) {
-            throw new IllegalArgumentException("Shard is negative");
-        }
-        return shard;
     }
 
     // too many arguments

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -763,7 +763,7 @@ public class ConversionUtils {
      * @return its long value
      */
     public static long numberOfLongZero(@NonNull final byte[] explicit) {
-        final var number = longFrom(
+        return longFrom(
                 explicit[12],
                 explicit[13],
                 explicit[14],
@@ -772,10 +772,6 @@ public class ConversionUtils {
                 explicit[17],
                 explicit[18],
                 explicit[19]);
-        if (number < 0) {
-            throw new IllegalArgumentException("Number is negative");
-        }
-        return number;
     }
 
     // too many arguments

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/utils/ConversionUtils.java
@@ -114,7 +114,11 @@ public class ConversionUtils {
      */
     public static TokenID asTokenId(@NonNull final com.esaulpaugh.headlong.abi.Address address) {
         final var explicit = explicitFromHeadlong(address);
-        return TokenID.newBuilder().tokenNum(numberOfLongZero(explicit)).build();
+        return TokenID.newBuilder()
+                .shardNum(shardOfLongZero(explicit))
+                .realmNum(realmOfLongZero(explicit))
+                .tokenNum(numberOfLongZero(explicit))
+                .build();
     }
 
     /**
@@ -772,6 +776,34 @@ public class ConversionUtils {
                 explicit[17],
                 explicit[18],
                 explicit[19]);
+    }
+
+    /**
+     * Given an explicit 20-byte addresss, returns its realm value.
+     *
+     * @param explicit the explicit 20-byte address
+     * @return its realm value
+     */
+    public static long realmOfLongZero(@NonNull final byte[] explicit) {
+        return longFrom(
+                explicit[4],
+                explicit[5],
+                explicit[6],
+                explicit[7],
+                explicit[8],
+                explicit[9],
+                explicit[10],
+                explicit[11]);
+    }
+
+    /**
+     * Given an explicit 20-byte addresss, returns its shard value.
+     *
+     * @param explicit the explicit 20-byte address
+     * @return its shard value
+     */
+    public static int shardOfLongZero(@NonNull final byte[] explicit) {
+        return longFrom(explicit[0], explicit[1], explicit[2], explicit[3]);
     }
 
     // too many arguments

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
@@ -69,9 +69,7 @@ import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.log.LogsBloomFilter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -331,23 +329,13 @@ class ConversionUtilsTest {
 
     @Test
     void asTokenId() {
-        final var address = com.esaulpaugh.headlong.abi.Address.wrap("0x0000000500000000000000060000000000000007");
+        final var address = com.esaulpaugh.headlong.abi.Address.wrap("0x0000000000000000000000000000000000000007");
 
         var tokenId = ConversionUtils.asTokenId(address);
 
-        assertEquals(5, tokenId.shardNum());
-        assertEquals(6, tokenId.realmNum());
+        assertEquals(0, tokenId.shardNum());
+        assertEquals(0, tokenId.realmNum());
         assertEquals(7, tokenId.tokenNum());
-    }
-
-    @ParameterizedTest
-    @MethodSource("asTokenIdWithNegativeValuesProvideParameters")
-    void asTokenIdWithNegativeValues(String hex, String errorMessage) {
-        final var address = com.esaulpaugh.headlong.abi.Address.wrap(hex);
-
-        IllegalArgumentException exception =
-                assertThrows(IllegalArgumentException.class, () -> ConversionUtils.asTokenId(address));
-        assertEquals(errorMessage, exception.getMessage());
     }
 
     private static Stream<Arguments> asTokenIdWithNegativeValuesProvideParameters() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/utils/ConversionUtilsTest.java
@@ -329,12 +329,12 @@ class ConversionUtilsTest {
 
     @Test
     void asTokenId() {
-        final var address = com.esaulpaugh.headlong.abi.Address.wrap("0x0000000000000000000000000000000000000007");
+        final var address = com.esaulpaugh.headlong.abi.Address.wrap("0x0000000500000000000000060000000000000007");
 
         var tokenId = ConversionUtils.asTokenId(address);
 
-        assertEquals(0, tokenId.shardNum());
-        assertEquals(0, tokenId.realmNum());
+        assertEquals(5, tokenId.shardNum());
+        assertEquals(6, tokenId.realmNum());
         assertEquals(7, tokenId.tokenNum());
     }
 


### PR DESCRIPTION
**Description**:
when converting a possible long zero token address into a token Id, remove the check for negative values as this used to not throw an exception when the address is a non-long zero EVM address

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
