### PR TITLE
feat: replace hashmap with an array to improve performace for ops duration lookups

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEVM.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEVM.java
@@ -4,7 +4,6 @@ package com.hedera.node.app.service.contract.impl.hevm;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.checkHederaOpsDuration;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.getHederaOpsDuration;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.incrementOpsDuration;
-import static com.hedera.node.app.service.contract.impl.hevm.HederaOpsDuration.MULTIPLIER_FACTOR;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Optional;
@@ -104,6 +103,7 @@ public class HederaEVM extends EVM {
         long usedOpsDuration = 0;
         final long currentOpsDuration = getHederaOpsDuration(frame);
         final long hederaOpsDurationShift = this.hederaOpsDuration.durationCheckShift();
+        final long[] opsDurationArray = this.hederaOpsDuration.getOpsDuration();
 
         while (frame.getState() == State.CODE_EXECUTING) {
             int pc = frame.getPC();
@@ -216,11 +216,9 @@ public class HederaEVM extends EVM {
                  ** As the code is in a while loop it is difficult to isolate.  We will need to maintain these changes
                  ** against new versions of the EVM class.
                  */
-                usedOpsDuration += hederaOpsDuration
-                        .getOpsDuration()
-                        .getOrDefault(
-                                opcode,
-                                result.getGasCost() * hederaOpsDuration.opsDurationMultiplier() / MULTIPLIER_FACTOR);
+                usedOpsDuration += opsDurationArray[opcode] == 0
+                        ? result.getGasCost() * hederaOpsDuration.opsDurationMultiplier()
+                        : opsDurationArray[opcode];
 
                 // Check the duration of the operations every durationCheckShift opcodes.
                 // This is to avoid checking the duration too frequently and slowing down execution.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaOpsDuration.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaOpsDuration.java
@@ -18,25 +18,22 @@ public class HederaOpsDuration {
     // As floating point values cannot be used, we use a factor of 100 to use integers.
     public static final long MULTIPLIER_FACTOR = 100;
 
-    private final Map<Integer, Long> opsDuration = new HashMap<>();
+    private final long[] opsDuration = new long[256];
     private final Map<String, Long> gasBasedDurationMultiplier = new HashMap<>();
 
     public void applyDurationFromConfig(@NonNull final OpsDurationConfig opsDurationConfig) {
         opsDurationConfig
                 .opsDurations1_to_64()
-                .forEach(opsDurPair -> opsDuration.put(opsDurPair.left().intValue(), opsDurPair.right()));
+                .forEach(opsDurationPair -> opsDuration[opsDurationPair.left().intValue()] = opsDurationPair.right());
         opsDurationConfig
                 .opsDurations65_to_128()
-                .forEach(opsDurationPair ->
-                        opsDuration.put(opsDurationPair.left().intValue(), opsDurationPair.right()));
+                .forEach(opsDurationPair -> opsDuration[opsDurationPair.left().intValue()] = opsDurationPair.right());
         opsDurationConfig
                 .opsDurations129_to_192()
-                .forEach(opsDurationPair ->
-                        opsDuration.put(opsDurationPair.left().intValue(), opsDurationPair.right()));
+                .forEach(opsDurationPair -> opsDuration[opsDurationPair.left().intValue()] = opsDurationPair.right());
         opsDurationConfig
                 .opsDurations193_to_256()
-                .forEach(opsDurationPair ->
-                        opsDuration.put(opsDurationPair.left().intValue(), opsDurationPair.right()));
+                .forEach(opsDurationPair -> opsDuration[opsDurationPair.left().intValue()] = opsDurationPair.right());
         gasBasedDurationMultiplier.put(OP_DURATION_MULTIPLIER_KEY, opsDurationConfig.opsGasBasedDurationMultiplier());
         gasBasedDurationMultiplier.put(
                 PRECOMPILE_MULTIPLIER_KEY, opsDurationConfig.precompileGasBasedDurationMultiplier());
@@ -44,7 +41,7 @@ public class HederaOpsDuration {
                 SYSTEM_CONTRACT_MULTIPLIER_KEY, opsDurationConfig.systemContractGasBasedDurationMultiplier());
     }
 
-    public Map<Integer, Long> getOpsDuration() {
+    public long[] getOpsDuration() {
         return opsDuration;
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaOpsDurationTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/HederaOpsDurationTest.java
@@ -20,9 +20,9 @@ class HederaOpsDurationTest {
     void testAllDurationsAreLoadedFromConfig() {
         hederaOpsDuration.applyDurationFromConfig(DEFAULT_OPS_DURATION_CONFIG);
 
-        assertEquals(123, hederaOpsDuration.getOpsDuration().get(1));
-        assertEquals(105, hederaOpsDuration.getOpsDuration().get(2));
-        assertEquals(2091, hederaOpsDuration.getOpsDuration().get(250));
+        assertEquals(123, hederaOpsDuration.getOpsDuration()[1]);
+        assertEquals(105, hederaOpsDuration.getOpsDuration()[2]);
+        assertEquals(2091, hederaOpsDuration.getOpsDuration()[250]);
         assertEquals(566, hederaOpsDuration.opsDurationMultiplier());
         assertEquals(1575, hederaOpsDuration.precompileDurationMultiplier());
         assertEquals(566, hederaOpsDuration.systemContractDurationMultiplier());


### PR DESCRIPTION
Replace using a map that contains the ops duration values with a local array to improve performance in the `runToHalt` method in the HederaEVM class