### PR TITLE
fix: Add continue-on-error logic to failure reporting in workflows

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -229,6 +229,7 @@ jobs:
       - name: Collect run logs in a log file
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        continue-on-error: true
         run: |
           for job_id in $(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(.databaseId) | .[0:-1] | .[]'); do
             echo "Fetching logs for job $job_id..."
@@ -245,6 +246,7 @@ jobs:
 
       - name: Upload log as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        continue-on-error: true
         with:
           path: run.log
 
@@ -253,6 +255,7 @@ jobs:
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
           EMAIL: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit-email }}
+        continue-on-error: true
         run: |
           SLACK_USER_ID=$(curl -s -X GET "https://slack.com/api/users.list" \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" | jq -r --arg email "${EMAIL}" \

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -412,6 +412,7 @@ jobs:
       - name: Collect run logs in a log file
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        continue-on-error: true
         run: |
           for job_id in $(gh run view ${{ github.run_id }} --json jobs --jq '.jobs | map(.databaseId) | .[0:-1] | .[]'); do
             echo "Fetching logs for job $job_id..."
@@ -428,10 +429,12 @@ jobs:
 
       - name: Upload log as artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        continue-on-error: true
         with:
           path: run.log
 
       - name: Report failure (PagerDuty)
+        continue-on-error: true
         run: |
           curl --request 'POST' \
           --url 'https://events.pagerduty.com/v2/enqueue' \
@@ -458,6 +461,7 @@ jobs:
 
       - name: Find Commit Author in Slack
         id: find-commit-author-slack
+        continue-on-error: true
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
           EMAIL: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit-email }}


### PR DESCRIPTION
**Description**:

Adds failure reporting `node-flow-build-application.yaml` and `zxcron-extended-test-suite.yaml` to force them to get through the slack reporting steps.

**Related Issue(s)**:

closes #19550