### PR TITLE
fix: HbarAllowanceCall reversion gas (#19388)

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/hbarallowance/HbarAllowanceCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/hbarallowance/HbarAllowanceCall.java
@@ -11,7 +11,6 @@ import com.esaulpaugh.headlong.abi.Tuple;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.AccountCryptoAllowance;
-import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.AbstractCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -41,14 +40,13 @@ public class HbarAllowanceCall extends AbstractCall {
     @Override
     public PricedResult execute(final MessageFrame frame) {
         requireNonNull(frame);
-        if (owner == null || nativeOperations().getAccount(owner) == null) {
-            return reversionWith(
-                    INVALID_ALLOWANCE_OWNER_ID, gasCalculator.canonicalGasRequirement(DispatchType.APPROVE));
-        }
         final var gasRequirement = gasCalculator.viewGasRequirement();
+        if (owner == null || nativeOperations().getAccount(owner) == null) {
+            return reversionWith(INVALID_ALLOWANCE_OWNER_ID, gasRequirement);
+        }
 
         final var allowance = getAllowance(nativeOperations().getAccount(owner), spender);
-        return gasOnly(successResult(encodedAllowanceOutput(allowance), gasRequirement), SUCCESS, false);
+        return gasOnly(successResult(encodedAllowanceOutput(allowance), gasRequirement), SUCCESS, true);
     }
 
     @NonNull

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/hbarallowance/HbarAllowanceTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/has/hbarallowance/HbarAllowanceTranslator.java
@@ -19,7 +19,7 @@ import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /**
- * Translates {@code hbarApprove()} calls to the HAS system contract.
+ * Translates {@code hbarAllowance()} calls to the HAS system contract.
  */
 @Singleton
 public class HbarAllowanceTranslator extends AbstractCallTranslator<HasCallAttempt> {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hbarAllowance/HbarAllowanceCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/has/hbarAllowance/HbarAllowanceCallTest.java
@@ -1,32 +1,49 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.has.hbarAllowance;
 
-import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ALLOWANCE_OWNER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.APPROVED_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.B_NEW_ACCOUNT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OPERATOR;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.UNAUTHORIZED_SPENDER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.revertOutputFor;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.BDDMockito.given;
 
 import com.esaulpaugh.headlong.abi.Tuple;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.contract.impl.exec.gas.CanonicalDispatchPrices;
+import com.hedera.node.app.service.contract.impl.exec.gas.DispatchType;
+import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
+import com.hedera.node.app.service.contract.impl.exec.gas.TinybarValues;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.HasCallAttempt;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarallowance.HbarAllowanceCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.has.hbarallowance.HbarAllowanceTranslator;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import java.math.BigInteger;
+import java.util.function.ToLongBiFunction;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 
 class HbarAllowanceCallTest extends CallTestBase {
+
     private HbarAllowanceCall subject;
 
     @Mock
     private HasCallAttempt attempt;
+
+    @Mock
+    private TinybarValues tinybarValues;
+
+    @Mock
+    private CanonicalDispatchPrices dispatchPrices;
+
+    @Mock
+    private ToLongBiFunction<TransactionBody, AccountID> feeCalculator;
 
     @Test
     void revertsWithNoOwner() {
@@ -37,7 +54,7 @@ class HbarAllowanceCallTest extends CallTestBase {
         final var result = subject.execute(frame).fullResult().result();
 
         assertEquals(MessageFrame.State.REVERT, result.getState());
-        assertEquals(revertOutputFor(INVALID_ALLOWANCE_OWNER_ID), result.getOutput());
+        assertEquals(revertOutputFor(ResponseCodeEnum.INVALID_ALLOWANCE_OWNER_ID), result.getOutput());
     }
 
     @Test
@@ -52,8 +69,38 @@ class HbarAllowanceCallTest extends CallTestBase {
         assertEquals(
                 Bytes.wrap(HbarAllowanceTranslator.HBAR_ALLOWANCE_PROXY
                         .getOutputs()
-                        .encode(Tuple.of((long) SUCCESS.getNumber(), BigInteger.valueOf(0L)))
+                        .encode(Tuple.of(
+                                (long) com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS.getNumber(),
+                                BigInteger.valueOf(0L)))
                         .array()),
                 result.getOutput());
+    }
+
+    @Test
+    void sameSuccessAndRevertGas() {
+        given(attempt.systemContractGasCalculator())
+                .willReturn(new SystemContractGasCalculator(tinybarValues, dispatchPrices, feeCalculator));
+        given(dispatchPrices.canonicalPriceInTinycents(DispatchType.TOKEN_INFO)).willReturn(1_000_000L);
+        given(attempt.enhancement()).willReturn(mockEnhancement());
+        given(nativeOperations.getAccount(B_NEW_ACCOUNT_ID)).willReturn(OPERATOR);
+        subject = new HbarAllowanceCall(attempt, B_NEW_ACCOUNT_ID, UNAUTHORIZED_SPENDER_ID);
+
+        final var successResult = subject.execute(frame);
+        assertEquals(ResponseCodeEnum.SUCCESS, successResult.responseCode(), "responseCode should be SUCCESS");
+        assertTrue(successResult.fullResult().gasRequirement() > 0, "gasRequirement should be > 0");
+        assertTrue(successResult.isViewCall(), "isViewCall should be true");
+
+        given(nativeOperations.getAccount(B_NEW_ACCOUNT_ID)).willReturn(null);
+        final var revertResult = subject.execute(frame);
+        assertEquals(
+                ResponseCodeEnum.INVALID_ALLOWANCE_OWNER_ID,
+                revertResult.responseCode(),
+                "responseCode should be INVALID_ALLOWANCE_OWNER_ID");
+        assertTrue(revertResult.fullResult().gasRequirement() > 0, "gasRequirement should be > 0");
+        assertTrue(revertResult.isViewCall(), "isViewCall should be true");
+        assertEquals(
+                successResult.fullResult().gasRequirement(),
+                revertResult.fullResult().gasRequirement(),
+                "gasRequirement of 'successResult' and 'revertResult' should be the same");
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecSetup.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/HapiSpecSetup.java
@@ -8,6 +8,7 @@ import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType;
 import static com.hedera.services.bdd.spec.keys.deterministic.Bip0032.mnemonicToEd25519Key;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.bytecodePath;
 
+import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.hapi.utils.keys.Ed25519Utils;
 import com.hedera.node.app.hapi.utils.keys.Secp256k1Utils;
@@ -18,6 +19,7 @@ import com.hedera.services.bdd.spec.props.MapPropertySource;
 import com.hedera.services.bdd.spec.props.NodeConnectInfo;
 import com.hedera.services.bdd.spec.remote.RemoteNetworkSpec;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
+import com.hedera.services.bdd.suites.contract.Utils;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.ContractID;
 import com.hederahashgraph.api.proto.java.Duration;
@@ -475,6 +477,10 @@ public class HapiSpecSetup {
 
     public String invalidContractName() {
         return props.get("invalid.contract.name");
+    }
+
+    public Address missingAddress() {
+        return Utils.mirrorAddrWith(props.getAccount("missing.address"));
     }
 
     public Boolean suppressUnrecoverableNetworkFailures() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/assertions/ContractFnResultAsserts.java
@@ -29,7 +29,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.function.DoubleSupplier;
 import java.util.function.Function;
+import java.util.function.LongSupplier;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
@@ -223,7 +225,7 @@ public class ContractFnResultAsserts extends BaseErroringAssertsProvider<Contrac
     }
 
     public ContractFnResultAsserts contract(String contract) {
-        registerIdLookupAssert(contract, r -> r.getContractID(), ContractID.class, "Bad contract!");
+        registerIdLookupAssert(contract, ContractFunctionResult::getContractID, ContractID.class, "Bad contract!");
         return this;
     }
 
@@ -274,19 +276,28 @@ public class ContractFnResultAsserts extends BaseErroringAssertsProvider<Contrac
     }
 
     public ContractFnResultAsserts approxGasUsed(final long expected, final double allowedPercentDeviation) {
+        approxGasUsed(() -> expected, () -> allowedPercentDeviation);
+        return this;
+    }
+
+    public ContractFnResultAsserts approxGasUsed(LongSupplier expected, DoubleSupplier allowedPercentDeviation) {
         registerProvider((spec, o) -> {
             ContractFunctionResult result = (ContractFunctionResult) o;
             final var actual = result.getGasUsed();
-            final var epsilon = allowedPercentDeviation * actual / 100.0;
-            assertEquals(expected, result.getGasUsed(), epsilon, "Wrong amount of gas used");
+            final var epsilon = allowedPercentDeviation.getAsDouble() * actual / 100.0;
+            assertEquals(expected.getAsLong(), actual, epsilon, "Wrong amount of gas used");
         });
         return this;
     }
 
     public ContractFnResultAsserts gasUsed(long gasUsed) {
+        return gasUsed(() -> gasUsed);
+    }
+
+    public ContractFnResultAsserts gasUsed(LongSupplier gasUsed) {
         registerProvider((spec, o) -> {
             ContractFunctionResult result = (ContractFunctionResult) o;
-            assertEquals(gasUsed, result.getGasUsed(), "Wrong amount of Gas was used!");
+            assertEquals(gasUsed.getAsLong(), result.getGasUsed(), "Wrong amount of Gas was used!");
         });
         return this;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CreatePrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/CreatePrecompileSuite.java
@@ -83,8 +83,8 @@ public class CreatePrecompileSuite {
     public static final String FALSE = "false";
     public static final String CREATE_TOKEN_WITH_ALL_CUSTOM_FEES_AVAILABLE = "createTokenWithAllCustomFeesAvailable";
     private static final Logger log = LogManager.getLogger(CreatePrecompileSuite.class);
-    private static final long GAS_TO_OFFER = 4_000_000L;
-    private static final long GAS_TO_OFFER_2 = 4_000_000L;
+    private static final long CONTRACT_CREATE_GAS_TO_OFFER = 4_000_000L;
+    private static final long GAS_TO_OFFER = 1_000_000L;
     public static final long AUTO_RENEW_PERIOD = 8_000_000L;
     public static final String TOKEN_SYMBOL = "tokenSymbol";
     public static final String TOKEN_NAME = "tokenName";
@@ -121,7 +121,7 @@ public class CreatePrecompileSuite {
                 contractCreate(TOKEN_CREATE_CONTRACT)
                         .autoRenewAccountId(ACCOUNT)
                         .adminKey(CONTRACT_ADMIN_KEY)
-                        .gas(GAS_TO_OFFER),
+                        .gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 newKeyNamed(THRESHOLD_KEY)
                         .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ED25519_ON, TOKEN_CREATE_CONTRACT)))
                         .exposingKeyTo(k -> ed2551Key.set(k.getThresholdKey()
@@ -232,7 +232,7 @@ public class CreatePrecompileSuite {
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
                 contractCreate(TOKEN_CREATE_CONTRACT)
                         .autoRenewAccountId(ACCOUNT)
-                        .gas(GAS_TO_OFFER),
+                        .gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 newKeyNamed(THRESHOLD_KEY)
                         .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ED25519_ON, TOKEN_CREATE_CONTRACT)))
                         .exposingKeyTo(k -> ed2551Key.set(k.getThresholdKey()
@@ -301,7 +301,7 @@ public class CreatePrecompileSuite {
                 cryptoCreate(ACCOUNT_TO_ASSOCIATE).key(ACCOUNT_TO_ASSOCIATE_KEY),
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
                 contractCreate(TOKEN_CREATE_CONTRACT)
-                        .gas(GAS_TO_OFFER)
+                        .gas(CONTRACT_CREATE_GAS_TO_OFFER)
                         .adminKey(CONTRACT_ADMIN_KEY)
                         .autoRenewAccountId(ACCOUNT),
                 newKeyNamed(THRESHOLD_KEY)
@@ -366,7 +366,7 @@ public class CreatePrecompileSuite {
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
                 getAccountInfo(DEFAULT_CONTRACT_SENDER).savingSnapshot(DEFAULT_CONTRACT_SENDER),
                 withOpContext((spec, opLog) ->
-                        allRunFor(spec, contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER))),
+                        allRunFor(spec, contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER))),
                 withOpContext((spec, ignore) -> {
                     final var subop1 = balanceSnapshot(ACCOUNT_BALANCE, ACCOUNT);
                     final var preCallSnap = balanceSnapshot("preCallSnap", TOKEN_CREATE_CONTRACT);
@@ -383,7 +383,7 @@ public class CreatePrecompileSuite {
                                             asAddress(spec.registry().getAccountID(ACCOUNT))),
                                     AUTO_RENEW_PERIOD)
                             .via(FIRST_CREATE_TXN)
-                            .gas(GAS_TO_OFFER)
+                            .gas(3_000_000)
                             .payingWith(ACCOUNT)
                             .sending(DEFAULT_AMOUNT_TO_SEND)
                             .exposingResultTo(result -> {
@@ -414,7 +414,7 @@ public class CreatePrecompileSuite {
                     final var subop4 = getAccountBalance(ACCOUNT)
                             .hasTinyBars(changeFromSnapshot(ACCOUNT_BALANCE, -(gasCost + DEFAULT_AMOUNT_TO_SEND)));
                     final var contractBalanceCheck = getAccountBalance(TOKEN_CREATE_CONTRACT)
-                            .hasTinyBars(changeFromSnapshot("preCallSnap", +(DEFAULT_AMOUNT_TO_SEND - creationFee)));
+                            .hasTinyBars(changeFromSnapshot("preCallSnap", (DEFAULT_AMOUNT_TO_SEND - creationFee)));
                     final var getAccountTokenBalance =
                             getAccountBalance(ACCOUNT).hasTokenBalance(String.valueOf(createdTokenNum.get()), 0);
                     final var tokenInfo = getTokenInfo(String.valueOf(createdTokenNum.get()))
@@ -451,7 +451,7 @@ public class CreatePrecompileSuite {
         final AtomicReference<byte[]> ed2551Key = new AtomicReference<>();
         return hapiTest(
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
-                contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER),
+                contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 newKeyNamed(TOKEN_CREATE_CONTRACT_AS_KEY).shape(CONTRACT.signedWith(TOKEN_CREATE_CONTRACT)),
                 newKeyNamed(THRESHOLD_KEY)
                         .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ED25519_ON, TOKEN_CREATE_CONTRACT)))
@@ -540,7 +540,7 @@ public class CreatePrecompileSuite {
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
                 contractCreate(TOKEN_CREATE_CONTRACT)
                         .autoRenewAccountId(ACCOUNT)
-                        .gas(GAS_TO_OFFER),
+                        .gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, TOKEN_CREATE_CONTRACT))),
                 cryptoUpdate(ACCOUNT).key(THRESHOLD_KEY),
                 withOpContext((spec, opLog) -> allRunFor(
@@ -602,7 +602,7 @@ public class CreatePrecompileSuite {
         final var createdTokenNum = new AtomicLong();
         return hapiTest(
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
-                contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER),
+                contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 newKeyNamed(THRESHOLD_KEY)
                         .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ED25519_ON, TOKEN_CREATE_CONTRACT))),
                 cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS).key(THRESHOLD_KEY),
@@ -648,7 +648,7 @@ public class CreatePrecompileSuite {
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
                 getAccountInfo(DEFAULT_CONTRACT_SENDER).savingSnapshot(DEFAULT_CONTRACT_SENDER),
                 withOpContext((spec, opLog) ->
-                        allRunFor(spec, contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER))),
+                        allRunFor(spec, contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER))),
                 withOpContext((spec, ignore) -> {
                     final var balanceSnapshot = balanceSnapshot(
                             ACCOUNT_BALANCE, spec.isUsingEthCalls() ? DEFAULT_CONTRACT_SENDER : ACCOUNT);
@@ -689,7 +689,7 @@ public class CreatePrecompileSuite {
         return hapiTest(
                 cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS),
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
-                contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER),
+                contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCall(
@@ -717,7 +717,7 @@ public class CreatePrecompileSuite {
                 newKeyNamed(ECDSA_KEY).shape(SECP256K1),
                 cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS),
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
-                contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER),
+                contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCall(
@@ -752,7 +752,7 @@ public class CreatePrecompileSuite {
                 cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS),
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
                 withOpContext((spec, opLog) ->
-                        allRunFor(spec, contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER))),
+                        allRunFor(spec, contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER))),
                 withOpContext((spec, ignore) -> {
                     final var accountSnapshot = spec.isUsingEthCalls()
                             ? balanceSnapshot(ACCOUNT_BALANCE, DEFAULT_CONTRACT_SENDER)
@@ -798,7 +798,7 @@ public class CreatePrecompileSuite {
         return hapiTest(
                 cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS),
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
-                contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER),
+                contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCall(
@@ -832,7 +832,7 @@ public class CreatePrecompileSuite {
                 newKeyNamed(ED25519KEY).shape(ED25519),
                 cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS).key(ED25519KEY),
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
-                contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER),
+                contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCall(
@@ -874,7 +874,7 @@ public class CreatePrecompileSuite {
                 cryptoCreate(ACCOUNT).key(ED25519KEY).balance(ONE_MILLION_HBARS),
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
                 withOpContext((spec, opLog) ->
-                        allRunFor(spec, contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER))),
+                        allRunFor(spec, contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER))),
                 withOpContext((spec, ignore) -> {
                     final var balanceSnapshot = spec.isUsingEthCalls()
                             ? balanceSnapshot(ACCOUNT_BALANCE, DEFAULT_CONTRACT_SENDER)
@@ -930,7 +930,7 @@ public class CreatePrecompileSuite {
                 newKeyNamed(ED25519KEY).shape(ED25519),
                 cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS).key(ED25519KEY),
                 uploadInitCode(TOKEN_CREATE_CONTRACT),
-                contractCreate(TOKEN_CREATE_CONTRACT).gas(GAS_TO_OFFER),
+                contractCreate(TOKEN_CREATE_CONTRACT).gas(CONTRACT_CREATE_GAS_TO_OFFER),
                 withOpContext((spec, opLog) -> allRunFor(
                         spec,
                         contractCall(
@@ -964,7 +964,7 @@ public class CreatePrecompileSuite {
                 cryptoCreate(FEE_COLLECTOR).balance(0L),
                 uploadInitCode(TOKEN_MISC_OPERATIONS_CONTRACT),
                 contractCreate(TOKEN_MISC_OPERATIONS_CONTRACT)
-                        .gas(GAS_TO_OFFER_2)
+                        .gas(CONTRACT_CREATE_GAS_TO_OFFER)
                         .autoRenewAccountId(ACCOUNT),
                 newKeyNamed(THRESHOLD_KEY)
                         .shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ON, TOKEN_MISC_OPERATIONS_CONTRACT))),
@@ -992,7 +992,7 @@ public class CreatePrecompileSuite {
                                         HapiParserUtil.asHeadlongAddress(
                                                 asAddress(spec.registry().getAccountID(ACCOUNT))))
                                 .via(FIRST_CREATE_TXN)
-                                .gas(GAS_TO_OFFER_2)
+                                .gas(CONTRACT_CREATE_GAS_TO_OFFER)
                                 .sending(DEFAULT_AMOUNT_TO_SEND)
                                 .payingWith(ACCOUNT)
                                 .exposingResultTo(result -> {

--- a/hedera-node/test-clients/src/main/resources/spec-default.properties
+++ b/hedera-node/test-clients/src/main/resources/spec-default.properties
@@ -84,6 +84,7 @@ genesis.account=2
 genesis.account.name=GENESIS
 invalid.contract=0.0.999999999
 invalid.contract.name=INVALID_CONTRACT
+missing.address=0.0.999999
 node.addressBook.name=NODE_ADDRESS_BOOK
 node.details.id=102
 node.details.name=NODE_DETAILS


### PR DESCRIPTION
❗ This PR is created and maintained by @gkozyryatskyy. It was initially approved by the hiero-consensus-node-smart-contracts-codeowners here #19388

**Description**:
Fix `HbarAllowanceCall` reversion gas

**Related issue(s)**:

Fixes [19169](https://github.com/hiero-ledger/hiero-consensus-node/issues/19169) [19013](https://github.com/hiero-ledger/hiero-consensus-node/issues/19013)

**Notes for reviewer**:
- actual fix is in `HbarAllowanceCall`
- `ContractFnResultAsserts.approxGasUsed` uses suppliers because values should be returned at the step execution but not at the test start
- `HbarAllowanceCall` success result `isViewCall` changed to `true`. Because of this new child record is produced on success result (there was no child record before).
- `CreatePrecompileSuite` changes, fixes "unstable" tests for [19013](https://github.com/hiero-ledger/hiero-consensus-node/issues/19013)

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
