### PR TITLE
chore: make nigthly tests use latest build tag instead of commit

### DIFF
--- a/.github/workflows/flow-node-performance-tests.yaml
+++ b/.github/workflows/flow-node-performance-tests.yaml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
 
       - name: Authenticate to Google Cloud
         uses: step-security/google-github-auth@40f6deebd366f16c782d7a0ad0844e3b96a032a6 # v2.1.10
@@ -58,7 +60,12 @@ jobs:
           BRANCH_NAME_SAFE="$(echo "${BRANCH_NAME_LOWER}" | tr '/' '-' | tr '_' '.')"
 
           echo "branch-name-lower=${BRANCH_NAME_LOWER}" >>"${GITHUB_OUTPUT}"
-          echo "commit-id-short=$(echo "${{ github.sha }}" | cut -c1-8)" >>"${GITHUB_OUTPUT}"
+
+          LATEST_BUILD_TAG=$(git tag --sort=-creatordate | grep -E '^build-[0-9]+$' | head -n 1)
+          TAG_COMMIT_SHA=$(git rev-list -n 1 $LATEST_BUILD_TAG)
+          TAG_COMMIT_SHORT=$(echo $TAG_COMMIT_SHA | cut -c1-8)
+
+          echo "commit-id-short=$TAG_COMMIT_SHORT" >> "${GITHUB_OUTPUT}"
 
       - name: Check If Release Artifact Exist in Bucket
         id: check-if-exist


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

This PR introduces a small change that would make the nightly performance tests use the latest `build-xxxxx` tag as the source of the commit id for the build artifact used for the tests.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
