### PR TITLE
fix: 19623 Fixed `DataFileCollectionCompactionTest` intermittent failure.

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionCompactionTest.java
@@ -510,8 +510,9 @@ class DataFileCollectionCompactionTest {
                 // during merge,
                 // it depends on where pauseCompaction() happens inside
                 // compactFiles() above
+                // depending on the test scenario there may be 1, 2 or 3 files
                 assertTrue(
-                        List.of(2, 3).contains(store.getAllCompletedFiles().size()),
+                        List.of(1, 2, 3).contains(store.getAllCompletedFiles().size()),
                         "Unexpected files after compaction: " + store.getAllCompletedFiles());
             } catch (final Exception e) {
                 throw new RuntimeException(e);


### PR DESCRIPTION
**Description**:

`DataFileCollectionCompactionTest` was failing non-deterministically in a couple of scenarios: 

```
  com.swirlds.merkledb.files.DataFileCollectionCompactionTest > Snapshot + update in parallel with compaction ✘ [1] 0

    org.opentest4j.AssertionFailedError: Unexpected files after compaction: [11] ==> expected: <true> but was: <false>
        at app/com.swirlds.merkledb@0.64.0-SNAPSHOT/com.swirlds.merkledb.files.DataFileCollectionCompactionTest.lambda$testMergeUpdateSnapshotRestore$4(DataFileCollectionCompactionTest.java:513)

  com.swirlds.merkledb.files.DataFileCollectionCompactionTest > Snapshot + update in parallel with compaction ✘ [2] 1

    org.opentest4j.AssertionFailedError: Unexpected files after compaction: [11] ==> expected: <true> but was: <false>
        at app/com.swirlds.merkledb@0.64.0-SNAPSHOT/com.swirlds.merkledb.files.DataFileCollectionCompactionTest.lambda$testMergeUpdateSnapshotRestore$4(DataFileCollectionCompactionTest.java:513)
```


**Related issue(s)**:

Fixes #19623 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
