### PR TITLE
feat: Separate configuration for Mac PcesWriter, due to difference in performance between platforms

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/CommonPcesWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/CommonPcesWriter.java
@@ -124,7 +124,15 @@ public class CommonPcesWriter {
         spanOverlapFactor = pcesConfig.spanOverlapFactor();
         minimumSpan = pcesConfig.minimumSpan();
         preferredFileSizeMegabytes = pcesConfig.preferredFileSizeMegabytes();
-        pcesFileWriterType = pcesConfig.pcesFileWriterType();
+
+        // performance of FILE_CHANNEL is 150x slower on MacOS, but marginally better on Linux; it is so bad on Mac
+        // that basic tests cannot pass in some cases, so we need to make it system dependent, at same time allowing
+        // override if needed
+        if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+            pcesFileWriterType = pcesConfig.macPcesFileWriterType();
+        } else {
+            pcesFileWriterType = pcesConfig.pcesFileWriterType();
+        }
 
         averageSpanUtilization = new LongRunningAverage(pcesConfig.spanUtilizationRunningAverageLength());
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
@@ -74,6 +74,8 @@ import java.time.Duration;
  * @param maxEventReplayFrequency              the maximum number of events that can be replayed per second
  * @param inlinePcesSyncOption                 when to sync the preconsensus event file to disk (applies only to inline
  *                                             PCES)
+ * @param pcesFileWriterType                   type of pces writer to be used in default environment (Linux for now, Mac has its override at {@link #macPcesFileWriterType}
+ * @param macPcesFileWriterType                override for pcesFileWriterType to be used on Mac, as FileChannel is 150x slower there
  */
 @ConfigData("event.preconsensus")
 public record PcesConfig(
@@ -98,4 +100,5 @@ public record PcesConfig(
         @ConfigProperty(defaultValue = "true") boolean limitReplayFrequency,
         @ConfigProperty(defaultValue = "5000") int maxEventReplayFrequency,
         @ConfigProperty(defaultValue = "EVERY_EVENT") FileSyncOption inlinePcesSyncOption,
-        @ConfigProperty(defaultValue = "FILE_CHANNEL_SYNC") PcesFileWriterType pcesFileWriterType) {}
+        @ConfigProperty(defaultValue = "FILE_CHANNEL_SYNC") PcesFileWriterType pcesFileWriterType,
+        @ConfigProperty(defaultValue = "OUTPUT_STREAM") PcesFileWriterType macPcesFileWriterType) {}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileWriterType.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileWriterType.java
@@ -17,6 +17,7 @@ public enum PcesFileWriterType {
 
     /**
      * Creates the right instance of the PcesFileWriter for the type represented by this enum
+     *
      * @param path the path to the file to write to
      * @return the writer for writing PCES files
      * @throws IOException in case of error when creating the writer


### PR DESCRIPTION
**Description**:

Performance of FILE_CHANNEL is 150x slower on MacOS, but marginally better on Linux; it is so bad on Mac that basic tests cannot pass in some cases, so we need to make it system dependent, at the same time allowing override if needed

Extra setting just for mac is added, so values can be overwritten depending on the platform, without affecting each other.


**Related issue(s)**:

Fixes #19761 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
