### PR TITLE
fix: Log active config _after_ initializing props and permissions facilities

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -665,7 +665,6 @@ public final class Hedera implements SwirldMain<MerkleNodeState>, PlatformStatus
         }
         try {
             migrateSchemas(state, deserializedVersion, trigger, metrics, platformConfig);
-            logConfiguration();
         } catch (final Throwable t) {
             logger.fatal("Critical failure during schema migration", t);
             throw new IllegalStateException("Critical failure during migration", t);
@@ -1176,7 +1175,8 @@ public final class Hedera implements SwirldMain<MerkleNodeState>, PlatformStatus
                 .platformStateFacade(platformStateFacade)
                 .build();
         // Initialize infrastructure for fees, exchange rates, and throttles from the working state
-        daggerApp.initializer().accept(state);
+        daggerApp.initializer().initialize(state, streamMode);
+        logConfiguration();
         notifications.register(PlatformStatusChangeListener.class, this);
         notifications.register(ReconnectCompleteListener.class, daggerApp.reconnectListener());
         notifications.register(StateWriteToDiskCompleteListener.class, daggerApp.stateWriteToDiskListener());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
@@ -58,7 +58,6 @@ import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.state.notifications.AsyncFatalIssListener;
-import com.swirlds.state.State;
 import com.swirlds.state.lifecycle.StartupNetworks;
 import com.swirlds.state.lifecycle.info.NetworkInfo;
 import com.swirlds.state.lifecycle.info.NodeInfo;
@@ -69,7 +68,6 @@ import java.nio.charset.Charset;
 import java.time.InstantSource;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.inject.Provider;
 import javax.inject.Singleton;
@@ -100,7 +98,7 @@ public interface HederaInjectionComponent {
 
     WorkingStateAccessor workingStateAccessor();
 
-    Consumer<State> initializer();
+    FacilityInitModule.FacilityInitializer initializer();
 
     RecordCache recordCache();
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/ExecutorComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/ExecutorComponent.java
@@ -31,7 +31,6 @@ import com.swirlds.metrics.api.Metrics;
 import com.swirlds.state.State;
 import dagger.BindsInstance;
 import dagger.Component;
-import java.util.function.Consumer;
 import javax.inject.Singleton;
 
 /**
@@ -95,7 +94,7 @@ public interface ExecutorComponent {
         ExecutorComponent build();
     }
 
-    Consumer<State> initializer();
+    FacilityInitModule.FacilityInitializer initializer();
 
     AppFeeCharging appFeeCharging();
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutors.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/TransactionExecutors.java
@@ -27,6 +27,7 @@ import com.hedera.node.app.throttle.AppThrottleFactory;
 import com.hedera.node.app.throttle.ThrottleAccumulator;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.data.HederaConfig;
+import com.hedera.node.config.types.StreamMode;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.metrics.noop.NoOpMetrics;
 import com.swirlds.metrics.api.Metrics;
@@ -215,7 +216,7 @@ public enum TransactionExecutors {
         final var executor = newExecutorComponent(
                 state, properties, tracerBinding, customOps, softwareVersionFactory, entityIdFactory);
         executor.stateNetworkInfo().initFrom(state);
-        executor.initializer().accept(state);
+        executor.initializer().initialize(state, StreamMode.BOTH);
         final var exchangeRateManager = executor.exchangeRateManager();
         return (transactionBody, consensusNow, operationTracers) -> {
             final var dispatch = executor.standaloneDispatchFactory().newDispatch(state, transactionBody, consensusNow);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/TransactionExecutorsTest.java
@@ -37,6 +37,7 @@ import com.hedera.hapi.node.state.file.File;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.transaction.ThrottleDefinitions;
 import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.blocks.BlockStreamService;
 import com.hedera.node.app.config.BootstrapConfigProviderImpl;
 import com.hedera.node.app.config.ConfigProviderImpl;
 import com.hedera.node.app.fees.FeeService;
@@ -500,6 +501,7 @@ public class TransactionExecutorsTest {
                         new UtilServiceImpl(appContext, (signedTxn, config) -> null),
                         new RecordCacheService(),
                         new BlockRecordService(),
+                        new BlockStreamService(),
                         new FeeService(),
                         new CongestionThrottleService(),
                         new NetworkServiceImpl(),


### PR DESCRIPTION
**Description** 
- Closes #19402 
- Updates `FacilityModule` to prefer checking for genesis txn handling in `BlockStreamInfo` when `StreamMode` permits.