### PR TITLE
feat: Config API to make sets deterministic

### DIFF
--- a/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/Configuration.java
+++ b/platform-sdk/swirlds-config-api/src/main/java/com/swirlds/config/api/Configuration.java
@@ -150,6 +150,7 @@ public interface Configuration {
 
     /**
      * Returns a {@link Set} of string elements of the property with the given name.
+     * The set has a stable iteration order.
      *
      * @param propertyName the name of the property
      * @return a {@link Set} of elements of the property with the given name
@@ -162,6 +163,7 @@ public interface Configuration {
 
     /**
      * Returns a {@link Set} of string elements of the property with the given name or the given default {@link Set}.
+     * The set has a stable iteration order.
      *
      * @param propertyName the name of the property
      * @param defaultValue the default {@link Set}
@@ -174,6 +176,7 @@ public interface Configuration {
 
     /**
      * Returns a {@link Set} of elements of the property with the given name.
+     * The set has a stable iteration order.
      *
      * @param propertyName the name of the property
      * @param propertyType the type of the elements
@@ -189,6 +192,7 @@ public interface Configuration {
 
     /**
      * Returns a {@link Set} of elements of the property with the given name or the given default {@link Set}.
+     * The set has a stable iteration order.
      *
      * @param propertyName the name of the property
      * @param propertyType the type of the elements

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigDataFactory.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigDataFactory.java
@@ -12,6 +12,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.ParameterizedType;
 import java.lang.reflect.RecordComponent;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -143,7 +144,8 @@ class ConfigDataFactory {
         }
         return (Set<T>) ConfigListUtils.createList(rawValue).stream()
                 .map(value -> converterService.convert(value, type))
-                .collect(Collectors.toSet());
+                // We want to retain the iteration order of items from the original list, so we use a LinkedHashSet:
+                .collect(Collectors.toCollection(() -> new LinkedHashSet<>()));
     }
 
     @SuppressWarnings("unchecked")

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationImpl.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationImpl.java
@@ -8,6 +8,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
@@ -171,7 +172,6 @@ class ConfigurationImpl implements Configuration, ConfigLifecycle {
      * @param propertyType a non-null type of elements in the collection
      * @return null, or a set with a stable iteration order
      * @param <T> the type of elements in the set
-     * @throws IllegalArgumentException if the type of elements isn't Enum or Comparable
      */
     private <T> Set<T> createStableSet(@Nullable final Collection<T> collection, @NonNull final Class<T> propertyType) {
         if (collection == null) {
@@ -186,7 +186,8 @@ class ConfigurationImpl implements Configuration, ConfigLifecycle {
         if (Comparable.class.isAssignableFrom(propertyType)) {
             return Collections.unmodifiableSortedSet(new TreeSet<>(collection));
         }
-        throw new IllegalArgumentException("Unsupported, not-Comparable property type: " + propertyType);
+        // For non-sortable elements, we retain the order in which they're listed in the original collection
+        return Collections.unmodifiableSet(new LinkedHashSet<>(collection));
     }
 
     @Override

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationImpl.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationImpl.java
@@ -186,7 +186,7 @@ class ConfigurationImpl implements Configuration, ConfigLifecycle {
         if (Comparable.class.isAssignableFrom(propertyType)) {
             return Collections.unmodifiableSortedSet(new TreeSet<>(collection));
         }
-        throw new IllegalArgumentException("Unsupported property type: " + propertyType);
+        throw new IllegalArgumentException("Unsupported, not-Comparable property type: " + propertyType);
     }
 
     @Override

--- a/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationImpl.java
+++ b/platform-sdk/swirlds-config-impl/src/main/java/com/swirlds/config/impl/internal/ConfigurationImpl.java
@@ -6,10 +6,13 @@ import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.stream.Stream;
 
 class ConfigurationImpl implements Configuration, ConfigLifecycle {
@@ -162,23 +165,44 @@ class ConfigurationImpl implements Configuration, ConfigLifecycle {
         return getValues(propertyName, propertyType);
     }
 
+    /**
+     * Creates an immutable set with a stable iteration order out of the provided collection.
+     * @param collection a nullable collection
+     * @param propertyType a non-null type of elements in the collection
+     * @return null, or a set with a stable iteration order
+     * @param <T> the type of elements in the set
+     * @throws IllegalArgumentException if the type of elements isn't Enum or Comparable
+     */
+    private <T> Set<T> createStableSet(@Nullable final Collection<T> collection, @NonNull final Class<T> propertyType) {
+        if (collection == null) {
+            return null;
+        }
+        if (collection.isEmpty()) {
+            return Collections.emptySet();
+        }
+        if (Enum.class.isAssignableFrom(propertyType)) {
+            return Collections.unmodifiableSet(EnumSet.copyOf((Collection<? extends Enum>) collection));
+        }
+        if (Comparable.class.isAssignableFrom(propertyType)) {
+            return Collections.unmodifiableSortedSet(new TreeSet<>(collection));
+        }
+        throw new IllegalArgumentException("Unsupported property type: " + propertyType);
+    }
+
     @Override
     @Nullable
     public Set<String> getValueSet(@NonNull final String propertyName) {
         final List<String> values = getValues(propertyName);
-        if (values == null) {
-            return null;
-        }
-        return Set.copyOf(values);
+        return createStableSet(values, String.class);
     }
 
     @Override
     @Nullable
     public Set<String> getValueSet(@NonNull final String propertyName, @Nullable final Set<String> defaultValue) {
         if (!exists(propertyName)) {
-            return defaultValue;
+            return createStableSet(defaultValue, String.class);
         }
-        return getValueSet(propertyName);
+        return createStableSet(getValues(propertyName), String.class);
     }
 
     @Override
@@ -186,10 +210,7 @@ class ConfigurationImpl implements Configuration, ConfigLifecycle {
     public <T> Set<T> getValueSet(@NonNull final String propertyName, @NonNull final Class<T> propertyType)
             throws NoSuchElementException, IllegalArgumentException {
         final List<T> values = getValues(propertyName, propertyType);
-        if (values == null) {
-            return null;
-        }
-        return Set.copyOf(values);
+        return createStableSet(values, propertyType);
     }
 
     @Override
@@ -200,9 +221,9 @@ class ConfigurationImpl implements Configuration, ConfigLifecycle {
             @Nullable final Set<T> defaultValue)
             throws IllegalArgumentException {
         if (!exists(propertyName)) {
-            return defaultValue;
+            return createStableSet(defaultValue, propertyType);
         }
-        return getValueSet(propertyName, propertyType);
+        return createStableSet(getValues(propertyName, propertyType), propertyType);
     }
 
     @NonNull

--- a/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiSetTests.java
+++ b/platform-sdk/swirlds-config-impl/src/test/java/com/swirlds/config/impl/ConfigApiSetTests.java
@@ -2,6 +2,7 @@
 package com.swirlds.config.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -9,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.extensions.sources.SimpleConfigSource;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
@@ -113,5 +115,73 @@ class ConfigApiSetTests {
         assertThrows(NoSuchElementException.class, () -> configuration.getValueSet("sample.list"));
         assertThrows(NoSuchElementException.class, () -> configuration.getValueSet("sample.list", String.class));
         assertThrows(NoSuchElementException.class, () -> configuration.getValueSet("sample.list", Integer.class));
+    }
+
+    @Test
+    void checkIntegerSetStable() {
+        // given
+        final Configuration configuration = ConfigurationBuilder.create()
+                .withSource(new SimpleConfigSource("testNumbers", "3,1,2"))
+                .build();
+
+        // when
+        final Set<Integer> values = configuration.getValueSet("testNumbers", Integer.class);
+
+        // then
+        final Iterator<Integer> iterator = values.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(1, iterator.next().intValue(), "The set should be stable");
+        assertTrue(iterator.hasNext());
+        assertEquals(2, iterator.next().intValue(), "The set should be stable");
+        assertTrue(iterator.hasNext());
+        assertEquals(3, iterator.next().intValue(), "The set should be stable");
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    void checkStringSetStable() {
+        // given
+        final Configuration configuration = ConfigurationBuilder.create()
+                .withSource(new SimpleConfigSource("testStrings", "x,a,d"))
+                .build();
+
+        // when
+        final Set<String> values = configuration.getValueSet("testStrings", String.class);
+
+        // then
+        final Iterator<String> iterator = values.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals("a", iterator.next(), "The set should be stable");
+        assertTrue(iterator.hasNext());
+        assertEquals("d", iterator.next(), "The set should be stable");
+        assertTrue(iterator.hasNext());
+        assertEquals("x", iterator.next(), "The set should be stable");
+        assertFalse(iterator.hasNext());
+    }
+
+    @Test
+    void checkEnumSetStable() {
+        // given
+        final Configuration configuration = ConfigurationBuilder.create()
+                .withSource(new SimpleConfigSource("testEnums", "x,a,d"))
+                .build();
+        enum TestEnum {
+            d,
+            x,
+            a
+        }
+
+        // when
+        final Set<TestEnum> values = configuration.getValueSet("testEnums", TestEnum.class);
+
+        // then
+        final Iterator<TestEnum> iterator = values.iterator();
+        assertTrue(iterator.hasNext());
+        assertEquals(TestEnum.d, iterator.next(), "The set should be stable");
+        assertTrue(iterator.hasNext());
+        assertEquals(TestEnum.x, iterator.next(), "The set should be stable");
+        assertTrue(iterator.hasNext());
+        assertEquals(TestEnum.a, iterator.next(), "The set should be stable");
+        assertFalse(iterator.hasNext());
     }
 }


### PR DESCRIPTION
**Description**:
To ensure deterministic behavior we're making the Config API return sets with a stable iteration order. See the linked issue for more details.

**Related issue(s)**:

Fixes #19724

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
