### PR TITLE
chore: Add always condition to reporting job

### DIFF
--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -209,6 +209,7 @@ jobs:
     name: ${{ inputs.custom-job-name || 'Standard' }} Slack Report
     runs-on: hiero-network-node-linux-large
     needs: tck-regression
+    if: ${{ always() }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@4d991eb9b905ef189e4c376166672c3f2f230481 # v2.11.0


### PR DESCRIPTION
**Description**:

This pull request includes a single change to the `.github/workflows/zxc-tck-regression.yaml` file. The change ensures that the job always runs by adding an `if: ${{ always() }}` condition to the `jobs:` configuration.

**Related issue(s)**:

Fixes #19844
