### PR TITLE
chore(19352): Add debug Information to DefaultTransactionHandler

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/stream/DefaultConsensusEventStream.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/stream/DefaultConsensusEventStream.java
@@ -216,7 +216,9 @@ public class DefaultConsensusEventStream implements ConsensusEventStream {
                 }
             } else {
                 eventAfterFreezeLogger.warn(
-                        EVENT_STREAM.getMarker(), "Event {} dropped after freezePeriodStarted!", event.getTimestamp());
+                        EVENT_STREAM.getMarker(),
+                        "Event {} dropped after freezePeriodStarted!",
+                        event.getPlatformEvent().getDescriptor());
             }
         });
     }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -183,7 +183,6 @@ public class DefaultTransactionHandler implements TransactionHandler {
         if (swirldStateManager.isInFreezePeriod(consensusRound.getConsensusTimestamp())) {
             statusActionSubmitter.submitStatusAction(new FreezePeriodEnteredAction(consensusRound.getRoundNum()));
             freezeRoundReceived = true;
-            freezeRound = consensusRound.getRoundNum();
         }
 
         handlerMetrics.recordEventsPerRound(consensusRound.getNumEvents());
@@ -256,11 +255,10 @@ public class DefaultTransactionHandler implements TransactionHandler {
                         .getRunningHash()
                         .getFutureHash()
                         .getAndRethrow();
-
-                if (freezeRound == round.getRoundNum()) {
+                if (freezeRoundReceived) {
                     logger.info(
                             "Last event in the freezeRound:{} is:{}",
-                            freezeRound,
+                            round.getRoundNum(),
                             round.getStreamedEvents()
                                     .getLast()
                                     .getPlatformEvent()

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -253,7 +253,7 @@ public class DefaultTransactionHandler implements TransactionHandler {
             final CesEvent last = round.getStreamedEvents().getLast();
             if (freezeRoundReceived) {
                 logger.info(
-                        "Last event in the freezeRound:{} is:{} and has consensus time:{}",
+                        "Last event in the freezeRound {} has consensus time {} {}",
                         round.getRoundNum(),
                         last.getPlatformEvent().getConsensusTimestamp(),
                         last.getPlatformEvent().getDescriptor());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/eventhandling/DefaultTransactionHandler.java
@@ -105,6 +105,8 @@ public class DefaultTransactionHandler implements TransactionHandler {
      */
     private long accumulatedHashComplexity = 0;
 
+    private long freezeRound = 0;
+
     /**
      * Constructor
      *
@@ -181,6 +183,7 @@ public class DefaultTransactionHandler implements TransactionHandler {
         if (swirldStateManager.isInFreezePeriod(consensusRound.getConsensusTimestamp())) {
             statusActionSubmitter.submitStatusAction(new FreezePeriodEnteredAction(consensusRound.getRoundNum()));
             freezeRoundReceived = true;
+            freezeRound = consensusRound.getRoundNum();
         }
 
         handlerMetrics.recordEventsPerRound(consensusRound.getNumEvents());
@@ -253,6 +256,16 @@ public class DefaultTransactionHandler implements TransactionHandler {
                         .getRunningHash()
                         .getFutureHash()
                         .getAndRethrow();
+
+                if (freezeRound == round.getRoundNum()) {
+                    logger.info(
+                            "Last event in the freezeRound:{} is:{}",
+                            freezeRound,
+                            round.getStreamedEvents()
+                                    .getLast()
+                                    .getPlatformEvent()
+                                    .getDescriptor());
+                }
             }
 
             platformStateFacade.setLegacyRunningEventHashTo(consensusState, previousRoundLegacyRunningEventHash);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stream/ConsensusEventStreamTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stream/ConsensusEventStreamTest.java
@@ -31,13 +31,13 @@ class ConsensusEventStreamTest {
             Time.getCurrent(), multiStreamMock, ConsensusEventStreamTest::isFreezeEvent);
     private static final Random RANDOM = RandomUtils.getRandomPrintSeed();
 
-    private static final CesEvent freezeEvent = createRndEvent();
+    private static final CesEvent freezeEvent = createRandomEvent();
 
     @Test
     void addEventTest() {
         final int nonFreezeEventsNum = 10;
         for (int i = 0; i < nonFreezeEventsNum; i++) {
-            final CesEvent event = createRndEvent();
+            final CesEvent event = createRandomEvent();
             CONSENSUS_EVENT_STREAM.addEvents(List.of(event));
 
             verify(multiStreamMock).addObject(event);
@@ -60,7 +60,7 @@ class ConsensusEventStreamTest {
         // for freeze event, multiStream should be closed after adding it
         verify(multiStreamMock).close();
 
-        final CesEvent eventAddAfterFrozen = createRndEvent();
+        final CesEvent eventAddAfterFrozen = createRandomEvent();
         CONSENSUS_EVENT_STREAM.addEvents(List.of(eventAddAfterFrozen));
         // after frozen, when adding event to the EventStreamManager, multiStream.add(event) should not be called
         verify(multiStreamMock, never()).addObject(eventAddAfterFrozen);
@@ -101,7 +101,7 @@ class ConsensusEventStreamTest {
      * Creates a random CesEvent
      * @return a random CesEvent
      */
-    private static CesEvent createRndEvent() {
+    private static CesEvent createRandomEvent() {
         return RecoveryTestUtils.generateRandomEvent(RANDOM, RANDOM.nextLong(), false, Instant.now());
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stream/ConsensusEventStreamTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/event/stream/ConsensusEventStreamTest.java
@@ -14,6 +14,8 @@ import com.swirlds.component.framework.component.ComponentWiring;
 import com.swirlds.component.framework.model.WiringModel;
 import com.swirlds.component.framework.model.WiringModelBuilder;
 import com.swirlds.component.framework.schedulers.builders.TaskSchedulerType;
+import com.swirlds.platform.recovery.RecoveryTestUtils;
+import java.time.Instant;
 import java.util.List;
 import java.util.Random;
 import org.hiero.base.crypto.Hash;
@@ -27,14 +29,15 @@ class ConsensusEventStreamTest {
     private static final MultiStream<CesEvent> multiStreamMock = mock(MultiStream.class);
     private static final ConsensusEventStream CONSENSUS_EVENT_STREAM = new DefaultConsensusEventStream(
             Time.getCurrent(), multiStreamMock, ConsensusEventStreamTest::isFreezeEvent);
+    private static final Random RANDOM = RandomUtils.getRandomPrintSeed();
 
-    private static final CesEvent freezeEvent = mock(CesEvent.class);
+    private static final CesEvent freezeEvent = createRndEvent();
 
     @Test
     void addEventTest() {
         final int nonFreezeEventsNum = 10;
         for (int i = 0; i < nonFreezeEventsNum; i++) {
-            final CesEvent event = mock(CesEvent.class);
+            final CesEvent event = createRndEvent();
             CONSENSUS_EVENT_STREAM.addEvents(List.of(event));
 
             verify(multiStreamMock).addObject(event);
@@ -57,7 +60,7 @@ class ConsensusEventStreamTest {
         // for freeze event, multiStream should be closed after adding it
         verify(multiStreamMock).close();
 
-        final CesEvent eventAddAfterFrozen = mock(CesEvent.class);
+        final CesEvent eventAddAfterFrozen = createRndEvent();
         CONSENSUS_EVENT_STREAM.addEvents(List.of(eventAddAfterFrozen));
         // after frozen, when adding event to the EventStreamManager, multiStream.add(event) should not be called
         verify(multiStreamMock, never()).addObject(eventAddAfterFrozen);
@@ -92,5 +95,13 @@ class ConsensusEventStreamTest {
      */
     private static boolean isFreezeEvent(final CesEvent event) {
         return event == freezeEvent;
+    }
+
+    /**
+     * Creates a random CesEvent
+     * @return a random CesEvent
+     */
+    private static CesEvent createRndEvent() {
+        return RecoveryTestUtils.generateRandomEvent(RANDOM, RANDOM.nextLong(), false, Instant.now());
     }
 }


### PR DESCRIPTION
**Description**:
A new instance of a failure for JRS test FCM-VM-RestartEventStream-1k-10m occurred.
The symptom is that the node entered CHECKING instead of the expected FREEZING
We are adding debug information to the  default transaction handler to be able to have more details

**Related issue(s)**:

Related #19352
