### PR TITLE
test: Unify start() and revive()

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
@@ -73,7 +73,7 @@ public class BirthRoundFreezeTest {
         final long freezeRound =
                 network.getNodes().getFirst().getConsensusResult().lastRoundNum();
 
-        assertThat(network.getPcesResults()).hasMaxBirthRoundEqualTo(freezeRound);
+        assertThat(network.getPcesResults()).hasMaxBirthRoundLessThanOrEqualTo(freezeRound);
 
         for (final Node node : network.getNodes()) {
             node.getConfiguration().set(SOFTWARE_VERSION, NEW_VERSION);

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationAndFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundMigrationAndFreezeTest.java
@@ -88,7 +88,7 @@ public class BirthRoundMigrationAndFreezeTest {
         final long freezeRound =
                 network.getNodes().getFirst().getConsensusResult().lastRoundNum();
 
-        assertThat(network.getPcesResults()).hasMaxBirthRoundEqualTo(freezeRound);
+        assertThat(network.getPcesResults()).hasMaxBirthRoundLessThanOrEqualTo(freezeRound);
 
         // Restart the network. The version before and after this freeze have birth rounds enabled.
         network.resume(ONE_MINUTE);

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
@@ -44,7 +44,7 @@ public class SandboxTest {
         timeManager.waitFor(TWO_MINUTES);
 
         // Revive node
-        node.revive(ONE_MINUTE);
+        node.start(ONE_MINUTE);
 
         // Wait for two minutes
         timeManager.waitFor(TWO_MINUTES);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Node.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Node.java
@@ -23,8 +23,8 @@ public interface Node {
      * preserve the current state, or any other similar operation is made. To simulate a graceful
      * shutdown, use {@link #shutdownGracefully(Duration)} instead.
      *
-     *
      * @param timeout the duration to wait before considering the kill operation as failed
+     * @throws InterruptedException if the thread is interrupted while waiting
      */
     void failUnexpectedly(@NonNull Duration timeout) throws InterruptedException;
 
@@ -35,15 +35,19 @@ public interface Node {
      * ongoing work, preserve the current state, and perform any other necessary cleanup operations
      * before shutting down. If the simulation of a sudden failure is desired, use
      * {@link #failUnexpectedly(Duration)} instead.
+     *
+     * @param timeout the duration to wait before considering the shutdown operation as failed
+     * @throws InterruptedException if the thread is interrupted while waiting
      */
     void shutdownGracefully(@NonNull Duration timeout) throws InterruptedException;
 
     /**
-     * Revive the node.
+     * Start the node.
      *
-     * @param timeout the duration to wait before considering the revive operation as failed
+     * @param timeout the duration to wait before considering the start operation as failed
+     * @throws InterruptedException if the thread is interrupted while waiting
      */
-    void revive(@NonNull Duration timeout) throws InterruptedException;
+    void start(@NonNull Duration timeout) throws InterruptedException;
 
     /**
      * Submit a transaction to the node.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -143,7 +143,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
         log.info("Starting network...");
         state = State.RUNNING;
         for (final TurtleNode node : nodes) {
-            node.start();
+            node.start(Duration.ZERO);
         }
 
         log.debug("Waiting for nodes to become active...");
@@ -192,7 +192,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
 
         log.debug("Shutting down nodes gracefully...");
         for (final TurtleNode node : nodes) {
-            node.shutdownGracefully(timeout);
+            node.shutdownGracefully(Duration.ZERO);
         }
     }
 
@@ -203,7 +203,7 @@ public class TurtleNetwork implements Network, TurtleTimeManager.TimeTickReceive
     public void resume(@NonNull final Duration timeout) {
         log.info("Resuming network...");
         for (final TurtleNode node : nodes) {
-            node.revive(timeout);
+            node.start(Duration.ZERO);
         }
 
         log.debug("Waiting for nodes to become active again...");


### PR DESCRIPTION
**Description**:

This PR renames `Node.revive()` to `Node.start()` and removes `TurtleNode.start()`.
Plus some additional minor improvements.

**Related issue(s)**:

Fixes #19471 