### PR TITLE
fix: Pass ref to publish-production-image to fix cache keys mismatch

### DIFF
--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -536,6 +536,7 @@ jobs:
       dry-run-enabled: ${{ inputs.dry-run-enabled }}
       registry-name: gcp
       custom-job-name: "Publish Production Image (GCP)"
+      ref: ${{ needs.validate.outputs.commit-id }}
     secrets:
       jf-url: ${{ secrets.jf-url }}
       jf-user-name: ${{ secrets.jf-user-name }}
@@ -554,6 +555,7 @@ jobs:
       dry-run-enabled: ${{ inputs.dry-run-enabled }}
       registry-name: jfrog
       custom-job-name: "Publish Production Image (JFrog)"
+      ref: ${{ needs.validate.outputs.commit-id }}
     secrets:
       jf-url: ${{ secrets.jf-url }}
       jf-user-name: ${{ secrets.jf-user-name }}

--- a/.github/workflows/zxc-publish-production-image.yaml
+++ b/.github/workflows/zxc-publish-production-image.yaml
@@ -7,6 +7,10 @@ on:
         description: "Version:"
         type: string
         required: true
+      ref:
+        description: "Git Reference - branch, tag, or commit SHA."
+        type: string
+        required: true
       # Valid version policies are as follows: specified, branch-commit, adhoc-commit
       version-policy:
         description: "Version Policy:"
@@ -85,7 +89,7 @@ jobs:
         with:
           fail-on-cache-miss: true
           path: ~/artifact-build
-          key: node-build-artifacts-${{ inputs.version }}-${{ github.sha }}
+          key: node-build-artifacts-${{ inputs.version }}-${{ inputs.ref }}
 
       - name: Authenticate to Google Cloud
         id: google-auth


### PR DESCRIPTION
**Description**:

This pull request introduces changes to workflow files to enhance flexibility and consistency in handling Git references (`ref`) for build and release processes. The updates ensure that Git references are passed explicitly as inputs and used uniformly across jobs.

### Enhancements to Git reference handling:

* [`.github/workflows/node-zxc-build-release-artifact.yaml`](diffhunk://#diff-c4507eafecb6e04bf4d768bd725d1f4ac3707e6c7524678afeadbd40f421bd0bR539): Added `ref` input to both GCP and JFrog production image publishing jobs, ensuring the commit ID from validation outputs is used consistently. [[1]](diffhunk://#diff-c4507eafecb6e04bf4d768bd725d1f4ac3707e6c7524678afeadbd40f421bd0bR539) [[2]](diffhunk://#diff-c4507eafecb6e04bf4d768bd725d1f4ac3707e6c7524678afeadbd40f421bd0bR558)
* [`.github/workflows/zxc-publish-production-image.yaml`](diffhunk://#diff-72d4988de0c62fb789200ca92b13119e411dab31b768624fb8ce00e375c5e8d0R10-R13): Introduced a new `ref` input parameter to allow specifying a Git reference (branch, tag, or commit SHA) explicitly. Updated the cache key to use this `ref` input instead of `github.sha` for artifact builds. [[1]](diffhunk://#diff-72d4988de0c62fb789200ca92b13119e411dab31b768624fb8ce00e375c5e8d0R10-R13) [[2]](diffhunk://#diff-72d4988de0c62fb789200ca92b13119e411dab31b768624fb8ce00e375c5e8d0L88-R92)

**Related Issue(s)**:

Fixes #19676
