### PR TITLE
fix: (cherry-pick 0.63): Allow erasure of web proxy via node update

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/node_update.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/node_update.proto
@@ -162,7 +162,9 @@ message NodeUpdateTransactionBody {
      * This endpoint MUST use a valid port and SHALL be reachable over TLS.<br/>
      * This field MAY be omitted if the node does not support gRPC-Web access.<br/>
      * This field MUST be updated if the gRPC-Web endpoint changes.<br/>
-     * This field SHALL enable frontend clients to avoid hard-coded proxy endpoints.
+     * This field SHALL enable frontend clients to avoid hard-coded proxy endpoints.<br/>
+     * This field MAY be set to `ServiceEndpoint.DEFAULT` to remove a previously-valid
+     * web proxy.
      */
     proto.ServiceEndpoint grpc_proxy_endpoint = 10;
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeUpdateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/NodeUpdateTest.java
@@ -43,6 +43,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SERVICE_ENDPOI
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UPDATE_NODE_ACCOUNT_NOT_ALLOWED;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -51,7 +52,6 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hederahashgraph.api.proto.java.ServiceEndpoint;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.List;
@@ -354,19 +354,43 @@ public class NodeUpdateTest {
                         .hasKnownStatus(GOSSIP_ENDPOINTS_EXCEEDED_LIMIT));
     }
 
-    @LeakyHapiTest(overrides = {"nodes.webProxyEndpointsEnabled"})
-    final Stream<DynamicTest> updateWithDefaultGrpcProxyFails() throws CertificateEncodingException {
+    @LeakyEmbeddedHapiTest(
+            reason = NEEDS_STATE_ACCESS,
+            overrides = {"nodes.webProxyEndpointsEnabled"})
+    final Stream<DynamicTest> sentinelUnsetsGrpcWebProxyEndpoint() throws CertificateEncodingException {
         return hapiTest(
                 overriding("nodes.webProxyEndpointsEnabled", "true"),
                 newKeyNamed("adminKey"),
                 nodeCreate("testNode")
                         .adminKey("adminKey")
                         .gossipCaCertificate(gossipCertificates.getFirst().getEncoded())
+                        .grpcWebProxyEndpoint(GRPC_PROXY_ENDPOINT_FQDN)
                         .description("newNode"),
+                viewNode("testNode", node -> assertNotNull(node.grpcProxyEndpoint())),
                 nodeUpdate("testNode")
-                        .grpcProxyEndpoint(toPbj(ServiceEndpoint.getDefaultInstance()))
-                        .signedBy("adminKey", DEFAULT_PAYER)
-                        .hasKnownStatus(INVALID_ENDPOINT));
+                        .grpcProxyEndpoint(com.hedera.hapi.node.base.ServiceEndpoint.DEFAULT)
+                        .description("updatedNode")
+                        .signedByPayerAnd("adminKey"),
+                viewNode("testNode", node -> assertNull(node.grpcProxyEndpoint())));
+    }
+
+    @LeakyEmbeddedHapiTest(
+            reason = NEEDS_STATE_ACCESS,
+            overrides = {"nodes.webProxyEndpointsEnabled"})
+    final Stream<DynamicTest> unsetGrpcProxyFieldDoesntEraseExistingGrpcProxy() throws CertificateEncodingException {
+        return hapiTest(
+                overriding("nodes.webProxyEndpointsEnabled", "true"),
+                newKeyNamed("adminKey"),
+                nodeCreate("testNode")
+                        .adminKey("adminKey")
+                        .gossipCaCertificate(gossipCertificates.getFirst().getEncoded())
+                        .grpcWebProxyEndpoint(GRPC_PROXY_ENDPOINT_FQDN)
+                        .description("newNode"),
+                viewNode("testNode", node -> assertNotNull(node.grpcProxyEndpoint())),
+                nodeUpdate("testNode")
+                        .description("arbitrary update of something other than the grpc proxy endpoint")
+                        .signedByPayerAnd("adminKey"),
+                viewNode("testNode", node -> assertNotNull(node.grpcProxyEndpoint())));
     }
 
     @LeakyHapiTest(overrides = {"nodes.nodeMaxDescriptionUtf8Bytes"})


### PR DESCRIPTION
Cherry-picks ability to remove a web proxy endpoint. Depends on merging [this PR](https://github.com/hiero-ledger/hiero-consensus-node/pull/19797) first. 

Original PR to main [here](https://github.com/hiero-ledger/hiero-consensus-node/pull/19795)