### PR TITLE
chore(19684): Increase timeout on IntegerNotificationTests

### DIFF
--- a/platform-sdk/swirlds-common/src/timingSensitive/java/com/swirlds/common/notification/IntegerNotificationTests.java
+++ b/platform-sdk/swirlds-common/src/timingSensitive/java/com/swirlds/common/notification/IntegerNotificationTests.java
@@ -46,6 +46,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 public class IntegerNotificationTests {
 
     private static final boolean ENABLE_DIAG_PRINTOUT = false;
+    private static final Duration TIMEOUT = Duration.ofMinutes(1);
 
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 5, 21, 57, 1_000, 10_000, 100_000})
@@ -891,7 +892,7 @@ public class IntegerNotificationTests {
                                 "callback should have completed with the same result");
                     }
                 },
-                Duration.ofSeconds(1),
+                TIMEOUT,
                 "callbacks and futures should be completed by now");
 
         engine.shutdown();


### PR DESCRIPTION
**Description**:
Increase the timeout to reduce the probability of flaky results

**Related issue(s)**:

Fixes #19684
