### PR TITLE
feat: (cherry-pick) Support grpcProxyEndpoint in yahcli DAB transactions

### DIFF
--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/CreateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/CreateCommand.java
@@ -3,6 +3,7 @@ package com.hedera.services.yahcli.commands.nodes;
 
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asCsServiceEndpoints;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asTypedServiceEndpoint;
 import static com.hedera.services.yahcli.commands.nodes.NodesCommand.validatedX509Cert;
 import static com.hedera.services.yahcli.config.ConfigUtils.keyFileFor;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
@@ -86,6 +87,11 @@ public class CreateCommand implements Callable<Integer> {
             fallbackValue = "true")
     Boolean declineRewards;
 
+    @CommandLine.Option(
+            names = {"--grpcProxyEndpoint"},
+            paramLabel = "a web proxy endpoint for gRPC from non-gRPC clients, e.g. 10.0.0.1:50051,my.fqdn.com:50051")
+    String grpcProxyEndpoint;
+
     @Override
     public Integer call() throws Exception {
         final var yahcli = nodesCommand.getYahcli();
@@ -115,7 +121,8 @@ public class CreateCommand implements Callable<Integer> {
                 noThrowSha384HashOf(allBytesAt(Paths.get(hapiCertificatePath))),
                 adminKeyPath,
                 maybeFeeAccountKeyPath,
-                parsedDeclineRewards);
+                parsedDeclineRewards,
+                grpcProxyEndpoint == null ? null : asTypedServiceEndpoint(grpcProxyEndpoint));
         delegate.runSuiteSync();
 
         if (delegate.getFinalSpecs().getFirst().getStatus() == HapiSpec.SpecStatus.PASSED) {

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/CreateNodeSuite.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/CreateNodeSuite.java
@@ -12,6 +12,7 @@ import com.hedera.hapi.node.base.ServiceEndpoint;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.props.MapPropertySource;
+import com.hedera.services.bdd.spec.transactions.node.HapiNodeCreate;
 import com.hedera.services.bdd.suites.HapiSuite;
 import com.hedera.services.yahcli.config.ConfigManager;
 import com.hedera.services.yahcli.util.HapiSpecUtils;
@@ -40,6 +41,7 @@ public class CreateNodeSuite extends HapiSuite {
     private final List<ServiceEndpoint> serviceEndpoints;
     private final byte[] gossipCaCertificate;
     private final byte[] grpcCertificateHash;
+    private final ServiceEndpoint grpcProxyEndpoint;
 
     @Nullable
     private Long createdId;
@@ -54,7 +56,8 @@ public class CreateNodeSuite extends HapiSuite {
             @NonNull final byte[] grpcCertificateHash,
             @NonNull final String adminKeyLoc,
             @Nullable final String feeAccountKeyLoc,
-            final boolean declineRewards) {
+            final boolean declineRewards,
+            @Nullable final ServiceEndpoint grpcProxyEndpoint) {
         this.configManager = requireNonNull(configManager);
         this.accountId = accountId;
         this.description = requireNonNull(description);
@@ -65,6 +68,7 @@ public class CreateNodeSuite extends HapiSuite {
         this.adminKeyLoc = requireNonNull(adminKeyLoc);
         this.feeAccountKeyLoc = feeAccountKeyLoc;
         this.declineRewards = declineRewards;
+        this.grpcProxyEndpoint = grpcProxyEndpoint;
     }
 
     public long createdIdOrThrow() {
@@ -82,24 +86,30 @@ public class CreateNodeSuite extends HapiSuite {
         final var fqAcctId = asAccount(
                 configManager.shard().getShardNum(), configManager.realm().getRealmNum(), accountId);
 
+        HapiNodeCreate nodeCreate = nodeCreate("node")
+                .signedBy(availableSigners())
+                .accountId(fqAcctId)
+                .description(description)
+                .gossipEndpoint(fromPbj(gossipEndpoints))
+                .serviceEndpoint(fromPbj(serviceEndpoints))
+                .gossipCaCertificate(gossipCaCertificate)
+                .grpcCertificateHash(grpcCertificateHash)
+                .adminKey(adminKey)
+                .declineReward(declineRewards)
+                .advertisingCreation()
+                .exposingCreatedIdTo(createdId -> this.createdId = createdId);
+
+        if (grpcProxyEndpoint != null) {
+            nodeCreate = nodeCreate.grpcWebProxyEndpoint(fromPbj(grpcProxyEndpoint));
+        }
+
         final var spec =
                 new HapiSpec("CreateNode", new MapPropertySource(configManager.asSpecConfig()), new SpecOperation[] {
                     keyFromFile(adminKey, adminKeyLoc).yahcliLogged(),
                     feeAccountKeyLoc == null
                             ? noOp()
                             : keyFromFile(feeAccountKey, feeAccountKeyLoc).yahcliLogged(),
-                    nodeCreate("node")
-                            .signedBy(availableSigners())
-                            .accountId(fqAcctId)
-                            .description(description)
-                            .gossipEndpoint(fromPbj(gossipEndpoints))
-                            .serviceEndpoint(fromPbj(serviceEndpoints))
-                            .gossipCaCertificate(gossipCaCertificate)
-                            .grpcCertificateHash(grpcCertificateHash)
-                            .adminKey(adminKey)
-                            .declineReward(declineRewards)
-                            .advertisingCreation()
-                            .exposingCreatedIdTo(createdId -> this.createdId = createdId)
+                    nodeCreate
                 });
         return HapiSpecUtils.targeted(spec, configManager);
     }

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/UpdateNodeSuite.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/UpdateNodeSuite.java
@@ -60,6 +60,9 @@ public class UpdateNodeSuite extends HapiSuite {
 
     private final Boolean declineRewards;
 
+    @Nullable
+    private final ServiceEndpoint grpcProxyEndpoint;
+
     public UpdateNodeSuite(
             @NonNull final ConfigManager configManager,
             final long nodeId,
@@ -72,7 +75,8 @@ public class UpdateNodeSuite extends HapiSuite {
             @Nullable final List<ServiceEndpoint> hapiEndpoints,
             @Nullable final byte[] gossipCaCertificate,
             @Nullable final byte[] hapiCertificateHash,
-            @Nullable final Boolean declineRewards) {
+            @Nullable final Boolean declineRewards,
+            @Nullable final ServiceEndpoint grpcProxyEndpoint) {
         this.configManager = requireNonNull(configManager);
         this.nodeId = nodeId;
         this.accountId = accountId;
@@ -85,6 +89,7 @@ public class UpdateNodeSuite extends HapiSuite {
         this.gossipCaCertificate = gossipCaCertificate;
         this.hapiCertificateHash = hapiCertificateHash;
         this.declineRewards = declineRewards;
+        this.grpcProxyEndpoint = grpcProxyEndpoint;
     }
 
     @Override
@@ -137,6 +142,9 @@ public class UpdateNodeSuite extends HapiSuite {
         }
         if (declineRewards != null) {
             op.declineReward(declineRewards);
+        }
+        if (grpcProxyEndpoint != null) {
+            op.grpcProxyEndpoint(grpcProxyEndpoint);
         }
         return op.signedBy(availableSigners());
     }

--- a/hedera-node/test-clients/yahcli/README.md
+++ b/hedera-node/test-clients/yahcli/README.md
@@ -790,6 +790,8 @@ Independent of the gossip CA certificate format, the `--declineRewards` option c
 new node should decline reward payments. Use `--declineRewards` to decline rewards, or `--declineRewards false`
 to accept rewards. This value defaults to `true` (declines the rewards) if not specified.
 
+The `--grpcProxyEndpoint` option, given in the form `{<IPV4>|<FQDN>}:<PORT>`, can be used to specify a gRPC proxy endpoint for the node. This is optional.
+
 :warning: If the payer and admin keys do not meet the signing requirements of the new node's fee collection account,
 there must be a key in the target network's _keys/_ directory for that account.
 
@@ -861,3 +863,5 @@ Targeting localhost, paying with 0.0.2
 A node can also be updated to begin declining or accepting reward payments. Use `--startDecliningRewards` to
 begin accepting reward payments, or `--stopDecliningRewards` to stop accepting reward payments. These params have
 no default values.
+
+A node's gRPC proxy endpoint can also be updated with the `--grpcProxyEndpoint` option, given in the form `{<IPV4>|<FQDN>}:<PORT>`. This is optional.

--- a/hedera-node/test-clients/yahcli/run/build.sh
+++ b/hedera-node/test-clients/yahcli/run/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.7.8'}
+TAG=${1:-'0.7.9'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""

--- a/hedera-node/test-clients/yahcli/run/publish.sh
+++ b/hedera-node/test-clients/yahcli/run/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.7.8'}
+TAG=${1:-'0.7.9'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""


### PR DESCRIPTION
**Description**:
This PR cherry-pick's commit 0af47db into release/0.63

This pull request introduces support for specifying and updating a gRPC proxy endpoint for nodes in the `yahcli` tool. It includes changes to the `CreateCommand` and `UpdateCommand` classes, updates to the corresponding suites for node creation and updates, README update, and version updates in build scripts.

### Feature Enhancements:
* Added a new `--grpcProxyEndpoint` option to both `CreateCommand` and `UpdateCommand` for specifying a gRPC proxy endpoint in the format `{<IPV4>|<FQDN>}:<PORT>`. This allows users to define or update the gRPC proxy endpoint for nodes.
* Integrated the `grpcProxyEndpoint` parameter into the `CreateNodeSuite` and `UpdateNodeSuite` classes to handle the new option during node creation and updates.

### Codebase Updates:
* Updated the `CreateNodeSuite` and `UpdateNodeSuite` logic to include the `grpcProxyEndpoint` in the node creation/update operations if specified.

### Documentation:
* Updated the `README.md` to document the usage of the `--grpcProxyEndpoint` option for both node creation and updates, clarifying its format and optional nature.

### Build Script Updates:
* Updated the default version tag in `build.sh` and `publish.sh` scripts from `0.7.8` to `0.7.9` to reflect the new changes.

**Related issue(s)**:

Fixes #19660

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
