### PR TITLE
chore: Fixes flaky test `TopicCreateSuite.signingRequirementsEnforced`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicCreate.java
@@ -2,7 +2,6 @@
 package com.hedera.services.bdd.spec.transactions.consensus;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTopicString;
-import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asDuration;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.bannerWith;
@@ -19,7 +18,6 @@ import com.hedera.node.app.hapi.utils.CommonUtils;
 import com.hedera.node.app.hapi.utils.fee.ConsensusServiceFeeBuilder;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyShape;
-import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
 import com.hederahashgraph.api.proto.java.FixedCustomFee;
@@ -63,7 +61,6 @@ public class HapiTopicCreate extends HapiTxnOp<HapiTopicCreate> {
     private boolean clearAutoRenewPeriod = false;
 
     public HapiTopicCreate(final String topic) {
-        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
         this.topic = topic;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicCreate.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/consensus/HapiTopicCreate.java
@@ -2,6 +2,7 @@
 package com.hedera.services.bdd.spec.transactions.consensus;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTopicString;
+import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asDuration;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.asId;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.bannerWith;
@@ -18,6 +19,7 @@ import com.hedera.node.app.hapi.utils.CommonUtils;
 import com.hedera.node.app.hapi.utils.fee.ConsensusServiceFeeBuilder;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hederahashgraph.api.proto.java.ConsensusCreateTopicTransactionBody;
 import com.hederahashgraph.api.proto.java.FixedCustomFee;
@@ -61,6 +63,7 @@ public class HapiTopicCreate extends HapiTxnOp<HapiTopicCreate> {
     private boolean clearAutoRenewPeriod = false;
 
     public HapiTopicCreate(final String topic) {
+        sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES));
         this.topic = topic;
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/TopicCreateSuite.java
@@ -293,6 +293,7 @@ public class TopicCreateSuite {
                         .autoRenewAccountId("autoRenewAccount")
                         /* SigMap missing signature from auto-renew account's key. */
                         .signedBy("payer", "adminKey")
+                        .sigMapPrefixes(uniqueWithFullPrefixesFor("payer", "adminKey"))
                         .hasKnownStatus(INVALID_SIGNATURE),
                 createTopic("testTopic")
                         .payingWith("payer")
@@ -300,6 +301,7 @@ public class TopicCreateSuite {
                         .autoRenewAccountId("autoRenewAccount")
                         /* SigMap missing signature from adminKey. */
                         .signedBy("payer", "autoRenewAccount")
+                        .sigMapPrefixes(uniqueWithFullPrefixesFor("payer", "autoRenewAccount"))
                         .hasKnownStatus(INVALID_SIGNATURE),
                 // In hedera-app, we'll allow contracts with admin keys to be auto-renew accounts
                 createTopic("withContractAutoRenew").adminKeyName("adminKey").autoRenewAccountId(contractWithAdminKey),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenCreateSpecs.java
@@ -12,6 +12,7 @@ import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.account
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairs;
 import static com.hedera.services.bdd.spec.assertions.AutoAssocAsserts.accountTokenPairsInAnyOrder;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.uniqueWithFullPrefixesFor;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
@@ -495,6 +496,7 @@ public class TokenCreateSpecs {
                         .feeScheduleKey("feeScheduleKey")
                         .pauseKey(pauseKey)
                         .signedBy(DEFAULT_PAYER, ADMIN_KEY, AUTO_RENEW_ACCOUNT)
+                        .sigMapPrefixes(uniqueWithFullPrefixesFor(DEFAULT_PAYER, ADMIN_KEY, AUTO_RENEW_ACCOUNT))
                         .hasKnownStatus(INVALID_SIGNATURE),
                 tokenCreate(PRIMARY)
                         .supplyType(TokenSupplyType.FINITE)
@@ -514,6 +516,8 @@ public class TokenCreateSpecs {
                         .feeScheduleKey("feeScheduleKey")
                         .pauseKey(pauseKey)
                         .signedBy(DEFAULT_PAYER, ADMIN_KEY, AUTO_RENEW_ACCOUNT, TOKEN_TREASURY)
+                        .sigMapPrefixes(
+                                uniqueWithFullPrefixesFor(DEFAULT_PAYER, ADMIN_KEY, AUTO_RENEW_ACCOUNT, TOKEN_TREASURY))
                         .via(CREATE_TXN),
                 withOpContext((spec, opLog) -> {
                     var createTxn = getTxnRecord(CREATE_TXN);
@@ -932,6 +936,7 @@ public class TokenCreateSpecs {
                                 .payingWith(PAYER)
                                 .adminKey(ADMIN_KEY)
                                 .signedBy(PAYER, ADMIN_KEY)
+                                .sigMapPrefixes(uniqueWithFullPrefixesFor(PAYER, ADMIN_KEY))
                                 .hasKnownStatus(INVALID_SIGNATURE));
     }
 


### PR DESCRIPTION
Fixes #19646 
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/19668

Similar to https://github.com/hiero-ledger/hiero-consensus-node/pull/19356.
Fixes a flaky test by using full prefix signatures. When there is more than one signature in the transaction and it is suing short signature prefixes, if signature prefixes match, we verify more signatures and charge more transaction fee. 