### PR TITLE
fix: Update expiration time handling in file create

### DIFF
--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileCreateTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/handlers/FileCreateTest.java
@@ -261,21 +261,6 @@ class FileCreateTest extends FileTestBase {
     }
 
     @Test
-    @DisplayName("Translates INVALID_EXPIRATION_TIME to AUTO_RENEW_DURATION_NOT_IN_RANGE")
-    void translatesInvalidExpiryException() {
-        final var txBody = newCreateTxn(keys, expirationTime, SHARD, REALM);
-
-        given(handleContext.body()).willReturn(txBody);
-        given(handleContext.expiryValidator()).willReturn(expiryValidator);
-        given(storeFactory.writableStore(WritableFileStore.class)).willReturn(writableStore);
-        given(expiryValidator.resolveCreationAttempt(anyBoolean(), any(), any()))
-                .willThrow(new HandleException(ResponseCodeEnum.INVALID_EXPIRATION_TIME));
-
-        final var failure = assertThrows(HandleException.class, () -> subject.handle(handleContext));
-        assertEquals(ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE, failure.getStatus());
-    }
-
-    @Test
     @DisplayName("Memo Validation Failure will throw")
     void handleThrowsIfAttributeValidatorFails() {
         final var keys = anotherKeys;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileCreateSuite.java
@@ -33,7 +33,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.FEE_SCHEDULE;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.NODE_DETAILS;
 import static com.hedera.services.bdd.suites.HapiSuite.ZERO_BYTE_MEMO;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_FILE_ID;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
@@ -53,7 +53,6 @@ import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.CurrentAndNextFeeSchedule;
 import com.hederahashgraph.api.proto.java.ExchangeRateSet;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
-import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ServicesConfigurationList;
 import com.hederahashgraph.api.proto.java.Transaction;
 import java.nio.file.Path;
@@ -80,7 +79,7 @@ public class FileCreateSuite {
     final Stream<DynamicTest> createFailsWithExcessiveLifetime() {
         return hapiTest(doWithStartupConfig("entities.maxLifetime", value -> fileCreate("test")
                 .lifetime(Long.parseLong(value) + 12_345L)
-                .hasPrecheck(AUTORENEW_DURATION_NOT_IN_RANGE)));
+                .hasPrecheck(INVALID_EXPIRATION_TIME)));
     }
 
     @HapiTest
@@ -141,8 +140,7 @@ public class FileCreateSuite {
         var now = Instant.now();
         System.out.println(now.getEpochSecond());
 
-        return hapiTest(
-                fileCreate("notHere").lifetime(-60L).hasPrecheck(ResponseCodeEnum.AUTORENEW_DURATION_NOT_IN_RANGE));
+        return hapiTest(fileCreate("notHere").lifetime(-60L).hasPrecheck(INVALID_EXPIRATION_TIME));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
Update `fileCreate() `error handling to return proper error when giving invalid expiration time.
The current impementation of returning `AUTORENEW_DURATION_NOT_IN_RANGE` was created for mono parity testing.

**Related issue(s)**:

Fixes #
https://github.com/hiero-ledger/hiero-consensus-node/issues/19791
**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
