### PR TITLE
test: Split the method Network.prepareUpgrade() in freeze() and shutdown()

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
@@ -64,7 +64,8 @@ public class BirthRoundFreezeTest {
 
         // Initiate the migration
         env.transactionGenerator().stop();
-        network.prepareUpgrade(ONE_MINUTE);
+        network.freeze(ONE_MINUTE);
+        network.shutdown(ONE_MINUTE);
 
         // Events with a created time before this time should have a maximum birth round of
         // the freeze round. Events created after this time should have a birth round greater

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationAndFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationAndFreezeTest.java
@@ -62,7 +62,8 @@ public class BirthRoundMigrationAndFreezeTest {
 
         // Initiate the migration
         env.transactionGenerator().stop();
-        network.prepareUpgrade(ONE_MINUTE);
+        network.freeze(ONE_MINUTE);
+        network.shutdown(ONE_MINUTE);
 
         for (final Node node : network.getNodes()) {
             node.getConfiguration()
@@ -79,7 +80,8 @@ public class BirthRoundMigrationAndFreezeTest {
 
         // Initiate the migration
         env.transactionGenerator().stop();
-        network.prepareUpgrade(ONE_MINUTE);
+        network.freeze(ONE_MINUTE);
+        network.shutdown(ONE_MINUTE);
 
         // Events with a created time before this time should have a maximum birth round of
         // the freeze round. Events created after this time should have a birth round greater

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationTest.java
@@ -52,7 +52,8 @@ class BirthRoundMigrationTest {
 
         // Initiate the migration
         env.transactionGenerator().stop();
-        network.prepareUpgrade(ONE_MINUTE);
+        network.freeze(ONE_MINUTE);
+        network.shutdown(ONE_MINUTE);
 
         // Before migrating to birth round, all events should have a birth round of 1L
         assertThat(network.getPcesResults()).hasAllBirthRoundsEqualTo(1L);

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
@@ -38,7 +38,7 @@ public class SandboxTest {
 
         // Kill node
         final Node node = nodes.getFirst();
-        node.failUnexpectedly(ONE_MINUTE);
+        node.killImmediately(ONE_MINUTE);
 
         // Wait for two minutes
         timeManager.waitFor(TWO_MINUTES);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Network.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Network.java
@@ -55,6 +55,10 @@ public interface Network {
     /**
      * Freezes the network.
      *
+     * <p>This method sends a freeze transaction to one of the active nodes with a freeze time shortly after the
+     * current time. The method returns once all nodes entered the
+     * {@link org.hiero.consensus.model.status.PlatformStatus#FREEZE_COMPLETE} state.
+     *
      * @param timeout the duration to wait before considering the freeze operation as failed
      * @throws InterruptedException if the thread is interrupted while waiting
      */

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Network.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Network.java
@@ -65,7 +65,8 @@ public interface Network {
     void freeze(@NonNull Duration timeout) throws InterruptedException;
 
     /**
-     * Shuts down the network. Once shutdown, it is possible to change the configuration etc. before resuming the
+     * Shuts down the network. The nodes are killed immediately. No attempt is made to finish any outstanding tasks
+     * or preserve any state. Once shutdown, it is possible to change the configuration etc. before resuming the
      * network with {@link #resume(Duration)}.
      *
      * @param timeout the duration to wait before considering the shutdown operation as failed

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Network.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Network.java
@@ -53,14 +53,21 @@ public interface Network {
     List<Node> getNodes();
 
     /**
-     * Prepares the network for an upgrade. All required preparations steps are executed and the network
-     * is shutdown. Once shutdown, it is possible to change the configuration etc. before resuming the
-     * network with {@link #resume(Duration)}.
+     * Freezes the network.
      *
-     * @param timeout the duration to wait before considering the preparation operation as failed
+     * @param timeout the duration to wait before considering the freeze operation as failed
      * @throws InterruptedException if the thread is interrupted while waiting
      */
-    void prepareUpgrade(@NonNull Duration timeout) throws InterruptedException;
+    void freeze(@NonNull Duration timeout) throws InterruptedException;
+
+    /**
+     * Shuts down the network. Once shutdown, it is possible to change the configuration etc. before resuming the
+     * network with {@link #resume(Duration)}.
+     *
+     * @param timeout the duration to wait before considering the shutdown operation as failed
+     * @throws InterruptedException if the thread is interrupted while waiting
+     */
+    void shutdown(@NonNull Duration timeout) throws InterruptedException;
 
     /**
      * Resumes the network after it has previously been paused, e.g. to prepare for an upgrade.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Node.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Node.java
@@ -14,6 +14,7 @@ import org.hiero.otter.fixtures.result.SingleNodeStatusProgression;
  *
  * <p>This interface provides methods to control the state of the node, such as killing and reviving it.
  */
+@SuppressWarnings("unused")
 public interface Node {
 
     /**
@@ -26,7 +27,7 @@ public interface Node {
      *
      * @param timeout the duration to wait before considering the kill operation as failed
      */
-    void failUnexpectedly(@NonNull Duration timeout) throws InterruptedException;
+    void killImmediately(@NonNull Duration timeout) throws InterruptedException;
 
     /**
      * Shutdown the node gracefully.
@@ -34,7 +35,7 @@ public interface Node {
      * <p>This method simulates a graceful shutdown of the node. It allows the node to finish any
      * ongoing work, preserve the current state, and perform any other necessary cleanup operations
      * before shutting down. If the simulation of a sudden failure is desired, use
-     * {@link #failUnexpectedly(Duration)} instead.
+     * {@link #killImmediately(Duration)} instead.
      */
     void shutdownGracefully(@NonNull Duration timeout) throws InterruptedException;
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -200,9 +200,9 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
             throw new IllegalStateException("Can only shutdown when the network is running.");
         }
 
-        log.info("Shutting down nodes gracefully...");
+        log.info("Killing nodes immediately...");
         for (final TurtleNode node : nodes) {
-            node.shutdownGracefully(timeout);
+            node.killImmediately(timeout);
         }
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -77,6 +77,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
      *
      * @param randotron the random generator
      * @param timeManager the time manager
+     * @param logging the logging utility
      * @param rootOutputDirectory the directory where the node output will be stored, like saved state and so on
      */
     public TurtleNetwork(
@@ -174,11 +175,11 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
      * {@inheritDoc}
      */
     @Override
-    public void prepareUpgrade(@NonNull final Duration timeout) throws InterruptedException {
+    public void freeze(@NonNull final Duration timeout) {
         if (state != State.RUNNING) {
-            throw new IllegalStateException("Cannot prepare upgrade when the network is not running.");
+            throw new IllegalStateException("Can only freeze when the network is running.");
         }
-        log.info("Preparing upgrade...");
+        log.info("Preparing freeze...");
 
         log.debug("Sending TurtleFreezeTransaction transaction...");
         final TurtleTransaction freezeTransaction =
@@ -189,8 +190,18 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
         if (!timeManager.waitForCondition(allNodesInStatus(FREEZE_COMPLETE), timeout)) {
             fail("Timeout while waiting for all nodes to freeze.");
         }
+    }
 
-        log.debug("Shutting down nodes gracefully...");
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void shutdown(@NonNull final Duration timeout) throws InterruptedException {
+        if (state != State.RUNNING) {
+            throw new IllegalStateException("Can only shutdown when the network is running.");
+        }
+
+        log.info("Shutting down nodes gracefully...");
         for (final TurtleNode node : nodes) {
             node.shutdownGracefully(timeout);
         }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -179,9 +179,8 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
         if (state != State.RUNNING) {
             throw new IllegalStateException("Can only freeze when the network is running.");
         }
-        log.info("Preparing freeze...");
 
-        log.debug("Sending TurtleFreezeTransaction transaction...");
+        log.info("Sending freeze transaction...");
         final TurtleTransaction freezeTransaction =
                 TransactionFactory.createFreezeTransaction(timeManager.now().plus(FREEZE_DELAY));
         nodes.getFirst().submitTransaction(freezeTransaction.toByteArray());

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -172,7 +172,7 @@ public class TurtleNode implements Node, TurtleTimeManager.TimeTickReceiver {
      * {@inheritDoc}
      */
     @Override
-    public void failUnexpectedly(@NonNull final Duration timeout) throws InterruptedException {
+    public void killImmediately(@NonNull final Duration timeout) throws InterruptedException {
         try {
             ThreadContext.put(THREAD_CONTEXT_NODE_ID, selfId.toString());
 


### PR DESCRIPTION
**Description**:

This PR splits the method `Network.prepareUpgrade()` into `freeze()` and `shutdown()` and updates the Turtle implementation accordingly.

**Related issue(s)**:

Fixes #19468 