### PR TITLE
fix: Issue with dry-run-enabled in node-flow-deploy-release-artifact

### DIFF
--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -222,7 +222,6 @@ jobs:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "ref": "${{ inputs.ref }}",
-            "ref-name": "${{ inputs.ref-name }}",
             "dry-run-enabled": "${{ inputs.dry-run-enabled }}"
             }'
 

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -15,6 +15,7 @@ on:
       dry-run-enabled:
         required: false
         default: false
+        type: boolean
         description: "Specify that this is a test run which will skip certain steps."
 
 defaults:


### PR DESCRIPTION
**Description**:

This pull request includes a small change to the `.github/workflows/node-flow-deploy-release-artifact.yaml` file. The change adds a `type: boolean` property to the `dry-run-enabled` input to specify its data type.

**Related Issue(s)**

Fixes #19585

