### PR TITLE
feat: Allow updating previous value in Gauge metrics

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpDoubleGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpDoubleGauge.java
@@ -27,4 +27,10 @@ public class NoOpDoubleGauge extends AbstractNoOpMetric implements DoubleGauge {
      */
     @Override
     public void set(final double newValue) {}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void update(final double change) {}
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpIntegerGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpIntegerGauge.java
@@ -26,4 +26,10 @@ public class NoOpIntegerGauge extends AbstractNoOpMetric implements IntegerGauge
      */
     @Override
     public void set(final int newValue) {}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void update(final int change) {}
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpLongGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/noop/internal/NoOpLongGauge.java
@@ -26,4 +26,10 @@ public class NoOpLongGauge extends AbstractNoOpMetric implements LongGauge {
      */
     @Override
     public void set(final long newValue) {}
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void update(final long change) {}
 }

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/DoubleGauge.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/DoubleGauge.java
@@ -73,6 +73,14 @@ public interface DoubleGauge extends Metric {
     void set(final double newValue);
 
     /**
+     * Update the current value
+     *
+     * @param change
+     * 		value change
+     */
+    void update(final double change);
+
+    /**
      * Configuration of a {@link DoubleGauge}
      */
     final class Config extends MetricConfig<DoubleGauge, Config> {

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/IntegerGauge.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/IntegerGauge.java
@@ -71,6 +71,14 @@ public interface IntegerGauge extends Metric {
     void set(final int newValue);
 
     /**
+     * Update the current value
+     *
+     * @param change
+     * 		value change
+     */
+    void update(final int change);
+
+    /**
      * Configuration of a {@link IntegerGauge}
      */
     final class Config extends MetricConfig<IntegerGauge, IntegerGauge.Config> {

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/LongGauge.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/LongGauge.java
@@ -71,6 +71,14 @@ public interface LongGauge extends Metric {
     void set(final long newValue);
 
     /**
+     * Update the current value
+     *
+     * @param change
+     * 		value change
+     */
+    void update(final long change);
+
+    /**
      * Configuration of a {@link LongGauge}
      */
     final class Config extends MetricConfig<LongGauge, LongGauge.Config> {

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultDoubleGauge.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultDoubleGauge.java
@@ -50,6 +50,14 @@ public class DefaultDoubleGauge extends AbstractMetric implements DoubleGauge {
      * {@inheritDoc}
      */
     @Override
+    public void update(final double change) {
+        this.value.addAndGet(change);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .appendSuper(super.toString())

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultIntegerGauge.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultIntegerGauge.java
@@ -51,6 +51,14 @@ public class DefaultIntegerGauge extends AbstractMetric implements IntegerGauge 
      * {@inheritDoc}
      */
     @Override
+    public void update(final int change) {
+        this.value.addAndGet(change);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .appendSuper(super.toString())

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultLongGauge.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultLongGauge.java
@@ -51,6 +51,14 @@ public class DefaultLongGauge extends AbstractMetric implements LongGauge {
      * {@inheritDoc}
      */
     @Override
+    public void update(final long change) {
+        value.addAndGet(change);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String toString() {
         return new ToStringBuilder(this)
                 .appendSuper(super.toString())

--- a/platform-sdk/swirlds-metrics-impl/src/test/java/com/swirlds/metrics/impl/test/DefaultDoubleGaugeTest.java
+++ b/platform-sdk/swirlds-metrics-impl/src/test/java/com/swirlds/metrics/impl/test/DefaultDoubleGaugeTest.java
@@ -69,6 +69,34 @@ class DefaultDoubleGaugeTest {
     }
 
     @Test
+    void testGetAndUpdate() {
+        // given
+        final DoubleGauge.Config config = new DoubleGauge.Config(CATEGORY, NAME).withInitialValue(Math.PI);
+        final DoubleGauge gauge = new DefaultDoubleGauge(config);
+
+        // when
+        gauge.set(5);
+
+        // then
+        assertEquals(5, gauge.get(), "Value should be 5");
+        assertEquals(5, gauge.get(VALUE), "Value should be 5");
+
+        // when
+        gauge.update(3.5);
+
+        // then
+        assertEquals(8.5, gauge.get(), "Value should be 8.5");
+        assertEquals(8.5, gauge.get(VALUE), "Value should be 8.5");
+
+        // when
+        gauge.update(-12);
+
+        // then
+        assertEquals(-3.5, gauge.get(), "Value should be -3.5");
+        assertEquals(-3.5, gauge.get(VALUE), "Value should be -3.5");
+    }
+
+    @Test
     void testSpecialValues() {
         // given
         final DoubleGauge.Config config = new DoubleGauge.Config(CATEGORY, NAME);

--- a/platform-sdk/swirlds-metrics-impl/src/test/java/com/swirlds/metrics/impl/test/DefaultIntegerGaugeTest.java
+++ b/platform-sdk/swirlds-metrics-impl/src/test/java/com/swirlds/metrics/impl/test/DefaultIntegerGaugeTest.java
@@ -68,18 +68,50 @@ class DefaultIntegerGaugeTest {
     }
 
     @Test
+    @DisplayName("Test of get() and update()-operation")
+    void testGetAndUpdate() {
+        // given
+        final IntegerGauge.Config config = new IntegerGauge.Config(CATEGORY, NAME).withInitialValue(2);
+        final IntegerGauge gauge = new DefaultIntegerGauge(config);
+
+        // when
+        gauge.set(5);
+
+        // then
+        assertEquals(5, gauge.get(), "Value should be 5");
+        assertEquals(5, gauge.get(VALUE), "Value should be 5");
+
+        // when
+        gauge.update(3);
+
+        // then
+        assertEquals(8, gauge.get(), "Value should be 8");
+        assertEquals(8, gauge.get(VALUE), "Value should be 8");
+
+        // when
+        gauge.update(-12);
+
+        // then
+        assertEquals(-4, gauge.get(), "Value should be -4");
+        assertEquals(-4, gauge.get(VALUE), "Value should be -4");
+    }
+
+    @Test
     void testSnapshot() {
         // given
         final IntegerGauge.Config config = new IntegerGauge.Config(CATEGORY, NAME).withInitialValue(2);
         final DefaultIntegerGauge gauge = new DefaultIntegerGauge(config);
 
+        gauge.set(3);
         // when
         final List<SnapshotEntry> snapshot = gauge.takeSnapshot();
 
+        gauge.set(4);
+
         // then
-        assertEquals(2, gauge.get(), "Value should be 2");
-        assertEquals(2, gauge.get(VALUE), "Value should be 2");
-        assertThat(snapshot).containsExactly(new SnapshotEntry(VALUE, 2));
+        assertEquals(4, gauge.get(), "Value should be 4");
+        assertEquals(4, gauge.get(VALUE), "Value should be 4");
+        assertThat(snapshot).containsExactly(new SnapshotEntry(VALUE, 3));
     }
 
     @Test

--- a/platform-sdk/swirlds-metrics-impl/src/test/java/com/swirlds/metrics/impl/test/DefaultLongGaugeTest.java
+++ b/platform-sdk/swirlds-metrics-impl/src/test/java/com/swirlds/metrics/impl/test/DefaultLongGaugeTest.java
@@ -68,6 +68,35 @@ class DefaultLongGaugeTest {
     }
 
     @Test
+    @DisplayName("Test of get() and update()-operation")
+    void testGetAndUpdate() {
+        // given
+        final LongGauge.Config config = new LongGauge.Config(CATEGORY, NAME).withInitialValue(2L);
+        final LongGauge gauge = new DefaultLongGauge(config);
+
+        // when
+        gauge.set(5);
+
+        // then
+        assertEquals(5, gauge.get(), "Value should be 5");
+        assertEquals(5, gauge.get(VALUE), "Value should be 5");
+
+        // when
+        gauge.update(3);
+
+        // then
+        assertEquals(8, gauge.get(), "Value should be 8");
+        assertEquals(8, gauge.get(VALUE), "Value should be 8");
+
+        // when
+        gauge.update(-12);
+
+        // then
+        assertEquals(-4, gauge.get(), "Value should be -4");
+        assertEquals(-4, gauge.get(VALUE), "Value should be -4");
+    }
+
+    @Test
     void testSnapshot() {
         // given
         final LongGauge.Config config = new LongGauge.Config(CATEGORY, NAME).withInitialValue(2L);


### PR DESCRIPTION
**Description**:

Currently, Gauge supports only set method. This PR adds update method, which makes atomic addition of provided value to store value, support subtraction as well.

**Related issue(s)**:

Fixes #19609
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
