### PR TITLE
chore: The real change that updates the run to use central publishing portal

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -793,12 +793,16 @@ jobs:
             gpg --output "${PUBLIC_ARCHIVE_FILE}.sha256.asc" --detach-sig "${PUBLIC_ARCHIVE_FILE}.sha256"
           echo "::endgroup::"
 
-      - name: Gradle Publish to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'Google Artifact Registry' }} (${{ inputs.release-profile }})
-        if: ${{ inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
+      - name: Gradle Publish to Google Artifact Registry (${{ inputs.release-profile }})
+        if: ${{ inputs.version-policy != 'specified' && inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
+        run: ./gradlew release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --no-configuration-cache
+
+      - name: Gradle Publish to Maven Central
+        if: ${{ inputs.version-policy == 'specified' && 'Maven Central' && inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
         env:
           NEXUS_USERNAME: ${{ secrets.svcs-ossrh-username }}
           NEXUS_PASSWORD: ${{ secrets.svcs-ossrh-password }}
-        run: ./gradlew release${{ inputs.release-profile }} -PpublishingPackageGroup=com.hedera.hashgraph -PpublishSigningEnabled=true --no-configuration-cache
+        run: ./gradlew publishAggregationToCentralPortal -PpublishSigningEnabled=true -PpublishTestRelease=true
 
       - name: Upload SDK Release Archives
         if: ${{ inputs.dry-run-enabled != true && inputs.version-policy == 'specified' && !cancelled() && !failure() }}

--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -5,10 +5,11 @@ plugins {
     id("org.hiero.gradle.report.code-coverage")
     id("org.hiero.gradle.check.spotless")
     id("org.hiero.gradle.check.spotless-kotlin")
+    id("org.hiero.gradle.feature.publish-maven-central-aggregation")
 }
 
 dependencies {
-    implementation(project(":app"))
+    published(project(":app"))
     // examples that also contain tests we would like to run
     implementation(project(":swirlds-platform-base-example"))
     implementation(project(":AddressBookTestingTool"))


### PR DESCRIPTION
## Description

This pull request includes changes to streamline the Gradle publishing process and improve dependency management for the `gradle/aggregation` module. The most significant updates involve splitting publishing tasks for Maven Central and Google Artifact Registry, as well as introducing a new plugin for Maven Central aggregation publishing.

### Gradle Publishing Process Updates:

* [`.github/workflows/node-zxc-build-release-artifact.yaml`](diffhunk://#diff-c4507eafecb6e04bf4d768bd725d1f4ac3707e6c7524678afeadbd40f421bd0bL796-R805): Refactored the Gradle publishing steps to separate tasks for Google Artifact Registry and Maven Central. Added specific `run` commands for each publishing target, ensuring clearer workflows.

### Dependency Management Enhancements:

* [`gradle/aggregation/build.gradle.kts`](diffhunk://#diff-a65c8229ecd9fb764212fe9d750b5fa5b3e9d9aa4d988f88e8ef3672ab178723R8-R12): Introduced the `org.hiero.gradle.feature.publish-maven-central-aggregation` plugin to facilitate Maven Central aggregation publishing. Updated the dependency type for `:app` from `implementation` to `published` to align with the new publishing strategy.

### Related issue(s)

Fixes #19565 

## Notes for reviewer

:warning: cannot merge this PR until com.hedera namespace is migrated to Maven Centrals Central Publishing Portal :warning:

:rotating_light: **This change will need to be cherry picked into supported release branches for additional publishing of data.** :rotating_light:

**Checklist**

- [x] [Tested](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/15445094764/job/43472484399#step:16:669)

  ```text
  > Task :aggregation:publishAggregationToCentralPortal
  Nmcp: deployment bundle '7caa892a-71dc-454b-b1e7-602fcc25e159' uploaded to 'https://central.sonatype.com/'.
  Nmcp: verifying deployment status...
  Deployment status is 'PENDING', will try again in 2s (9m 59.801192573s left)...
  Deployment status is 'PENDING', will try again in 4s (9m 57.630290547s left)...
  Deployment status is 'PENDING', will try again in 8s (9m 53.467616304s left)...
  Deployment status is 'PENDING', will try again in 16s (9m 45.303687553s left)...
  Deployment status is 'PENDING', will try again in 32s (9m 29.036663583s left)...
  Deployment status is 'PENDING', will try again in 64s (8m 56.858324338s left)...
  Deployment status is 'PENDING', will try again in 64s (7m 52.654004169s left)...
  Deployment has passed validation, publish it manually from the Central Portal UI.

  BUILD SUCCESSFUL in 4m 44s
  ```
  ![image](https://github.com/user-attachments/assets/e06fa9e3-f3bd-4a75-9e6a-5c6759c53a80)


