### PR TITLE
fix: 19424: Backport the fix for 19319 to release 0.62

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -11,19 +11,15 @@ import com.swirlds.common.threading.framework.config.ThreadConfiguration;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import com.swirlds.merkledb.files.DataFileCompactor;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.channels.ClosedByInterruptException;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -80,95 +76,32 @@ class MerkleDbCompactionCoordinator {
     public static final String HASH_STORE_DISK_SUFFIX = "HashStoreDisk";
     public static final String OBJECT_KEY_TO_PATH_SUFFIX = "ObjectKeyToPath";
     public static final String PATH_TO_KEY_VALUE_SUFFIX = "PathToKeyValue";
-    private final AtomicBoolean compactionEnabled = new AtomicBoolean();
-    // we need a map of exactly three elements, one per storage
-    final ConcurrentMap<String, Future<Boolean>> compactionFuturesByName = new ConcurrentHashMap<>(3);
-    private final CompactionTask objectKeyToPathTask;
-    private final CompactionTask hashesStoreDiskTask;
-    private final CompactionTask pathToKeyValueTask;
 
-    @Nullable
-    private final DataFileCompactor objectKeyToPath;
+    // Synchronized on this
+    private boolean compactionEnabled = false;
 
-    @Nullable
-    private final DataFileCompactor hashesStoreDisk;
-
-    @NonNull
-    private final DataFileCompactor pathToKeyValue;
+    // A map of compactors by task names. Synchronized on this
+    final Map<String, DataFileCompactor> compactorsByName = new HashMap<>(16);
 
     @NonNull
     private final MerkleDbConfig merkleDbConfig;
 
-    // Number of compaction tasks currently running. Checked during shutdown to make sure all
-    // tasks are stopped
-    private final AtomicInteger tasksRunning = new AtomicInteger(0);
-
     /**
      * Creates a new instance of {@link MerkleDbCompactionCoordinator}.
      * @param tableName the name of the table
-     * @param objectKeyToPath an object key to path store
-     * @param hashesStoreDisk a hash store
-     * @param pathToKeyValue a path to key-value store
      * @param merkleDbConfig platform config for MerkleDbDataSource
      */
-    public MerkleDbCompactionCoordinator(
-            @NonNull String tableName,
-            @Nullable DataFileCompactor objectKeyToPath,
-            @Nullable DataFileCompactor hashesStoreDisk,
-            @NonNull DataFileCompactor pathToKeyValue,
-            @NonNull MerkleDbConfig merkleDbConfig) {
+    public MerkleDbCompactionCoordinator(@NonNull String tableName, @NonNull MerkleDbConfig merkleDbConfig) {
         requireNonNull(tableName);
-        requireNonNull(pathToKeyValue);
         requireNonNull(merkleDbConfig);
-        this.objectKeyToPath = objectKeyToPath;
-        this.hashesStoreDisk = hashesStoreDisk;
-        this.pathToKeyValue = pathToKeyValue;
         this.merkleDbConfig = merkleDbConfig;
-        if (objectKeyToPath != null) {
-            objectKeyToPathTask = new CompactionTask(tableName + OBJECT_KEY_TO_PATH_SUFFIX, objectKeyToPath);
-        } else {
-            objectKeyToPathTask = null;
-        }
-        if (hashesStoreDisk != null) {
-            hashesStoreDiskTask = new CompactionTask(tableName + HASH_STORE_DISK_SUFFIX, hashesStoreDisk);
-        } else {
-            hashesStoreDiskTask = null;
-        }
-        this.pathToKeyValueTask = new CompactionTask(tableName + PATH_TO_KEY_VALUE_SUFFIX, pathToKeyValue);
-    }
-
-    /**
-     * Compacts the object key to path store asynchronously if it's present.
-     */
-    void compactDiskStoreForKeyToPathAsync() {
-        if (objectKeyToPathTask == null) {
-            return;
-        }
-        submitCompactionTaskForExecution(objectKeyToPathTask);
-    }
-
-    /**
-     * Compacts the hash store asynchronously if it's present.
-     */
-    void compactDiskStoreForHashesAsync() {
-        if (hashesStoreDiskTask == null) {
-            return;
-        }
-        submitCompactionTaskForExecution(hashesStoreDiskTask);
-    }
-
-    /**
-     * Compacts the path to key-value store asynchronously.
-     */
-    void compactPathToKeyValueAsync() {
-        submitCompactionTaskForExecution(pathToKeyValueTask);
     }
 
     /**
      * Enables background compaction.
      */
-    void enableBackgroundCompaction() {
-        compactionEnabled.set(true);
+    synchronized void enableBackgroundCompaction() {
+        compactionEnabled = true;
     }
 
     /**
@@ -177,27 +110,16 @@ class MerkleDbCompactionCoordinator {
      * critical for snapshots (e.g. update an index), it will be stopped until {@link
      * #resumeCompaction()}} is called.
      */
-    public void pauseCompaction() throws IOException {
-        if (hashesStoreDisk != null) {
-            hashesStoreDisk.pauseCompaction();
-        }
-
-        pathToKeyValue.pauseCompaction();
-
-        if (objectKeyToPath != null) {
-            objectKeyToPath.pauseCompaction();
+    synchronized void pauseCompaction() throws IOException {
+        for (final DataFileCompactor compactor : compactorsByName.values()) {
+            compactor.pauseCompaction();
         }
     }
+
     /** Resumes previously stopped data file collection compaction. */
-    public void resumeCompaction() throws IOException {
-        if (hashesStoreDisk != null) {
-            hashesStoreDisk.resumeCompaction();
-        }
-
-        pathToKeyValue.resumeCompaction();
-
-        if (objectKeyToPath != null) {
-            objectKeyToPath.resumeCompaction();
+    synchronized void resumeCompaction() throws IOException {
+        for (final DataFileCompactor compactor : compactorsByName.values()) {
+            compactor.resumeCompaction();
         }
     }
 
@@ -205,56 +127,49 @@ class MerkleDbCompactionCoordinator {
      * Stops all compactions in progress and disables background compaction.
      * All subsequent calls to compacting methods will be ignored until {@link #enableBackgroundCompaction()} is called.
      */
-    void stopAndDisableBackgroundCompaction() {
-        compactionEnabled.set(false);
+    synchronized void stopAndDisableBackgroundCompaction() {
+        compactionEnabled = false;
         // Interrupt all running compaction tasks, if any
-        synchronized (compactionFuturesByName) {
-            for (var futureEntry : compactionFuturesByName.values()) {
-                futureEntry.cancel(true);
-            }
-            compactionFuturesByName.clear();
+        for (final DataFileCompactor compactor : compactorsByName.values()) {
+            compactor.interruptCompaction();
         }
         // Wait till all the tasks are stopped
-        final long now = System.currentTimeMillis();
         try {
-            while ((tasksRunning.get() != 0) && (System.currentTimeMillis() - now < SHUTDOWN_TIMEOUT_MILLIS)) {
-                Thread.sleep(1);
+            while (!compactorsByName.isEmpty()) {
+                wait(SHUTDOWN_TIMEOUT_MILLIS);
             }
         } catch (final InterruptedException e) {
             logger.warn(MERKLE_DB.getMarker(), "Interrupted while waiting for compaction tasks to complete", e);
         }
         // If some tasks are still running, there is nothing else to than to log it
-        if (tasksRunning.get() != 0) {
-            logger.error(MERKLE_DB.getMarker(), "Failed to stop all compactions tasks");
+        if (!compactorsByName.isEmpty()) {
+            logger.warn(MERKLE_DB.getMarker(), "Timed out waiting to stop all compactions tasks");
         }
     }
 
     /**
      * Submits a compaction task for execution. If a compaction task for the same storage type is already in progress,
      * the call is effectively no op.
-     * @param task a compaction task to execute
+     *
+     * @param key Compaction task name
+     * @param compactor Compactor to run
      */
-    private void submitCompactionTaskForExecution(CompactionTask task) {
-        synchronized (compactionFuturesByName) {
-            if (!compactionEnabled.get()) {
-                return;
-            }
-            if (compactionFuturesByName.containsKey(task.id)) {
-                Future<?> future = compactionFuturesByName.get(task.id);
-                if (future.isDone()) {
-                    compactionFuturesByName.remove(task.id);
-                } else {
-                    logger.debug(MERKLE_DB.getMarker(), "Compaction for {} is already in progress", task.id);
-                    return;
-                }
-            }
-            final ExecutorService executor = getCompactionExecutor(merkleDbConfig);
-            compactionFuturesByName.put(task.id, executor.submit(task));
+    public synchronized void compactIfNotRunningYet(final String key, final DataFileCompactor compactor) {
+        if (!compactionEnabled) {
+            return;
         }
+        if (compactorsByName.containsKey(key)) {
+            logger.debug(MERKLE_DB.getMarker(), "Compaction for {} is already in progress", key);
+            return;
+        }
+        compactorsByName.put(key, compactor);
+        final ExecutorService executor = getCompactionExecutor(merkleDbConfig);
+        final CompactionTask task = new CompactionTask(key, compactor);
+        executor.submit(task);
     }
 
-    boolean isCompactionEnabled() {
-        return compactionEnabled.get();
+    synchronized boolean isCompactionEnabled() {
+        return compactionEnabled;
     }
 
     /**
@@ -275,7 +190,6 @@ class MerkleDbCompactionCoordinator {
 
         @Override
         public Boolean call() {
-            tasksRunning.incrementAndGet();
             try {
                 return compactor.compact();
             } catch (final InterruptedException | ClosedByInterruptException e) {
@@ -285,7 +199,10 @@ class MerkleDbCompactionCoordinator {
                 // will stop all  future merges from happening.
                 logger.error(EXCEPTION.getMarker(), "[{}] Compaction failed", id, e);
             } finally {
-                tasksRunning.decrementAndGet();
+                synchronized (MerkleDbCompactionCoordinator.this) {
+                    compactorsByName.remove(id);
+                    MerkleDbCompactionCoordinator.this.notifyAll();
+                }
             }
             return false;
         }

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/CASableLongIndex.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/CASableLongIndex.java
@@ -1,6 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.merkledb.collections;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.function.BooleanSupplier;
+
 /**
  * An interface for classes that provide long index functionality. Such long indices must
  * support Compare-And-Swap operations and iterations over all valid index entries.
@@ -34,17 +38,25 @@ public interface CASableLongIndex {
     /**
      * Iterates over all valid index entries and calls the specified action for each of them.
      *
-     * @param action Action to call.
+     * <p>If a condition to check is provided, implementations should do their best checking it,
+     * but there is no guarantee it is checked before each entry in the list, or checked at all.
+     * If the condition is {@code false}, no more index entries are iterated over, and this
+     * method returns.
+     *
      * @param <T> Type of throwables allowed to throw by this method
+     * @param action Action to call
+     * @param whileCondition Optional condition to check if this method should be stopped
+     * @return {@code true} if all index items have been processed by this method
      * @throws InterruptedException If the thread running the method is interrupted
      * @throws T If an error occurs
      */
-    <T extends Throwable> void forEach(LongAction<T> action) throws InterruptedException, T;
+    <T extends Throwable> boolean forEach(@NonNull LongAction<T> action, @Nullable BooleanSupplier whileCondition)
+            throws InterruptedException, T;
 
     /**
-     * Action interface to use in {@link #forEach(LongAction)}. It could be a standard Java API
-     * interface like BiFunction, but all these APIs work with boxed Long type instead of
-     * primitive longs, which adds unnecessary load on GC. So let's use something more simple
+     * Action interface to use in {@link #forEach(LongAction, BooleanSupplier)}. It could be a standard Java
+     * API interface like BiFunction, but all these APIs work with boxed Long type instead of primitive
+     * longs, which adds unnecessary load on GC. So let's use something more simple
      *
      * @param <T> Type of throwable allowed to throw by the action
      */

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongList.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/collections/LongList.java
@@ -140,9 +140,5 @@ public interface LongList extends CASableLongIndex, Closeable {
 
     /** {@inheritDoc} */
     @Override
-    <T extends Throwable> void forEach(LongAction<T> action) throws InterruptedException, T;
-
-    /** {@inheritDoc} */
-    @Override
     void close();
 }

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
@@ -15,17 +15,15 @@ import com.swirlds.merkledb.collections.CASableLongIndex;
 import com.swirlds.merkledb.config.MerkleDbConfig;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
-import java.nio.channels.ClosedByInterruptException;
 import java.nio.file.Path;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.stream.Collectors;
 import org.apache.logging.log4j.LogManager;
@@ -39,6 +37,10 @@ import org.apache.logging.log4j.Logger;
 public class DataFileCompactor {
 
     private static final Logger logger = LogManager.getLogger(DataFileCompactor.class);
+
+    public static final String HASH_STORE_DISK = "HashStoreDisk";
+    public static final String OBJECT_KEY_TO_PATH = "ObjectKeyToPath";
+    public static final String PATH_TO_KEY_VALUE = "PathToKeyValue";
 
     /**
      * This is the compaction level that non-compacted files have.
@@ -88,7 +90,7 @@ public class DataFileCompactor {
      * compaction on hold, which is critical as snapshots should be as fast as possible, while
      * compactions are just background processes.
      */
-    private final Semaphore snapshotCompactionLock = new Semaphore(1);
+    private final Lock snapshotCompactionLock = new ReentrantLock();
 
     /**
      * Start time of the current compaction, or null if compaction isn't running
@@ -116,15 +118,23 @@ public class DataFileCompactor {
     /**
      * Indicates whether compaction is in progress at the time when {@link #pauseCompaction()}
      * is called. This flag is then checked in {@link DataFileCompactor#resumeCompaction()} )} to start a new
-     * compacted file or not.
+     * compacted file or not. This field is synchronized using {@link #snapshotCompactionLock}.
      */
-    private final AtomicBoolean compactionWasInProgress = new AtomicBoolean(false);
+    private boolean compactionWasInProgress = false;
 
     /**
      * This variable keeps track of the compaction level that was in progress at the time when it was suspended.
-     * Once the compaction is resumed, this level is used to start a new compacted file, and then it's reset to 0.
+     * Once the compaction is resumed, this level is used to start a new compacted file, and then it's reset to
+     * 0. This field is synchronized using {@link #snapshotCompactionLock}.
      */
-    private final AtomicInteger compactionLevelInProgress = new AtomicInteger(0);
+    private int compactionLevelInProgress = 0;
+
+    /**
+     * A flag used to interrupt this compaction task rather than using {@link Thread#interrupt()}.
+     * This flag is set in {@link #interruptCompaction()} and checked periodically in the main
+     * compaction loop.
+     */
+    private volatile boolean interruptFlag = false;
 
     /**
      * @param dbConfig                       MerkleDb config
@@ -167,7 +177,7 @@ public class DataFileCompactor {
      * @throws IOException          If there was a problem with the compaction
      * @throws InterruptedException If the compaction thread was interrupted
      */
-    synchronized List<Path> compactFiles(
+    List<Path> compactFiles(
             final CASableLongIndex index,
             final List<? extends DataFileReader> filesToCompact,
             final int targetCompactionLevel)
@@ -178,19 +188,21 @@ public class DataFileCompactor {
             return Collections.emptyList();
         }
 
+        interruptFlag = false;
+
         // create a merge time stamp, this timestamp is the newest time of the set of files we are
         // merging
         final Instant startTime = filesToCompact.stream()
                 .map(file -> file.getMetadata().getCreationDate())
                 .max(Instant::compareTo)
                 .orElseGet(Instant::now);
-        snapshotCompactionLock.acquire();
+        snapshotCompactionLock.lock();
         try {
             currentCompactionStartTime.set(startTime);
             newCompactedFiles.clear();
             startNewCompactionFile(targetCompactionLevel);
         } finally {
-            snapshotCompactionLock.release();
+            snapshotCompactionLock.unlock();
         }
 
         // We need a map to find readers by file index below. It doesn't have to be synchronized
@@ -213,61 +225,65 @@ public class DataFileCompactor {
         boolean allDataItemsProcessed = false;
         try {
             final KeyRange keyRange = dataFileCollection.getValidKeyRange();
-            index.forEach((path, dataLocation) -> {
-                if (!keyRange.withinRange(path)) {
-                    return;
-                }
-                final int fileIndex = DataFileCommon.fileIndexFromDataLocation(dataLocation);
-                if ((fileIndex < firstIndexInc) || (fileIndex >= lastIndexExc)) {
-                    return;
-                }
-                final DataFileReader reader = readers[fileIndex - firstIndexInc];
-                if (reader == null) {
-                    return;
-                }
-                final long fileOffset = DataFileCommon.byteOffsetFromDataLocation(dataLocation);
-                // Take the lock. If a snapshot is started in a different thread, this call
-                // will block until the snapshot is done. The current file will be flushed,
-                // and current data file writer and reader will point to a new file
-                snapshotCompactionLock.acquire();
-                try {
-                    final DataFileWriter newFileWriter = currentWriter.get();
-                    final BufferedData itemBytes = reader.readDataItem(fileOffset);
-                    assert itemBytes != null;
-                    long newLocation = newFileWriter.storeDataItem(itemBytes);
-                    // update the index
-                    index.putIfEqual(path, dataLocation, newLocation);
-                } catch (final ClosedByInterruptException e) {
-                    logger.info(
-                            MERKLE_DB.getMarker(),
-                            "Failed to copy data item {} / {} due to thread interruption",
-                            fileIndex,
-                            fileOffset,
-                            e);
-                    throw e;
-                } catch (final IOException z) {
-                    logger.error(EXCEPTION.getMarker(), "Failed to copy data item {} / {}", fileIndex, fileOffset, z);
-                    throw z;
-                } finally {
-                    snapshotCompactionLock.release();
-                }
-            });
-            allDataItemsProcessed = true;
+            allDataItemsProcessed = index.forEach(
+                    (path, dataLocation) -> {
+                        if (!keyRange.withinRange(path)) {
+                            return;
+                        }
+                        final int fileIndex = DataFileCommon.fileIndexFromDataLocation(dataLocation);
+                        if ((fileIndex < firstIndexInc) || (fileIndex >= lastIndexExc)) {
+                            return;
+                        }
+                        final DataFileReader reader = readers[fileIndex - firstIndexInc];
+                        if (reader == null) {
+                            return;
+                        }
+                        final long fileOffset = DataFileCommon.byteOffsetFromDataLocation(dataLocation);
+                        // Take the lock. If a snapshot is started in a different thread, this call
+                        // will block until the snapshot is done. The current file will be flushed,
+                        // and current data file writer and reader will point to a new file
+                        snapshotCompactionLock.lock();
+                        try {
+                            final DataFileWriter newFileWriter = currentWriter.get();
+                            final BufferedData itemBytes = reader.readDataItem(fileOffset);
+                            assert itemBytes != null;
+                            long newLocation = newFileWriter.storeDataItem(itemBytes);
+                            // update the index
+                            index.putIfEqual(path, dataLocation, newLocation);
+                        } catch (final IOException z) {
+                            logger.error(
+                                    EXCEPTION.getMarker(),
+                                    "Failed to copy data item {} / {}",
+                                    fileIndex,
+                                    fileOffset,
+                                    z);
+                            throw z;
+                        } finally {
+                            snapshotCompactionLock.unlock();
+                        }
+                    },
+                    this::notInterrupted);
         } finally {
             // Even if the thread is interrupted, make sure the new compacted file is properly closed
             // and is included to future compactions
-            snapshotCompactionLock.acquire();
+            snapshotCompactionLock.lock();
             try {
                 // Finish writing the last file. In rare cases, it may be an empty file
                 finishCurrentCompactionFile();
                 // Clear compaction start time
                 currentCompactionStartTime.set(null);
                 if (allDataItemsProcessed) {
+                    logger.info(
+                            MERKLE_DB.getMarker(), "All files to compact have been processed, they will be deleted");
                     // Close the readers and delete compacted files
                     dataFileCollection.deleteFiles(filesToCompact);
+                } else {
+                    logger.info(
+                            MERKLE_DB.getMarker(),
+                            "Some files to compact haven't been processed, they will be compacted later");
                 }
             } finally {
-                snapshotCompactionLock.release();
+                snapshotCompactionLock.unlock();
             }
         }
 
@@ -336,13 +352,13 @@ public class DataFileCompactor {
      * @see #resumeCompaction()
      */
     public void pauseCompaction() throws IOException {
-        snapshotCompactionLock.acquireUninterruptibly();
+        snapshotCompactionLock.lock();
         // Check if compaction is currently in progress. If so, flush and close the current file, so
         // it's included to the snapshot
         final DataFileWriter compactionWriter = currentWriter.get();
         if (compactionWriter != null) {
-            compactionWasInProgress.set(true);
-            compactionLevelInProgress.set(compactionWriter.getMetadata().getCompactionLevel());
+            compactionWasInProgress = true;
+            compactionLevelInProgress = compactionWriter.getMetadata().getCompactionLevel();
             finishCurrentCompactionFile();
             // Don't start a new compaction file here, as it would be included to snapshots, but
             // it shouldn't, as it isn't fully written yet. Instead, a new file will be started
@@ -357,23 +373,44 @@ public class DataFileCompactor {
      * Resumes compaction previously put on hold with {@link #pauseCompaction()}. If there was no
      * compaction running at that moment, but new compaction was started (and blocked) since {@link
      * #pauseCompaction()}, this new compaction is resumed.
-     * <p>
-     * <b>This method must be always balanced with and called after {@link #pauseCompaction()}. If
-     * there are more / less calls to resume compactions than to pause, or if they are called in a
-     * wrong order, it will result in deadlocks.</b>
+     *
+     * <p><b>This method must be always balanced with and called after {@link #pauseCompaction()} on
+     * the same thread. If there are more or less calls to resume compactions than to pause, or if
+     * they are called in a wrong order, it will result in deadlocks.</b>
      *
      * @throws IOException If an I/O error occurs
+     * @throws IllegalMonitorStateException If this method is called on a different thread than
+     *      {@link #pauseCompaction()}
      */
     public void resumeCompaction() throws IOException {
         try {
-            if (compactionWasInProgress.getAndSet(false)) {
+            if (compactionWasInProgress) {
+                compactionWasInProgress = false;
                 assert currentWriter.get() == null;
                 assert currentReader.get() == null;
-                startNewCompactionFile(compactionLevelInProgress.getAndSet(0));
+                startNewCompactionFile(compactionLevelInProgress);
+                compactionLevelInProgress = 0;
             }
         } finally {
-            snapshotCompactionLock.release();
+            snapshotCompactionLock.unlock();
         }
+    }
+
+    /**
+     * Interrupts this compaction task. This is a less invasive way to stop the task than
+     * {@link Thread#interrupt()}, which has side effects like interrupt exceptions and
+     * closed file channels.
+     *
+     * <p>There is no guarantee that the task, if currently running, is stopped immediately
+     * after this method is called, but it's stopped in reasonable time.
+     */
+    public void interruptCompaction() {
+        interruptFlag = true;
+    }
+
+    // A helper method to avoid using a lambda in compactFiles()
+    public boolean notInterrupted() {
+        return !interruptFlag;
     }
 
     /**

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/collections/AbstractLongListTest.java
@@ -510,12 +510,14 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
             // Count valid entries and collect their indices
             final AtomicLong count = new AtomicLong(0);
             final Set<Long> keysInForEach = new HashSet<>();
-            longList.forEach((path, location) -> {
-                count.incrementAndGet();
-                keysInForEach.add(path);
+            longList.forEach(
+                    (path, location) -> {
+                        count.incrementAndGet();
+                        keysInForEach.add(path);
 
-                assertEquals(path + 100, location, "Mismatch in value for index " + path);
-            });
+                        assertEquals(path + 100, location, "Mismatch in value for index " + path);
+                    },
+                    null);
 
             // Ensure the number of valid indices matches the expected range
             assertEquals(
@@ -622,6 +624,40 @@ abstract class AbstractLongListTest<T extends AbstractLongList<?>> {
                 Files.delete(tmpFile);
                 Files.delete(tmpDir);
             }
+        }
+    }
+
+    @Test
+    void forEachWhileTest() throws Exception {
+        try (final LongList list = createLongList(10, 100, 0)) {
+            list.updateValidRange(0, 99);
+            for (int i = 0; i < 100; i++) {
+                list.put(i, i + 1000);
+            }
+            final AtomicInteger counter = new AtomicInteger(0);
+            list.forEach(
+                    (l, v) -> {
+                        counter.incrementAndGet();
+                    },
+                    () -> counter.get() < 42);
+            assertEquals(42, counter.get());
+        }
+    }
+
+    @Test
+    void forEachWhileNullCondTest() throws Exception {
+        try (final LongList list = createLongList(10, 100, 0)) {
+            list.updateValidRange(0, 99);
+            for (int i = 0; i < 100; i++) {
+                list.put(i, i + 1000);
+            }
+            final AtomicInteger counter = new AtomicInteger(0);
+            list.forEach(
+                    (l, v) -> {
+                        counter.incrementAndGet();
+                    },
+                    null);
+            assertEquals(100, counter.get());
         }
     }
 

--- a/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/CompactionInterruptTest.java
+++ b/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/CompactionInterruptTest.java
@@ -3,9 +3,6 @@ package com.swirlds.merkledb;
 
 import static com.swirlds.common.test.fixtures.AssertionUtils.assertEventuallyEquals;
 import static com.swirlds.common.test.fixtures.AssertionUtils.assertEventuallyTrue;
-import static com.swirlds.merkledb.MerkleDbCompactionCoordinator.HASH_STORE_DISK_SUFFIX;
-import static com.swirlds.merkledb.MerkleDbCompactionCoordinator.OBJECT_KEY_TO_PATH_SUFFIX;
-import static com.swirlds.merkledb.MerkleDbCompactionCoordinator.PATH_TO_KEY_VALUE_SUFFIX;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.CONFIGURATION;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.runTaskAndCleanThreadLocals;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
@@ -13,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.swirlds.merkledb.config.MerkleDbConfig;
+import com.swirlds.merkledb.files.DataFileCompactor;
 import com.swirlds.merkledb.test.fixtures.TestType;
 import com.swirlds.virtualmap.serialize.KeySerializer;
 import com.swirlds.virtualmap.serialize.ValueSerializer;
@@ -73,9 +71,9 @@ class CompactionInterruptTest {
             createData(dataSource);
             coordinator.enableBackgroundCompaction();
             // start compaction
-            coordinator.compactDiskStoreForHashesAsync();
-            coordinator.compactDiskStoreForKeyToPathAsync();
-            coordinator.compactPathToKeyValueAsync();
+            coordinator.compactIfNotRunningYet("hashStoreDisk", dataSource.newHashStoreDiskCompactor());
+            coordinator.compactIfNotRunningYet("keyToPath", dataSource.newKeyToPathCompactor());
+            coordinator.compactIfNotRunningYet("pathToKeyValue", dataSource.newPathToKeyValueCompactor());
             // wait a small-time for merging to start
             MILLISECONDS.sleep(20);
             stopCompactionAndVerifyItsStopped(tableName, coordinator);
@@ -130,9 +128,9 @@ class CompactionInterruptTest {
             // we should take into account previous test runs
             long initTaskCount = compactingExecutor.getTaskCount();
             // start compaction for all three storages
-            coordinator.compactDiskStoreForHashesAsync();
-            coordinator.compactDiskStoreForKeyToPathAsync();
-            coordinator.compactPathToKeyValueAsync();
+            coordinator.compactIfNotRunningYet("hashStoreDisk", dataSource.newHashStoreDiskCompactor());
+            coordinator.compactIfNotRunningYet("keyToPath", dataSource.newKeyToPathCompactor());
+            coordinator.compactIfNotRunningYet("pathToKeyValue", dataSource.newPathToKeyValueCompactor());
 
             assertEventuallyEquals(
                     initTaskCount + 3L,
@@ -156,21 +154,26 @@ class CompactionInterruptTest {
         long initCount = compactingExecutor.getCompletedTaskCount();
 
         // getting access to the guts of the compactor to check the state of the futures
-        Future<Boolean> hashStoreDiskFuture = compactor.compactionFuturesByName.get(tableName + HASH_STORE_DISK_SUFFIX);
-        Future<Boolean> pathToKeyValueFuture =
-                compactor.compactionFuturesByName.get(tableName + PATH_TO_KEY_VALUE_SUFFIX);
-        Future<Boolean> objectKeyToPathFuture =
-                compactor.compactionFuturesByName.get(tableName + OBJECT_KEY_TO_PATH_SUFFIX);
+        final DataFileCompactor pathToKeyValueFuture;
+        final DataFileCompactor hashStoreDiskFuture;
+        final DataFileCompactor objectKeyToPathFuture;
+        synchronized (compactor) {
+            hashStoreDiskFuture = compactor.compactorsByName.get("hashStoreDisk");
+            pathToKeyValueFuture = compactor.compactorsByName.get("pathToKeyValue");
+            objectKeyToPathFuture = compactor.compactorsByName.get("keyToPath");
+        }
 
         // stopping the compaction
         compactor.stopAndDisableBackgroundCompaction();
 
         assertFalse(compactor.isCompactionEnabled(), "compactionEnabled should be false");
 
-        assertFutureCancelled(hashStoreDiskFuture, "hashStoreDiskFuture should have been cancelled");
-        assertFutureCancelled(pathToKeyValueFuture, "pathToKeyValueFuture should have been cancelled");
-        assertFutureCancelled(objectKeyToPathFuture, "objectKeyToPathFuture should have been cancelled");
-        assertTrue(compactor.compactionFuturesByName.isEmpty(), "compactionFuturesByName should be empty");
+        assertFalse(hashStoreDiskFuture.notInterrupted(), "hashStoreDiskFuture should be interrupted");
+        assertFalse(pathToKeyValueFuture.notInterrupted(), "pathToKeyValueFuture should be interrupted");
+        assertFalse(objectKeyToPathFuture.notInterrupted(), "objectKeyToPathFuture should be interrupted");
+        synchronized (compactor) {
+            assertTrue(compactor.compactorsByName.isEmpty(), "compactorsByName should be empty");
+        }
         assertEventuallyEquals(
                 0, () -> compactingExecutor.getQueue().size(), Duration.ofMillis(100), "The queue should be empty");
         long expectedTaskCount = initCount + 3;

--- a/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLongArray;
+import java.util.function.BooleanSupplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -116,10 +117,12 @@ class DataFileCollectionCompactionTest {
                 return false;
             }
 
-            public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
+            public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
+                    throws InterruptedException, T {
                 for (final Map.Entry<Long, Long> e : index.entrySet()) {
                     action.handle(e.getKey(), e.getValue());
                 }
+                return true;
             }
         };
         final var compactor =
@@ -208,11 +211,12 @@ class DataFileCollectionCompactionTest {
                             return true;
                         }
 
-                        public <T extends Throwable> void forEach(final LongAction<T> action)
+                        public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
                                 throws InterruptedException, T {
                             for (int i = 0; i < MAXKEYS; i++) {
                                 action.handle(i, index[i]);
                             }
+                            return true;
                         }
                     };
 
@@ -265,10 +269,12 @@ class DataFileCollectionCompactionTest {
                     return true;
                 }
 
-                public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
+                public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
+                        throws InterruptedException, T {
                     for (int i = 0; i < MAXKEYS; i++) {
                         action.handle(i, index[i]);
                     }
+                    return true;
                 }
             };
 
@@ -323,11 +329,12 @@ class DataFileCollectionCompactionTest {
                         return index.compareAndSet((int) key, oldValue, newValue);
                     }
 
-                    public <T extends Throwable> void forEach(final LongAction<T> action)
+                    public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
                             throws InterruptedException, T {
                         for (int i = 0; i < index.length(); i++) {
                             action.handle(i, index.get(i));
                         }
+                        return true;
                     }
                 };
 
@@ -396,11 +403,12 @@ class DataFileCollectionCompactionTest {
                         return index.compareAndSet((int) key, oldValue, newValue);
                     }
 
-                    public <T extends Throwable> void forEach(final LongAction<T> action)
+                    public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
                             throws InterruptedException, T {
                         for (int i = 0; i < index.length(); i++) {
                             action.handle(i, index.get(i));
                         }
+                        return true;
                     }
                 };
 
@@ -616,8 +624,9 @@ class DataFileCollectionCompactionTest {
                 return true;
             }
 
-            public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
-                index.forEach(action);
+            public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
+                    throws InterruptedException, T {
+                return index.forEach(action, cond);
             }
         };
 
@@ -648,8 +657,9 @@ class DataFileCollectionCompactionTest {
                 return true;
             }
 
-            public <T extends Throwable> void forEach(final LongAction<T> action) throws InterruptedException, T {
-                index2.forEach(action);
+            public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
+                    throws InterruptedException, T {
+                return index2.forEach(action, cond);
             }
         };
 

--- a/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/timingSensitive/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -41,8 +41,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BooleanSupplier;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -395,9 +397,9 @@ class DataFileCollectionTest {
                             return storedOffsets.putIfEqual(key, oldValue, newValue);
                         }
 
-                        public <T extends Throwable> void forEach(final LongAction<T> action)
+                        public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
                                 throws InterruptedException, T {
-                            storedOffsets.forEach(action);
+                            return storedOffsets.forEach(action, cond);
                         }
                     };
 
@@ -505,10 +507,15 @@ class DataFileCollectionTest {
         final LongListHeap storedOffsets = storedOffsetsMap.get(testType);
         final AtomicBoolean mergeComplete = new AtomicBoolean(false);
         // start compaction paused so that we can test pausing
-        fileCompactor.pauseCompaction();
+        final CountDownLatch compactionPausedLatch = new CountDownLatch(1);
 
         IntStream.range(0, 3).parallel().forEach(thread -> {
             if (thread == 0) { // checking thread, keep reading and checking data all
+                try {
+                    compactionPausedLatch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
                 // the time while we are merging
                 while (!mergeComplete.get()) {
                     try {
@@ -531,6 +538,11 @@ class DataFileCollectionTest {
                     }
                 }
             } else if (thread == 1) { // move thread
+                try {
+                    compactionPausedLatch.await();
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
                 // merge 2 files
                 try {
                     List<DataFileReader> allFiles = fileCollection.getAllCompletedFiles();
@@ -555,9 +567,9 @@ class DataFileCollectionTest {
                             return storedOffsets.putIfEqual(key, oldValue, newValue);
                         }
 
-                        public <T extends Throwable> void forEach(final LongAction<T> action)
+                        public <T extends Throwable> boolean forEach(final LongAction<T> action, BooleanSupplier cond)
                                 throws InterruptedException, T {
-                            storedOffsets.forEach(action);
+                            return storedOffsets.forEach(action, cond);
                         }
                     };
                     fileCompactor.compactFiles(indexUpdater, allFiles, 1);
@@ -567,6 +579,12 @@ class DataFileCollectionTest {
                 }
                 mergeComplete.set(true);
             } else if (thread == 2) { // un-pause merging thread
+                try {
+                    fileCompactor.pauseCompaction();
+                    compactionPausedLatch.countDown();
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
                 System.out.println("Unpause thread starting and waiting 300ms");
                 try {
                     MILLISECONDS.sleep(300);
@@ -704,18 +722,19 @@ class DataFileCollectionTest {
     }
 
     /**
-     * This test emulates scenario in which compaction is interrupted by thread interruption. This event shouldn't be
-     * reported as an error in the logs.
+     * This test emulates scenario in which compaction is interrupted. This event shouldn't be
+     * reported as an error in the logs, and there should be no exceptions on the threads running
+     * compaction tasks.
      */
     @Test
-    public void testClosedByInterruptException() throws IOException {
+    public void testClosedByInterrupt() throws IOException {
         // mock appender to capture the log statements
-        final MockAppender mockAppender = new MockAppender("testClosedByInterruptException");
+        final MockAppender mockAppender = new MockAppender("testClosedByInterrupt");
         Logger logger = (Logger) LogManager.getLogger(DataFileCompactor.class);
         mockAppender.start();
         logger.addAppender(mockAppender);
-        final Path dbDir = tempFileDir.resolve("testClosedByInterruptException");
-        final String storeName = "testClosedByInterruptException";
+        final Path dbDir = tempFileDir.resolve("testClosedByInterrupt");
+        final String storeName = "testClosedByInterrupt";
 
         // init file collection with some content to compact
         final DataFileCollection fileCollection = new DataFileCollection(MERKLE_DB_CONFIG, dbDir, storeName, null);
@@ -725,26 +744,20 @@ class DataFileCollectionTest {
                 MERKLE_DB_CONFIG, storeName, fileCollection, storedOffsets, null, null, null, null);
         populateDataFileCollection(FilesTestType.fixed, fileCollection, storedOffsets);
 
-        // a flag to make sure that `compactFiles` th
-        AtomicBoolean closedByInterruptFromCompaction = new AtomicBoolean(false);
-
         final Thread thread = new Thread(() -> {
             List<DataFileReader> allCompletedFiles = fileCollection.getAllCompletedFiles();
             DataFileReader spy = Mockito.spy(allCompletedFiles.get(0));
             try {
                 when(spy.leaseFileChannel()).thenAnswer(invocation -> {
                     // on the first call to leaseFileChannel(), we interrupt the thread
-                    Thread.currentThread().interrupt();
+                    compactor.interruptCompaction();
                     return invocation.callRealMethod();
                 });
 
                 List<DataFileReader> allCompletedFilesUpdated = new ArrayList<>(allCompletedFiles);
                 allCompletedFilesUpdated.set(0, spy);
                 compactor.compactFiles(storedOffsets, allCompletedFilesUpdated, 1);
-            } catch (InterruptedException e) {
-                // we expect interrupted exception here
-                closedByInterruptFromCompaction.set(true);
-            } catch (IOException e) {
+            } catch (IOException | InterruptedException e) {
                 fail("Exception should not be thrown");
             }
             reset(spy);
@@ -753,15 +766,11 @@ class DataFileCollectionTest {
         try {
             assertEventuallyTrue(
                     () -> {
-                        if (!closedByInterruptFromCompaction.get()) {
-                            return false;
-                        }
                         if (mockAppender.size() == 0) {
                             return false;
                         }
                         final String logMsg = mockAppender.get(0);
-                        assertTrue(logMsg.startsWith("MERKLE_DB - INFO - Failed to copy data item 0"));
-                        assertTrue(logMsg.endsWith("due to thread interruption"));
+                        assertTrue(logMsg.contains("Some files to compact haven't been processed"));
                         return true;
                     },
                     Duration.ofMillis(5000),


### PR DESCRIPTION
Fix summary: changes for #19319 and related fixes are backported to the `release/0.62` branch.

*!* There are no plans to merge this to `release/0.62` yet. However, I'd like to have this PR ready, in case issues described in the original ticket are observed in real networks.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/19424
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
