### PR TITLE
test: Support transaction submission, registration for batch components

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecOperation.java
@@ -229,12 +229,8 @@ public abstract class HapiSpecOperation implements SpecOperation {
         return Optional.empty();
     }
 
-    private void registerTxnSubmitted(final HapiSpec spec) throws Throwable {
-        if (txnSubmitted != Transaction.getDefaultInstance()) {
-            spec.registry().saveBytes(txnName, txnSubmitted.toByteString());
-            final TransactionID txnId = extractTxnId(txnSubmitted);
-            spec.registry().saveTxnId(txnName, txnId);
-        }
+    protected void registerTxnSubmitted(final HapiSpec spec) throws Throwable {
+        registerTransaction(spec, txnName, txnSubmitted);
     }
 
     protected Consumer<TransactionBody.Builder> bodyDef(final HapiSpec spec) {
@@ -457,9 +453,34 @@ public abstract class HapiSpecOperation implements SpecOperation {
         return payer;
     }
 
+    public String getTxnName() {
+        return txnName;
+    }
+
+    public boolean shouldRegisterTxn() {
+        return shouldRegisterTxn;
+    }
+
     protected ByteString rationalize(final String expectedLedgerId) {
         final var hex = expectedLedgerId.substring(2);
         final var bytes = HexFormat.of().parseHex(hex);
         return ByteString.copyFrom(bytes);
+    }
+
+    /**
+     * Registers a transaction in a {@link HapiSpec}'s registry by a given name
+     *
+     * @param spec the spec to register the transaction with
+     * @param txnName the name given to reference the transaction
+     * @param txn the value to store for the given name
+     * @throws Throwable if no transaction ID can be extracted from the given `txn` param
+     */
+    public static void registerTransaction(final HapiSpec spec, final String txnName, final Transaction txn)
+            throws Throwable {
+        if (txn != Transaction.getDefaultInstance()) {
+            spec.registry().saveBytes(txnName, txn.toByteString());
+            final TransactionID txnId = extractTxnId(txn);
+            spec.registry().saveTxnId(txnName, txnId);
+        }
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -180,6 +180,10 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
         return finalizedTxn(spec, opBodyDef(spec));
     }
 
+    public void setTransactionSubmitted(final Transaction txn) {
+        this.txnSubmitted = txn;
+    }
+
     @Override
     protected boolean submitOp(HapiSpec spec) throws Throwable {
         configureTlsFor(spec);
@@ -236,7 +240,7 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
                 }
             } finally {
                 /* Used by superclass to perform standard housekeeping. */
-                txnSubmitted = txn;
+                setTransactionSubmitted(txn);
             }
 
             actualPrecheck = response.getNodeTransactionPrecheckCode();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiContractCall.java
@@ -198,10 +198,6 @@ public class HapiContractCall extends HapiBaseCall<HapiContractCall> {
         this.params = Optional.of(params);
     }
 
-    public String getTxnName() {
-        return txnName;
-    }
-
     public Optional<Long> getGas() {
         return gas;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/util/HapiAtomicBatch.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/util/HapiAtomicBatch.java
@@ -13,6 +13,7 @@ import com.hedera.node.app.hapi.fees.usage.crypto.CryptoCreateMeta;
 import com.hedera.node.app.hapi.fees.usage.state.UsageAccumulator;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
 import com.hedera.services.bdd.spec.queries.meta.HapiGetTxnRecord;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
@@ -38,8 +39,8 @@ public class HapiAtomicBatch extends HapiTxnOp<HapiAtomicBatch> {
     private static final Logger log = LogManager.getLogger(HapiAtomicBatch.class);
     private static final String DEFAULT_NODE_ACCOUNT_ID = "0.0.0";
     private final List<HapiTxnOp<?>> operationsToBatch = new ArrayList<>();
-    private final Map<TransactionID, Transaction> innerTransactions = new HashMap<>();
-    private final Map<TransactionID, HapiTxnOp<?>> operationsMap = new HashMap<>();
+    private final Map<TransactionID, HapiTxnOp<?>> innerOpsByTxnId = new HashMap<>();
+    private final Map<TransactionID, Transaction> innerTnxsByTxnId = new HashMap<>();
     private final List<String> txnIdsForOrderValidation = new ArrayList<>();
 
     public HapiAtomicBatch() {}
@@ -90,10 +91,10 @@ public class HapiAtomicBatch extends HapiTxnOp<HapiAtomicBatch> {
                                                 spec.logPrefix(),
                                                 txnToString(transaction));
                                     }
-                                    // save transaction id
+                                    // save transaction id and transaction
                                     final var txnId = extractTxnId(transaction);
-                                    operationsMap.put(txnId, op);
-                                    innerTransactions.put(txnId, transaction);
+                                    innerOpsByTxnId.put(txnId, op);
+                                    innerTnxsByTxnId.put(txnId, transaction);
 
                                     // add the transaction to the batch
                                     b.addTransactions(transaction.getSignedTransactionBytes());
@@ -107,18 +108,30 @@ public class HapiAtomicBatch extends HapiTxnOp<HapiAtomicBatch> {
 
     @Override
     public void setTransactionSubmitted(final Transaction txn) {
-        // Set the outer (batch) transaction
+        // Set the submitted outer (batch) transaction
         this.txnSubmitted = txn;
 
         // For each of the included operations, also set the submitted transaction
-        this.operationsMap.forEach(
-                (transactionID, hapiTxnOp) -> hapiTxnOp.setTransactionSubmitted(innerTransactions.get(transactionID)));
+        this.innerOpsByTxnId.forEach(
+                (transactionID, hapiTxnOp) -> hapiTxnOp.setTransactionSubmitted(innerTnxsByTxnId.get(transactionID)));
+    }
+
+    @Override
+    protected void registerTxnSubmitted(final HapiSpec spec) throws Throwable {
+        super.registerTxnSubmitted(spec);
+
+        for (final var entry : innerTnxsByTxnId.entrySet()) {
+            final var op = innerOpsByTxnId.get(entry.getKey());
+            if (op != null && op.shouldRegisterTxn()) {
+                HapiSpecOperation.registerTransaction(spec, op.getTxnName(), entry.getValue());
+            }
+        }
     }
 
     @Override
     public void updateStateOf(HapiSpec spec) throws Throwable {
         if (actualStatus == SUCCESS) {
-            for (Map.Entry<TransactionID, HapiTxnOp<?>> entry : operationsMap.entrySet()) {
+            for (Map.Entry<TransactionID, HapiTxnOp<?>> entry : innerOpsByTxnId.entrySet()) {
                 TransactionID txnId = entry.getKey();
                 HapiTxnOp<?> op = entry.getValue();
 


### PR DESCRIPTION
Certain Hapi operations require access to the transaction submitted as part of a `HapiSpecOperation`. In order to function with batch transactions, `HapiAtomicBatch` must set `txnSubmitted` for all its inner transactions; this PR adds support for doing so. Also included is the capability to reference inner transactions via the typical `HapiTxnOp.via(string)` mechanism. 