### PR TITLE
feat: Apply EIP-3529 refund limits

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/TestHelpers.java
@@ -152,7 +152,7 @@ public class TestHelpers {
             .getOrCreateConfig();
     public static final ContractsConfig DEV_CHAIN_ID_CONTRACTS_CONFIG =
             DEV_CHAIN_ID_CONFIG.getConfigData(ContractsConfig.class);
-    public static final int HEDERA_MAX_REFUND_PERCENTAGE = 20;
+    public static final int HEDERA_MAX_REFUND_PERCENTAGE = 100;
     public static final Instant ETERNAL_NOW = Instant.ofEpochSecond(1_234_567L, 890);
     public static final Key AN_ED25519_KEY = Key.newBuilder()
             .ed25519(Bytes.fromHex("0101010101010101010101010101010101010101010101010101010101010101"))
@@ -179,7 +179,7 @@ public class TestHelpers {
     public static final long USER_OFFERED_GAS_PRICE = 666;
     public static final long NETWORK_GAS_PRICE = 777;
     public static final Wei WEI_NETWORK_GAS_PRICE = Wei.of(NETWORK_GAS_PRICE);
-    public static final long BESU_MAX_REFUND_QUOTIENT = 2;
+    public static final long BESU_MAX_REFUND_QUOTIENT = 5;
     public static final long MAX_GAS_ALLOWANCE = 666_666_666;
     public static final int STACK_DEPTH = 1;
     public static final Bytes INITCODE = Bytes.wrap("0060a06040526000600b55".getBytes());

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/FrameRunnerTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/FrameRunnerTest.java
@@ -48,7 +48,6 @@ import java.util.ArrayDeque;
 import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Wei;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -63,6 +62,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class FrameRunnerTest {
+
+    private static final long EXPECTED_GAS_USED_NO_REFUNDS = 400000;
+
     @Mock
     private MessageFrame frame;
 
@@ -108,6 +110,13 @@ class FrameRunnerTest {
                 .build();
         given(entityIdFactory.newContractIdWithEvmAddress(any())).willReturn(contractId);
 
+        // Gas refund setup
+        final var nominalRefund = 500_000L;
+        final var nominalGasUsed = 500_000L;
+        final var expectedGasUsedPostRefunds = nominalGasUsed - nominalRefund / BESU_MAX_REFUND_QUOTIENT;
+        given(frame.getRemainingGas()).willReturn(GAS_LIMIT - nominalGasUsed);
+        given(frame.getGasRefund()).willReturn(nominalRefund);
+
         final var result = subject.runToCompletion(
                 GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor);
 
@@ -117,12 +126,12 @@ class FrameRunnerTest {
         inOrder.verify(tracer).sanitizeTracedActions(frame);
 
         assertTrue(result.isSuccess());
-        assertEquals(expectedGasUsed(frame), result.gasUsed());
+        assertEquals(expectedGasUsedPostRefunds, result.gasUsed());
         assertEquals(List.of(BESU_LOG), result.logs());
         assertEquals(CALLED_CONTRACT_ID, result.recipientId());
         assertEquals(CALLED_CONTRACT_EVM_ADDRESS, result.recipientEvmAddress());
 
-        assertSuccessExpectationsWith(CALLED_CONTRACT_ID, CALLED_CONTRACT_EVM_ADDRESS, frame, result);
+        assertSuccessExpectationsWith(CALLED_CONTRACT_ID, CALLED_CONTRACT_EVM_ADDRESS, result);
     }
 
     @Test
@@ -140,12 +149,13 @@ class FrameRunnerTest {
                 GAS_LIMIT, SENDER_ID, frame, tracer, messageCallProcessor, contractCreationProcessor);
 
         inOrder.verify(tracer).traceOriginAction(frame);
+        assertEquals(EXPECTED_GAS_USED_NO_REFUNDS, result.gasUsed());
         inOrder.verify(contractCreationProcessor).process(frame, tracer);
         inOrder.verify(messageCallProcessor).process(childFrame, tracer);
         inOrder.verify(tracer).sanitizeTracedActions(frame);
 
         assertSuccessExpectationsWith(
-                NON_SYSTEM_CONTRACT_ID, asEvmContractId(entityIdFactory, NON_SYSTEM_LONG_ZERO_ADDRESS), frame, result);
+                NON_SYSTEM_CONTRACT_ID, asEvmContractId(entityIdFactory, NON_SYSTEM_LONG_ZERO_ADDRESS), result);
     }
 
     @Test
@@ -254,10 +264,8 @@ class FrameRunnerTest {
     private void assertSuccessExpectationsWith(
             @NonNull final ContractID expectedReceiverId,
             @NonNull final ContractID expectedReceiverAddress,
-            @NonNull final MessageFrame frame,
             @NonNull final HederaEvmTransactionResult result) {
         assertTrue(result.isSuccess());
-        assertEquals(expectedGasUsed(frame), result.gasUsed());
         assertEquals(List.of(BESU_LOG), result.logs());
         assertEquals(expectedReceiverId, result.recipientId());
         assertEquals(expectedReceiverAddress, result.recipientEvmAddress());
@@ -267,7 +275,7 @@ class FrameRunnerTest {
     private void assertFailureExpectationsWith(
             @NonNull final MessageFrame frame, @NonNull final HederaEvmTransactionResult result) {
         assertFalse(result.isSuccess());
-        assertEquals(expectedGasUsed(frame), result.gasUsed());
+        assertEquals(EXPECTED_GAS_USED_NO_REFUNDS, result.gasUsed());
         assertEquals(Bytes.EMPTY, result.output());
     }
 
@@ -305,10 +313,8 @@ class FrameRunnerTest {
                 })
                 .when(messageCallProcessor)
                 .process(childFrame, tracer);
-        given(gasCalculator.getSelfDestructRefundAmount()).willReturn(GAS_LIMIT / 32);
         given(gasCalculator.getMaxRefundQuotient()).willReturn(BESU_MAX_REFUND_QUOTIENT);
         given(frame.getRemainingGas()).willReturn(GAS_LIMIT / 2);
-        given(frame.getSelfDestructs()).willReturn(Set.of(EIP_1014_ADDRESS, NON_SYSTEM_LONG_ZERO_ADDRESS));
         given(frame.getGasRefund()).willReturn(GAS_LIMIT / 8);
         final var config = HederaTestConfigBuilder.create()
                 .withValue("contracts.maxRefundPercentOfGasLimit", HEDERA_MAX_REFUND_PERCENTAGE)
@@ -331,13 +337,5 @@ class FrameRunnerTest {
                 .evmAddress(Bytes.wrap(receiver.toArray()))
                 .build();
         given(childFrame.getMessageFrameStack()).willReturn(messageFrameStack);
-    }
-
-    private long expectedGasUsed(@NonNull final MessageFrame frame) {
-        var nominalUsage = GAS_LIMIT - frame.getRemainingGas();
-        final var selfDestructRefund = gasCalculator.getSelfDestructRefundAmount()
-                * Math.min(frame.getSelfDestructs().size(), nominalUsage / gasCalculator.getMaxRefundQuotient());
-        nominalUsage -= (selfDestructRefund + frame.getGasRefund());
-        return Math.max(nominalUsage, GAS_LIMIT - GAS_LIMIT * HEDERA_MAX_REFUND_PERCENTAGE / 100);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/LeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/LeakyContractTestsSuite.java
@@ -778,8 +778,8 @@ public class LeakyContractTestsSuite {
                             .getContractCallResult()
                             .getGasUsed();
 
-                    Assertions.assertTrue(gasUsedForTemporaryHoldTx < 23739L);
-                    Assertions.assertTrue(gasUsedForPermanentHoldTx > 20000L);
+                    Assertions.assertTrue(gasUsedForTemporaryHoldTx < 35000L);
+                    Assertions.assertTrue(gasUsedForPermanentHoldTx > 40000L);
                 }));
     }
 


### PR DESCRIPTION
Addresses https://github.com/hiero-ledger/hiero-consensus-node/issues/19732 (a subtask of https://github.com/hiero-ledger/hiero-consensus-node/issues/19176).

Summary of changes:
- Post [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) selfdestruct refund has been removed - I do so in this PR (its value was always `0` anyway, so no functional difference in that regard)
- [EIP-3529](https://eips.ethereum.org/EIPS/eip-3529) specifies a limit on the total gas refund amount (1/5th of gas used). We used to apply it wrongly - only to the selfdestruct component, while SSTORE refund was unlimited. I fix it in this PR.
- I've updated the tests. The "temporary hold" scenario falls under this path: " .... If original value is 0, add SSTORE_SET_GAS - SLOAD_GAS to refund counter." in [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200), and it's now being limited correctly.

As a side note, the Hedera-specific limit (80% of gasLimit) is to be lifted soon - it was decided to keep its implementation in the code and only update the config parameter (`maxRefundPercentOfGasLimit`) - to be done (or already done?) in a separate PR.

I have run the gas testing script mentioned in https://github.com/hiero-ledger/hiero-consensus-node/issues/19176 against my local node running this branch and the erc721 burn scenario gas usage now matches between Hedera and Sepolia.

Fixes: #19732 