### PR TITLE
chore(19651): Mtt is able to generate states for freeze rounds

### DIFF
--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolConfig.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolConfig.java
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.demo.migration;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+
+@ConfigData("migrationTestingToolConfig")
+public record MigrationTestingToolConfig(
+        @ConfigProperty(defaultValue = "false") boolean generateFreezeState,
+        @ConfigProperty(defaultValue = "400") long targetFreezeRoundAfter) {}

--- a/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolMain.java
+++ b/platform-sdk/platform-apps/tests/MigrationTestingTool/src/main/java/com/swirlds/demo/migration/MigrationTestingToolMain.java
@@ -19,6 +19,7 @@ import com.swirlds.platform.system.SwirldMain;
 import com.swirlds.platform.test.fixtures.state.TestingAppStateInitializer;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.SignatureException;
+import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.constructable.ClassConstructorPair;
@@ -176,6 +177,15 @@ public class MigrationTestingToolMain implements SwirldMain<MigrationTestingTool
     @Override
     public ConsensusStateEventHandler<MigrationTestingToolState> newConsensusStateEvenHandler() {
         return new MigrationTestToolConsensusStateEventHandler();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public List<Class<? extends Record>> getConfigDataTypes() {
+        return List.of(MigrationTestingToolConfig.class);
     }
 
     /**


### PR DESCRIPTION
**Description**:
Mtt is able to generate states for freeze rounds

**Related issue(s)**:

Fixes #19651