### PR TITLE
feat: Enable web proxy endpoints by default

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NodesConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NodesConfig.java
@@ -41,4 +41,4 @@ public record NodesConfig(
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean adjustNodeFees,
         @ConfigProperty(defaultValue = "10") @NetworkProperty int activeRoundsPercent,
         @ConfigProperty(defaultValue = "true") @NetworkProperty boolean preserveMinNodeRewardBalance,
-        @ConfigProperty(defaultValue = "false") @NetworkProperty boolean webProxyEndpointsEnabled) {}
+        @ConfigProperty(defaultValue = "true") @NetworkProperty boolean webProxyEndpointsEnabled) {}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeCreateTest.java
@@ -346,11 +346,11 @@ public class NodeCreateTest {
                 }));
     }
 
-    @LeakyHapiTest(overrides = {"nodes.gossipFqdnRestricted"})
+    @LeakyHapiTest(overrides = {"nodes.gossipFqdnRestricted", "nodes.webProxyEndpointsEnabled"})
     final Stream<DynamicTest> webProxySetWhenNotEnabledReturnsNotSupported() throws CertificateEncodingException {
         final var nodeCreate = canonicalNodeCreate();
         return hapiTest(
-                overriding("nodes.gossipFqdnRestricted", "false"),
+                overridingTwo("nodes.gossipFqdnRestricted", "false", "nodes.webProxyEndpointsEnabled", "false"),
                 newKeyNamed(ED_25519_KEY).shape(KeyShape.ED25519),
                 nodeCreate.hasKnownStatus(GRPC_WEB_PROXY_NOT_SUPPORTED));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeUpdateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeUpdateTest.java
@@ -174,9 +174,12 @@ public class NodeUpdateTest {
                         .hasKnownStatus(INVALID_SERVICE_ENDPOINT));
     }
 
-    @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
+    @LeakyEmbeddedHapiTest(
+            reason = NEEDS_STATE_ACCESS,
+            overrides = {"nodes.webProxyEndpointsEnabled"})
     final Stream<DynamicTest> cantUpdateGrpcProxyEndpointIfDisabled() throws CertificateEncodingException {
         return hapiTest(
+                overriding("nodes.webProxyEndpointsEnabled", "false"),
                 newKeyNamed("adminKey"),
                 nodeCreate("testNode")
                         .adminKey("adminKey")


### PR DESCRIPTION
Now that the feature is better tested, we want the gRPC web proxy feature flag to be enabled by default. This PR enables it as the default in `NodesConfig`. 