### PR TITLE
chore: Remove gracefulShutdown from Otter interface

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/AsyncNodeActions.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/AsyncNodeActions.java
@@ -17,15 +17,6 @@ public interface AsyncNodeActions {
     void killImmediately() throws InterruptedException;
 
     /**
-     * Shutdown the node gracefully with the configured timeout.
-     *
-     * @see Node#shutdownGracefully()
-     *
-     * @throws InterruptedException if the thread is interrupted while waiting
-     */
-    void shutdownGracefully() throws InterruptedException;
-
-    /**
      * Start the node with the configured timeout.
      *
      * @see Node#start()

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Node.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Node.java
@@ -29,8 +29,7 @@ public interface Node {
      * Kill the node without prior cleanup.
      *
      * <p>This method simulates a sudden failure of the node. No attempt to finish ongoing work,
-     * preserve the current state, or any other similar operation is made. To simulate a graceful
-     * shutdown, use {@link #shutdownGracefully()} instead.
+     * preserve the current state, or any other similar operation is made.
      *
      * <p>The method will wait for a environment-specific timeout before throwing an exception if the nodes cannot be
      * killed. The default can be overridden by calling {@link #withTimeout(Duration)}.
@@ -38,21 +37,6 @@ public interface Node {
      * @throws InterruptedException if the thread is interrupted while waiting
      */
     void killImmediately() throws InterruptedException;
-
-    /**
-     * Shutdown the node gracefully.
-     *
-     * <p>This method simulates a graceful shutdown of the node. It allows the node to finish any
-     * ongoing work, preserve the current state, and perform any other necessary cleanup operations
-     * before shutting down. If the simulation of a sudden failure is desired, use
-     * {@link #killImmediately()} instead.
-     *
-     * <p>The method will wait for a environment-specific timeout before throwing an exception if the nodes cannot be
-     * shut down. The default can be overridden by calling {@link #withTimeout(Duration)}.
-     *
-     * @throws InterruptedException if the thread is interrupted while waiting
-     */
-    void shutdownGracefully() throws InterruptedException;
 
     /**
      * Start the node.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/solo/SoloNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/solo/SoloNode.java
@@ -55,14 +55,6 @@ public class SoloNode implements Node {
      * {@inheritDoc}
      */
     @Override
-    public void shutdownGracefully() throws InterruptedException {
-        defaultAsyncAction.shutdownGracefully();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void start() throws InterruptedException {
         defaultAsyncAction.start();
     }
@@ -202,14 +194,6 @@ public class SoloNode implements Node {
          */
         @Override
         public void start() throws InterruptedException {
-            throw new UnsupportedOperationException("Not implemented yet!");
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public void shutdownGracefully() throws InterruptedException {
             throw new UnsupportedOperationException("Not implemented yet!");
         }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -221,24 +221,6 @@ public class TurtleNode implements Node, TurtleTimeManager.TimeTickReceiver {
      * {@inheritDoc}
      */
     @Override
-    public void shutdownGracefully() throws InterruptedException {
-        try {
-            ThreadContext.put(THREAD_CONTEXT_NODE_ID, selfId.toString());
-
-            if (platformWiring != null) {
-                platformWiring.flushIntakePipeline();
-            }
-            doShutdownNode();
-
-        } finally {
-            ThreadContext.remove(THREAD_CONTEXT_NODE_ID);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
     public void start() {
         try {
             ThreadContext.put(THREAD_CONTEXT_NODE_ID, selfId.toString());
@@ -478,14 +460,6 @@ public class TurtleNode implements Node, TurtleTimeManager.TimeTickReceiver {
         @Override
         public void killImmediately() throws InterruptedException {
             TurtleNode.this.killImmediately();
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public void shutdownGracefully() throws InterruptedException {
-            TurtleNode.this.shutdownGracefully();
         }
 
         /**


### PR DESCRIPTION
Fixes #19473
