### PR TITLE
chore: Fix flaky tests

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigMapGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigMapGenerator.java
@@ -13,7 +13,7 @@ import java.util.List;
  * nature. Generally that nature is that each prefix is be the shortest unique prefix to
  * identify its corresponding public key among all that sign; though in some cases we
  * must always include the full prefix. (E.g., to trigger a hollow account completion.)
- *In case of {@link Nature#FULL_PREFIXES} the prefixes are the full public keys.
+ * In case of {@link Nature#FULL_PREFIXES} the prefixes are the full public keys.
  *
  * <p>For negative testing there are also natures like {@link Nature#AMBIGUOUS_PREFIXES}
  * and {@link Nature#CONFUSED_PREFIXES} which may construct invalid maps.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigMapGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/SigMapGenerator.java
@@ -13,6 +13,7 @@ import java.util.List;
  * nature. Generally that nature is that each prefix is be the shortest unique prefix to
  * identify its corresponding public key among all that sign; though in some cases we
  * must always include the full prefix. (E.g., to trigger a hollow account completion.)
+ *In case of {@link Nature#FULL_PREFIXES} the prefixes are the full public keys.
  *
  * <p>For negative testing there are also natures like {@link Nature#AMBIGUOUS_PREFIXES}
  * and {@link Nature#CONFUSED_PREFIXES} which may construct invalid maps.
@@ -23,6 +24,7 @@ public interface SigMapGenerator {
         AMBIGUOUS_PREFIXES,
         CONFUSED_PREFIXES,
         UNIQUE_WITH_SOME_FULL_PREFIXES,
+        FULL_PREFIXES,
     }
 
     SignatureMap forPrimitiveSigs(@Nullable HapiSpec spec, List<Entry<byte[], byte[]>> keySigs);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/TrieSigMapGenerator.java
@@ -41,25 +41,25 @@ public class TrieSigMapGenerator implements SigMapGenerator {
         this.fullPrefixKeys = fullPrefixKeys;
     }
 
+    private static final TrieSigMapGenerator fullInstance;
     private static final TrieSigMapGenerator uniqueInstance;
     private static final TrieSigMapGenerator ambiguousInstance;
     private static final TrieSigMapGenerator confusedInstance;
 
     static {
+        fullInstance = new TrieSigMapGenerator(Nature.FULL_PREFIXES);
         uniqueInstance = new TrieSigMapGenerator(Nature.UNIQUE_PREFIXES);
         ambiguousInstance = new TrieSigMapGenerator(Nature.AMBIGUOUS_PREFIXES);
         confusedInstance = new TrieSigMapGenerator(Nature.CONFUSED_PREFIXES);
     }
 
     public static SigMapGenerator withNature(Nature nature) {
-        switch (nature) {
-            default:
-                return uniqueInstance;
-            case AMBIGUOUS_PREFIXES:
-                return ambiguousInstance;
-            case CONFUSED_PREFIXES:
-                return confusedInstance;
-        }
+        return switch (nature) {
+            case AMBIGUOUS_PREFIXES -> ambiguousInstance;
+            case CONFUSED_PREFIXES -> confusedInstance;
+            case FULL_PREFIXES -> fullInstance;
+            case UNIQUE_PREFIXES, UNIQUE_WITH_SOME_FULL_PREFIXES -> uniqueInstance;
+        };
     }
 
     public static SigMapGenerator uniqueWithFullPrefixesFor(String... fullPrefixKeys) {
@@ -89,7 +89,7 @@ public class TrieSigMapGenerator implements SigMapGenerator {
                 .map(keySig -> {
                     final var key = keySig.getKey();
                     final var wrappedKey = ByteString.copyFrom(key);
-                    final var effPrefix = alwaysFullPrefixes.contains(wrappedKey)
+                    final var effPrefix = (nature == Nature.FULL_PREFIXES || alwaysFullPrefixes.contains(wrappedKey))
                             ? wrappedKey
                             : ByteString.copyFrom(prefixCalc.apply(key));
                     if (key.length == 32) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicUpdate.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.transactions.consensus;
 
+import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asDuration;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asTimestamp;
@@ -15,6 +16,7 @@ import com.hedera.node.app.hapi.utils.CommonUtils;
 import com.hedera.node.app.hapi.utils.fee.ConsensusServiceFeeBuilder;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.FeeCalculator;
+import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
 import com.hederahashgraph.api.proto.java.ConsensusUpdateTopicTransactionBody;
@@ -57,6 +59,7 @@ public class HapiTopicUpdate extends HapiTxnOp<HapiTopicUpdate> {
 
     public HapiTopicUpdate(final String topic) {
         this.topic = topic;
+        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
     }
 
     public HapiTopicUpdate topicMemo(final String s) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractUpdate.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.transactions.contract;
 
+import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.transactions.TxnFactory.expiryNowFor;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
 import static com.hedera.services.bdd.spec.transactions.contract.HapiContractCall.HEXED_EVM_ADDRESS_LEN;
@@ -15,6 +16,7 @@ import com.google.protobuf.StringValue;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.FeeCalculator;
 import com.hedera.services.bdd.spec.keys.KeyRole;
+import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.ContractID;
@@ -58,6 +60,7 @@ public class HapiContractUpdate extends HapiTxnOp<HapiContractUpdate> {
 
     public HapiContractUpdate(String contract) {
         this.contract = contract;
+        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/crypto/HapiCryptoUpdate.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.spec.transactions.crypto;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.bdd.spec.PropertySource.asAccountString;
+import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.*;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -20,6 +21,7 @@ import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
 import com.hedera.services.bdd.spec.fees.FeeCalculator;
+import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.queries.crypto.HapiGetAccountInfo;
 import com.hedera.services.bdd.spec.queries.crypto.ReferenceType;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
@@ -61,6 +63,7 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
 
     public HapiCryptoUpdate(String account) {
         this.account = account;
+        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
     }
 
     public HapiCryptoUpdate(String reference, ReferenceType type) {
@@ -70,6 +73,7 @@ public class HapiCryptoUpdate extends HapiTxnOp<HapiCryptoUpdate> {
         } else {
             account = reference;
         }
+        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
     }
 
     public HapiCryptoUpdate withYahcliLogging() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/file/HapiFileUpdate.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.transactions.file;
 
+import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileContents;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnFactory.expiryNowFor;
@@ -19,6 +20,7 @@ import com.google.protobuf.StringValue;
 import com.hedera.node.app.hapi.fees.usage.file.ExtantFileContext;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.FeeCalculator;
+import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.queries.file.HapiGetFileContents;
 import com.hedera.services.bdd.spec.queries.file.HapiGetFileInfo;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
@@ -83,6 +85,7 @@ public class HapiFileUpdate extends HapiTxnOp<HapiFileUpdate> {
 
     public HapiFileUpdate(String file) {
         this.file = file;
+        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/node/HapiNodeUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/node/HapiNodeUpdate.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.spec.transactions.node;
 
 import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
 import static com.hedera.node.app.hapi.utils.CommonPbjConverters.toPbj;
+import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asPosNodeId;
 import static com.hedera.services.bdd.suites.HapiSuite.EMPTY_KEY;
@@ -22,6 +23,7 @@ import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.junit.hedera.subprocess.SubProcessNetwork;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
+import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.FeeData;
@@ -65,6 +67,7 @@ public class HapiNodeUpdate extends HapiTxnOp<HapiNodeUpdate> {
 
     public HapiNodeUpdate(@NonNull final String nodeName) {
         this.nodeName = nodeName;
+        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
     }
 
     public HapiNodeUpdate accountId(@NonNull final String accountId) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleSign.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/schedule/HapiScheduleSign.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.transactions.schedule;
 
+import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asScheduleId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 import static com.hedera.services.bdd.spec.transactions.schedule.HapiScheduleCreate.correspondingScheduledTxnId;
@@ -11,6 +12,7 @@ import com.google.common.base.MoreObjects;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.fees.FeeCalculator;
 import com.hedera.services.bdd.spec.infrastructure.RegistryNotFound;
+import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hederahashgraph.api.proto.java.HederaFunctionality;
@@ -39,6 +41,7 @@ public class HapiScheduleSign extends HapiTxnOp<HapiScheduleSign> {
 
     public HapiScheduleSign(String schedule) {
         this.schedule = schedule;
+        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
     }
 
     public HapiScheduleSign alsoSigningWith(String... keys) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenUpdate.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.spec.transactions.token;
 
 import static com.hedera.node.app.hapi.fees.usage.SingletonEstimatorUtils.ESTIMATOR_UTILS;
+import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.suFrom;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
@@ -17,6 +18,7 @@ import com.hedera.services.bdd.spec.fees.FeeCalculator;
 import com.hedera.services.bdd.spec.infrastructure.HapiSpecRegistry;
 import com.hedera.services.bdd.spec.infrastructure.RegistryNotFound;
 import com.hedera.services.bdd.spec.keys.KeyRole;
+import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.suites.HapiSuite;
@@ -92,6 +94,7 @@ public class HapiTokenUpdate extends HapiTxnOp<HapiTokenUpdate> {
 
     public HapiTokenUpdate(String token) {
         this.token = token;
+        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
     }
 
     public HapiTokenUpdate freezeKey(String name) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/LeakyCryptoTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/LeakyCryptoTestsSuite.java
@@ -164,7 +164,7 @@ public class LeakyCryptoTestsSuite {
                         .payingWith(shortLivedAutoAssocUser)
                         .maxAutomaticAssociations(10)
                         .via(updateWithExpiredAccount),
-                validateChargedUsd(updateWithExpiredAccount, baseFee));
+                validateChargedUsd(updateWithExpiredAccount, baseFee, 5));
     }
 
     @RepeatableHapiTest(NEEDS_SYNCHRONOUS_HANDLE_WORKFLOW)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/TokenServiceFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/TokenServiceFeesSuite.java
@@ -708,7 +708,7 @@ public class TokenServiceFeesSuite {
                         .entityMemo("")
                         .symbol("a"),
                 tokenUpdate(FUNGIBLE_COMMON_TOKEN).via("uniqueTokenUpdate").payingWith(TOKEN_TREASURY),
-                validateChargedUsd("uniqueTokenUpdate", expectedUpdatePriceUsd));
+                validateChargedUsd("uniqueTokenUpdate", expectedUpdatePriceUsd, 5));
     }
 
     @HapiTest


### PR DESCRIPTION
Fixes the flaky tests related to `INSUFFICIENT_TX_FEE`. 

Currently when any of the keys signing are having same short prefixes, we will be verifying extra signatures and are charging extra fee. This can easily happen with the Update tests and Schedule sign tests. 

To stabilize the tests, full prefix signatures are used in those tests. 
