### PR TITLE
test: Fix HapiTest logs

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -190,6 +190,7 @@ tasks.register<Test>("testSubprocessWithBlockNodeSimulator") {
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
     maxParallelForks = 1
+    modularity.inferModulePath.set(false)
 }
 
 tasks.register<Test>("testSubprocess") {
@@ -455,6 +456,7 @@ tasks.register<Test>("testRepeatable") {
     // Limit heap and number of processors
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
+    modularity.inferModulePath.set(false)
 }
 
 application.mainClass = "com.hedera.services.bdd.suites.SuiteRunner"

--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -295,6 +295,7 @@ tasks.register<Test>("testSubprocess") {
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
     maxParallelForks = 1
+    modularity.inferModulePath.set(false)
 }
 
 tasks.register<Test>("testRemote") {
@@ -410,6 +411,7 @@ tasks.register<Test>("testEmbedded") {
     // Limit heap and number of processors
     maxHeapSize = "8g"
     jvmArgs("-XX:ActiveProcessorCount=6")
+    modularity.inferModulePath.set(false)
 }
 
 val prRepeatableCheckTags = mapOf("hapiRepeatableMisc" to "REPEATABLE")


### PR DESCRIPTION
**Description**:

1. Fixed log outputs for Hapi tests to ensure logs are displayed in the correct console output
(see [#19786](https://github.com/hiero-ledger/hiero-consensus-node/issues/19786) for more details).
2. Set `modularity.inferModulePath` to `false` for:
	•	`testEmbedded`
	•	`testRepeatable`
	•	`testSubprocess`

**Related issue(s)**:
https://github.com/hiero-ledger/hiero-consensus-node/issues/19786
Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
