### PR TITLE
fix: Verify standard nondeterminism test improvement

### DIFF
--- a/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/model/DeterministicModelTests.java
+++ b/platform-sdk/swirlds-component-framework/src/test/java/com/swirlds/component/framework/model/DeterministicModelTests.java
@@ -94,8 +94,7 @@ class DeterministicModelTests {
     private record WiringMesh(
             @NonNull InputWire<Long> inputWire,
             @NonNull AtomicLong outputValue,
-            @NonNull BooleanSupplier isQuiescent) {
-    }
+            @NonNull BooleanSupplier isQuiescent) {}
 
     /**
      * Generates a wiring mesh that yields non-deterministic results when data is fed in using the standard wiring
@@ -385,8 +384,7 @@ class DeterministicModelTests {
         final DeterministicWiringModel deterministicWiringModel1 = WiringModelBuilder.create(new NoOpMetrics(), time)
                 .withDeterministicModeEnabled(true)
                 .build();
-        final DeterministicWiringModel deterministicWiringModel2 = WiringModelBuilder.create(new NoOpMetrics(),
-                        time)
+        final DeterministicWiringModel deterministicWiringModel2 = WiringModelBuilder.create(new NoOpMetrics(), time)
                 .withDeterministicModeEnabled(true)
                 .build();
         try {


### PR DESCRIPTION
**Description**:
Improvement for `DeterministicModelTests.verifyStandardNondeterminism` test
Details was discussed at slack thread https://swirldslabs.slack.com/archives/C07PQPT2H18/p1751037542638409

Related issue(s):

Fixes [#19975](https://github.com/hiero-ledger/hiero-consensus-node/issues/19975)

**Notes for reviewer**:
Problems was found:
- `WiringMesh` can sleep more then period of `Heartbeat` generation
   - `8 schedulers `in a row, `0.5 microsecond avg` = `4 millisecond` pure sleep
   - `Heartbeat` produced each `5 millisecond`
   - if there is at least `1 millisecond` "lag", test with Heartbeats will be infinite
- If any exception is thrown (for example `AssertionFailedError`) `WiringModel`s will not be stoped
   - for isolated test its ok, but for single process for all the tests it will run for a long time in background with Heartbeats generation

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
