### PR TITLE
test: Fix PrngPrecompileSuite flakiness

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
@@ -200,13 +200,13 @@ public class PrngPrecompileSuite {
                 cryptoCreate(BOB),
                 uploadInitCode(prng),
                 contractCreate(prng),
-                sourcing(() -> contractCall(prng, GET_SEED)
+                contractCall(prng, GET_SEED)
                         .gas(GAS_TO_OFFER)
                         .payingWith(BOB)
-                        .via(randomBits)),
+                        .via(randomBits),
                 getTxnRecord(randomBits)
                         .andAllChildRecords()
-                        .hasChildRecordCount(1)
+                        .hasNonStakingChildRecordCount(1)
                         .hasChildRecords(recordWith()
                                 .pseudoRandomBytes()
                                 .contractCallResult(resultWith()


### PR DESCRIPTION
**Description**:
Sometimes in the contractCall txnRecord there is a **End of staking period calculation record** which causes flakiness. Changed the test to use `hasNonStakingChildRecordCount()` for consistency.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
