### PR TITLE
ci: write workflow to update GS_STATE variable

### DIFF
--- a/.github/workflows/zxf-update-gs-state-variable.yaml
+++ b/.github/workflows/zxf-update-gs-state-variable.yaml
@@ -1,0 +1,33 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "ZXF: Update GS_STATE Variable"
+on:
+  workflow_dispatch:
+    inputs:
+      value:
+        description: "New value for GS_STATE:"
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: write
+
+jobs:
+  update-gs-state-variable:
+    name: Update GS_STATE Variable
+    runs-on: hiero-network-node-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Update GS_STATE to input value
+        run: |
+          curl -X PATCH \
+            -H "Authorization: Bearer ${{ secrets.GH_ACCESS_TOKEN }}" \
+            -H "Accept: application/vnd.github+json" \
+            https://api.github.com/repos/${{ github.repository }}/actions/variables/Test_Variable \
+            -d '{"name":"Test_Variable","value":"${{ inputs.value }}"}'

--- a/.github/workflows/zxf-update-gs-state-variable.yaml
+++ b/.github/workflows/zxf-update-gs-state-variable.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Update GS_STATE to input value
         uses: mmoyaferrer/set-github-variable@31e0d07964802728d7bf8e09dc45b86ee2c8d5f8 # v1.0.0
         with:
-          name: 'GS_STATE'
+          name: "GS_STATE"
           value: ${{ inputs.value }}
           repository: ${{ github.repository }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/zxf-update-gs-state-variable.yaml
+++ b/.github/workflows/zxf-update-gs-state-variable.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Update GS_STATE to input value
         uses: mmoyaferrer/set-github-variable@31e0d07964802728d7bf8e09dc45b86ee2c8d5f8 # v1.0.0
         with:
-          name: 'TEST_VARIABLE'
+          name: 'GS_STATE'
           value: ${{ inputs.value }}
           repository: ${{ github.repository }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/zxf-update-gs-state-variable.yaml
+++ b/.github/workflows/zxf-update-gs-state-variable.yaml
@@ -25,9 +25,9 @@ jobs:
           egress-policy: audit
 
       - name: Update GS_STATE to input value
-        run: |
-          curl -X PATCH \
-            -H "Authorization: Bearer ${{ secrets.GH_ACCESS_TOKEN }}" \
-            -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${{ github.repository }}/actions/variables/GS_STATE \
-            -d '{"name":"GS_STATE","value":"${{ inputs.value }}"}'
+        uses: mmoyaferrer/set-github-variable@31e0d07964802728d7bf8e09dc45b86ee2c8d5f8 # v1.0.0
+        with:
+          name: 'TEST_VARIABLE'
+          value: ${{ inputs.value }}
+          repository: ${{ github.repository }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}

--- a/.github/workflows/zxf-update-gs-state-variable.yaml
+++ b/.github/workflows/zxf-update-gs-state-variable.yaml
@@ -13,7 +13,7 @@ defaults:
 
 permissions:
   contents: write
-
+break
 jobs:
   update-gs-state-variable:
     name: Update GS_STATE Variable

--- a/.github/workflows/zxf-update-gs-state-variable.yaml
+++ b/.github/workflows/zxf-update-gs-state-variable.yaml
@@ -13,7 +13,7 @@ defaults:
 
 permissions:
   contents: write
-break
+
 jobs:
   update-gs-state-variable:
     name: Update GS_STATE Variable

--- a/.github/workflows/zxf-update-gs-state-variable.yaml
+++ b/.github/workflows/zxf-update-gs-state-variable.yaml
@@ -29,5 +29,5 @@ jobs:
           curl -X PATCH \
             -H "Authorization: Bearer ${{ secrets.GH_ACCESS_TOKEN }}" \
             -H "Accept: application/vnd.github+json" \
-            https://api.github.com/repos/${{ github.repository }}/actions/variables/Test_Variable \
-            -d '{"name":"Test_Variable","value":"${{ inputs.value }}"}'
+            https://api.github.com/repos/${{ github.repository }}/actions/variables/GS_STATE \
+            -d '{"name":"GS_STATE","value":"${{ inputs.value }}"}'


### PR DESCRIPTION
**Description**:

Write a new workflow to update the GS_STATE variable based on input.

**Testing**:

Successful testing with `TEST_VARIABLE` [here](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/15536803867/job/43737719906).

Reworked from `TEST_VARIABLE` to `GS_STATE`.

- [ ] Need to remove the `TEST_VARIABLE` from the list of action vars.

**Related Issue(s)**:

Fixes #19637
