### PR TITLE
chore: Validation cleanup

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/AbstractContinuousAssertion.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/AbstractContinuousAssertion.java
@@ -24,6 +24,7 @@ public abstract class AbstractContinuousAssertion<SELF extends AbstractAssert<SE
         DESTROYED
     }
 
+    // This class may be used in a multi-threaded context, so we use volatile to ensure visibility of state changes
     protected volatile State state = State.ACTIVE;
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodeConsensusResultsAssert.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodeConsensusResultsAssert.java
@@ -3,12 +3,12 @@ package org.hiero.otter.fixtures.assertions;
 
 import static java.util.Comparator.comparingInt;
 
+import com.swirlds.platform.test.fixtures.consensus.framework.validation.ConsensusRoundValidator;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.Assertions;
 import org.assertj.core.data.Percentage;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.node.NodeId;
@@ -53,11 +53,9 @@ public class MultipleNodeConsensusResultsAssert
     @NonNull
     public MultipleNodeConsensusResultsAssert haveLastRoundNum(final long expected) {
         isNotNull();
-
         for (final SingleNodeConsensusResult result : actual.results()) {
             OtterAssertions.assertThat(result).hasLastRoundNum(expected);
         }
-
         return this;
     }
 
@@ -70,11 +68,9 @@ public class MultipleNodeConsensusResultsAssert
     @NonNull
     public MultipleNodeConsensusResultsAssert haveAdvancedSinceRound(final long expected) {
         isNotNull();
-
         for (final SingleNodeConsensusResult result : actual.results()) {
             OtterAssertions.assertThat(result).hasAdvancedSinceRound(expected);
         }
-
         return this;
     }
 
@@ -124,16 +120,25 @@ public class MultipleNodeConsensusResultsAssert
             }
             final int size = currentNodeResult.size();
             final List<ConsensusRound> expectedSublist = longestResult.rounds().subList(0, size);
-            Assertions.assertThat(currentNodeResult.rounds())
-                    .withFailMessage(
-                            "Expected node %s to have the same consensus rounds as node %s, but the former had %s while the later had %s",
-                            currentNodeResult.nodeId(),
-                            longestResult.nodeId(),
-                            currentNodeResult.rounds(),
-                            expectedSublist)
-                    .containsExactlyElementsOf(expectedSublist);
+            ConsensusRoundValidator.validate(currentNodeResult.rounds(), expectedSublist);
         }
 
+        return this;
+    }
+
+    /**
+     * Verifies that the created consensus rounds are consistent.
+     *
+     * <p>This includes checking if the ancient thresholds are increasing and the timestamps of
+     * events are strictly increasing.
+     *
+     * @return this assertion object for method chaining
+     */
+    public MultipleNodeConsensusResultsAssert haveConsistentRounds() {
+        isNotNull();
+        for (final SingleNodeConsensusResult result : actual.results()) {
+            OtterAssertions.assertThat(result).hasConsistentRounds();
+        }
         return this;
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodeConsensusResultsContinuousAssert.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodeConsensusResultsContinuousAssert.java
@@ -4,11 +4,14 @@ package org.hiero.otter.fixtures.assertions;
 import static org.hiero.otter.fixtures.result.SubscriberAction.CONTINUE;
 import static org.hiero.otter.fixtures.result.SubscriberAction.UNSUBSCRIBE;
 
+import com.swirlds.platform.test.fixtures.consensus.framework.validation.ConsensusRoundValidator;
+import com.swirlds.platform.test.fixtures.consensus.framework.validation.RoundInternalEqualityValidation;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Stream;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.otter.fixtures.result.ConsensusRoundSubscriber;
@@ -45,6 +48,48 @@ public class MultipleNodeConsensusResultsContinuousAssert
     }
 
     /**
+     * Verifies that the created consensus rounds are consistent.
+     *
+     * <p>This includes checking if the ancient thresholds are increasing and the timestamps of
+     * events are strictly increasing.
+     *
+     * @return this assertion object for method chaining
+     */
+    @NonNull
+    public MultipleNodeConsensusResultsContinuousAssert haveConsistentRounds() {
+        isNotNull();
+
+        final ConsensusRoundSubscriber subscriber = new ConsensusRoundSubscriber() {
+
+            // For some validations to function properly, we have to prepend the last round
+            private ConsensusRound lastRound = null;
+
+            @Override
+            public SubscriberAction onConsensusRounds(
+                    @NonNull final NodeId nodeId, final @NonNull List<ConsensusRound> rounds) {
+                return switch (state) {
+                    case ACTIVE -> {
+                        if (!suppressedNodeIds.contains(nodeId)) {
+                            final List<ConsensusRound> includingLast = Stream.concat(
+                                            Stream.ofNullable(lastRound), rounds.stream())
+                                    .toList();
+                            ConsensusRoundValidator.validate(includingLast);
+                            lastRound = rounds.getLast();
+                        }
+                        yield CONTINUE;
+                    }
+                    case PAUSED -> CONTINUE;
+                    case DESTROYED -> UNSUBSCRIBE;
+                };
+            }
+        };
+
+        actual.subscribe(subscriber);
+
+        return this;
+    }
+
+    /**
      * Verifies that all nodes produce equal rounds as they are produces. This check only compares the rounds produced by the nodes, i.e.,
      * if a node produces no rounds or is significantly behind the others, this check will NOT fail.
      *
@@ -67,9 +112,8 @@ public class MultipleNodeConsensusResultsContinuousAssert
                             for (final ConsensusRound round : rounds) {
                                 final RoundFromNode reference = referenceRounds.computeIfAbsent(
                                         round.getRoundNum(), key -> new RoundFromNode(nodeId, round));
-                                if (!nodeId.equals(reference.nodeId) && !round.equals(reference.round())) {
-                                    failWithMessage(summarizeDifferences(
-                                            reference.nodeId, nodeId, round.getRoundNum(), reference.round(), round));
+                                if (!nodeId.equals(reference.nodeId)) {
+                                    RoundInternalEqualityValidation.INSTANCE.validate(reference.round(), round);
                                 }
                             }
                         }
@@ -84,33 +128,6 @@ public class MultipleNodeConsensusResultsContinuousAssert
         actual.subscribe(subscriber);
 
         return this;
-    }
-
-    private static String summarizeDifferences(
-            @NonNull final NodeId node1,
-            @NonNull final NodeId node2,
-            final long roundNum,
-            @NonNull final ConsensusRound round1,
-            @NonNull final ConsensusRound round2) {
-        if (round1.getEventCount() != round2.getEventCount()) {
-            return "Expected rounds to be equal, but round %d of node %s has %d events, while the same round of node %s has %d events."
-                    .formatted(roundNum, node1, round1.getEventCount(), node2, round2.getEventCount());
-        }
-
-        final StringBuilder sb = new StringBuilder();
-        sb.append("Expected rounds to be equal, but round ")
-                .append(roundNum)
-                .append(" has the following differences:\n");
-        for (int i = 0; i < round1.getEventCount(); i++) {
-            final var event1 = round1.getConsensusEvents().get(i);
-            final var event2 = round2.getConsensusEvents().get(i);
-            if (!event1.equals(event2)) {
-                sb.append("Event ").append(i).append(" differs:\n");
-                sb.append("Node ").append(node1).append(" produced\n").append(event1);
-                sb.append("Node ").append(node2).append(" produced\n").append(event2);
-            }
-        }
-        return sb.toString();
     }
 
     private record RoundFromNode(@NonNull NodeId nodeId, @NonNull ConsensusRound round) {}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/SingleNodeConsensusResultAssert.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/SingleNodeConsensusResultAssert.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.fixtures.assertions;
 
+import com.swirlds.platform.test.fixtures.consensus.framework.validation.ConsensusRoundValidator;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
@@ -85,6 +86,20 @@ public class SingleNodeConsensusResultAssert
                         "Expected consensus rounds of node %s to be <%s> but was <%s>",
                         actual.nodeId(), expected, actual.consensusRounds())
                 .containsExactlyElementsOf(expected);
+        return this;
+    }
+
+    /**
+     * Verifies that the created consensus rounds are consistent.
+     *
+     * <p>This includes checking if the ancient thresholds are increasing and the timestamps of
+     * events are strictly increasing.
+     *
+     * @return this assertion object for method chaining
+     */
+    public SingleNodeConsensusResultAssert hasConsistentRounds() {
+        isNotNull();
+        ConsensusRoundValidator.validate(actual.consensusRounds());
         return this;
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/SingleNodeConsensusResultContinuousAssert.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/SingleNodeConsensusResultContinuousAssert.java
@@ -1,9 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.fixtures.assertions;
 
+import static org.hiero.otter.fixtures.result.SubscriberAction.CONTINUE;
+import static org.hiero.otter.fixtures.result.SubscriberAction.UNSUBSCRIBE;
+
+import com.swirlds.platform.test.fixtures.consensus.framework.validation.ConsensusRoundValidator;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.List;
+import java.util.stream.Stream;
+import org.hiero.consensus.model.hashgraph.ConsensusRound;
+import org.hiero.consensus.model.node.NodeId;
+import org.hiero.otter.fixtures.result.ConsensusRoundSubscriber;
 import org.hiero.otter.fixtures.result.SingleNodeConsensusResult;
+import org.hiero.otter.fixtures.result.SubscriberAction;
 
 /**
  * Continuous assertions for {@link SingleNodeConsensusResult}.
@@ -31,5 +41,45 @@ public class SingleNodeConsensusResultContinuousAssert
     public static SingleNodeConsensusResultContinuousAssert assertContinuouslyThat(
             @Nullable final SingleNodeConsensusResult actual) {
         return new SingleNodeConsensusResultContinuousAssert(actual);
+    }
+
+    /**
+     * Verifies that the created consensus rounds are consistent.
+     *
+     * <p>This includes checking if the ancient thresholds are increasing and the timestamps of
+     * events are strictly increasing.
+     *
+     * @return this assertion object for method chaining
+     */
+    @NonNull
+    public SingleNodeConsensusResultContinuousAssert hasConsistentRounds() {
+        isNotNull();
+
+        final ConsensusRoundSubscriber subscriber = new ConsensusRoundSubscriber() {
+
+            // For some validations to function properly, we have to prepend the last round
+            private ConsensusRound lastRound = null;
+
+            @Override
+            public SubscriberAction onConsensusRounds(
+                    @NonNull final NodeId nodeId, final @NonNull List<ConsensusRound> rounds) {
+                return switch (state) {
+                    case ACTIVE -> {
+                        final List<ConsensusRound> includingLast = Stream.concat(
+                                        Stream.ofNullable(lastRound), rounds.stream())
+                                .toList();
+                        ConsensusRoundValidator.validate(includingLast);
+                        lastRound = rounds.getLast();
+                        yield CONTINUE;
+                    }
+                    case PAUSED -> CONTINUE;
+                    case DESTROYED -> UNSUBSCRIBE;
+                };
+            }
+        };
+
+        actual.subscribe(subscriber);
+
+        return this;
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeLogResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeLogResultsImpl.java
@@ -33,7 +33,7 @@ public class MultipleNodeLogResultsImpl implements MultipleNodeLogResults {
         this.results = unmodifiableList(requireNonNull(results));
 
         // The subscription mechanism is a bit tricky, because we have two levels of subscriptions.
-        // A subscriber A can subscribe to this class. It will be notified if any of the nodes has new rounds.
+        // A subscriber A can subscribe to this class. It will be notified if any of the nodes has new log entries.
         // To implement this, we define a meta-subscriber that will be subscribed to the results of all nodes.
         // This meta-subscriber will notify all child-subscribers to this class (among them A).
         // If a child-subscriber wants to be unsubscribed, it will return SubscriberAction.UNSUBSCRIBE.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/NodeResultsCollector.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/NodeResultsCollector.java
@@ -26,6 +26,8 @@ public class NodeResultsCollector {
     private final Queue<ConsensusRound> consensusRounds = new ConcurrentLinkedQueue<>();
     private final List<ConsensusRoundSubscriber> consensusRoundSubscribers = new CopyOnWriteArrayList<>();
     private final List<PlatformStatus> platformStatuses = new ArrayList<>();
+
+    // This class may be used in a multi-threaded context, so we use volatile to ensure visibility of state changes
     private volatile boolean destroyed = false;
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/SingleNodeConsensusResultImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/SingleNodeConsensusResultImpl.java
@@ -15,6 +15,8 @@ import org.hiero.otter.fixtures.result.SingleNodeConsensusResult;
 public class SingleNodeConsensusResultImpl implements SingleNodeConsensusResult {
 
     private final NodeResultsCollector collector;
+
+    // This class may be used in a multi-threaded context, so we use volatile to ensure visibility of state changes
     private volatile int startIndex = 0;
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/SingleNodeLogResultImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/SingleNodeLogResultImpl.java
@@ -25,6 +25,8 @@ public class SingleNodeLogResultImpl implements SingleNodeLogResult {
 
     private final NodeId nodeId;
     private final Set<Marker> suppressedLogMarkers;
+
+    // This class may be used in a multi-threaded context, so we use volatile to ensure visibility of state changes
     private volatile int startIndex = 0;
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/LogSubscriber.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/LogSubscriber.java
@@ -2,7 +2,6 @@
 package org.hiero.otter.fixtures.result;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.otter.fixtures.logging.StructuredLog;
 
 /**
@@ -12,7 +11,7 @@ import org.hiero.otter.fixtures.logging.StructuredLog;
 public interface LogSubscriber {
 
     /**
-     * Called when new {@link ConsensusRound}s are available.
+     * Called when new {@link StructuredLog}s are available.
      *
      * @param logEntry the new {@link StructuredLog} entry
      * @return {@link SubscriberAction#UNSUBSCRIBE} to unsubscribe, {@link SubscriberAction#CONTINUE} to continue

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/SubscriberAction.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/SubscriberAction.java
@@ -2,7 +2,7 @@
 package org.hiero.otter.fixtures.result;
 
 /**
- * Return value to indicate whether the subscriber should continue receiving rounds or unsubscribe.
+ * Return value to indicate whether the subscriber should continue receiving data or unsubscribe.
  */
 public enum SubscriberAction {
     CONTINUE,

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/AncientParentsTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/consensus/AncientParentsTest.java
@@ -164,7 +164,7 @@ class AncientParentsTest {
     }
 
     private static void assertConsensusEvents(final TestIntake node1, final TestIntake node2) {
-        new ConsensusRoundValidator().validate(node1.getConsensusRounds(), node2.getConsensusRounds());
+        ConsensusRoundValidator.validate(node1.getConsensusRounds(), node2.getConsensusRounds());
         node1.getConsensusRounds().clear();
         node2.getConsensusRounds().clear();
     }

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/ConsensusTestOrchestrator.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/ConsensusTestOrchestrator.java
@@ -17,7 +17,6 @@ import org.hiero.consensus.model.roster.AddressBook;
 
 /** A type which orchestrates the generation of events and the validation of the consensus output */
 public class ConsensusTestOrchestrator {
-    private final ConsensusRoundValidator consensusRoundValidatorWithAllChecks = new ConsensusRoundValidator();
     private final PlatformContext platformContext;
     private final List<ConsensusTestNode> nodes;
     private long currentSequence = 0;
@@ -108,12 +107,16 @@ public class ConsensusTestOrchestrator {
      * @param consensusOutputValidator the validator to run
      */
     public void validate(final ConsensusOutputValidator consensusOutputValidator) {
+        for (final ConsensusTestNode node : nodes) {
+            ConsensusRoundValidator.validate(node.getOutput().getConsensusRounds());
+        }
+
         final ConsensusTestNode node1 = nodes.getFirst();
         for (int i = 1; i < nodes.size(); i++) {
             final ConsensusTestNode otherNode = nodes.get(i);
 
             consensusOutputValidator.validate(node1.getOutput(), otherNode.getOutput());
-            consensusRoundValidatorWithAllChecks.validate(
+            ConsensusRoundValidator.validate(
                     node1.getOutput().getConsensusRounds(),
                     otherNode.getOutput().getConsensusRounds());
         }

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/ConsensusRoundComparisonValidation.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/ConsensusRoundComparisonValidation.java
@@ -8,13 +8,14 @@ import org.hiero.consensus.model.hashgraph.ConsensusRound;
  * Validates rounds produced by a test. The type of validation that is done depends on the implementation.
  */
 @FunctionalInterface
-public interface ConsensusRoundValidation {
+public interface ConsensusRoundComparisonValidation {
 
     /**
      * Perform validation on the passed consensus rounds.
      *
      * @param round1 the round from one node
      * @param round2 the round from another node
+     * @throws AssertionError if the validation fails
      */
     void validate(@NonNull final ConsensusRound round1, @NonNull final ConsensusRound round2);
 }

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/ConsensusRoundConsistencyValidation.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/ConsensusRoundConsistencyValidation.java
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.platform.test.fixtures.consensus.framework.validation;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import org.hiero.consensus.model.hashgraph.ConsensusRound;
+
+/**
+ * Validates rounds produced by a single node during a test. The type of validation that is done depends on the implementation.
+ */
+@FunctionalInterface
+public interface ConsensusRoundConsistencyValidation {
+
+    /**
+     * Perform validation on the passed consensus rounds.
+     *
+     * <p>An empty list is considered valid.
+     *
+     * @param rounds the rounds to validate
+     * @throws AssertionError if the validation fails
+     */
+    void validate(@NonNull final List<ConsensusRound> rounds);
+}

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/RoundAncientThresholdIncreasesValidation.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/RoundAncientThresholdIncreasesValidation.java
@@ -5,35 +5,37 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.hedera.hapi.platform.state.MinimumJudgeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 
 /**
  * A validator that ensures that the ancient threshold increases between rounds from the same node.
  */
-public class RoundAncientThresholdIncreasesValidation implements ConsensusRoundValidation {
+public enum RoundAncientThresholdIncreasesValidation implements ConsensusRoundConsistencyValidation {
+    INSTANCE;
 
     /**
-     * Validates that the threshold info of consequent rounds for the same node are increasing.
+     * Validates that the threshold info of consecutive rounds for the same node are increasing.
      *
-     * @param round1 a given node's round be validated
-     * @param round2 the consequent round from the same node to be validated
+     * @param rounds the rounds produced by a node
      */
     @Override
-    public void validate(@NonNull final ConsensusRound round1, @NonNull final ConsensusRound round2) {
-        final MinimumJudgeInfo thresholdInfoForRound1 =
-                round1.getSnapshot().minimumJudgeInfoList().getLast();
-        final MinimumJudgeInfo thresholdInfoForRound2 =
-                round2.getSnapshot().minimumJudgeInfoList().getLast();
-        assertThat(round1.getRoundNum())
-                .withFailMessage(String.format(
-                        "the last threshold should be equal for the current round %d", round1.getRoundNum()))
-                .isEqualTo(thresholdInfoForRound1.round());
-        assertThat(round2.getRoundNum())
-                .withFailMessage(String.format(
-                        "the last threshold should be equal for the current round %d", round2.getRoundNum()))
-                .isEqualTo(thresholdInfoForRound2.round());
-        assertThat(thresholdInfoForRound2.minimumJudgeAncientThreshold())
-                .withFailMessage("the ancient threshold should never decrease")
-                .isGreaterThanOrEqualTo(thresholdInfoForRound1.minimumJudgeAncientThreshold());
+    public void validate(@NonNull final List<ConsensusRound> rounds) {
+        if (rounds.isEmpty()) {
+            // An empty list is considered valid
+            return;
+        }
+
+        for (int i = 1; i < rounds.size(); i++) {
+
+            final MinimumJudgeInfo previousThresholdInfo =
+                    rounds.get(i - 1).getSnapshot().minimumJudgeInfoList().getLast();
+            final MinimumJudgeInfo currentThresholdInfo =
+                    rounds.get(i).getSnapshot().minimumJudgeInfoList().getLast();
+
+            assertThat(currentThresholdInfo.minimumJudgeAncientThreshold())
+                    .withFailMessage("the ancient threshold should never decrease")
+                    .isGreaterThanOrEqualTo(previousThresholdInfo.minimumJudgeAncientThreshold());
+        }
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/RoundInternalConsistencyValidation.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/RoundInternalConsistencyValidation.java
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.platform.test.fixtures.consensus.framework.validation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.platform.state.MinimumJudgeInfo;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import org.hiero.consensus.model.hashgraph.ConsensusRound;
+
+/**
+ * A validator that checks the internal consistency of all rounds in a list.
+ */
+public enum RoundInternalConsistencyValidation implements ConsensusRoundConsistencyValidation {
+    INSTANCE;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void validate(@NonNull final List<ConsensusRound> rounds) {
+        for (final ConsensusRound round : rounds) {
+            final MinimumJudgeInfo minimumJudgeInfo =
+                    round.getSnapshot().minimumJudgeInfoList().getLast();
+            assertThat(round.getRoundNum())
+                    .withFailMessage(String.format(
+                            "the last threshold should be equal for the current round %d", round.getRoundNum()))
+                    .isEqualTo(minimumJudgeInfo.round());
+        }
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/RoundInternalEqualityValidation.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/consensus/framework/validation/RoundInternalEqualityValidation.java
@@ -12,7 +12,8 @@ import org.hiero.consensus.model.hashgraph.ConsensusRound;
 /**
  * A validator that ensures that the internal state of two rounds from different nodes are equal.
  */
-public class RoundInternalEqualityValidation implements ConsensusRoundValidation {
+public enum RoundInternalEqualityValidation implements ConsensusRoundComparisonValidation {
+    INSTANCE;
 
     /**
      * Validates that the internal state of two rounds from different nodes are equal.


### PR DESCRIPTION
**Description**:

This PR cleans up the consensus round validations and integrates them with the Otter framework.

**Related issue(s)**:

Fixes #19371 