### PR TITLE
chore: Stabilize `HRCTokenCancelTest`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/airdrops/HRCTokenCancelTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/airdrops/HRCTokenCancelTest.java
@@ -11,6 +11,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.dsl.annotations.Account;
 import com.hedera.services.bdd.spec.dsl.annotations.FungibleToken;
@@ -28,6 +29,7 @@ import org.junit.jupiter.api.Tag;
 
 @Tag(SMART_CONTRACT)
 @HapiTestLifecycle
+@OrderedInIsolation
 public class HRCTokenCancelTest {
 
     @Account(name = "sender", tinybarBalance = 100_000_000_000L)


### PR DESCRIPTION
**Description**:
 - Stabilizes possible race condition between leaky tests in `HRCTokenCancelTest`.