### PR TITLE
ci: remove pbj repo checkout from SDPT

### DIFF
--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -108,12 +108,6 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
 
-      - name: Checkout pbj Repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: hashgraph/pbj
-          path: pbj
-
       - name: Checkout solo Repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
**Description**:

Remove the `pbj` repo checkout from the Single Day Performance Test workflow.

**Related Issue(s)**:

Fixes #19924
