### PR TITLE
chore: Update solo to use v0.37.1

### DIFF
--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -110,7 +110,7 @@ jobs:
       # Install solo and configure to use the artifacts from
       # the hiero-consensus-node build
       - name: Install Solo
-        run: npm install -g @hashgraph/solo@0.36.0
+        run: npm install -g @hashgraph/solo@0.37.1
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind


### PR DESCRIPTION
**Description**:

This pull request updates the version of the `@hashgraph/solo` pack  the `.github/workflows/zxc-tck-regression.yaml` file to ensure compatibility with the latest features and fixes.

Dependency update:

* Updated the `@hashgraph/solo` package from version `0.36.0` to `0.37.1` in the `Install Solo` step of the workflow file `.github/workflows/zxc-tck-regression.yaml`.

**Related issue(s)**:

Fixes #19745

**Testing**:
[eXtended Test Suite - Dry Run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/15735890648)
