### PR TITLE
fix: don't use nodes which haven't reported us as fallen behind for reconnect

### DIFF
--- a/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/FallenBehindManager.java
+++ b/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/FallenBehindManager.java
@@ -10,10 +10,17 @@ public interface FallenBehindManager {
      * Notify the fallen behind manager that a node has reported that they don't have events we need. This means we have
      * probably fallen behind and will need to reconnect
      *
-     * @param id
-     * 		the id of the node who says we have fallen behind
+     * @param id the id of the node who says we have fallen behind
      */
     void reportFallenBehind(@NonNull NodeId id);
+
+    /**
+     * Notify the fallen behind manager that a node has reported that node is providing us with events we need. This
+     * means we are not in fallen behind state against that node.
+     *
+     * @param id the id of the node who is providing us with up to date events
+     */
+    void clearFallenBehind(@NonNull NodeId id);
 
     /**
      * We have determined that we have not fallen behind, or we have reconnected, so reset everything to the initial
@@ -31,8 +38,7 @@ public interface FallenBehindManager {
     /**
      * Should I attempt a reconnect with this neighbor?
      *
-     * @param peerId
-     * 		the ID of the neighbor
+     * @param peerId the ID of the neighbor
      * @return true if I should attempt a reconnect
      */
     boolean shouldReconnectFrom(@NonNull NodeId peerId);
@@ -44,7 +50,8 @@ public interface FallenBehindManager {
 
     /**
      * Notify about changes in list of node ids we should be taking into account for falling behind
-     * @param added node ids which were added from the roster
+     *
+     * @param added   node ids which were added from the roster
      * @param removed node ids which were removed from the roster
      */
     void addRemovePeers(@NonNull Set<NodeId> added, @NonNull Set<NodeId> removed);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/FallenBehindManagerImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/FallenBehindManagerImpl.java
@@ -47,11 +47,22 @@ public class FallenBehindManagerImpl implements FallenBehindManager {
         this.config = Objects.requireNonNull(config, "config must not be null");
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public synchronized void reportFallenBehind(@NonNull final NodeId id) {
         if (reportFallenBehind.add(id)) {
             checkAndNotifyFallingBehind();
         }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public synchronized void clearFallenBehind(@NonNull final NodeId id) {
+        reportFallenBehind.remove(id);
     }
 
     private void checkAndNotifyFallingBehind() {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowgraphSynchronizer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowgraphSynchronizer.java
@@ -283,6 +283,8 @@ public class ShadowgraphSynchronizer {
         final SyncFallenBehindStatus status = SyncFallenBehindStatus.getStatus(self, other);
         if (status == SyncFallenBehindStatus.SELF_FALLEN_BEHIND) {
             fallenBehindManager.reportFallenBehind(connection.getOtherId());
+        } else {
+            fallenBehindManager.clearFallenBehind(connection.getOtherId());
         }
 
         if (status != SyncFallenBehindStatus.NONE_FALLEN_BEHIND) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncManagerImpl.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/SyncManagerImpl.java
@@ -22,8 +22,8 @@ public class SyncManagerImpl implements FallenBehindManager {
     /**
      * Creates a new SyncManager
      *
-     * @param platformContext         the platform context
-     * @param fallenBehindManager     the fallen behind manager
+     * @param platformContext     the platform context
+     * @param fallenBehindManager the fallen behind manager
      */
     public SyncManagerImpl(
             @NonNull final PlatformContext platformContext, @NonNull final FallenBehindManager fallenBehindManager) {
@@ -52,6 +52,14 @@ public class SyncManagerImpl implements FallenBehindManager {
     @Override
     public void reportFallenBehind(@NonNull final NodeId id) {
         fallenBehindManager.reportFallenBehind(id);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clearFallenBehind(@NonNull final NodeId id) {
+        fallenBehindManager.clearFallenBehind(id);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/sync/TestingSyncManager.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/sync/TestingSyncManager.java
@@ -17,6 +17,11 @@ public class TestingSyncManager implements FallenBehindManager {
     }
 
     @Override
+    public void clearFallenBehind(@NonNull final NodeId id) {
+        fallenBehind = false;
+    }
+
+    @Override
     public void resetFallenBehind() {
         fallenBehind = false;
     }


### PR DESCRIPTION
**Description**:

When some node has reported us as falling behind, this marker was never cleared, until we have finished full reconnect ourselves. In rare situations, if we managed to get back on our own, then other node was stuck and we again have fallen behind, we might have been chosing broken node for reconnect target, just because it reported issues to us once.

This fix clears the markers not only after each reconnect, but each time we are catching up with the node (or it has falled behind compared to us), so they won't get used in far future when real reconnect happens.

**Related issue(s)**:

Fixes #19271 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
