### PR TITLE
chore: Add overrides for `nodes.nodeRewardsEnabled=false`

### DIFF
--- a/hedera-node/configuration/mainnet/application.properties
+++ b/hedera-node/configuration/mainnet/application.properties
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
+
 # This file mirrors file 121 on mainnet, and MUST match bootstrap.properties.
-# Post deprecation of bootstrap.properties (upon transition from mono-service to 
+# Post deprecation of bootstrap.properties (upon transition from mono-service to
 # hedera-config), this requirement will no longer be valid.
-# It's used by modular code for property overrides, taking hedera-config/ as the base, 
+# It's used by modular code for property overrides, taking hedera-config/ as the base,
 # with overrides from this file (configuration/mainnet/application.properties).
 ledger.id=0x00
 nodes.nodeRewardsEnabled=false

--- a/hedera-node/configuration/mainnet/application.properties
+++ b/hedera-node/configuration/mainnet/application.properties
@@ -5,3 +5,4 @@
 # It's used by modular code for property overrides, taking hedera-config/ as the base, 
 # with overrides from this file (configuration/mainnet/application.properties).
 ledger.id=0x00
+nodes.nodeRewardsEnabled=false

--- a/hedera-node/configuration/previewnet/application.properties
+++ b/hedera-node/configuration/previewnet/application.properties
@@ -9,3 +9,4 @@
 bootstrap.genesisPublicKey=c249a323c878f5b5e2daccda6d731e6fdc32f870228d1cd4fae559d947dbc36c
 contracts.chainId=297
 ledger.id=0x02
+nodes.nodeRewardsEnabled=false

--- a/hedera-node/configuration/testnet/application.properties
+++ b/hedera-node/configuration/testnet/application.properties
@@ -1,8 +1,4 @@
 # SPDX-License-Identifier: Apache-2.0
-# Except for network-specific properties (e.g. testnet vs. mainnet), this file is intended to be an
-# exact replica of file 121 on testnet and should match bootstrap.properties exactly.
-# It will be used by modular code for all the property overrides.
-# It does not have to match bootstrap.properties once that file is deprecated by the switch from mono-service to hedera-config.
 
 #Overrides that differ based on the network
 bootstrap.genesisPublicKey=e06b22e0966108fa5d63fc6ae53f9824319b891cd4d6050dbf2b242be7e13344

--- a/hedera-node/configuration/testnet/application.properties
+++ b/hedera-node/configuration/testnet/application.properties
@@ -8,3 +8,4 @@
 bootstrap.genesisPublicKey=e06b22e0966108fa5d63fc6ae53f9824319b891cd4d6050dbf2b242be7e13344
 contracts.chainId=296
 ledger.id=0x01
+nodes.nodeRewardsEnabled=false


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/19456
- Disable node rewards by adding an override to `application.properties` , `nodes.nodeRewardsEnabled=false`
- When needed this will be enabled with dynamic property update