### PR TITLE
fix: 19748 Fixed `BreakableDataSource` lifecycle management for reconnect tests

### DIFF
--- a/platform-sdk/swirlds-merkle/build.gradle.kts
+++ b/platform-sdk/swirlds-merkle/build.gradle.kts
@@ -27,6 +27,7 @@ timingSensitiveModuleInfo {
     requires("com.swirlds.fchashmap")
     requires("com.swirlds.merkle.test.fixtures")
     requires("com.swirlds.merkledb")
+    requires("com.swirlds.merkledb.test.fixtures")
     requires("com.swirlds.metrics.api")
     requires("com.swirlds.virtualmap")
     requires("org.hiero.base.crypto")

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
@@ -3,13 +3,11 @@ package com.swirlds.virtual.merkle.reconnect;
 
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
-
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
 
@@ -29,8 +27,7 @@ public final class BrokenBuilder implements VirtualDataSourceBuilder {
 
     static final Set<VirtualDataSource> COPIES_TO_DESTROY = ConcurrentHashMap.newKeySet();
 
-    public BrokenBuilder() {
-    }
+    public BrokenBuilder() {}
 
     public BrokenBuilder(VirtualDataSourceBuilder delegate) {
         this.delegate = delegate;

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/BrokenBuilder.java
@@ -3,10 +3,13 @@ package com.swirlds.virtual.merkle.reconnect;
 
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
+
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Iterator;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
 
@@ -24,9 +27,10 @@ public final class BrokenBuilder implements VirtualDataSourceBuilder {
     volatile int numCalls = 0;
     volatile int numTimesBroken = 0;
 
-    static volatile Set<VirtualDataSource> COPIES_TO_DESTROY = ConcurrentHashMap.newKeySet();
+    static final Set<VirtualDataSource> COPIES_TO_DESTROY = ConcurrentHashMap.newKeySet();
 
-    public BrokenBuilder() {}
+    public BrokenBuilder() {
+    }
 
     public BrokenBuilder(VirtualDataSourceBuilder delegate) {
         this.delegate = delegate;
@@ -100,12 +104,14 @@ public final class BrokenBuilder implements VirtualDataSourceBuilder {
     }
 
     public static void closeDatasourceCopies() {
-        COPIES_TO_DESTROY.forEach(v -> {
+        Iterator<VirtualDataSource> iterator = COPIES_TO_DESTROY.iterator();
+        while (iterator.hasNext()) {
             try {
-                v.close();
+                iterator.next().close();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
-        });
+            iterator.remove();
+        }
     }
 }

--- a/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-merkle/src/timingSensitive/java/com/swirlds/virtual/merkle/reconnect/VirtualMapReconnectTestBase.java
@@ -21,6 +21,7 @@ import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import com.swirlds.merkledb.MerkleDb;
 import com.swirlds.merkledb.MerkleDbDataSourceBuilder;
 import com.swirlds.merkledb.MerkleDbTableConfig;
+import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
 import com.swirlds.virtual.merkle.TestKey;
 import com.swirlds.virtual.merkle.TestKeySerializer;
 import com.swirlds.virtual.merkle.TestValue;
@@ -41,6 +42,7 @@ import org.hiero.base.constructable.ClassConstructorPair;
 import org.hiero.base.constructable.ConstructableRegistry;
 import org.hiero.base.constructable.ConstructableRegistryException;
 import org.hiero.base.crypto.DigestType;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 
@@ -237,5 +239,11 @@ public class VirtualMapReconnectTestBase {
             brokenTeacherTree.release();
             copy.release();
         }
+    }
+
+    @AfterEach
+    public void tearDown() {
+        BrokenBuilder.closeDatasourceCopies();
+        MerkleDbTestUtils.assertAllDatabasesClosed();
     }
 }


### PR DESCRIPTION
**Description**:

This PR makes sure that instances `BreakableDataSource` instances get released. If not done properly, it may cause OOM errors. 

**Related issue(s)**:

Fixes #19748 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
