### PR TITLE
fix: Ignore ID literals for individual input parameters

### DIFF
--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.accounts;
 
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
+
 import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.BalanceSuite;
+
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
@@ -32,7 +36,8 @@ public class BalanceCommand implements Callable<Integer> {
 
         printTable(balanceRegister);
 
-        var delegate = new BalanceSuite(config.asSpecConfig(), accounts);
+		var normalizedAccounts = Arrays.stream(accounts).map(s -> normalizePossibleIdLiteral(config, s)).toArray(String[]::new);
+        var delegate = new BalanceSuite(config.asSpecConfig(), normalizedAccounts);
         delegate.runSuiteSync();
 
         return 0;

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/BalanceCommand.java
@@ -5,7 +5,6 @@ import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLite
 
 import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.BalanceSuite;
-
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
@@ -36,7 +35,9 @@ public class BalanceCommand implements Callable<Integer> {
 
         printTable(balanceRegister);
 
-		var normalizedAccounts = Arrays.stream(accounts).map(s -> normalizePossibleIdLiteral(config, s)).toArray(String[]::new);
+        final var normalizedAccounts = Arrays.stream(accounts)
+                .map(s -> normalizePossibleIdLiteral(config, s))
+                .toArray(String[]::new);
         var delegate = new BalanceSuite(config.asSpecConfig(), normalizedAccounts);
         delegate.runSuiteSync();
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/InfoCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/InfoCommand.java
@@ -5,7 +5,6 @@ import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLite
 
 import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.InfoSuite;
-
 import java.util.Arrays;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
@@ -36,7 +35,9 @@ public class InfoCommand implements Callable<Integer> {
 
         printTable(balanceRegister);
 
-		var normalizedAccounts = Arrays.stream(accounts).map(s -> normalizePossibleIdLiteral(config, s)).toArray(String[]::new);
+        final var normalizedAccounts = Arrays.stream(accounts)
+                .map(s -> normalizePossibleIdLiteral(config, s))
+                .toArray(String[]::new);
         var delegate = new InfoSuite(config.asSpecConfig(), normalizedAccounts);
         delegate.runSuiteSync();
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/InfoCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/InfoCommand.java
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.accounts;
 
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
+
 import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.InfoSuite;
+
+import java.util.Arrays;
 import java.util.concurrent.Callable;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.HelpCommand;
@@ -32,7 +36,8 @@ public class InfoCommand implements Callable<Integer> {
 
         printTable(balanceRegister);
 
-        var delegate = new InfoSuite(config.asSpecConfig(), accounts);
+		var normalizedAccounts = Arrays.stream(accounts).map(s -> normalizePossibleIdLiteral(config, s)).toArray(String[]::new);
+        var delegate = new InfoSuite(config.asSpecConfig(), normalizedAccounts);
         delegate.runSuiteSync();
 
         return 0;

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/RekeyCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/RekeyCommand.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.accounts;
 
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.google.common.io.Files;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -59,7 +59,7 @@ public class RekeyCommand implements Callable<Integer> {
                     "Must set --gen-new-key if no --replacement-key given");
         }
 
-		final var normalizedAcct = normalizePossibleIdLiteral(config, accountNum);
+        final var normalizedAcct = normalizePossibleIdLiteral(config, accountNum);
 
         final var optKeyFile = backupCurrentAssets(config, normalizedAcct);
         final String replTarget = optKeyFile
@@ -73,9 +73,11 @@ public class RekeyCommand implements Callable<Integer> {
         delegate.runSuiteSync();
 
         if (delegate.getFinalSpecs().getFirst().getStatus() == HapiSpec.SpecStatus.PASSED) {
-            COMMON_MESSAGES.info("SUCCESS - account " + config.shard() + "." + config.realm() + "." + normalizedAcct + " has been re-keyed");
+            COMMON_MESSAGES.info("SUCCESS - account " + config.shard() + "." + config.realm() + "." + normalizedAcct
+                    + " has been re-keyed");
         } else {
-            COMMON_MESSAGES.warn("FAILED to re-key account " + config.shard() + "." + config.realm() + "." + normalizedAcct);
+            COMMON_MESSAGES.warn(
+                    "FAILED to re-key account " + config.shard() + "." + config.realm() + "." + normalizedAcct);
             return 1;
         }
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/SendCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/SendCommand.java
@@ -2,8 +2,8 @@
 package com.hedera.services.yahcli.commands.accounts;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.yahcli.Yahcli;
@@ -66,7 +66,7 @@ public class SendCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         var config = ConfigUtils.configFrom(accountsCommand.getYahcli());
 
-		var normalizedBeneficiary = normalizePossibleIdLiteral(config, beneficiary);
+        var normalizedBeneficiary = normalizePossibleIdLiteral(config, beneficiary);
         if (!config.isAllowListEmptyOrContainsAccount(Long.parseLong(normalizedBeneficiary))) {
             throw new CommandLine.ParameterException(
                     accountsCommand.getYahcli().getSpec().commandLine(),

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/SendCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/SendCommand.java
@@ -2,6 +2,7 @@
 package com.hedera.services.yahcli.commands.accounts;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -65,10 +66,11 @@ public class SendCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         var config = ConfigUtils.configFrom(accountsCommand.getYahcli());
 
-        if (!config.isAllowListEmptyOrContainsAccount(Long.parseLong(beneficiary))) {
+		var normalizedBeneficiary = normalizePossibleIdLiteral(config, beneficiary);
+        if (!config.isAllowListEmptyOrContainsAccount(Long.parseLong(normalizedBeneficiary))) {
             throw new CommandLine.ParameterException(
                     accountsCommand.getYahcli().getSpec().commandLine(),
-                    "Beneficiary " + beneficiary + " supposed to be in allow list");
+                    "Beneficiary " + normalizedBeneficiary + " supposed to be in allow list");
         }
 
         long amount;
@@ -82,7 +84,7 @@ public class SendCommand implements Callable<Integer> {
         final var effectiveMemo = memo != null ? memo : "";
         var delegate = new SendSuite(
                 config,
-                beneficiary,
+                normalizedBeneficiary,
                 amount,
                 effectiveMemo,
                 denomination,
@@ -98,7 +100,7 @@ public class SendCommand implements Callable<Integer> {
                     + " "
                     + originalDenomination
                     + " to account "
-                    + asEntityString(firstSpec.shard(), firstSpec.realm(), beneficiary)
+                    + asEntityString(firstSpec.shard(), firstSpec.realm(), normalizedBeneficiary)
                     + " with memo: '"
                     + memo
                     + "'");
@@ -109,7 +111,7 @@ public class SendCommand implements Callable<Integer> {
                     + " "
                     + originalDenomination
                     + " to account "
-                    + beneficiary
+                    + normalizedBeneficiary
                     + " with memo: '"
                     + memo
                     + "'");

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
@@ -2,9 +2,11 @@
 package com.hedera.services.yahcli.commands.accounts;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.yahcli.config.ConfigManager;
 import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.StakeSuite;
 import com.hedera.services.yahcli.suites.Utils;
@@ -45,15 +47,16 @@ public class StakeCommand implements Callable<Integer> {
     @Override
     public Integer call() throws Exception {
         final var config = ConfigUtils.configFrom(accountsCommand.getYahcli());
-        assertValidParams();
+        assertValidParams(config);
         final String target;
         final StakeSuite.TargetType type;
-        if (electedNodeId != null) {
+		final var normalizedElectedAccountNum = normalizePossibleIdLiteral(config, electedAccountNum);
+        if (normalizedElectedAccountNum != null) {
             type = StakeSuite.TargetType.NODE;
-            target = electedNodeId;
-        } else if (electedAccountNum != null) {
+            target = normalizedElectedAccountNum;
+        } else if (normalizedElectedAccountNum != null) {
             type = StakeSuite.TargetType.ACCOUNT;
-            target = electedAccountNum;
+            target = normalizedElectedAccountNum;
         } else {
             target = null;
             type = StakeSuite.TargetType.NONE;
@@ -64,25 +67,27 @@ public class StakeCommand implements Callable<Integer> {
         } else if (stopDecliningRewards != null) {
             declineReward = Boolean.FALSE;
         }
+		var normalizedStakedAccountNum = normalizePossibleIdLiteral(config, stakedAccountNum);
         final var delegate =
-                new StakeSuite(config, config.asSpecConfig(), target, type, stakedAccountNum, declineReward);
+                new StakeSuite(config, config.asSpecConfig(), target, type, normalizedStakedAccountNum, declineReward);
         delegate.runSuiteSync();
 
-        if (stakedAccountNum == null) {
-            stakedAccountNum = asEntityString(config.getDefaultPayer());
+        if (normalizedStakedAccountNum == null) {
+			normalizedStakedAccountNum = asEntityString(config.getDefaultPayer());
         }
-        if (delegate.getFinalSpecs().get(0).getStatus() == HapiSpec.SpecStatus.PASSED) {
+        if (delegate.getFinalSpecs().getFirst().getStatus() == HapiSpec.SpecStatus.PASSED) {
             final var msgSb = new StringBuilder("SUCCESS - account ")
-                    .append(Utils.extractAccount(stakedAccountNum))
+                    .append(Utils.extractAccount(normalizedStakedAccountNum))
                     .append(" updated");
+			final var normalizedElectedNodeId = normalizePossibleIdLiteral(config, electedNodeId);
             if (type != StakeSuite.TargetType.NONE) {
                 msgSb.append(", now staked to ")
                         .append(type.name())
                         .append(" ")
                         .append(
                                 type == StakeSuite.TargetType.NODE
-                                        ? electedNodeId
-                                        : Utils.extractAccount(electedAccountNum));
+                                        ? normalizedElectedNodeId
+                                        : Utils.extractAccount(normalizedElectedAccountNum));
             }
             if (declineReward != null) {
                 msgSb.append(" with declineReward=").append(declineReward);
@@ -90,7 +95,7 @@ public class StakeCommand implements Callable<Integer> {
             COMMON_MESSAGES.info(msgSb.toString());
         } else {
             COMMON_MESSAGES.warn(
-                    "FAILED to change staking election for account " + Utils.extractAccount(stakedAccountNum));
+                    "FAILED to change staking election for account " + Utils.extractAccount(normalizedStakedAccountNum));
             return 1;
         }
 
@@ -98,51 +103,54 @@ public class StakeCommand implements Callable<Integer> {
     }
 
     @SuppressWarnings({"java:S3776", "java:S1192"})
-    private void assertValidParams() {
+    private void assertValidParams(ConfigManager config) {
         if (stopDecliningRewards != null && startDecliningRewards != null) {
             throw new CommandLine.ParameterException(
                     accountsCommand.getYahcli().getSpec().commandLine(),
                     "Cannot both start and stop declining rewards");
         }
+		final var normalizedElectedNodeId = normalizePossibleIdLiteral(config, electedNodeId);
+		final var normalizedElectedAccountNum = normalizePossibleIdLiteral(config, electedAccountNum);
         final var changedDeclineRewards = startDecliningRewards != null || stopDecliningRewards != null;
-        if (electedNodeId != null) {
-            if (electedAccountNum != null) {
+        if (normalizedElectedNodeId != null) {
+            if (normalizedElectedAccountNum != null) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
-                        "Cannot stake to both node (" + electedNodeId + ") and account (" + electedAccountNum + ")");
+                        "Cannot stake to both node (" + normalizedElectedNodeId + ") and account (" + normalizedElectedAccountNum + ")");
             }
             try {
-                Long.parseLong(electedNodeId);
+                Long.parseLong(normalizedElectedNodeId);
             } catch (final Exception any) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
-                        "--node-id value '" + electedNodeId + "' is un-parseable (" + any.getMessage() + ")");
+                        "--node-id value '" + normalizedElectedNodeId + "' is un-parseable (" + any.getMessage() + ")");
             }
-        } else if (electedAccountNum == null && !changedDeclineRewards) {
+        } else if (normalizedElectedAccountNum == null && !changedDeclineRewards) {
             throw new CommandLine.ParameterException(
                     accountsCommand.getYahcli().getSpec().commandLine(),
                     "Must stake to either a node or an account ("
-                            + electedAccountNum
+                            + normalizedElectedAccountNum
                             + "); or "
                             + "start/stop declining rewards");
-        } else if (electedAccountNum != null) {
+        } else if (normalizedElectedAccountNum != null) {
             try {
-                Utils.extractAccount(electedAccountNum);
+                Utils.extractAccount(normalizedElectedAccountNum);
             } catch (final Exception any) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
-                        "--account-num value '" + electedAccountNum + "' is un-parseable (" + any.getMessage() + ")");
+                        "--account-num value '" + normalizedElectedAccountNum + "' is un-parseable (" + any.getMessage() + ")");
             }
         }
 
-        if (stakedAccountNum != null) {
+		final var normalizedStakedAccountNum = normalizePossibleIdLiteral(config, stakedAccountNum);
+        if (normalizedStakedAccountNum != null) {
             try {
-                Utils.extractAccount(stakedAccountNum);
+                Utils.extractAccount(normalizedStakedAccountNum);
             } catch (final Exception any) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
                         "staked account parameter '"
-                                + stakedAccountNum
+                                + normalizedStakedAccountNum
                                 + "' is un-parseable ("
                                 + any.getMessage()
                                 + ")");

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/StakeCommand.java
@@ -2,8 +2,8 @@
 package com.hedera.services.yahcli.commands.accounts;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.yahcli.config.ConfigManager;
@@ -50,7 +50,7 @@ public class StakeCommand implements Callable<Integer> {
         assertValidParams(config);
         final String target;
         final StakeSuite.TargetType type;
-		final var normalizedElectedAccountNum = normalizePossibleIdLiteral(config, electedAccountNum);
+        final var normalizedElectedAccountNum = normalizePossibleIdLiteral(config, electedAccountNum);
         if (normalizedElectedAccountNum != null) {
             type = StakeSuite.TargetType.NODE;
             target = normalizedElectedAccountNum;
@@ -67,19 +67,19 @@ public class StakeCommand implements Callable<Integer> {
         } else if (stopDecliningRewards != null) {
             declineReward = Boolean.FALSE;
         }
-		var normalizedStakedAccountNum = normalizePossibleIdLiteral(config, stakedAccountNum);
+        var normalizedStakedAccountNum = normalizePossibleIdLiteral(config, stakedAccountNum);
         final var delegate =
                 new StakeSuite(config, config.asSpecConfig(), target, type, normalizedStakedAccountNum, declineReward);
         delegate.runSuiteSync();
 
         if (normalizedStakedAccountNum == null) {
-			normalizedStakedAccountNum = asEntityString(config.getDefaultPayer());
+            normalizedStakedAccountNum = asEntityString(config.getDefaultPayer());
         }
         if (delegate.getFinalSpecs().getFirst().getStatus() == HapiSpec.SpecStatus.PASSED) {
             final var msgSb = new StringBuilder("SUCCESS - account ")
                     .append(Utils.extractAccount(normalizedStakedAccountNum))
                     .append(" updated");
-			final var normalizedElectedNodeId = normalizePossibleIdLiteral(config, electedNodeId);
+            final var normalizedElectedNodeId = normalizePossibleIdLiteral(config, electedNodeId);
             if (type != StakeSuite.TargetType.NONE) {
                 msgSb.append(", now staked to ")
                         .append(type.name())
@@ -94,8 +94,8 @@ public class StakeCommand implements Callable<Integer> {
             }
             COMMON_MESSAGES.info(msgSb.toString());
         } else {
-            COMMON_MESSAGES.warn(
-                    "FAILED to change staking election for account " + Utils.extractAccount(normalizedStakedAccountNum));
+            COMMON_MESSAGES.warn("FAILED to change staking election for account "
+                    + Utils.extractAccount(normalizedStakedAccountNum));
             return 1;
         }
 
@@ -109,14 +109,15 @@ public class StakeCommand implements Callable<Integer> {
                     accountsCommand.getYahcli().getSpec().commandLine(),
                     "Cannot both start and stop declining rewards");
         }
-		final var normalizedElectedNodeId = normalizePossibleIdLiteral(config, electedNodeId);
-		final var normalizedElectedAccountNum = normalizePossibleIdLiteral(config, electedAccountNum);
+        final var normalizedElectedNodeId = normalizePossibleIdLiteral(config, electedNodeId);
+        final var normalizedElectedAccountNum = normalizePossibleIdLiteral(config, electedAccountNum);
         final var changedDeclineRewards = startDecliningRewards != null || stopDecliningRewards != null;
         if (normalizedElectedNodeId != null) {
             if (normalizedElectedAccountNum != null) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
-                        "Cannot stake to both node (" + normalizedElectedNodeId + ") and account (" + normalizedElectedAccountNum + ")");
+                        "Cannot stake to both node (" + normalizedElectedNodeId + ") and account ("
+                                + normalizedElectedAccountNum + ")");
             }
             try {
                 Long.parseLong(normalizedElectedNodeId);
@@ -138,11 +139,12 @@ public class StakeCommand implements Callable<Integer> {
             } catch (final Exception any) {
                 throw new CommandLine.ParameterException(
                         accountsCommand.getYahcli().getSpec().commandLine(),
-                        "--account-num value '" + normalizedElectedAccountNum + "' is un-parseable (" + any.getMessage() + ")");
+                        "--account-num value '" + normalizedElectedAccountNum + "' is un-parseable (" + any.getMessage()
+                                + ")");
             }
         }
 
-		final var normalizedStakedAccountNum = normalizePossibleIdLiteral(config, stakedAccountNum);
+        final var normalizedStakedAccountNum = normalizePossibleIdLiteral(config, stakedAccountNum);
         if (normalizedStakedAccountNum != null) {
             try {
                 Utils.extractAccount(normalizedStakedAccountNum);

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/UpdateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/UpdateCommand.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.accounts;
 
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
@@ -54,7 +54,7 @@ public class UpdateCommand implements Callable<Integer> {
         var config = ConfigUtils.configFrom(accountsCommand.getYahcli());
 
         final var effectiveMemo = memo != null ? memo : "";
-		final var normalizedTargetAccount = normalizePossibleIdLiteral(config, targetAccount);
+        final var normalizedTargetAccount = normalizePossibleIdLiteral(config, targetAccount);
         final var effectiveTargetAccount = normalizedTargetAccount != null ? normalizedTargetAccount : "";
         final var keysPath = pathKeys != null ? pathKeys : "";
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/UpdateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/accounts/UpdateCommand.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.accounts;
 
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.google.common.collect.Lists;
@@ -53,7 +54,8 @@ public class UpdateCommand implements Callable<Integer> {
         var config = ConfigUtils.configFrom(accountsCommand.getYahcli());
 
         final var effectiveMemo = memo != null ? memo : "";
-        final var effectiveTargetAccount = targetAccount != null ? targetAccount : "";
+		final var normalizedTargetAccount = normalizePossibleIdLiteral(config, targetAccount);
+        final var effectiveTargetAccount = normalizedTargetAccount != null ? normalizedTargetAccount : "";
         final var keysPath = pathKeys != null ? pathKeys : "";
 
         final var effectivePublicKeys = unHexListOfKeys(readPublicKeyFromFile(keysPath));
@@ -70,7 +72,7 @@ public class UpdateCommand implements Callable<Integer> {
                 accountsCommand.getYahcli().isScheduled());
         delegate.runSuiteSync();
 
-        if (delegate.getFinalSpecs().get(0).getStatus() == HapiSpec.SpecStatus.PASSED) {
+        if (delegate.getFinalSpecs().getFirst().getStatus() == HapiSpec.SpecStatus.PASSED) {
             COMMON_MESSAGES.info("SUCCESS - "
                     + "Scheduled update account "
                     + effectiveTargetAccount

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/files/SysFileDownloadCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/files/SysFileDownloadCommand.java
@@ -7,10 +7,8 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.SysFileDownloadSuite;
 import com.hedera.services.yahcli.util.ParseUtils;
-
 import java.util.Arrays;
 import java.util.concurrent.Callable;
-
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ParentCommand;
@@ -38,12 +36,14 @@ public class SysFileDownloadCommand implements Callable<Integer> {
                     + "{ 101, 102, 111, 112, 121, 122, 123, 150, 159 })---or 'all'")
     private String[] sysFiles;
 
-	@Override
+    @Override
     public Integer call() throws Exception {
         var config = ConfigUtils.configFrom(sysFilesCommand.getYahcli());
         destDir = SysFilesCommand.resolvedDir(destDir, config);
 
-		final var normalizedSysFiles = Arrays.stream(sysFiles).map(s -> ParseUtils.normalizePossibleIdLiteral(config, s)).toArray(String[]::new);
+        final var normalizedSysFiles = Arrays.stream(sysFiles)
+                .map(s -> ParseUtils.normalizePossibleIdLiteral(config, s))
+                .toArray(String[]::new);
         var delegate = new SysFileDownloadSuite(destDir, config, normalizedSysFiles);
         delegate.runSuiteSync();
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/files/SysFileUploadCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/files/SysFileUploadCommand.java
@@ -5,8 +5,11 @@ import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
+import com.hedera.services.yahcli.config.ConfigManager;
 import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.SysFileUploadSuite;
+import com.hedera.services.yahcli.util.ParseUtils;
+
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 import picocli.CommandLine;
@@ -69,7 +72,7 @@ public class SysFileUploadCommand implements Callable<Integer> {
         srcDir = SysFilesCommand.resolvedDir(srcDir, config);
         activeSrcDir.set(srcDir);
 
-        if (isSpecialFile()) {
+        if (isSpecialFile(config)) {
             if (bytesPerAppend == null) {
                 bytesPerAppend = TxnUtils.BYTES_4K;
             }
@@ -97,10 +100,11 @@ public class SysFileUploadCommand implements Callable<Integer> {
             }
         }
 
-        var delegate = isSpecialFile()
+		final String normalizedSysFile = ParseUtils.normalizePossibleIdLiteral(config, sysFile);
+        var delegate = isSpecialFile(config)
                 ? new SysFileUploadSuite(
-                        bytesPerAppend, appendsPerBurst, restartFromFailure, srcDir, config, sysFile, dryRun)
-                : new SysFileUploadSuite(srcDir, config, sysFile, dryRun);
+                        bytesPerAppend, appendsPerBurst, restartFromFailure, srcDir, config, normalizedSysFile, dryRun)
+                : new SysFileUploadSuite(srcDir, config, normalizedSysFile, dryRun);
 
         delegate.runSuiteSync();
 
@@ -117,10 +121,11 @@ public class SysFileUploadCommand implements Callable<Integer> {
         return 0;
     }
 
-    private boolean isSpecialFile() {
-        return "software-zip".equals(sysFile)
-                || "150".equals(sysFile)
-                || "telemetry-zip".equals(sysFile)
-                || "159".equals(sysFile);
+    private boolean isSpecialFile(ConfigManager config) {
+		final var normalizedSysFile = ParseUtils.normalizePossibleIdLiteral(config, sysFile);
+        return "software-zip".equals(normalizedSysFile)
+                || "150".equals(normalizedSysFile)
+                || "telemetry-zip".equals(normalizedSysFile)
+                || "159".equals(normalizedSysFile);
     }
 }

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/files/SysFileUploadCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/files/SysFileUploadCommand.java
@@ -9,7 +9,6 @@ import com.hedera.services.yahcli.config.ConfigManager;
 import com.hedera.services.yahcli.config.ConfigUtils;
 import com.hedera.services.yahcli.suites.SysFileUploadSuite;
 import com.hedera.services.yahcli.util.ParseUtils;
-
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicReference;
 import picocli.CommandLine;
@@ -100,7 +99,7 @@ public class SysFileUploadCommand implements Callable<Integer> {
             }
         }
 
-		final String normalizedSysFile = ParseUtils.normalizePossibleIdLiteral(config, sysFile);
+        final String normalizedSysFile = ParseUtils.normalizePossibleIdLiteral(config, sysFile);
         var delegate = isSpecialFile(config)
                 ? new SysFileUploadSuite(
                         bytesPerAppend, appendsPerBurst, restartFromFailure, srcDir, config, normalizedSysFile, dryRun)
@@ -122,7 +121,7 @@ public class SysFileUploadCommand implements Callable<Integer> {
     }
 
     private boolean isSpecialFile(ConfigManager config) {
-		final var normalizedSysFile = ParseUtils.normalizePossibleIdLiteral(config, sysFile);
+        final var normalizedSysFile = ParseUtils.normalizePossibleIdLiteral(config, sysFile);
         return "software-zip".equals(normalizedSysFile)
                 || "150".equals(normalizedSysFile)
                 || "telemetry-zip".equals(normalizedSysFile)

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/CreateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/CreateCommand.java
@@ -4,10 +4,10 @@ package com.hedera.services.yahcli.commands.nodes;
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asCsServiceEndpoints;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTypedServiceEndpoint;
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.commands.nodes.NodesCommand.validatedX509Cert;
 import static com.hedera.services.yahcli.config.ConfigUtils.keyFileFor;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.inventory.AccessoryUtils;
@@ -99,7 +99,7 @@ public class CreateCommand implements Callable<Integer> {
         var config = ConfigUtils.configFrom(yahcli);
 
         validateAdminKeyLoc(adminKeyPath);
-		final var normalizedAcctNum = normalizePossibleIdLiteral(config, accountNum);
+        final var normalizedAcctNum = normalizePossibleIdLiteral(config, accountNum);
         final var accountId = Long.parseLong(normalizedAcctNum);
         final var feeAccountKeyFile = keyFileFor(config.keysLoc(), "account" + accountId);
         final var maybeFeeAccountKeyPath = feeAccountKeyFile.map(File::getPath).orElse(null);

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/CreateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/CreateCommand.java
@@ -4,6 +4,7 @@ package com.hedera.services.yahcli.commands.nodes;
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asCsServiceEndpoints;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTypedServiceEndpoint;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.commands.nodes.NodesCommand.validatedX509Cert;
 import static com.hedera.services.yahcli.config.ConfigUtils.keyFileFor;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
@@ -98,7 +99,8 @@ public class CreateCommand implements Callable<Integer> {
         var config = ConfigUtils.configFrom(yahcli);
 
         validateAdminKeyLoc(adminKeyPath);
-        final var accountId = Long.parseLong(accountNum);
+		final var normalizedAcctNum = normalizePossibleIdLiteral(config, accountNum);
+        final var accountId = Long.parseLong(normalizedAcctNum);
         final var feeAccountKeyFile = keyFileFor(config.keysLoc(), "account" + accountId);
         final var maybeFeeAccountKeyPath = feeAccountKeyFile.map(File::getPath).orElse(null);
         if (maybeFeeAccountKeyPath == null) {

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/DeleteCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/DeleteCommand.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.nodes;
 
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -34,7 +35,8 @@ public class DeleteCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var yahcli = nodesCommand.getYahcli();
         var config = ConfigUtils.configFrom(yahcli);
-        final var targetId = validatedNodeId(nodeId);
+		var normalizedNodeId = normalizePossibleIdLiteral(config, nodeId);
+        final var targetId = validatedNodeId(normalizedNodeId);
 
         if (adminKeyPath == null) {
             COMMON_MESSAGES.warn("No --adminKey option, payer signature alone must meet signing requirements");
@@ -46,9 +48,9 @@ public class DeleteCommand implements Callable<Integer> {
         delegate.runSuiteSync();
 
         if (delegate.getFinalSpecs().getFirst().getStatus() == HapiSpec.SpecStatus.PASSED) {
-            COMMON_MESSAGES.info("SUCCESS - node" + nodeId + " has been deleted");
+            COMMON_MESSAGES.info("SUCCESS - node" + normalizedNodeId + " has been deleted");
         } else {
-            COMMON_MESSAGES.warn("FAILED to delete node" + nodeId);
+            COMMON_MESSAGES.warn("FAILED to delete node" + normalizedNodeId);
             return 1;
         }
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/DeleteCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/DeleteCommand.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.nodes;
 
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.yahcli.config.ConfigUtils;
@@ -35,7 +35,7 @@ public class DeleteCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var yahcli = nodesCommand.getYahcli();
         var config = ConfigUtils.configFrom(yahcli);
-		var normalizedNodeId = normalizePossibleIdLiteral(config, nodeId);
+        var normalizedNodeId = normalizePossibleIdLiteral(config, nodeId);
         final var targetId = validatedNodeId(normalizedNodeId);
 
         if (adminKeyPath == null) {

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/UpdateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/UpdateCommand.java
@@ -5,12 +5,12 @@ import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asCsServiceEndpoints;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTypedServiceEndpoint;
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.commands.nodes.CreateCommand.allBytesAt;
 import static com.hedera.services.yahcli.commands.nodes.NodesCommand.validateKeyAt;
 import static com.hedera.services.yahcli.commands.nodes.NodesCommand.validatedX509Cert;
 import static com.hedera.services.yahcli.config.ConfigUtils.keyFileFor;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.hapi.node.base.ServiceEndpoint;
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -110,7 +110,7 @@ public class UpdateCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var yahcli = nodesCommand.getYahcli();
         var config = ConfigUtils.configFrom(yahcli);
-		final var normalizedNodeId = normalizePossibleIdLiteral(config, nodeId);
+        final var normalizedNodeId = normalizePossibleIdLiteral(config, nodeId);
         final var targetNodeId = validatedNodeId(normalizedNodeId);
         final AccountID newAccountId;
         final String feeAccountKeyLoc;
@@ -119,7 +119,7 @@ public class UpdateCommand implements Callable<Integer> {
         final byte[] newGossipCaCertificate;
         final byte[] newHapiCertificateHash;
         final ServiceEndpoint newGrpcProxyEndpoint;
-		final var normalizedAccountId = normalizePossibleIdLiteral(config, accountId);
+        final var normalizedAccountId = normalizePossibleIdLiteral(config, accountId);
         if (normalizedAccountId == null) {
             newAccountId = null;
             feeAccountKeyLoc = null;

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/UpdateCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/nodes/UpdateCommand.java
@@ -5,6 +5,7 @@ import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asCsServiceEndpoints;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asTypedServiceEndpoint;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.commands.nodes.CreateCommand.allBytesAt;
 import static com.hedera.services.yahcli.commands.nodes.NodesCommand.validateKeyAt;
 import static com.hedera.services.yahcli.commands.nodes.NodesCommand.validatedX509Cert;
@@ -109,7 +110,8 @@ public class UpdateCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var yahcli = nodesCommand.getYahcli();
         var config = ConfigUtils.configFrom(yahcli);
-        final var targetNodeId = validatedNodeId(nodeId);
+		final var normalizedNodeId = normalizePossibleIdLiteral(config, nodeId);
+        final var targetNodeId = validatedNodeId(normalizedNodeId);
         final AccountID newAccountId;
         final String feeAccountKeyLoc;
         final List<ServiceEndpoint> newGossipEndpoints;
@@ -117,12 +119,13 @@ public class UpdateCommand implements Callable<Integer> {
         final byte[] newGossipCaCertificate;
         final byte[] newHapiCertificateHash;
         final ServiceEndpoint newGrpcProxyEndpoint;
-        if (accountId == null) {
+		final var normalizedAccountId = normalizePossibleIdLiteral(config, accountId);
+        if (normalizedAccountId == null) {
             newAccountId = null;
             feeAccountKeyLoc = null;
         } else {
             newAccountId = validatedAccountId(
-                    config.shard().getShardNum(), config.realm().getRealmNum(), accountId);
+                    config.shard().getShardNum(), config.realm().getRealmNum(), normalizedAccountId);
             final var feeAccountKeyFile = keyFileFor(config.keysLoc(), "account" + newAccountId.getAccountNum());
             feeAccountKeyLoc = feeAccountKeyFile.map(File::getPath).orElse(null);
             if (feeAccountKeyLoc == null) {

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/schedules/SignCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/schedules/SignCommand.java
@@ -1,9 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.schedules;
 
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.config.ConfigUtils.configFrom;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.yahcli.suites.ScheduleSuite;
@@ -32,7 +32,7 @@ public class SignCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         var config = configFrom(scheduleCommand.getYahcli());
 
-		final var normalizedScheduleId = normalizePossibleIdLiteral(config, scheduleId);
+        final var normalizedScheduleId = normalizePossibleIdLiteral(config, scheduleId);
         final var effectiveScheduleId = normalizedScheduleId != null ? normalizedScheduleId : "";
         var delegate = new ScheduleSuite(config, effectiveScheduleId);
         delegate.runSuiteSync();

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/schedules/SignCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/schedules/SignCommand.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.commands.schedules;
 
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.config.ConfigUtils.configFrom;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
@@ -31,7 +32,8 @@ public class SignCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         var config = configFrom(scheduleCommand.getYahcli());
 
-        final var effectiveScheduleId = scheduleId != null ? scheduleId : "";
+		final var normalizedScheduleId = normalizePossibleIdLiteral(config, scheduleId);
+        final var effectiveScheduleId = normalizedScheduleId != null ? normalizedScheduleId : "";
         var delegate = new ScheduleSuite(config, effectiveScheduleId);
         delegate.runSuiteSync();
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/FreezeUpgradeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/FreezeUpgradeCommand.java
@@ -2,8 +2,8 @@
 package com.hedera.services.yahcli.commands.system;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.yahcli.Yahcli;
@@ -42,7 +42,7 @@ public class FreezeUpgradeCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var config = ConfigUtils.configFrom(yahcli);
 
-		final var normalizedUpgradeFileNum = normalizePossibleIdLiteral(config, upgradeFileNum);
+        final var normalizedUpgradeFileNum = normalizePossibleIdLiteral(config, upgradeFileNum);
         final var upgradeFile =
                 asEntityString(config.shard().getShardNum(), config.realm().getRealmNum(), normalizedUpgradeFileNum);
         final var unhexedHash = CommonUtils.unhex(upgradeFileHash);

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/FreezeUpgradeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/FreezeUpgradeCommand.java
@@ -2,6 +2,7 @@
 package com.hedera.services.yahcli.commands.system;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -41,8 +42,9 @@ public class FreezeUpgradeCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var config = ConfigUtils.configFrom(yahcli);
 
+		final var normalizedUpgradeFileNum = normalizePossibleIdLiteral(config, upgradeFileNum);
         final var upgradeFile =
-                asEntityString(config.shard().getShardNum(), config.realm().getRealmNum(), upgradeFileNum);
+                asEntityString(config.shard().getShardNum(), config.realm().getRealmNum(), normalizedUpgradeFileNum);
         final var unhexedHash = CommonUtils.unhex(upgradeFileHash);
         final var startInstant = Utils.parseFormattedInstant(startTime);
         final var delegate = new UpgradeHelperSuite(config, unhexedHash, upgradeFile, startInstant);

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/PrepareUpgradeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/PrepareUpgradeCommand.java
@@ -2,8 +2,8 @@
 package com.hedera.services.yahcli.commands.system;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.yahcli.Yahcli;
@@ -36,7 +36,7 @@ public class PrepareUpgradeCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var config = ConfigUtils.configFrom(yahcli);
 
-		final var normalizedUpgradeFileNum = normalizePossibleIdLiteral(config, upgradeFileNum);
+        final var normalizedUpgradeFileNum = normalizePossibleIdLiteral(config, upgradeFileNum);
         final var upgradeFile =
                 asEntityString(config.shard().getShardNum(), config.realm().getRealmNum(), normalizedUpgradeFileNum);
         final var unhexedHash = CommonUtils.unhex(upgradeFileHash);

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/PrepareUpgradeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/PrepareUpgradeCommand.java
@@ -2,6 +2,7 @@
 package com.hedera.services.yahcli.commands.system;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -35,8 +36,9 @@ public class PrepareUpgradeCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var config = ConfigUtils.configFrom(yahcli);
 
+		final var normalizedUpgradeFileNum = normalizePossibleIdLiteral(config, upgradeFileNum);
         final var upgradeFile =
-                asEntityString(config.shard().getShardNum(), config.realm().getRealmNum(), upgradeFileNum);
+                asEntityString(config.shard().getShardNum(), config.realm().getRealmNum(), normalizedUpgradeFileNum);
         final var unhexedHash = CommonUtils.unhex(upgradeFileHash);
         final var delegate = new UpgradeHelperSuite(config, unhexedHash, upgradeFile);
 

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/TelemetryUpgradeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/TelemetryUpgradeCommand.java
@@ -2,8 +2,8 @@
 package com.hedera.services.yahcli.commands.system;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
-import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.yahcli.Yahcli;
@@ -42,7 +42,7 @@ public class TelemetryUpgradeCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var config = ConfigUtils.configFrom(yahcli);
 
-		final var normalizedUpgradeFileNum = normalizePossibleIdLiteral(config, upgradeFileNum);
+        final var normalizedUpgradeFileNum = normalizePossibleIdLiteral(config, upgradeFileNum);
         final var upgradeFile =
                 asEntityString(config.shard().getShardNum(), config.realm().getRealmNum(), normalizedUpgradeFileNum);
         final var unhexedHash = CommonUtils.unhex(upgradeFileHash);

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/TelemetryUpgradeCommand.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/commands/system/TelemetryUpgradeCommand.java
@@ -2,6 +2,7 @@
 package com.hedera.services.yahcli.commands.system;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.hedera.services.bdd.spec.HapiSpec;
@@ -41,8 +42,9 @@ public class TelemetryUpgradeCommand implements Callable<Integer> {
     public Integer call() throws Exception {
         final var config = ConfigUtils.configFrom(yahcli);
 
+		final var normalizedUpgradeFileNum = normalizePossibleIdLiteral(config, upgradeFileNum);
         final var upgradeFile =
-                asEntityString(config.shard().getShardNum(), config.realm().getRealmNum(), upgradeFileNum);
+                asEntityString(config.shard().getShardNum(), config.realm().getRealmNum(), normalizedUpgradeFileNum);
         final var unhexedHash = CommonUtils.unhex(upgradeFileHash);
         final var startInstant = Utils.parseFormattedInstant(startTime);
         final var delegate = new UpgradeHelperSuite(config, unhexedHash, upgradeFile, startInstant, true);

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/ConfigManager.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/ConfigManager.java
@@ -4,6 +4,7 @@ package com.hedera.services.yahcli.config;
 import static com.hedera.node.app.hapi.utils.keys.Ed25519Utils.readKeyPairFrom;
 import static com.hedera.node.app.hapi.utils.keys.Secp256k1Utils.readECKeyFrom;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
+import static com.hedera.services.yahcli.util.ParseUtils.normalizePossibleIdLiteral;
 
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.props.NodeConnectInfo;
@@ -219,17 +220,19 @@ public class ConfigManager {
     }
 
     private void assertDefaultNodeAccountIsKnown() {
+		final var normalizedNodeAccount = normalizePossibleIdLiteral(this, yahcli.getNodeAccount());
         defaultNodeAccount =
-                Optional.ofNullable(yahcli.getNodeAccount()).orElse(String.valueOf(targetNet.getDefaultNodeAccount()));
+                Optional.ofNullable(normalizedNodeAccount).orElse(String.valueOf(targetNet.getDefaultNodeAccount()));
     }
 
     private void assertDefaultPayerIsKnown() {
-        if (yahcli.getPayer() == null && targetNet.getDefaultPayer() == null) {
+		final var normalizedPayer = normalizePossibleIdLiteral(this, yahcli.getPayer());
+        if (normalizedPayer == null && targetNet.getDefaultPayer() == null) {
             fail(String.format(
                     "No payer was specified, and no default is available in %s for network" + " '%s'",
                     yahcli.getConfigLoc(), targetName));
         }
-        defaultPayer = Optional.ofNullable(yahcli.getPayer()).orElse(targetNet.getDefaultPayer());
+        defaultPayer = Optional.ofNullable(normalizedPayer).orElse(targetNet.getDefaultPayer());
     }
 
     private void assertTargetNetIsKnown() {
@@ -255,8 +258,9 @@ public class ConfigManager {
         targetNet = global.getNetworks().get(targetName);
         if (yahcli.getNodeIpv4Addr() != null) {
             final var ip = yahcli.getNodeIpv4Addr();
+			final var normalizedNodeAccount = normalizePossibleIdLiteral(this, yahcli.getNodeAccount());
             var nodeAccount =
-                    (yahcli.getNodeAccount() == null) ? MISSING_NODE_ACCOUNT : Long.parseLong(yahcli.getNodeAccount());
+                    (normalizedNodeAccount == null) ? MISSING_NODE_ACCOUNT : Long.parseLong(normalizedNodeAccount);
             final var nodes = targetNet.getNodes();
             if (nodeAccount == MISSING_NODE_ACCOUNT) {
                 for (final var node : nodes) {

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/ConfigManager.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/config/ConfigManager.java
@@ -220,13 +220,13 @@ public class ConfigManager {
     }
 
     private void assertDefaultNodeAccountIsKnown() {
-		final var normalizedNodeAccount = normalizePossibleIdLiteral(this, yahcli.getNodeAccount());
+        final var normalizedNodeAccount = normalizePossibleIdLiteral(this, yahcli.getNodeAccount());
         defaultNodeAccount =
                 Optional.ofNullable(normalizedNodeAccount).orElse(String.valueOf(targetNet.getDefaultNodeAccount()));
     }
 
     private void assertDefaultPayerIsKnown() {
-		final var normalizedPayer = normalizePossibleIdLiteral(this, yahcli.getPayer());
+        final var normalizedPayer = normalizePossibleIdLiteral(this, yahcli.getPayer());
         if (normalizedPayer == null && targetNet.getDefaultPayer() == null) {
             fail(String.format(
                     "No payer was specified, and no default is available in %s for network" + " '%s'",
@@ -258,7 +258,7 @@ public class ConfigManager {
         targetNet = global.getNetworks().get(targetName);
         if (yahcli.getNodeIpv4Addr() != null) {
             final var ip = yahcli.getNodeIpv4Addr();
-			final var normalizedNodeAccount = normalizePossibleIdLiteral(this, yahcli.getNodeAccount());
+            final var normalizedNodeAccount = normalizePossibleIdLiteral(this, yahcli.getNodeAccount());
             var nodeAccount =
                     (normalizedNodeAccount == null) ? MISSING_NODE_ACCOUNT : Long.parseLong(normalizedNodeAccount);
             final var nodes = targetNet.getNodes();

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/Utils.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/Utils.java
@@ -94,12 +94,12 @@ public class Utils {
             Map.entry("throttles.json", 123L),
             Map.entry("software-zip", 150L),
             Map.entry("telemetry-zip", 159L));
-	private static final Map<FileID, String> IDS_TO_NAMES = NAMES_TO_NUMBERS.entrySet().stream()
-			.filter(entry -> !entry.getKey().contains("."))
-			.collect(Collectors.toMap(
-					(Map.Entry<String, Long> entry) ->
-							FileID.newBuilder().setFileNum(entry.getValue()).build(),
-					Map.Entry::getKey));
+    private static final Map<FileID, String> IDS_TO_NAMES = NAMES_TO_NUMBERS.entrySet().stream()
+            .filter(entry -> !entry.getKey().contains("."))
+            .collect(Collectors.toMap(
+                    (Map.Entry<String, Long> entry) ->
+                            FileID.newBuilder().setFileNum(entry.getValue()).build(),
+                    Map.Entry::getKey));
 
     private static final Set<Long> VALID_NUMBERS = new HashSet<>(NAMES_TO_NUMBERS.values());
 
@@ -107,10 +107,12 @@ public class Utils {
         return Optional.ofNullable(IDS_TO_NAMES.get(fid)).orElse("<N/A>");
     }
 
-	public static void mismatchedShardRealmMsg(ConfigManager config, final String entityId) {
-			COMMON_MESSAGES.warn("Configured shard/realm for entity ID " + entityId + " does not match " +
-					"the target network's configured shard/realm of " + config.shard().getShardNum() + "." + config.realm().getRealmNum() + "! Using shard/realm configured for network instead.");
-	}
+    public static void mismatchedShardRealmMsg(ConfigManager config, final String entityId) {
+        COMMON_MESSAGES.warn("Configured shard/realm for entity ID " + entityId + " does not match "
+                + "the target network's configured shard/realm of "
+                + config.shard().getShardNum() + "." + config.realm().getRealmNum()
+                + "! Using shard/realm configured for network instead.");
+    }
 
     public static EnumSet<ServiceType> rationalizedServices(final String[] services) {
         if (Arrays.asList(services).contains("all")) {

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/Utils.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/suites/Utils.java
@@ -3,8 +3,10 @@ package com.hedera.services.yahcli.suites;
 
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.isIdLiteral;
+import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
 
 import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.yahcli.config.ConfigManager;
 import com.hederahashgraph.api.proto.java.FileID;
 import java.io.File;
 import java.time.Instant;
@@ -56,7 +58,7 @@ public class Utils {
         return Instant.from(DATE_TIME_FORMAT.parse(timeStampInStr));
     }
 
-    enum ServiceType {
+    public enum ServiceType {
         CRYPTO,
         CONSENSUS,
         TOKEN,
@@ -92,16 +94,23 @@ public class Utils {
             Map.entry("throttles.json", 123L),
             Map.entry("software-zip", 150L),
             Map.entry("telemetry-zip", 159L));
-    private static final Map<Long, String> NUMBERS_TO_NAMES = NAMES_TO_NUMBERS.entrySet().stream()
-            // For any found duplicates, use the actual file name as the key
-            .filter(e -> e.getKey().matches("^[a-zA-Z0-9-]\\.[a-z0-9]+$"))
-            .collect(Collectors.toMap(Map.Entry::getValue, Map.Entry::getKey));
+	private static final Map<FileID, String> IDS_TO_NAMES = NAMES_TO_NUMBERS.entrySet().stream()
+			.filter(entry -> !entry.getKey().contains("."))
+			.collect(Collectors.toMap(
+					(Map.Entry<String, Long> entry) ->
+							FileID.newBuilder().setFileNum(entry.getValue()).build(),
+					Map.Entry::getKey));
 
     private static final Set<Long> VALID_NUMBERS = new HashSet<>(NAMES_TO_NUMBERS.values());
 
     public static String nameOf(FileID fid) {
-        return Optional.ofNullable(NUMBERS_TO_NAMES.get(fid.getFileNum())).orElse("<N/A>");
+        return Optional.ofNullable(IDS_TO_NAMES.get(fid)).orElse("<N/A>");
     }
+
+	public static void mismatchedShardRealmMsg(ConfigManager config, final String entityId) {
+			COMMON_MESSAGES.warn("Configured shard/realm for entity ID " + entityId + " does not match " +
+					"the target network's configured shard/realm of " + config.shard().getShardNum() + "." + config.realm().getRealmNum() + "! Using shard/realm configured for network instead.");
+	}
 
     public static EnumSet<ServiceType> rationalizedServices(final String[] services) {
         if (Arrays.asList(services).contains("all")) {

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/util/ParseUtils.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/util/ParseUtils.java
@@ -1,9 +1,15 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.yahcli.util;
 
+import static com.hedera.services.bdd.spec.HapiPropertySource.asDotDelimitedLongArray;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.isIdLiteral;
 import static com.hedera.services.yahcli.output.CommonMessages.COMMON_MESSAGES;
+import static com.hedera.services.yahcli.suites.Utils.mismatchedShardRealmMsg;
 
 import com.hedera.services.bdd.spec.keys.SigControl;
+import com.hedera.services.yahcli.config.ConfigManager;
+
+import java.util.Arrays;
 
 public class ParseUtils {
 
@@ -29,4 +35,35 @@ public class ParseUtils {
 
         return sigType;
     }
+
+	/**
+	 * Takes a string and, IF it is a fully-qualified entity ID, converts the ID to ONLY the third part.
+	 * For any other values (including `null`), the value passed in will be the value returned.
+	 * <p>
+	 * E.g.:
+	 * <li>
+	 *     <ul>`1.2.3` will return `3`</ul>
+	 *     <ul>`5` will return `5`</ul>
+	 *     <ul>`null` will return `null`</ul>
+	 *     <ul>`whatever value you want` will return `whatever value you want`</ul>
+	 * </li>
+	 * @param config the yahcli configuration, specifically the target shard and realm.
+	 *                  Included only to indicate any mismatch to the end user (via console message)
+	 *
+	 * @param idLiteral the entity ID literal to (possibly) normalize
+	 * @return the normalized ID literal, which is a string representation of the entity number
+	 */
+	public static String normalizePossibleIdLiteral(ConfigManager config, String idLiteral) {
+		if (isIdLiteral(idLiteral)) {
+			final var entityIdParts = asDotDelimitedLongArray(idLiteral);
+			if (entityIdParts[0] != config.shard().getShardNum() || entityIdParts[1] != config.realm().getRealmNum()) {
+				mismatchedShardRealmMsg(config, Arrays.toString(entityIdParts));
+			}
+
+			return "" + entityIdParts[2];
+		} else {
+			// (FUTURE) Also handle null, empty values
+			return idLiteral;
+		}
+	}
 }

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/util/ParseUtils.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/util/ParseUtils.java
@@ -18,6 +18,7 @@ public class ParseUtils {
 
     /**
      * Parses the key type–ED25519 or SECP256K1–from a string (typically a command line parameter)
+     *
      * @param keyType the key type string
      * @return the corresponding SigControl value, or null if the key type is not one of the expected values
      */
@@ -35,17 +36,23 @@ public class ParseUtils {
         return sigType;
     }
 
+    public static void main(String[] args) {
+        normalizePossibleIdLiteral(null, null);
+    }
+
     /**
      * Takes a string and, IF it is a fully-qualified entity ID, converts the ID to ONLY the third part.
      * For any other values (including `null`), the value passed in will be the value returned.
      * <p>
      * E.g.:
      * <li>
-     *     <ul>`1.2.3` will return `3`</ul>
-     *     <ul>`5` will return `5`</ul>
+     *     <ul>`"1.2.3"` will return `"3"`</ul>
+     *     <ul>`"5"` will return `"5"`</ul>
      *     <ul>`null` will return `null`</ul>
-     *     <ul>`whatever value you want` will return `whatever value you want`</ul>
+     *     <ul>`"null"` will return `"null"`</ul>
+     *     <ul>`"whatever value you want"` will return `"whatever value you want"`</ul>
      * </li>
+     *
      * @param config the yahcli configuration, specifically the target shard and realm.
      *                  Included only to indicate any mismatch to the end user (via console message)
      *
@@ -53,14 +60,14 @@ public class ParseUtils {
      * @return the normalized ID literal, which is a string representation of the entity number
      */
     public static String normalizePossibleIdLiteral(ConfigManager config, String idLiteral) {
-        if (isIdLiteral(idLiteral)) {
+        if (idLiteral != null && isIdLiteral(idLiteral)) {
             final var entityIdParts = asDotDelimitedLongArray(idLiteral);
             if (entityIdParts[0] != config.shard().getShardNum()
                     || entityIdParts[1] != config.realm().getRealmNum()) {
                 mismatchedShardRealmMsg(config, Arrays.toString(entityIdParts));
             }
 
-            return "" + entityIdParts[2];
+            return Long.toString(entityIdParts[2]);
         } else {
             // (FUTURE) Also handle null, empty values
             return idLiteral;

--- a/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/util/ParseUtils.java
+++ b/hedera-node/test-clients/src/yahcli/java/com/hedera/services/yahcli/util/ParseUtils.java
@@ -8,7 +8,6 @@ import static com.hedera.services.yahcli.suites.Utils.mismatchedShardRealmMsg;
 
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.yahcli.config.ConfigManager;
-
 import java.util.Arrays;
 
 public class ParseUtils {
@@ -36,34 +35,35 @@ public class ParseUtils {
         return sigType;
     }
 
-	/**
-	 * Takes a string and, IF it is a fully-qualified entity ID, converts the ID to ONLY the third part.
-	 * For any other values (including `null`), the value passed in will be the value returned.
-	 * <p>
-	 * E.g.:
-	 * <li>
-	 *     <ul>`1.2.3` will return `3`</ul>
-	 *     <ul>`5` will return `5`</ul>
-	 *     <ul>`null` will return `null`</ul>
-	 *     <ul>`whatever value you want` will return `whatever value you want`</ul>
-	 * </li>
-	 * @param config the yahcli configuration, specifically the target shard and realm.
-	 *                  Included only to indicate any mismatch to the end user (via console message)
-	 *
-	 * @param idLiteral the entity ID literal to (possibly) normalize
-	 * @return the normalized ID literal, which is a string representation of the entity number
-	 */
-	public static String normalizePossibleIdLiteral(ConfigManager config, String idLiteral) {
-		if (isIdLiteral(idLiteral)) {
-			final var entityIdParts = asDotDelimitedLongArray(idLiteral);
-			if (entityIdParts[0] != config.shard().getShardNum() || entityIdParts[1] != config.realm().getRealmNum()) {
-				mismatchedShardRealmMsg(config, Arrays.toString(entityIdParts));
-			}
+    /**
+     * Takes a string and, IF it is a fully-qualified entity ID, converts the ID to ONLY the third part.
+     * For any other values (including `null`), the value passed in will be the value returned.
+     * <p>
+     * E.g.:
+     * <li>
+     *     <ul>`1.2.3` will return `3`</ul>
+     *     <ul>`5` will return `5`</ul>
+     *     <ul>`null` will return `null`</ul>
+     *     <ul>`whatever value you want` will return `whatever value you want`</ul>
+     * </li>
+     * @param config the yahcli configuration, specifically the target shard and realm.
+     *                  Included only to indicate any mismatch to the end user (via console message)
+     *
+     * @param idLiteral the entity ID literal to (possibly) normalize
+     * @return the normalized ID literal, which is a string representation of the entity number
+     */
+    public static String normalizePossibleIdLiteral(ConfigManager config, String idLiteral) {
+        if (isIdLiteral(idLiteral)) {
+            final var entityIdParts = asDotDelimitedLongArray(idLiteral);
+            if (entityIdParts[0] != config.shard().getShardNum()
+                    || entityIdParts[1] != config.realm().getRealmNum()) {
+                mismatchedShardRealmMsg(config, Arrays.toString(entityIdParts));
+            }
 
-			return "" + entityIdParts[2];
-		} else {
-			// (FUTURE) Also handle null, empty values
-			return idLiteral;
-		}
-	}
+            return "" + entityIdParts[2];
+        } else {
+            // (FUTURE) Also handle null, empty values
+            return idLiteral;
+        }
+    }
 }

--- a/hedera-node/test-clients/yahcli/run/build.sh
+++ b/hedera-node/test-clients/yahcli/run/build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.7.9'}
+TAG=${1:-'0.7.10'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""

--- a/hedera-node/test-clients/yahcli/run/publish.sh
+++ b/hedera-node/test-clients/yahcli/run/publish.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-TAG=${1:-'0.7.9'}
+TAG=${1:-'0.7.10'}
 SCRIPT_SOURCE="${BASH_SOURCE[0]}"
 
 READLINK_OPTS=""


### PR DESCRIPTION
**Description**:
Yahcli configuration now supports configuring nonzero shard/realm via its config file, but it's still possible to cause unexpected behavior by specifying a fully-qualified entity ID as an input param (for many different commands). This PR accounts for possible ID literals by stripping said literals of their shard/realm, warning the end user with a console message, and falling back to the shard/realm in the configuration.

Also fixes:
* a bug that outputs the wrong shard/realm for a rekey operation
* a bug that outputs `NA` as the system file type for uploading/downloading system files 

Closes #19720 
