### PR TITLE
chore: Fix trigger to zxf-single-day-performance-test-controller

### DIFF
--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -173,7 +173,7 @@ jobs:
             "add-settings": "",
             "crypto-bench-merkle-db-java-args": "-XX:+UseZGC -XX:+ZGenerational -XX:ZAllocationSpikeTolerance=2 -XX:ConcGCThreads=14 -XX:ZMarkStackSpaceLimit=12g -XX:MaxDirectMemorySize=24g -Xmx90g",
             "crypto-bench-merkle-db-test-params": "-p maxKey=500000000 -p numRecords=100000 -p keySize=24 -p recordSize=1024 -p numFiles=6000",
-            "dry-run-enabled": "false"
+            "disable-notifications": "false"
             }'
 
   report-promotion:


### PR DESCRIPTION
**Description**:

This pull request includes a minor change to the `.github/workflows/zxcron-promote-build-candidate.yaml` file. The `dry-run-enabled` parameter was replaced with `disable-notifications`.
