### PR TITLE
chore(19408): report pces metrics in nanoseconds

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/PcesWriterBenchmark.java
+++ b/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/PcesWriterBenchmark.java
@@ -71,6 +71,15 @@ public class PcesWriterBenchmark {
     //PcesWriterBenchmark.writeEventAndSync          FILE_CHANNEL  thrpt    3     984.342 ±    352.266  ops/s
     //PcesWriterBenchmark.writeEventAndSync     FILE_CHANNEL_SYNC  thrpt    3     881.496 ±   2015.275  ops/s
 
+    //Mac
+    //Benchmark                              (pcesFileWriterType)   Mode  Cnt        Score        Error  Units
+    //PcesWriterBenchmark.writeEvent                OUTPUT_STREAM  thrpt    3  1303269.327 ± 504357.504  ops/s
+    //PcesWriterBenchmark.writeEvent                 FILE_CHANNEL  thrpt    3   504392.068 ± 256097.035  ops/s
+    //PcesWriterBenchmark.writeEvent            FILE_CHANNEL_SYNC  thrpt    3    21016.552 ±  38940.830  ops/s
+    //PcesWriterBenchmark.writeEventAndSync         OUTPUT_STREAM  thrpt    3    39814.333 ± 138823.994  ops/s
+    //PcesWriterBenchmark.writeEventAndSync          FILE_CHANNEL  thrpt    3      187.900 ±    129.852  ops/s
+    //PcesWriterBenchmark.writeEventAndSync     FILE_CHANNEL_SYNC  thrpt    3      177.976 ±    241.287  ops/s
+
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)

--- a/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/PcesWriterBenchmark.java
+++ b/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/PcesWriterBenchmark.java
@@ -61,15 +61,16 @@ public class PcesWriterBenchmark {
         mutableFile.close();
         FileUtils.deleteDirectory(directory);
     }
-    /*
-    Results on a M1 Max MacBook Pro:
 
-    Benchmark                       (syncEveryEvent)  (useFileChannelWriter)   Mode  Cnt       Score        Error  Units
-    PcesWriterBenchmark.writeEvent              true                    true  thrpt    3   12440.268 ±  42680.146  ops/s
-    PcesWriterBenchmark.writeEvent              true                   false  thrpt    3   16244.412 ±  38461.148  ops/s
-    PcesWriterBenchmark.writeEvent             false                    true  thrpt    3  411138.079 ± 110692.138  ops/s
-    PcesWriterBenchmark.writeEvent             false                   false  thrpt    3  643582.781 ± 154393.415  ops/s
-    */
+    //Linux benchmark
+    //Benchmark                              (pcesFileWriterType)   Mode  Cnt       Score        Error  Units
+    //PcesWriterBenchmark.writeEvent                OUTPUT_STREAM  thrpt    3  402513.131 ± 266641.090  ops/s
+    //PcesWriterBenchmark.writeEvent                 FILE_CHANNEL  thrpt    3  465751.805 ± 633311.931  ops/s
+    //PcesWriterBenchmark.writeEvent            FILE_CHANNEL_SYNC  thrpt    3    1200.434 ±   2370.299  ops/s
+    //PcesWriterBenchmark.writeEventAndSync         OUTPUT_STREAM  thrpt    3    1126.327 ±   2161.654  ops/s
+    //PcesWriterBenchmark.writeEventAndSync          FILE_CHANNEL  thrpt    3     984.342 ±    352.266  ops/s
+    //PcesWriterBenchmark.writeEventAndSync     FILE_CHANNEL_SYNC  thrpt    3     881.496 ±   2015.275  ops/s
+
     @Benchmark
     @BenchmarkMode(Mode.Throughput)
     @OutputTimeUnit(TimeUnit.SECONDS)

--- a/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/PcesWriterBenchmark.java
+++ b/platform-sdk/swirlds-platform-core/src/jmh/java/com/swirlds/platform/core/jmh/PcesWriterBenchmark.java
@@ -62,23 +62,21 @@ public class PcesWriterBenchmark {
         FileUtils.deleteDirectory(directory);
     }
 
-    //Linux benchmark
-    //Benchmark                              (pcesFileWriterType)   Mode  Cnt       Score        Error  Units
-    //PcesWriterBenchmark.writeEvent                OUTPUT_STREAM  thrpt    3  402513.131 ± 266641.090  ops/s
-    //PcesWriterBenchmark.writeEvent                 FILE_CHANNEL  thrpt    3  465751.805 ± 633311.931  ops/s
-    //PcesWriterBenchmark.writeEvent            FILE_CHANNEL_SYNC  thrpt    3    1200.434 ±   2370.299  ops/s
-    //PcesWriterBenchmark.writeEventAndSync         OUTPUT_STREAM  thrpt    3    1126.327 ±   2161.654  ops/s
-    //PcesWriterBenchmark.writeEventAndSync          FILE_CHANNEL  thrpt    3     984.342 ±    352.266  ops/s
-    //PcesWriterBenchmark.writeEventAndSync     FILE_CHANNEL_SYNC  thrpt    3     881.496 ±   2015.275  ops/s
+    // Linux Benchmark                              (pcesFileWriterType)   Mode  Cnt       Score        Error  Units
+    // PcesWriterBenchmark.writeEvent                OUTPUT_STREAM  thrpt    3  402513.131 ± 266641.090  ops/s
+    // PcesWriterBenchmark.writeEvent                 FILE_CHANNEL  thrpt    3  465751.805 ± 633311.931  ops/s
+    // PcesWriterBenchmark.writeEvent            FILE_CHANNEL_SYNC  thrpt    3    1200.434 ±   2370.299  ops/s
+    // PcesWriterBenchmark.writeEventAndSync         OUTPUT_STREAM  thrpt    3    1126.327 ±   2161.654  ops/s
+    // PcesWriterBenchmark.writeEventAndSync          FILE_CHANNEL  thrpt    3     984.342 ±    352.266  ops/s
+    // PcesWriterBenchmark.writeEventAndSync     FILE_CHANNEL_SYNC  thrpt    3     881.496 ±   2015.275  ops/s
 
-    //Mac
-    //Benchmark                              (pcesFileWriterType)   Mode  Cnt        Score        Error  Units
-    //PcesWriterBenchmark.writeEvent                OUTPUT_STREAM  thrpt    3  1303269.327 ± 504357.504  ops/s
-    //PcesWriterBenchmark.writeEvent                 FILE_CHANNEL  thrpt    3   504392.068 ± 256097.035  ops/s
-    //PcesWriterBenchmark.writeEvent            FILE_CHANNEL_SYNC  thrpt    3    21016.552 ±  38940.830  ops/s
-    //PcesWriterBenchmark.writeEventAndSync         OUTPUT_STREAM  thrpt    3    39814.333 ± 138823.994  ops/s
-    //PcesWriterBenchmark.writeEventAndSync          FILE_CHANNEL  thrpt    3      187.900 ±    129.852  ops/s
-    //PcesWriterBenchmark.writeEventAndSync     FILE_CHANNEL_SYNC  thrpt    3      177.976 ±    241.287  ops/s
+    // Mac Benchmark                              (pcesFileWriterType)   Mode  Cnt        Score        Error  Units
+    // PcesWriterBenchmark.writeEvent                OUTPUT_STREAM  thrpt    3  1303269.327 ± 504357.504  ops/s
+    // PcesWriterBenchmark.writeEvent                 FILE_CHANNEL  thrpt    3   504392.068 ± 256097.035  ops/s
+    // PcesWriterBenchmark.writeEvent            FILE_CHANNEL_SYNC  thrpt    3    21016.552 ±  38940.830  ops/s
+    // PcesWriterBenchmark.writeEventAndSync         OUTPUT_STREAM  thrpt    3    39814.333 ± 138823.994  ops/s
+    // PcesWriterBenchmark.writeEventAndSync          FILE_CHANNEL  thrpt    3      187.900 ±    129.852  ops/s
+    // PcesWriterBenchmark.writeEventAndSync     FILE_CHANNEL_SYNC  thrpt    3      177.976 ±    241.287  ops/s
 
     @Benchmark
     @BenchmarkMode(Mode.Throughput)

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileChannelWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileChannelWriter.java
@@ -68,7 +68,7 @@ public class PcesFileChannelWriter implements PcesFileWriter {
 
     @Override
     public void writeEvent(@NonNull final GossipEvent event) throws IOException {
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         final int size = GossipEvent.PROTOBUF.measureRecord(event);
         boolean bufferExpanded = false;
         try {
@@ -82,7 +82,7 @@ public class PcesFileChannelWriter implements PcesFileWriter {
             GossipEvent.PROTOBUF.write(event, writableSequentialData);
             flipWriteClear();
         } finally {
-            stats.updateWriteStats(startTime, System.currentTimeMillis(), size, bufferExpanded);
+            stats.updateWriteStats(startTime, System.nanoTime(), size, bufferExpanded);
         }
     }
 
@@ -94,7 +94,7 @@ public class PcesFileChannelWriter implements PcesFileWriter {
     private void flipWriteClear() throws IOException {
 
         buffer.flip();
-        long writeStart = System.currentTimeMillis();
+        long writeStart = System.nanoTime();
         try {
             final int bytesWritten = channel.write(buffer);
             fileSize += bytesWritten;
@@ -104,7 +104,7 @@ public class PcesFileChannelWriter implements PcesFileWriter {
             }
             buffer.clear();
         } finally {
-            stats.updatePartialWriteStats(writeStart, System.currentTimeMillis());
+            stats.updatePartialWriteStats(writeStart, System.nanoTime());
         }
     }
 
@@ -115,11 +115,11 @@ public class PcesFileChannelWriter implements PcesFileWriter {
 
     @Override
     public void sync() throws IOException {
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         // benchmarks show that this has horrible performance for the channel writer (in mac-os)
         channel.force(false);
 
-        stats.updateSyncStats(startTime, System.currentTimeMillis());
+        stats.updateSyncStats(startTime, System.nanoTime());
     }
 
     @Override

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileWriterStats.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileWriterStats.java
@@ -6,6 +6,9 @@ import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * Keeps local stats of the writing process.
+ * The class is independent of the time unit selected for averaging the results
+ * The consistency metrics units should be managed by the caller.
+ * The suggested time unit for the events is nanoseconds.
  * Used by {@link PcesFileWriter}
  */
 public class PcesFileWriterStats {
@@ -17,8 +20,8 @@ public class PcesFileWriterStats {
 
     /**
      * Updates the stats related to the total write operation
-     * @param startTime when the operation started in ms
-     * @param endTime when the operation finished in ms
+     * @param startTime when the operation started
+     * @param endTime when the operation finished
      * @param size the written event size in bytes
      * @param bufferExpanded whether a buffer expansion happened
      */
@@ -32,8 +35,8 @@ public class PcesFileWriterStats {
 
     /**
      * Updates the stats related to the total and partial write operation
-     * @param startTime when the operation started in ms
-     * @param endTime when the operation finished in ms
+     * @param startTime when the operation started
+     * @param endTime when the operation finished
      * @param size the written event size in bytes
      */
     void updateWriteStats(final long startTime, final long endTime, final int size) {
@@ -43,8 +46,8 @@ public class PcesFileWriterStats {
 
     /**
      * Updates the stats related to the partial write operation
-     * @param startTime when the operation started in ms
-     * @param endTime when the operation finished in ms
+     * @param startTime when the operation started
+     * @param endTime when the operation finished
      */
     void updatePartialWriteStats(final long startTime, final long endTime) {
         averageWriteDuration.add(endTime - startTime);
@@ -52,8 +55,8 @@ public class PcesFileWriterStats {
 
     /**
      * Updates the stats related to the sync operation
-     * @param startTime when the operation started in ms
-     * @param endTime when the operation finished in ms
+     * @param startTime when the operation started
+     * @param endTime when the operation finished
      */
     void updateSyncStats(final long startTime, final long endTime) {
         averageSyncDuration.add(endTime - startTime);
@@ -67,7 +70,7 @@ public class PcesFileWriterStats {
     }
 
     /**
-     * @return the average write operation time in ms
+     * @return the average write operation time
      */
     public long averageTotalWriteDuration() {
         return averageTotalWriteDuration.getAverage();
@@ -81,14 +84,14 @@ public class PcesFileWriterStats {
     }
 
     /**
-     * @return the average sync operation time in ms
+     * @return the average sync operation time
      */
     public long averageSyncDuration() {
         return averageSyncDuration.getAverage();
     }
 
     /**
-     * @return the number of times the buffer was expandeds
+     * @return the number of times the buffer was expanded
      */
     public long totalExpansions() {
         return totalExpansions.get();

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesOutputStreamFileWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesOutputStreamFileWriter.java
@@ -48,11 +48,11 @@ public class PcesOutputStreamFileWriter implements PcesFileWriter {
 
     @Override
     public void writeEvent(@NonNull final GossipEvent event) throws IOException {
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         try {
             out.writePbjRecord(event, GossipEvent.PROTOBUF);
         } finally {
-            stats.updateWriteStats(startTime, System.currentTimeMillis(), GossipEvent.PROTOBUF.measureRecord(event));
+            stats.updateWriteStats(startTime, System.nanoTime(), GossipEvent.PROTOBUF.measureRecord(event));
         }
     }
 
@@ -63,14 +63,14 @@ public class PcesOutputStreamFileWriter implements PcesFileWriter {
 
     @Override
     public void sync() throws IOException {
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
         out.flush();
         try {
             fileDescriptor.sync();
         } catch (final SyncFailedException e) {
             throw new IOException("Failed to sync file", e);
         } finally {
-            stats.updateSyncStats(startTime, System.currentTimeMillis());
+            stats.updateSyncStats(startTime, System.nanoTime());
         }
     }
 


### PR DESCRIPTION
**Description**:

Report pcs writer metrics in nanoseconds to have a finer grain measurement of the impact of the pces operations

**Related issue(s)**:

Fixes #19408
