### PR TITLE
chore: Add otter tests to the MATS unit test section on main

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -18,6 +18,11 @@ on:
         type: boolean
         required: false
         default: true
+      enable-otter-tests:
+        description: "Otter Testing Enabled"
+        type: boolean
+        required: false
+        default: true
       enable-snyk-scan:
         description: "Snyk Scan Enabled"
         type: boolean
@@ -130,6 +135,7 @@ jobs:
       enable-hapi-tests-nd-reconnect: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
       enable-spotless-check: ${{ github.event_name == 'push' || github.event.inputs.enable-spotless-check == 'true' }}
       enable-snyk-scan: ${{ github.event_name == 'push' || github.event.inputs.enable-snyk-scan == 'true' }}
+      enable-otter-tests: ${{ github.event_name == 'push' || github.event.inputs.enable-otter-tests == 'true' }}
       enable-network-log-capture: true
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**Description**:

This pull request updates the `.github/workflows/node-flow-build-application.yaml` file to add support for enabling Otter tests as part of the workflow configuration. 

Workflow configuration updates:

* Added a new input parameter `enable-otter-tests` with a description, type, and default value to the workflow inputs section.
* Updated the `jobs` section to include a conditional for enabling Otter tests based on the `github.event_name` or the `enable-otter-tests` input parameter.

**Related Issue(s)**:

Closes #19829