### PR TITLE
fix: Stop populating generation after birth round migration occurs

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/DefaultInternalEventValidator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/validation/DefaultInternalEventValidator.java
@@ -163,6 +163,7 @@ public class DefaultInternalEventValidator implements InternalEventValidator {
 
     /**
      * Checks whether the transaction is null.
+     *
      * @param transaction the transaction to check
      * @return true if the transaction is null, otherwise false
      */
@@ -278,6 +279,11 @@ public class DefaultInternalEventValidator implements InternalEventValidator {
      * @return true if the generation of the event is valid, otherwise false
      */
     private boolean isEventGenerationValid(@NonNull final PlatformEvent event) {
+        if (ancientMode == AncientMode.BIRTH_ROUND_THRESHOLD) {
+            // Don't validate generations in birth round mode.
+            return true;
+        }
+
         final long eventGeneration = event.getGeneration();
 
         if (eventGeneration < FIRST_GENERATION) {


### PR DESCRIPTION
**Description**:
This PR makes events created after birth round migration takes place have a generation of `0L`, which is the same value in protobuf as not being set. This is necessary so that in the next release when the generation field is removed from the protobuf definition, we can still calculate the correct hashes for events from PCES files and gossip that were created with the previous version. This change must be in v63, but will go into v64 first then backported.

Sepcific changes:

1. Do not calculate generation for newly created events, since v63 will migrate to using birth rounds.
2. Do not calculate generation for events received from PCES Replay or Gossip if the birth round value 1 (true for all events created before birth round migration, including the events that get a birth round override value.

**Related issue(s)**:

Fixes #19394
