### PR TITLE
chore: Add error reporting to node-flow-build-application cleanup Hedera Services text in workflows

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -67,7 +67,7 @@ permissions:
 
 jobs:
   code:
-    name: Code
+    name: Compile Code
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     with:
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
@@ -192,3 +192,194 @@ jobs:
           inputs: '{
             "ref": "${{ github.ref }}"
             }'
+
+  report-failure:
+    name: Report XTS execution failure
+    runs-on: hiero-network-node-linux-medium
+    needs:
+      - code
+      - dependency-check
+      - spotless
+      - mats-unit-tests
+      - mats-gradle-determinism
+      - mats-docker-determinism
+      - deploy-ci-trigger
+    if: ${{ (needs.code.result != 'success' ||
+      needs.dependency-check.result != 'success' ||
+      needs.spotless.result != 'success' ||
+      needs.mats-unit-test.result != 'success' ||
+      needs.mats-gradle-determinism.result != 'success' ||
+      needs.mats-docker-determinism.result != 'success' ||
+      needs.deploy-ci-trigger.result != 'success') &&
+      !cancelled() && always() }}
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: "0"
+          ref: main
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Collect run logs in a log file
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
+          for job_id in $(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(.databaseId) | .[0:-1] | .[]'); do
+            echo "Fetching logs for job $job_id..."
+
+            current_job_name=$(gh run view ${{ github.run_id }} --json jobs | jq --argjson job_id "$job_id" -r '.jobs[] | select(.databaseId == $job_id) | .name')
+
+            echo "Logs for job $current_job_name :" >> run.log
+
+            gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            /repos/hiero-ledger/hiero-consensus-node/actions/jobs/$job_id/logs >> run.log
+          done
+
+      - name: Upload log as artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          path: run.log
+
+      - name: Find Commit Author in Slack
+        id: find-commit-author-slack
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
+          EMAIL: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit-email }}
+        run: |
+          SLACK_USER_ID=$(curl -s -X GET "https://slack.com/api/users.list" \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" | jq -r --arg email "${EMAIL}" \
+            '.members[] | select((.profile.email // "" | ascii_downcase) == ($email | ascii_downcase)) | .name')
+
+          if [[ -z "${SLACK_USER_ID}" || "${SLACK_USER_ID}" == "null" ]]; then
+            echo "No Slack user found for email: ${EMAIL}"
+            SLACK_USER_ID="No matching slack user found"
+          else
+            echo "Found slack user for email: ${EMAIL}"
+            SLACK_USER_ID="<@${SLACK_USER_ID}>"
+          fi
+          echo "slack-user-id=${SLACK_USER_ID}" >> "${GITHUB_OUTPUT}"
+
+      - name: Report failure (slack)
+        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload: |
+            {
+              "attachments": [
+                {
+                  "color": "#FF0000",
+                  "blocks": [
+                    {
+                      "type": "header",
+                      "text": {
+                        "type": "plain_text",
+                        "text": ":exclamation: Hiero Consensus Node - MATS Error Report",
+                        "emoji": true
+                      }
+                    },
+                    {
+                      "type": "divider"
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*MATS Job Resulted in failure on `main`. See status below.*"
+                      },
+                      "fields": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Code Compiles*: ${{ needs.code.result }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Dependency (Module Info)*: ${{ needs.dependency-check.result }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Spotless*: ${{ needs.spotless.result }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*MATS - Unit Tests*: ${{ needs.mats-unit-tests.result }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*MATS - Gradle Determinism*: ${{ needs.mats-gradle-determinism.result }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*MATS - Docker Determinism*: ${{ needs.mats-docker-determinism.result }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Deploy CI Triggers*: ${{ needs.deploy-ci-trigger.result }}"
+                        }
+                      ]
+                    },
+                    {
+                      "type": "divider"
+                    },
+                    {
+                      "type": "section",
+                      "text": {
+                        "type": "mrkdwn",
+                        "text": "*Workflow and Commit Information*"
+                      },
+                      "fields": [
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Source Commit*:"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}>"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Commit author*:"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "${{ needs.fetch-xts-candidate.outputs.xts-tag-commit-author }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Slack user*:"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "${{ steps.find-commit-author-slack.outputs.slack-user-id }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Workflow run ID*:"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": " ${{ github.run_id }}"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "*Workflow run URL*:"
+                        },
+                        {
+                          "type": "mrkdwn",
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -207,7 +207,7 @@ jobs:
     if: ${{ (needs.code.result != 'success' ||
       needs.dependency-check.result != 'success' ||
       needs.spotless.result != 'success' ||
-      needs.mats-unit-test.result != 'success' ||
+      needs.mats-unit-tests.result != 'success' ||
       needs.mats-gradle-determinism.result != 'success' ||
       needs.mats-docker-determinism.result != 'success' ||
       needs.deploy-ci-trigger.result != 'success') &&

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -186,7 +186,7 @@ jobs:
         with:
           egress-policy: audit
 
-      - name: Checkout Hedera Services Code
+      - name: Checkout Hiero Consensus Node Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/node-zxcron-release-branching.yaml
+++ b/.github/workflows/node-zxcron-release-branching.yaml
@@ -141,7 +141,7 @@ jobs:
                         "type": "header",
                         "text": {
                           "type": "plain_text",
-                          "text": ":evergreen_tree: Hedera Services - Automatic Release Branching",
+                          "text": ":evergreen_tree: Hiero Consensus Node - Automatic Release Branching",
                           "emoji": true
                         }
                       },
@@ -293,7 +293,7 @@ jobs:
                         "type": "header",
                         "text": {
                           "type": "plain_text",
-                          "text": ":ideograph_advantage: Hedera Services - Automatic Release Tagging",
+                          "text": ":ideograph_advantage: Hiero Consensus Node - Automatic Release Tagging",
                           "emoji": true
                         }
                       },

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -275,7 +275,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":tada: Hedera Services - eXtended Test Suite Passing Report",
+                        "text": ":tada: Hiero Consensus Node - eXtended Test Suite Passing Report",
                         "emoji": true
                       }
                     },
@@ -438,7 +438,7 @@ jobs:
           --header 'Content-Type: application/json' \
           --data '{
             "payload": {
-              "summary": "Hedera Services - eXtended Test Suite Failure",
+              "summary": "Hiero Consensus Node - eXtended Test Suite Failure",
               "severity": "error",
               "source": "GitHub Actions - eXtended Test Suite",
               "custom_details": {
@@ -491,7 +491,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":grey_exclamation: Hedera Services - eXtended Test Suite Error Report",
+                        "text": ":grey_exclamation: Hiero Consensus Node - eXtended Test Suite Error Report",
                         "emoji": true
                       }
                     },

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -173,7 +173,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":grey_exclamation: Hedera Services - XTS Candidate Promoted for Single Day Performance/Longevity Tests",
+                        "text": ":grey_exclamation: Hiero Consensus Node - XTS Candidate Promoted for Single Day Performance/Longevity Tests",
                         "emoji": true
                       }
                     },
@@ -238,7 +238,7 @@ jobs:
           --header 'Content-Type: application/json' \
           --data '{
             "payload": {
-              "summary": "Hedera Services - eXtended Test Suite Failure",
+              "summary": "Hiero Consensus Node - eXtended Test Suite Failure",
               "severity": "error",
               "source": "GitHub Actions - eXtended Test Suite",
               "custom_details": {
@@ -268,7 +268,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":grey_exclamation: Hedera Services - Build Candidate Promotion Error Report",
+                        "text": ":warning: Hiero Consensus Node - Build Candidate Promotion Error Report",
                         "emoji": true
                       }
                     },

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -128,7 +128,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":grey_exclamation: Hedera Services - XTS Candidate Tagging Failed",
+                        "text": ":grey_exclamation: Hiero Consensus Node - XTS Candidate Tagging Failed",
                         "emoji": true
                       }
                     },


### PR DESCRIPTION
**Description**:
- Adds error reporting to `node-flow-build-application`
- Updates steps throughout yaml files to change "Hedera Services" to "Hiero Consensus Node".

**Related Issue(s)**:

closes #19496
