### PR TITLE
chore: 19960 - Make MetricConfig as mutable builder

### DIFF
--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/DurationGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/DurationGauge.java
@@ -4,6 +4,7 @@ package com.swirlds.common.metrics;
 import static com.swirlds.metrics.api.Metric.ValueType.VALUE;
 
 import com.swirlds.base.units.UnitConstants;
+import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.metrics.api.FloatFormats;
 import com.swirlds.metrics.api.Metric;
 import com.swirlds.metrics.api.MetricType;
@@ -42,7 +43,7 @@ public interface DurationGauge extends Metric {
     @NonNull
     @Override
     default EnumSet<ValueType> getValueTypes() {
-        return EnumSet.of(VALUE);
+        return SINGLE_VALUE_TYPE_SET;
     }
 
     /**
@@ -96,47 +97,10 @@ public interface DurationGauge extends Metric {
          * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
          */
         public Config(@NonNull final String category, @NonNull final String name, final @NonNull ChronoUnit timeUnit) {
-            super(category, name, name, getUnit(timeUnit), getFormat(timeUnit));
+            super(category, name);
             this.timeUnit = timeUnit;
-        }
-
-        /**
-         * Constructor of {@code DoubleGauge.Config}
-         *
-         * @param category the kind of metric (metrics are grouped or filtered by this)
-         * @param name     a short name for the metric
-         * @param description metric description
-         * @param timeUnit the time unit in which to display this duration
-         * @throws NullPointerException     if one of the parameters is {@code null}
-         * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
-         */
-        private Config(
-                @NonNull final String category,
-                @NonNull final String name,
-                @NonNull final String description,
-                final @NonNull ChronoUnit timeUnit) {
-            super(category, name, description, getUnit(timeUnit), getFormat(timeUnit));
-            // at this point, timeUnit was checked for null in getUnit() and getFormat()
-            this.timeUnit = timeUnit;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public DurationGauge.Config withDescription(@NonNull final String description) {
-            return new DurationGauge.Config(getCategory(), getName(), description, getTimeUnit());
-        }
-
-        /**
-         * The unit of a {@link DurationGauge} depends on the configured {@link ChronoUnit}. Therefore, it is not
-         * possible to specify the unit and this method throws an {@link UnsupportedOperationException}
-         */
-        @NonNull
-        @Override
-        public DurationGauge.Config withUnit(@NonNull final String unit) {
-            throw new UnsupportedOperationException("a String unit is not compatible with this class");
+            withUnit(getUnit(timeUnit));
+            withFormat(getFormat(timeUnit));
         }
 
         /**
@@ -165,6 +129,19 @@ public interface DurationGauge extends Metric {
         @NonNull
         public DurationGauge create(@NonNull final PlatformMetricsFactory factory) {
             return factory.createDurationGauge(this);
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected Config self() {
+            return this;
+        }
+
+        @Override
+        protected ToStringBuilder selfToString() {
+            return super.selfToString().append("timeUnit", getTimeUnit());
         }
 
         @NonNull

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/FunctionGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/FunctionGauge.java
@@ -38,7 +38,7 @@ public interface FunctionGauge<T> extends Metric {
     @NonNull
     @Override
     default EnumSet<ValueType> getValueTypes() {
-        return EnumSet.of(VALUE);
+        return SINGLE_VALUE_TYPE_SET;
     }
 
     /**
@@ -90,73 +90,9 @@ public interface FunctionGauge<T> extends Metric {
                 @NonNull final String name,
                 @NonNull final Class<T> type,
                 @NonNull final Supplier<T> supplier) {
-            super(category, name, "%s");
+            super(category, name);
             this.type = Objects.requireNonNull(type, "type must not be null");
             this.supplier = Objects.requireNonNull(supplier, "supplier must not be null");
-        }
-
-        /**
-         * Constructor of {@code FunctionGauge.Config}
-         *
-         * @param category
-         * 		the kind of metric (metrics are grouped or filtered by this)
-         * @param name
-         * 		a short name for the metric
-         * @param description metric description
-         * @param unit the unit for metric
-         * @param format the format for metric
-         * @param type
-         * 		the type of the values this {@code FunctionGauge} returns
-         * @param supplier the format for metric
-         * @throws NullPointerException     if one of the parameters is {@code null}
-         * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
-         */
-        private Config(
-                @NonNull final String category,
-                @NonNull final String name,
-                @NonNull final String description,
-                @NonNull final String unit,
-                @NonNull final String format,
-                @NonNull final Class<T> type,
-                @NonNull final Supplier<T> supplier) {
-            super(category, name, description, unit, format);
-            this.type = Objects.requireNonNull(type, "type must not be null");
-            this.supplier = Objects.requireNonNull(supplier, "supplier must not be null");
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public FunctionGauge.Config<T> withDescription(@NonNull final String description) {
-            return new FunctionGauge.Config<>(
-                    getCategory(), getName(), description, getUnit(), getFormat(), getType(), getSupplier());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public FunctionGauge.Config<T> withUnit(@NonNull final String unit) {
-            return new FunctionGauge.Config<>(
-                    getCategory(), getName(), getDescription(), unit, getFormat(), getType(), getSupplier());
-        }
-
-        /**
-         * Sets the {@link Metric#getFormat() Metric.format} in fluent style.
-         *
-         * @param format
-         * 		the format-string
-         * @return a new configuration-object with updated {@code format}
-         * @throws IllegalArgumentException
-         * 		if {@code format} is {@code null} or consists only of whitespaces
-         */
-        @NonNull
-        public FunctionGauge.Config<T> withFormat(@NonNull final String format) {
-            return new FunctionGauge.Config<>(
-                    getCategory(), getName(), getDescription(), getUnit(), format, getType(), getSupplier());
         }
 
         /**
@@ -202,11 +138,18 @@ public interface FunctionGauge<T> extends Metric {
          * {@inheritDoc}
          */
         @Override
-        public String toString() {
-            return new ToStringBuilder(this)
-                    .appendSuper(super.toString())
+        protected Config<T> self() {
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected ToStringBuilder selfToString() {
+            return super.selfToString()
                     .append("type", type.getName())
-                    .toString();
+                    .append("supplier", supplier.getClass().getName());
         }
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/IntegerPairAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/IntegerPairAccumulator.java
@@ -44,7 +44,7 @@ public interface IntegerPairAccumulator<T> extends Metric {
     @NonNull
     @Override
     default EnumSet<ValueType> getValueTypes() {
-        return EnumSet.of(VALUE);
+        return SINGLE_VALUE_TYPE_SET;
     }
 
     /**
@@ -100,16 +100,13 @@ public interface IntegerPairAccumulator<T> extends Metric {
     final class Config<T> extends PlatformMetricConfig<IntegerPairAccumulator<T>, Config<T>> {
 
         private final @NonNull Class<T> type;
-
         private final @NonNull BiFunction<Integer, Integer, T> resultFunction;
 
-        private final @NonNull IntBinaryOperator leftAccumulator;
-        private final @NonNull IntBinaryOperator rightAccumulator;
+        private @NonNull IntBinaryOperator leftAccumulator;
+        private @NonNull IntBinaryOperator rightAccumulator;
 
-        private final @NonNull IntSupplier leftInitializer;
-        private final @NonNull IntSupplier rightInitializer;
-
-        private static final IntSupplier DEFAULT_INITIALIZER = () -> 0;
+        private @NonNull IntSupplier leftInitializer;
+        private @NonNull IntSupplier rightInitializer;
 
         /**
          * Constructor of {@code IntegerPairAccumulator.Config}
@@ -128,119 +125,13 @@ public interface IntegerPairAccumulator<T> extends Metric {
                 @NonNull final Class<T> type,
                 @NonNull final BiFunction<Integer, Integer, T> resultFunction) {
 
-            super(category, name, "%s");
+            super(category, name);
             this.type = Objects.requireNonNull(type, "type must not be null");
             this.resultFunction = Objects.requireNonNull(resultFunction, "resultFunction must not be null");
             this.leftAccumulator = Integer::sum;
             this.rightAccumulator = Integer::sum;
-            this.leftInitializer = DEFAULT_INITIALIZER;
-            this.rightInitializer = DEFAULT_INITIALIZER;
-        }
-
-        /**
-         * Constructor of {@code IntegerPairAccumulator.Config}
-         * <p>
-         * The accumulators are by default set to {@code Integer::sum}.
-         *
-         * @param category       the kind of metric (metrics are grouped or filtered by this)
-         * @param name           a short name for the metric
-         * @param description metric description
-         * @param unit the unit for metric
-         * @param format the format for metric
-         * @param type           the type of the values this {@code IntegerPairAccumulator} returns
-         * @param resultFunction the function that is used to calculate the {@code IntegerAccumulator}'s value.
-         * @param leftAccumulator the leftAccumulator for metric
-         * @param rightAccumulator the rightAccumulator for metric
-         * @param leftInitializer the leftInitializer for metric
-         * @param rightInitializer the rightInitializer for metric
-         * @throws NullPointerException     if one of the parameters is {@code null}
-         * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
-         */
-        private Config(
-                @NonNull final String category,
-                @NonNull final String name,
-                @NonNull final String description,
-                @NonNull final String unit,
-                @NonNull final String format,
-                @NonNull final Class<T> type,
-                @NonNull final BiFunction<Integer, Integer, T> resultFunction,
-                @NonNull final IntBinaryOperator leftAccumulator,
-                @NonNull final IntBinaryOperator rightAccumulator,
-                @NonNull final IntSupplier leftInitializer,
-                @NonNull final IntSupplier rightInitializer) {
-
-            super(category, name, description, unit, format);
-            this.type = Objects.requireNonNull(type, "type");
-            this.resultFunction = Objects.requireNonNull(resultFunction, "resultFunction must not be null");
-            this.leftAccumulator = Objects.requireNonNull(leftAccumulator, "leftAccumulator must not be null");
-            this.rightAccumulator = Objects.requireNonNull(rightAccumulator, "rightAccumulator must not be null");
-            this.leftInitializer = Objects.requireNonNull(leftInitializer, "leftInitializer must not be null");
-            this.rightInitializer = Objects.requireNonNull(rightInitializer, "rightInitializer must not be null");
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public IntegerPairAccumulator.Config<T> withDescription(@NonNull final String description) {
-            return new IntegerPairAccumulator.Config<>(
-                    getCategory(),
-                    getName(),
-                    description,
-                    getUnit(),
-                    getFormat(),
-                    getType(),
-                    getResultFunction(),
-                    getLeftAccumulator(),
-                    getRightAccumulator(),
-                    getLeftInitializer(),
-                    getRightInitializer());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public IntegerPairAccumulator.Config<T> withUnit(@NonNull final String unit) {
-            return new IntegerPairAccumulator.Config<>(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    unit,
-                    getFormat(),
-                    getType(),
-                    getResultFunction(),
-                    getLeftAccumulator(),
-                    getRightAccumulator(),
-                    getLeftInitializer(),
-                    getRightInitializer());
-        }
-
-        /**
-         * Sets the {@link Metric#getFormat() Metric.format} in fluent style.
-         *
-         * @param format the format-string
-         * @return a new configuration-object with updated {@code format}
-         * @throws NullPointerException     if one of the parameters is {@code null}
-         * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
-         *
-         */
-        @NonNull
-        public IntegerPairAccumulator.Config<T> withFormat(@NonNull final String format) {
-            return new IntegerPairAccumulator.Config<>(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    format,
-                    getType(),
-                    getResultFunction(),
-                    getLeftAccumulator(),
-                    getRightAccumulator(),
-                    getLeftInitializer(),
-                    getRightInitializer());
+            this.leftInitializer = INT_DEFAULT_INITIALIZER;
+            this.rightInitializer = INT_DEFAULT_INITIALIZER;
         }
 
         /**
@@ -281,18 +172,8 @@ public interface IntegerPairAccumulator<T> extends Metric {
          */
         @NonNull
         public IntegerPairAccumulator.Config<T> withLeftAccumulator(@NonNull final IntBinaryOperator leftAccumulator) {
-            return new IntegerPairAccumulator.Config<>(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    getFormat(),
-                    getType(),
-                    getResultFunction(),
-                    leftAccumulator,
-                    getRightAccumulator(),
-                    getLeftInitializer(),
-                    getRightInitializer());
+            this.leftAccumulator = Objects.requireNonNull(leftAccumulator, "leftAccumulator must not be null");
+            return this;
         }
 
         /**
@@ -314,18 +195,8 @@ public interface IntegerPairAccumulator<T> extends Metric {
         @NonNull
         public IntegerPairAccumulator.Config<T> withRightAccumulator(
                 @NonNull final IntBinaryOperator rightAccumulator) {
-            return new IntegerPairAccumulator.Config<>(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    getFormat(),
-                    getType(),
-                    getResultFunction(),
-                    getLeftAccumulator(),
-                    rightAccumulator,
-                    getLeftInitializer(),
-                    getRightInitializer());
+            this.rightAccumulator = Objects.requireNonNull(rightAccumulator, "rightAccumulator must not be null");
+            return this;
         }
 
         /**
@@ -346,18 +217,8 @@ public interface IntegerPairAccumulator<T> extends Metric {
          */
         @NonNull
         public IntegerPairAccumulator.Config<T> withLeftInitializer(@NonNull final IntSupplier leftInitializer) {
-            return new IntegerPairAccumulator.Config<>(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    getFormat(),
-                    getType(),
-                    getResultFunction(),
-                    getLeftAccumulator(),
-                    getRightAccumulator(),
-                    leftInitializer,
-                    getRightInitializer());
+            this.leftInitializer = Objects.requireNonNull(leftInitializer, "leftInitializer must not be null");
+            return this;
         }
 
         /**
@@ -368,18 +229,10 @@ public interface IntegerPairAccumulator<T> extends Metric {
          */
         @NonNull
         public IntegerPairAccumulator.Config<T> withLeftInitialValue(final int leftInitialValue) {
-            return new IntegerPairAccumulator.Config<>(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    getFormat(),
-                    getType(),
-                    getResultFunction(),
-                    getLeftAccumulator(),
-                    getRightAccumulator(),
-                    leftInitialValue == 0 ? DEFAULT_INITIALIZER : () -> leftInitialValue,
-                    getRightInitializer());
+            if (leftInitialValue == 0) {
+                return withLeftInitializer(INT_DEFAULT_INITIALIZER);
+            }
+            return withLeftInitializer(() -> leftInitialValue);
         }
 
         /**
@@ -400,18 +253,8 @@ public interface IntegerPairAccumulator<T> extends Metric {
          */
         @NonNull
         public IntegerPairAccumulator.Config<T> withRightInitializer(@NonNull final IntSupplier rightInitializer) {
-            return new IntegerPairAccumulator.Config<>(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    getFormat(),
-                    getType(),
-                    getResultFunction(),
-                    getLeftAccumulator(),
-                    getRightAccumulator(),
-                    getLeftInitializer(),
-                    rightInitializer);
+            this.rightInitializer = Objects.requireNonNull(rightInitializer, "rightInitializer must not be null");
+            return this;
         }
 
         /**
@@ -422,18 +265,10 @@ public interface IntegerPairAccumulator<T> extends Metric {
          */
         @NonNull
         public IntegerPairAccumulator.Config<T> withRightInitialValue(final int rightInitialValue) {
-            return new IntegerPairAccumulator.Config<>(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    getFormat(),
-                    getType(),
-                    getResultFunction(),
-                    getLeftAccumulator(),
-                    getRightAccumulator(),
-                    getLeftInitializer(),
-                    rightInitialValue == 0 ? DEFAULT_INITIALIZER : () -> rightInitialValue);
+            if (rightInitialValue == 0) {
+                return withRightInitializer(INT_DEFAULT_INITIALIZER);
+            }
+            return withRightInitializer(() -> rightInitialValue);
         }
 
         /**
@@ -459,11 +294,16 @@ public interface IntegerPairAccumulator<T> extends Metric {
          * {@inheritDoc}
          */
         @Override
-        public String toString() {
-            return new ToStringBuilder(this)
-                    .appendSuper(super.toString())
-                    .append("type", type.getName())
-                    .toString();
+        protected Config<T> self() {
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected ToStringBuilder selfToString() {
+            return super.selfToString().append("type", type.getName());
         }
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricConfig.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricConfig.java
@@ -20,29 +20,9 @@ public abstract class PlatformMetricConfig<T extends Metric, C extends MetricCon
      *
      * @param category    the category of the {@link Metric}
      * @param name        the name of the {@link Metric}
-     * @param description the description of the {@link Metric}
-     * @param unit        the unit of the {@link Metric}
-     * @param format      the format of the {@link Metric}
      */
-    protected PlatformMetricConfig(
-            @NonNull final String category,
-            @NonNull final String name,
-            @NonNull final String description,
-            @NonNull final String unit,
-            @NonNull final String format) {
-        super(category, name, description, unit, format);
-    }
-
-    /**
-     * Constructs a new {@link PlatformMetricConfig} with the given parameters.
-     *
-     * @param category      the category of the {@link Metric}
-     * @param name          the name of the {@link Metric}
-     * @param defaultFormat the default format of the {@link Metric}
-     */
-    protected PlatformMetricConfig(
-            @NonNull final String category, @NonNull final String name, @NonNull final String defaultFormat) {
-        super(category, name, defaultFormat);
+    protected PlatformMetricConfig(@NonNull final String category, @NonNull final String name) {
+        super(category, name);
     }
 
     /**

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricsFactory.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/PlatformMetricsFactory.java
@@ -2,10 +2,7 @@
 package com.swirlds.common.metrics;
 
 import com.swirlds.metrics.api.Metric;
-import com.swirlds.metrics.api.MetricConfig;
 import com.swirlds.metrics.api.MetricsFactory;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Objects;
 
 /**
  * Factory for all {@link Metric}-implementations
@@ -75,28 +72,4 @@ public interface PlatformMetricsFactory extends MetricsFactory {
      */
     @SuppressWarnings("removal")
     StatEntry createStatEntry(final StatEntry.Config<?> config);
-
-    /**
-     * Creates a {@link Metric}.
-     * <p>
-     * The default implementation calls the appropriate method within this factory.
-     *
-     * @param config
-     * 		the configuration
-     * @return the new {@code Metric}
-     * @param <T> sub-interface of the generated {@code Metric}
-     */
-    default <T extends Metric> T createMetric(@NonNull final MetricConfig<T, ?> config) {
-        Objects.requireNonNull(config, "config");
-
-        // We use the double-dispatch pattern to create a Metric. This simplifies the API, because it allows us
-        // to have a single method for all types of metrics. (The alternative would have been a method like
-        // getOrCreateCounter() for each type of metric.)
-        //
-        // This method here call MetricConfig.create() providing the MetricsFactory. This method is overridden by
-        // each subclass of MetricConfig to call the specific method in MetricsFactory, i.e. Counter.Config
-        // calls MetricsFactory.createCounter().
-
-        return config.create(this);
-    }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/AbstractDistributionMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/AbstractDistributionMetric.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.common.metrics.platform;
 
+import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.common.metrics.statistics.StatsBuffered;
 import com.swirlds.metrics.api.MetricConfig;
 import com.swirlds.metrics.api.snapshot.Snapshot.SnapshotEntry;
@@ -17,7 +18,7 @@ public abstract class AbstractDistributionMetric extends AbstractMetric {
     /**
      * Half-life of the metric
      */
-    protected final double halfLife;
+    private final double halfLife;
 
     /**
      * Constructs a new {@code AbstractStatsMetric} with the specified configuration and half-life.
@@ -90,5 +91,10 @@ public abstract class AbstractDistributionMetric extends AbstractMetric {
     @Override
     public void reset() {
         getStatsBuffered().reset(halfLife);
+    }
+
+    @Override
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("halfLife", halfLife).append("value", get());
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformDurationGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformDurationGauge.java
@@ -3,6 +3,7 @@ package com.swirlds.common.metrics.platform;
 
 import static com.swirlds.metrics.api.Metric.ValueType.VALUE;
 
+import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.common.metrics.DurationGauge;
 import com.swirlds.metrics.api.snapshot.Snapshot;
 import com.swirlds.metrics.impl.AbstractMetric;
@@ -16,6 +17,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * Platform-implementation of {@link DurationGauge}
  */
 public class PlatformDurationGauge extends AbstractMetric implements DurationGauge {
+
     private final AtomicLong nanos;
     private final ChronoUnit unit;
 
@@ -25,8 +27,9 @@ public class PlatformDurationGauge extends AbstractMetric implements DurationGau
      */
     public PlatformDurationGauge(@NonNull final DurationGauge.Config config) {
         super(config);
-        this.unit = config.getTimeUnit();
-        this.nanos = new AtomicLong();
+
+        unit = config.getTimeUnit();
+        nanos = new AtomicLong();
     }
 
     /**
@@ -58,5 +61,10 @@ public class PlatformDurationGauge extends AbstractMetric implements DurationGau
     @Override
     public double get() {
         return getAsDouble() / unit.getDuration().toNanos();
+    }
+
+    @Override
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("unit", unit).append("value", get());
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformFunctionGauge.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformFunctionGauge.java
@@ -26,8 +26,9 @@ public class PlatformFunctionGauge<T> extends AbstractMetric implements Function
      */
     public PlatformFunctionGauge(@NonNull final FunctionGauge.Config<T> config) {
         super(config);
-        this.dataType = MetricConfig.mapDataType(config.getType());
-        this.supplier = config.getSupplier();
+
+        dataType = MetricConfig.mapDataType(config.getType());
+        supplier = config.getSupplier();
     }
 
     /**
@@ -60,10 +61,7 @@ public class PlatformFunctionGauge<T> extends AbstractMetric implements Function
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", supplier.get())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", get());
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformIntegerPairAccumulator.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformIntegerPairAccumulator.java
@@ -31,13 +31,14 @@ public class PlatformIntegerPairAccumulator<T> extends AbstractMetric implements
      */
     public PlatformIntegerPairAccumulator(@NonNull final Config<T> config) {
         super(config);
-        this.dataType = MetricConfig.mapDataType(config.getType());
-        this.container = new AtomicIntPair(config.getLeftAccumulator(), config.getRightAccumulator());
-        this.resultFunction = config.getResultFunction();
-        this.leftInitializer = config.getLeftInitializer();
-        this.rightInitializer = config.getRightInitializer();
 
-        this.container.set(leftInitializer.getAsInt(), rightInitializer.getAsInt());
+        dataType = MetricConfig.mapDataType(config.getType());
+        container = new AtomicIntPair(config.getLeftAccumulator(), config.getRightAccumulator());
+        resultFunction = config.getResultFunction();
+        leftInitializer = config.getLeftInitializer();
+        rightInitializer = config.getRightInitializer();
+
+        container.set(leftInitializer.getAsInt(), rightInitializer.getAsInt());
     }
 
     /**
@@ -105,10 +106,7 @@ public class PlatformIntegerPairAccumulator<T> extends AbstractMetric implements
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", get())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", get());
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformMetricsFactoryImpl.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformMetricsFactoryImpl.java
@@ -55,7 +55,7 @@ public class PlatformMetricsFactoryImpl extends DefaultMetricsFactory implements
      */
     @Override
     public RunningAverageMetric createRunningAverageMetric(final RunningAverageMetric.Config config) {
-        if (config.isUseDefaultHalfLife()) {
+        if (config.getHalfLife() == 0.0) {
             return new PlatformRunningAverageMetric(config.withHalfLife(metricsConfig.halfLife()));
         }
         return new PlatformRunningAverageMetric(config);
@@ -66,7 +66,7 @@ public class PlatformMetricsFactoryImpl extends DefaultMetricsFactory implements
      */
     @Override
     public SpeedometerMetric createSpeedometerMetric(final SpeedometerMetric.Config config) {
-        if (config.isUseDefaultHalfLife()) {
+        if (config.getHalfLife() == 0.0) {
             return new PlatformSpeedometerMetric(config.withHalfLife(metricsConfig.halfLife()));
         }
         return new PlatformSpeedometerMetric(config);

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformRunningAverageMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformRunningAverageMetric.java
@@ -2,7 +2,6 @@
 package com.swirlds.common.metrics.platform;
 
 import com.swirlds.base.time.Time;
-import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.common.metrics.RunningAverageMetric;
 import com.swirlds.common.metrics.statistics.StatsBuffered;
 import com.swirlds.common.metrics.statistics.StatsRunningAverage;
@@ -31,7 +30,8 @@ public class PlatformRunningAverageMetric extends AbstractDistributionMetric imp
     @SuppressWarnings("removal")
     public PlatformRunningAverageMetric(final RunningAverageMetric.Config config, final Time time) {
         super(config, config.getHalfLife());
-        this.runningAverage = new StatsRunningAverage(halfLife, time);
+
+        runningAverage = new StatsRunningAverage(config.getHalfLife(), time);
     }
 
     /**
@@ -60,17 +60,5 @@ public class PlatformRunningAverageMetric extends AbstractDistributionMetric imp
     @Override
     public double get() {
         return runningAverage.getWeightedMean();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("halfLife", halfLife)
-                .append("value", get())
-                .toString();
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformSpeedometerMetric.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformSpeedometerMetric.java
@@ -2,7 +2,6 @@
 package com.swirlds.common.metrics.platform;
 
 import com.swirlds.base.time.Time;
-import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.common.metrics.SpeedometerMetric;
 import com.swirlds.common.metrics.statistics.StatsBuffered;
 import com.swirlds.common.metrics.statistics.StatsSpeedometer;
@@ -30,7 +29,7 @@ public class PlatformSpeedometerMetric extends AbstractDistributionMetric implem
     @SuppressWarnings("removal")
     public PlatformSpeedometerMetric(final SpeedometerMetric.Config config, final Time time) {
         super(config, config.getHalfLife());
-        this.speedometer = new StatsSpeedometer(halfLife, time);
+        this.speedometer = new StatsSpeedometer(config.getHalfLife(), time);
     }
 
     /**
@@ -67,17 +66,5 @@ public class PlatformSpeedometerMetric extends AbstractDistributionMetric implem
     @Override
     public double get() {
         return speedometer.getCyclesPerSecond();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("halfLife", halfLife)
-                .append("value", get())
-                .toString();
     }
 }

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformStatEntry.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/metrics/platform/PlatformStatEntry.java
@@ -50,12 +50,14 @@ public class PlatformStatEntry extends AbstractMetric implements StatEntry {
     @SuppressWarnings("unchecked")
     public PlatformStatEntry(@NonNull final StatEntry.Config<?> config) {
         super(config);
-        this.dataType = MetricConfig.mapDataType(config.getType());
-        this.buffered = config.getBuffered();
-        this.reset = config.getReset();
-        this.statsStringSupplier = (Supplier<Object>) config.getStatsStringSupplier();
-        this.resetStatsStringSupplier = (Supplier<Object>) config.getResetStatsStringSupplier();
+
+        dataType = MetricConfig.mapDataType(config.getType());
+        buffered = config.getBuffered();
+        reset = config.getReset();
+        statsStringSupplier = (Supplier<Object>) config.getStatsStringSupplier();
+        resetStatsStringSupplier = (Supplier<Object>) config.getResetStatsStringSupplier();
         halfLife = config.getHalfLife();
+
         if (config.getInit() != null) {
             config.getInit().apply(halfLife);
         }
@@ -143,10 +145,7 @@ public class PlatformStatEntry extends AbstractMetric implements StatEntry {
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", statsStringSupplier.get())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", statsStringSupplier.get());
     }
 }

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/FunctionGaugeConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/FunctionGaugeConfigTest.java
@@ -59,29 +59,20 @@ class FunctionGaugeConfigTest {
 
     @Test
     void testSetters() {
-        // given
-        final FunctionGauge.Config<String> config = new FunctionGauge.Config<>(CATEGORY, NAME, String.class, SUPPLIER);
-
         // when
-        final FunctionGauge.Config<String> result =
-                config.withDescription(DESCRIPTION).withUnit(UNIT).withFormat(FORMAT);
+        final FunctionGauge.Config<String> config = new FunctionGauge.Config<>(CATEGORY, NAME, String.class, SUPPLIER)
+                .withDescription(DESCRIPTION)
+                .withUnit(UNIT)
+                .withFormat(FORMAT);
 
         // then
         assertThat(config.getCategory()).isEqualTo(CATEGORY);
         assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
+        assertThat(config.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(config.getUnit()).isEqualTo(UNIT);
+        assertThat(config.getFormat()).isEqualTo(FORMAT);
         assertThat(config.getType()).isEqualTo(String.class);
         assertThat(config.getSupplier()).isEqualTo(SUPPLIER);
-
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getType()).isEqualTo(String.class);
-        assertThat(result.getSupplier()).isEqualTo(SUPPLIER);
     }
 
     @Test

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerPairAccumulatorConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/IntegerPairAccumulatorConfigTest.java
@@ -72,11 +72,11 @@ class IntegerPairAccumulatorConfigTest {
         final IntBinaryOperator leftAccumulator = mock(IntBinaryOperator.class);
         final IntBinaryOperator rightAccumulator = mock(IntBinaryOperator.class);
         final BiFunction<Integer, Integer, Integer> resultFunction = mock(BiFunction.class);
-        final IntegerPairAccumulator.Config<Integer> config =
-                new IntegerPairAccumulator.Config<>(CATEGORY, NAME, Integer.class, resultFunction);
 
         // when
-        final IntegerPairAccumulator.Config<Integer> result = config.withDescription(DESCRIPTION)
+        final IntegerPairAccumulator.Config<Integer> config = new IntegerPairAccumulator.Config<>(
+                        CATEGORY, NAME, Integer.class, resultFunction)
+                .withDescription(DESCRIPTION)
                 .withUnit(UNIT)
                 .withFormat(FORMAT)
                 .withLeftAccumulator(leftAccumulator)
@@ -85,23 +85,13 @@ class IntegerPairAccumulatorConfigTest {
         // then
         assertThat(config.getCategory()).isEqualTo(CATEGORY);
         assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
+        assertThat(config.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(config.getUnit()).isEqualTo(UNIT);
+        assertThat(config.getFormat()).isEqualTo(FORMAT);
         assertThat(config.getType()).isEqualTo(Integer.class);
-        assertThat(config.getLeftAccumulator().applyAsInt(2, 3)).isEqualTo(2 + 3);
-        assertThat(config.getRightAccumulator().applyAsInt(5, 7)).isEqualTo(5 + 7);
+        assertThat(config.getLeftAccumulator()).isEqualTo(leftAccumulator);
+        assertThat(config.getRightAccumulator()).isEqualTo(rightAccumulator);
         assertThat(config.getResultFunction()).isEqualTo(resultFunction);
-
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getType()).isEqualTo(Integer.class);
-        assertThat(result.getLeftAccumulator()).isEqualTo(leftAccumulator);
-        assertThat(result.getRightAccumulator()).isEqualTo(rightAccumulator);
-        assertThat(result.getResultFunction()).isEqualTo(resultFunction);
     }
 
     @SuppressWarnings("unchecked")

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/RunningAverageMetricConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/RunningAverageMetricConfigTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 class RunningAverageMetricConfigTest {
 
     private static final String DEFAULT_FORMAT = FloatFormats.FORMAT_11_3;
-    private static final float DEFAULT_HALF_LIFE = -1;
+    private static final float DEFAULT_HALF_LIFE = 0.0f;
 
     private static final String CATEGORY = "CaTeGoRy";
     private static final String NAME = "NaMe";
@@ -34,7 +34,6 @@ class RunningAverageMetricConfigTest {
         assertThat(config.getUnit()).isEmpty();
         assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
         assertThat(config.getHalfLife()).isEqualTo(DEFAULT_HALF_LIFE);
-        assertThat(config.isUseDefaultHalfLife()).isTrue();
     }
 
     @Test
@@ -56,11 +55,9 @@ class RunningAverageMetricConfigTest {
 
     @Test
     void testSetters() {
-        // given
-        final RunningAverageMetric.Config config = new RunningAverageMetric.Config(CATEGORY, NAME);
-
         // when
-        final RunningAverageMetric.Config result = config.withDescription(DESCRIPTION)
+        final RunningAverageMetric.Config config = new RunningAverageMetric.Config(CATEGORY, NAME)
+                .withDescription(DESCRIPTION)
                 .withUnit(UNIT)
                 .withFormat(FORMAT)
                 .withHalfLife(Math.PI);
@@ -68,19 +65,10 @@ class RunningAverageMetricConfigTest {
         // then
         assertThat(config.getCategory()).isEqualTo(CATEGORY);
         assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-        assertThat(config.getHalfLife()).isEqualTo(DEFAULT_HALF_LIFE);
-        assertThat(config.isUseDefaultHalfLife()).isTrue();
-
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getHalfLife()).isEqualTo(Math.PI, within(EPSILON));
-        assertThat(result.isUseDefaultHalfLife()).isFalse();
+        assertThat(config.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(config.getUnit()).isEqualTo(UNIT);
+        assertThat(config.getFormat()).isEqualTo(FORMAT);
+        assertThat(config.getHalfLife()).isEqualTo(Math.PI, within(EPSILON));
     }
 
     @Test

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/SpeedometerMetricConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/SpeedometerMetricConfigTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 class SpeedometerMetricConfigTest {
 
     private static final String DEFAULT_FORMAT = FloatFormats.FORMAT_11_3;
-    private static final float DEFAULT_HALF_LIFE = -1;
+    private static final float DEFAULT_HALF_LIFE = 0.0f;
 
     private static final String CATEGORY = "CaTeGoRy";
     private static final String NAME = "NaMe";
@@ -34,7 +34,6 @@ class SpeedometerMetricConfigTest {
         assertThat(config.getUnit()).isEmpty();
         assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
         assertThat(config.getHalfLife()).isEqualTo(DEFAULT_HALF_LIFE);
-        assertThat(config.isUseDefaultHalfLife()).isTrue();
     }
 
     @Test
@@ -54,11 +53,9 @@ class SpeedometerMetricConfigTest {
 
     @Test
     void testSetters() {
-        // given
-        final SpeedometerMetric.Config config = new SpeedometerMetric.Config(CATEGORY, NAME);
-
         // when
-        final SpeedometerMetric.Config result = config.withDescription(DESCRIPTION)
+        final SpeedometerMetric.Config config = new SpeedometerMetric.Config(CATEGORY, NAME)
+                .withDescription(DESCRIPTION)
                 .withUnit(UNIT)
                 .withFormat(FORMAT)
                 .withHalfLife(Math.PI);
@@ -66,19 +63,10 @@ class SpeedometerMetricConfigTest {
         // then
         assertThat(config.getCategory()).isEqualTo(CATEGORY);
         assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-        assertThat(config.getHalfLife()).isEqualTo(DEFAULT_HALF_LIFE);
-        assertThat(config.isUseDefaultHalfLife()).isTrue();
-
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getHalfLife()).isEqualTo(Math.PI, within(EPSILON));
-        assertThat(result.isUseDefaultHalfLife()).isFalse();
+        assertThat(config.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(config.getUnit()).isEqualTo(UNIT);
+        assertThat(config.getFormat()).isEqualTo(FORMAT);
+        assertThat(config.getHalfLife()).isEqualTo(Math.PI, within(EPSILON));
     }
 
     @Test

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/StatEntryConfigTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/StatEntryConfigTest.java
@@ -83,10 +83,10 @@ class StatEntryConfigTest {
         final Consumer<Double> reset = mock(Consumer.class);
         final Supplier<Object> getter = mock(Supplier.class);
         final Supplier<Object> getAndReset = mock(Supplier.class);
-        final StatEntry.Config config = new StatEntry.Config(CATEGORY, NAME, Object.class, getter);
 
         // when
-        final StatEntry.Config result = config.withDescription(DESCRIPTION)
+        final StatEntry.Config<Object> config = new StatEntry.Config<>(CATEGORY, NAME, Object.class, getter)
+                .withDescription(DESCRIPTION)
                 .withUnit(UNIT)
                 .withFormat(FORMAT)
                 .withBuffered(buffered)
@@ -94,30 +94,17 @@ class StatEntryConfigTest {
                 .withReset(reset)
                 .withResetStatsStringSupplier(getAndReset);
 
-        // then
         assertThat(config.getCategory()).isEqualTo(CATEGORY);
         assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
+        assertThat(config.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(config.getUnit()).isEqualTo(UNIT);
+        assertThat(config.getFormat()).isEqualTo(FORMAT);
         assertThat(config.getType()).isEqualTo(Object.class);
-        assertThat(config.getBuffered()).isNull();
-        assertThat(config.getInit()).isNull();
-        assertThat(config.getReset()).isNull();
+        assertThat(config.getBuffered()).isEqualTo(buffered);
+        assertThat(config.getInit()).isEqualTo(init);
+        assertThat(config.getReset()).isEqualTo(reset);
         assertThat(config.getStatsStringSupplier()).isEqualTo(getter);
-        assertThat(config.getResetStatsStringSupplier()).isEqualTo(getter);
-
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getType()).isEqualTo(Object.class);
-        assertThat(result.getBuffered()).isEqualTo(buffered);
-        assertThat(result.getInit()).isEqualTo(init);
-        assertThat(result.getReset()).isEqualTo(reset);
-        assertThat(result.getStatsStringSupplier()).isEqualTo(getter);
-        assertThat(result.getResetStatsStringSupplier()).isEqualTo(getAndReset);
+        assertThat(config.getResetStatsStringSupplier()).isEqualTo(getAndReset);
     }
 
     @SuppressWarnings("unchecked")
@@ -125,7 +112,7 @@ class StatEntryConfigTest {
     void testSettersWithIllegalParameters() {
         // given
         final Supplier<Object> getter = mock(Supplier.class);
-        final StatEntry.Config config = new StatEntry.Config(CATEGORY, NAME, Object.class, getter);
+        final StatEntry.Config<Object> config = new StatEntry.Config<>(CATEGORY, NAME, Object.class, getter);
         final String longDescription = DESCRIPTION.repeat(50);
 
         // then
@@ -148,7 +135,7 @@ class StatEntryConfigTest {
     void testToString() {
         // given
         final Supplier<Object> getter = mock(Supplier.class);
-        final StatEntry.Config config = new StatEntry.Config(CATEGORY, NAME, Object.class, getter)
+        final StatEntry.Config<Object> config = new StatEntry.Config<>(CATEGORY, NAME, Object.class, getter)
                 .withDescription(DESCRIPTION)
                 .withUnit(UNIT)
                 .withFormat(FORMAT);

--- a/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/PlatformStatEntryTest.java
+++ b/platform-sdk/swirlds-common/src/test/java/com/swirlds/common/metrics/platform/PlatformStatEntryTest.java
@@ -54,7 +54,7 @@ class PlatformStatEntryTest {
         final Supplier<Object> getAndReset = mock(Supplier.class);
 
         // when
-        final StatEntry.Config config = new StatEntry.Config(CATEGORY, NAME, Object.class, getter)
+        final StatEntry.Config<Object> config = new StatEntry.Config<>(CATEGORY, NAME, Object.class, getter)
                 .withDescription(DESCRIPTION)
                 .withUnit(UNIT)
                 .withFormat(FORMAT)
@@ -250,7 +250,7 @@ class PlatformStatEntryTest {
     void testToString() {
         // given
         final Supplier<Object> getter = mock(Supplier.class);
-        final StatEntry.Config config = new StatEntry.Config(CATEGORY, NAME, Object.class, getter)
+        final StatEntry.Config<Object> config = new StatEntry.Config<>(CATEGORY, NAME, Object.class, getter)
                 .withDescription(DESCRIPTION)
                 .withUnit(UNIT)
                 .withFormat(FORMAT);

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/Counter.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/Counter.java
@@ -3,7 +3,6 @@ package com.swirlds.metrics.api;
 
 import static com.swirlds.metrics.api.Metric.ValueType.VALUE;
 
-import com.swirlds.base.utility.ToStringBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.EnumSet;
 import java.util.Objects;
@@ -39,7 +38,7 @@ public interface Counter extends Metric {
     @Override
     @NonNull
     default EnumSet<ValueType> getValueTypes() {
-        return EnumSet.of(VALUE);
+        return SINGLE_VALUE_TYPE_SET;
     }
 
     /**
@@ -83,7 +82,9 @@ public interface Counter extends Metric {
     final class Config extends MetricConfig<Counter, Counter.Config> {
 
         /**
-         * Constructor of {@code Counter.Config}
+         * Constructor of {@code Counter.Config}.
+         * <p>
+         * By default, the {@link Metric#getFormat() Metric.format} is set to {@value MetricConfig#NUMBER_FORMAT}.
          *
          * @param category the kind of metric (metrics are grouped or filtered by this)
          * @param name     a short name for the metric
@@ -91,43 +92,8 @@ public interface Counter extends Metric {
          * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
          */
         public Config(@NonNull final String category, @NonNull final String name) {
-            super(category, name, "%d");
-        }
-
-        /**
-         * Constructor of {@code Counter.Config}
-         *
-         * @param category    the kind of metric (metrics are grouped or filtered by this)
-         * @param name        a short name for the metric
-         * @param description metric description
-         * @param unit        metric unit
-         * @throws NullPointerException     if one of the parameters is {@code null}
-         * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
-         */
-        private Config(
-                @NonNull final String category,
-                @NonNull final String name,
-                @NonNull final String description,
-                @NonNull final String unit) {
-            super(category, name, description, unit, "%d");
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public Counter.Config withDescription(@NonNull final String description) {
-            return new Counter.Config(getCategory(), getName(), description, getUnit());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public Counter.Config withUnit(@NonNull final String unit) {
-            return new Counter.Config(getCategory(), getName(), getDescription(), unit);
+            super(category, name);
+            withNumberFormat();
         }
 
         /**
@@ -152,8 +118,8 @@ public interface Counter extends Metric {
          * {@inheritDoc}
          */
         @Override
-        public String toString() {
-            return new ToStringBuilder(this).appendSuper(super.toString()).toString();
+        protected Config self() {
+            return this;
         }
     }
 }

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/DoubleGauge.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/DoubleGauge.java
@@ -40,7 +40,7 @@ public interface DoubleGauge extends Metric {
     @NonNull
     @Override
     default EnumSet<ValueType> getValueTypes() {
-        return EnumSet.of(VALUE);
+        return SINGLE_VALUE_TYPE_SET;
     }
 
     /**
@@ -85,14 +85,12 @@ public interface DoubleGauge extends Metric {
      */
     final class Config extends MetricConfig<DoubleGauge, Config> {
 
-        private final double initialValue;
+        private double initialValue;
 
         /**
          * Constructor of {@code DoubleGauge.Config}
          * <p>
-         * The {@link #getInitialValue() initialValue} is by default set to {@code 0.0}
-         * <p>
-         * The initial value is set to {@code 0.0}.
+         * The initial value is set to {@code 0.0} and format is set to {@value FloatFormats#FORMAT_11_3}.
          *
          * @param category the kind of metric (metrics are grouped or filtered by this)
          * @param name     a short name for the metric
@@ -100,67 +98,8 @@ public interface DoubleGauge extends Metric {
          * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
          */
         public Config(@NonNull final String category, @NonNull final String name) {
-            super(category, name, FloatFormats.FORMAT_11_3);
-            this.initialValue = 0.0;
-        }
-
-        /**
-         * Constructor of {@code DoubleGauge.Config}
-         *
-         *
-         * @param category     the kind of metric (metrics are grouped or filtered by this)
-         * @param name         a short name for the metric
-         * @param description  metric description
-         * @param unit         metric unit
-         * @param format       format for metric
-         * @param initialValue initialValue for metric
-         * @throws NullPointerException     if one of the parameters is {@code null}
-         * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
-         */
-        private Config(
-                @NonNull final String category,
-                @NonNull final String name,
-                @NonNull final String description,
-                @NonNull final String unit,
-                @NonNull final String format,
-                final double initialValue) {
-
-            super(category, name, description, unit, format);
-            this.initialValue = initialValue;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public DoubleGauge.Config withDescription(@NonNull final String description) {
-            return new DoubleGauge.Config(
-                    getCategory(), getName(), description, getUnit(), getFormat(), getInitialValue());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public DoubleGauge.Config withUnit(@NonNull final String unit) {
-            return new DoubleGauge.Config(
-                    getCategory(), getName(), getDescription(), unit, getFormat(), getInitialValue());
-        }
-
-        /**
-         * Sets the {@link Metric#getFormat() Metric.format} in fluent style.
-         *
-         * @param format the format-string
-         * @return a new configuration-object with updated {@code format}
-         * @throws NullPointerException     if {@code format} is {@code null}
-         * @throws IllegalArgumentException if {@code format} consists only of whitespaces
-         */
-        @NonNull
-        public DoubleGauge.Config withFormat(@NonNull final String format) {
-            return new DoubleGauge.Config(
-                    getCategory(), getName(), getDescription(), getUnit(), format, getInitialValue());
+            super(category, name);
+            withFormat(FloatFormats.FORMAT_11_3);
         }
 
         /**
@@ -176,12 +115,12 @@ public interface DoubleGauge extends Metric {
          * Fluent-style setter of the initial value.
          *
          * @param initialValue the initial value
-         * @return a new configuration-object with updated {@code initialValue}
+         * @return self-reference
          */
         @NonNull
         public DoubleGauge.Config withInitialValue(final double initialValue) {
-            return new DoubleGauge.Config(
-                    getCategory(), getName(), getDescription(), getUnit(), getFormat(), initialValue);
+            this.initialValue = initialValue;
+            return this;
         }
 
         /**
@@ -202,15 +141,17 @@ public interface DoubleGauge extends Metric {
             return factory.createDoubleGauge(this);
         }
 
+        @Override
+        protected Config self() {
+            return this;
+        }
+
         /**
          * {@inheritDoc}
          */
         @Override
-        public String toString() {
-            return new ToStringBuilder(this)
-                    .appendSuper(super.toString())
-                    .append("initialValue", initialValue)
-                    .toString();
+        public ToStringBuilder selfToString() {
+            return super.selfToString().append("initialValue", initialValue);
         }
     }
 }

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/IntegerGauge.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/IntegerGauge.java
@@ -39,7 +39,7 @@ public interface IntegerGauge extends Metric {
     @NonNull
     @Override
     default EnumSet<ValueType> getValueTypes() {
-        return EnumSet.of(VALUE);
+        return SINGLE_VALUE_TYPE_SET;
     }
 
     /**
@@ -83,88 +83,22 @@ public interface IntegerGauge extends Metric {
      */
     final class Config extends MetricConfig<IntegerGauge, IntegerGauge.Config> {
 
-        private final int initialValue;
+        private int initialValue;
 
         /**
          * Constructor of {@code IntegerGauge.Config}
          *
          * The {@link #getInitialValue() initialValue} is by default set to {@code 0},
-         * the {@link #getFormat() format} is set to "%d".
+         * the {@link #getFormat() format} is set to {@value MetricConfig#NUMBER_FORMAT}.
          *
-         * @param category
-         * 		the kind of metric (metrics are grouped or filtered by this)
-         * @param name
-         * 		a short name for the metric
+         * @param category the kind of metric (metrics are grouped or filtered by this)
+         * @param name a short name for the metric
          * @throws NullPointerException     if one of the parameters is {@code null}
          * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
          */
         public Config(@NonNull final String category, @NonNull final String name) {
-
-            super(category, name, "%d");
-            this.initialValue = 0;
-        }
-
-        /**
-         * Constructor of {@code IntegerGauge.Config}
-         *
-         * The {@link #getInitialValue() initialValue} is by default set to {@code 0},
-         * the {@link #getFormat() format} is set to "%d".
-         *
-         * @param category
-         * 		the kind of metric (metrics are grouped or filtered by this)
-         * @param name
-         * 		a short name for the metric
-         * @param description metric description
-         * @param unit        metric unit
-         * @param format format for metric
-         * @throws NullPointerException     if one of the parameters is {@code null}
-         * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
-         */
-        private Config(
-                @NonNull final String category,
-                @NonNull final String name,
-                @NonNull final String description,
-                @NonNull final String unit,
-                @NonNull final String format,
-                final int initialValue) {
-
-            super(category, name, description, unit, format);
-            this.initialValue = initialValue;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public IntegerGauge.Config withDescription(@NonNull final String description) {
-            return new IntegerGauge.Config(
-                    getCategory(), getName(), description, getUnit(), getFormat(), getInitialValue());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public IntegerGauge.Config withUnit(@NonNull final String unit) {
-            return new IntegerGauge.Config(
-                    getCategory(), getName(), getDescription(), unit, getFormat(), getInitialValue());
-        }
-
-        /**
-         * Sets the {@link Metric#getFormat() Metric.format} in fluent style.
-         *
-         * @param format
-         * 		the format-string
-         * @return a new configuration-object with updated {@code format}
-         * @throws NullPointerException     if {@code format} is {@code null}
-         * @throws IllegalArgumentException if {@code format} consists only of whitespaces
-         */
-        @NonNull
-        public IntegerGauge.Config withFormat(@NonNull final String format) {
-            return new IntegerGauge.Config(
-                    getCategory(), getName(), getDescription(), getUnit(), format, getInitialValue());
+            super(category, name);
+            withNumberFormat();
         }
 
         /**
@@ -179,14 +113,13 @@ public interface IntegerGauge extends Metric {
         /**
          * Fluent-style setter of the initial value.
          *
-         * @param initialValue
-         * 		the initial value
-         * @return a new configuration-object with updated {@code initialValue}
+         * @param initialValue the initial value
+         * @return self-reference
          */
         @NonNull
         public IntegerGauge.Config withInitialValue(final int initialValue) {
-            return new IntegerGauge.Config(
-                    getCategory(), getName(), getDescription(), getUnit(), getFormat(), initialValue);
+            this.initialValue = initialValue;
+            return this;
         }
 
         /**
@@ -207,15 +140,17 @@ public interface IntegerGauge extends Metric {
             return factory.createIntegerGauge(this);
         }
 
+        @Override
+        protected Config self() {
+            return this;
+        }
+
         /**
          * {@inheritDoc}
          */
         @Override
-        public String toString() {
-            return new ToStringBuilder(this)
-                    .appendSuper(super.toString())
-                    .append("initialValue", initialValue)
-                    .toString();
+        public ToStringBuilder selfToString() {
+            return super.selfToString().append("initialValue", initialValue);
         }
     }
 }

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/LongAccumulator.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/LongAccumulator.java
@@ -5,7 +5,6 @@ import static com.swirlds.metrics.api.Metric.ValueType.VALUE;
 
 import com.swirlds.base.utility.ToStringBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.EnumSet;
 import java.util.Objects;
 import java.util.function.LongBinaryOperator;
@@ -45,7 +44,7 @@ public interface LongAccumulator extends Metric {
     @NonNull
     @Override
     default EnumSet<ValueType> getValueTypes() {
-        return EnumSet.of(VALUE);
+        return SINGLE_VALUE_TYPE_SET;
     }
 
     /**
@@ -92,120 +91,24 @@ public interface LongAccumulator extends Metric {
      */
     final class Config extends MetricConfig<LongAccumulator, LongAccumulator.Config> {
 
-        private final @NonNull LongBinaryOperator accumulator;
-        private final @Nullable LongSupplier initializer;
-
-        private final long initialValue;
+        private @NonNull LongBinaryOperator accumulator = Long::max;
+        private @NonNull LongSupplier initializer = LONG_DEFAULT_INITIALIZER;
 
         /**
          * Constructor of {@code LongAccumulator.Config}
          *
          * By default, the {@link #getAccumulator() accumulator} is set to {@code Long::max},
          * the {@link #getInitialValue() initialValue} is set to {@code 0L},
-         * and {@link #getFormat() format} is set to {@code "%d"}.
+         * and {@link #getFormat() format} is set to {@value #NUMBER_FORMAT}.
          *
-         * @param category
-         * 		the kind of metric (metrics are grouped or filtered by this)
-         * @param name
-         * 		a short name for the metric
+         * @param category the kind of metric (metrics are grouped or filtered by this)
+         * @param name a short name for the metric
          * @throws IllegalArgumentException
          * 		if one of the parameters is {@code null} or consists only of whitespaces
          */
         public Config(@NonNull final String category, @NonNull final String name) {
-            super(category, name, "%d");
-            this.accumulator = Long::max;
-            this.initializer = null;
-            this.initialValue = 0L;
-        }
-
-        /**
-         * Constructor of {@code LongAccumulator.Config}
-         *
-         * By default, the {@link #getAccumulator() accumulator} is set to {@code Long::max},
-         * the {@link #getInitialValue() initialValue} is set to {@code 0L},
-         * and {@link #getFormat() format} is set to {@code "%d"}.
-         *
-         * @param category
-         * 		the kind of metric (metrics are grouped or filtered by this)
-         * @param name
-         * 		a short name for the metric
-         * @param description metric description
-         * @param unit        metric unit
-         * @param accumulator accumulator for metric
-         * @param initializer initializer for metric
-         * @throws NullPointerException     if one of the parameters is {@code null}
-         * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
-         */
-        private Config(
-                @NonNull final String category,
-                @NonNull final String name,
-                @NonNull final String description,
-                @NonNull final String unit,
-                @NonNull final String format,
-                @NonNull final LongBinaryOperator accumulator,
-                @Nullable final LongSupplier initializer,
-                final long initialValue) {
-
-            super(category, name, description, unit, format);
-            this.accumulator = Objects.requireNonNull(accumulator, "accumulator must not be null");
-            this.initializer = initializer;
-            this.initialValue = initialValue;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public LongAccumulator.Config withDescription(@NonNull final String description) {
-            return new LongAccumulator.Config(
-                    getCategory(),
-                    getName(),
-                    description,
-                    getUnit(),
-                    getFormat(),
-                    getAccumulator(),
-                    getInitializer(),
-                    getInitialValue());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public LongAccumulator.Config withUnit(@NonNull final String unit) {
-            return new LongAccumulator.Config(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    unit,
-                    getFormat(),
-                    getAccumulator(),
-                    getInitializer(),
-                    getInitialValue());
-        }
-
-        /**
-         * Sets the {@link Metric#getFormat() Metric.format} in fluent style.
-         *
-         * @param format
-         * 		the format-string
-         * @return a new configuration-object with updated {@code format}
-         * @throws NullPointerException     if {@code format} is {@code null}
-         * @throws IllegalArgumentException if {@code format} consists only of whitespaces
-         */
-        @NonNull
-        public LongAccumulator.Config withFormat(@NonNull final String format) {
-            return new LongAccumulator.Config(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    format,
-                    getAccumulator(),
-                    getInitializer(),
-                    getInitialValue());
+            super(category, name);
+            withNumberFormat();
         }
 
         /**
@@ -223,7 +126,7 @@ public interface LongAccumulator extends Metric {
          *
          * @return the initializer
          */
-        @Nullable
+        @NonNull
         public LongSupplier getInitializer() {
             return initializer;
         }
@@ -234,21 +137,13 @@ public interface LongAccumulator extends Metric {
          * The accumulator should be side-effect-free, since it may be re-applied when attempted updates fail
          * due to contention among threads.
          *
-         * @param accumulator
-         * 		The {@link LongBinaryOperator} that is used to accumulate the value.
-         * @return a new configuration-object with updated {@code initialValue}
+         * @param accumulator the {@link LongBinaryOperator} that is used to accumulate the value.
+         * @return self-reference
          */
         @NonNull
         public LongAccumulator.Config withAccumulator(@NonNull final LongBinaryOperator accumulator) {
-            return new LongAccumulator.Config(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    getFormat(),
-                    accumulator,
-                    getInitializer(),
-                    getInitialValue());
+            this.accumulator = Objects.requireNonNull(accumulator, "accumulator must not be null");
+            return this;
         }
 
         /**
@@ -256,50 +151,27 @@ public interface LongAccumulator extends Metric {
          * <p>
          * If both {@code initializer} and {@code initialValue} are set, the {@code initialValue} is ignored
          *
-         * @param initializer
-         * 		the initializer
-         * @return a new configuration-object with updated {@code initializer}
+         * @param initializer the initializer
+         * @return self-reference
          */
         @NonNull
         public LongAccumulator.Config withInitializer(@NonNull final LongSupplier initializer) {
-            return new LongAccumulator.Config(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    getFormat(),
-                    getAccumulator(),
-                    Objects.requireNonNull(initializer, "initializer"),
-                    getInitialValue());
-        }
-
-        /**
-         * Getter of the {@link LongAccumulator#getInitialValue() initialValue}
-         *
-         * @return the initial value
-         */
-        public long getInitialValue() {
-            return initialValue;
+            this.initializer = Objects.requireNonNull(initializer, "initializer must not be null");
+            return this;
         }
 
         /**
          * Fluent-style setter of the initial value.
          *
-         * @param initialValue
-         * 		the initial value
-         * @return a reference to {@code this}
+         * @param initialValue the initial value
+         * @return self-reference
          */
         @NonNull
         public LongAccumulator.Config withInitialValue(final long initialValue) {
-            return new LongAccumulator.Config(
-                    getCategory(),
-                    getName(),
-                    getDescription(),
-                    getUnit(),
-                    getFormat(),
-                    getAccumulator(),
-                    getInitializer(),
-                    initialValue);
+            if (initialValue == 0L) {
+                return withInitializer(LONG_DEFAULT_INITIALIZER);
+            }
+            return withInitializer(() -> initialValue);
         }
 
         /**
@@ -324,11 +196,16 @@ public interface LongAccumulator extends Metric {
          * {@inheritDoc}
          */
         @Override
-        public String toString() {
-            return new ToStringBuilder(this)
-                    .appendSuper(super.toString())
-                    .append("initialValue", initialValue)
-                    .toString();
+        protected Config self() {
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected ToStringBuilder selfToString() {
+            return super.selfToString().append("initialValue", initializer.getAsLong());
         }
     }
 }

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/LongGauge.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/LongGauge.java
@@ -39,7 +39,7 @@ public interface LongGauge extends Metric {
     @NonNull
     @Override
     default EnumSet<ValueType> getValueTypes() {
-        return EnumSet.of(VALUE);
+        return SINGLE_VALUE_TYPE_SET;
     }
 
     /**
@@ -83,90 +83,23 @@ public interface LongGauge extends Metric {
      */
     final class Config extends MetricConfig<LongGauge, LongGauge.Config> {
 
-        private final long initialValue;
+        private long initialValue;
 
         /**
          * Constructor of {@code LongGauge.Config}
          *
          *
          * The {@link #getInitialValue() initialValue} is by default set to {@code 0L},
-         * the {@link #getFormat() format} is set to "%d".
+         * the {@link #getFormat() format} is set to {@value NUMBER_FORMAT}.
          *
-         * @param category
-         * 		the kind of metric (metrics are grouped or filtered by this)
-         * @param name
-         * 		a short name for the metric
+         * @param category the kind of metric (metrics are grouped or filtered by this)
+         * @param name a short name for the metric
          * @throws NullPointerException     if one of the parameters is {@code null}
          * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
          */
         public Config(@NonNull final String category, @NonNull final String name) {
-            super(category, name, "%d");
-            this.initialValue = 0L;
-        }
-
-        /**
-         * Constructor of {@code LongGauge.Config}
-         *
-         *
-         * The {@link #getInitialValue() initialValue} is by default set to {@code 0L},
-         * the {@link #getFormat() format} is set to "%d".
-         *
-         * @param category
-         * 		the kind of metric (metrics are grouped or filtered by this)
-         * @param name
-         * 		a short name for the metric
-         * @param description metric description
-         * @param unit        metric unit
-         * @param format format for metric
-         * @param initialValue initialValue for metric
-         * @throws NullPointerException     if one of the parameters is {@code null}
-         * @throws IllegalArgumentException if one of the parameters consists only of whitespaces
-         */
-        private Config(
-                @NonNull final String category,
-                @NonNull final String name,
-                @NonNull final String description,
-                @NonNull final String unit,
-                @NonNull final String format,
-                final long initialValue) {
-
-            super(category, name, description, unit, format);
-            this.initialValue = initialValue;
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public LongGauge.Config withDescription(@NonNull final String description) {
-            return new LongGauge.Config(
-                    getCategory(), getName(), description, getUnit(), getFormat(), getInitialValue());
-        }
-
-        /**
-         * {@inheritDoc}
-         */
-        @NonNull
-        @Override
-        public LongGauge.Config withUnit(@NonNull final String unit) {
-            return new LongGauge.Config(
-                    getCategory(), getName(), getDescription(), unit, getFormat(), getInitialValue());
-        }
-
-        /**
-         * Sets the {@link Metric#getFormat() Metric.format} in fluent style.
-         *
-         * @param format
-         * 		the format-string
-         * @return a new configuration-object with updated {@code format}
-         * @throws NullPointerException     if {@code format} is {@code null}
-         * @throws IllegalArgumentException if {@code format} consists only of whitespaces
-         */
-        @NonNull
-        public LongGauge.Config withFormat(@NonNull final String format) {
-            return new LongGauge.Config(
-                    getCategory(), getName(), getDescription(), getUnit(), format, getInitialValue());
+            super(category, name);
+            withNumberFormat();
         }
 
         /**
@@ -181,14 +114,13 @@ public interface LongGauge extends Metric {
         /**
          * Fluent-style setter of the initial value.
          *
-         * @param initialValue
-         * 		the initial value
-         * @return a new configuration-object with updated {@code initialValue}
+         * @param initialValue the initial value
+         * @return self-reference
          */
         @NonNull
         public LongGauge.Config withInitialValue(final long initialValue) {
-            return new LongGauge.Config(
-                    getCategory(), getName(), getDescription(), getUnit(), getFormat(), initialValue);
+            this.initialValue = initialValue;
+            return this;
         }
 
         /**
@@ -213,11 +145,16 @@ public interface LongGauge extends Metric {
          * {@inheritDoc}
          */
         @Override
-        public String toString() {
-            return new ToStringBuilder(this)
-                    .appendSuper(super.toString())
-                    .append("initialValue", initialValue)
-                    .toString();
+        protected Config self() {
+            return this;
+        }
+
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        protected ToStringBuilder selfToString() {
+            return super.selfToString().append("initialValue", initialValue);
         }
     }
 }

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/Metric.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/Metric.java
@@ -9,6 +9,9 @@ import java.util.EnumSet;
  */
 public interface Metric {
 
+    EnumSet<ValueType> SINGLE_VALUE_TYPE_SET = EnumSet.of(ValueType.VALUE);
+    EnumSet<ValueType> ALL_VALUE_TYPES_SET = EnumSet.allOf(ValueType.class);
+
     /**
      * A {@code Metric} can keep track of several values, which are distinguished via the {@code MetricType}
      */

--- a/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/MetricsFactory.java
+++ b/platform-sdk/swirlds-metrics-api/src/main/java/com/swirlds/metrics/api/MetricsFactory.java
@@ -2,6 +2,7 @@
 package com.swirlds.metrics.api;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
 
 /**
  * Factory for basic {@link Metric}-implementations
@@ -77,4 +78,28 @@ public interface MetricsFactory {
      */
     @NonNull
     LongGauge createLongGauge(@NonNull final LongGauge.Config config);
+
+    /**
+     * Creates a {@link Metric}.
+     * <p>
+     * The default implementation calls the appropriate method within this factory.
+     *
+     * @param config
+     * 		the configuration
+     * @return the new {@code Metric}
+     * @param <T> sub-interface of the generated {@code Metric}
+     */
+    default <T extends Metric> T createMetric(@NonNull final MetricConfig<T, ?> config) {
+        Objects.requireNonNull(config, "config");
+
+        // We use the double-dispatch pattern to create a Metric. This simplifies the API, because it allows us
+        // to have a single method for all types of metrics. (The alternative would have been a method like
+        // getOrCreateCounter() for each type of metric.)
+        //
+        // This method here call MetricConfig.create() providing the MetricsFactory. This method is overridden by
+        // each subclass of MetricConfig to call the specific method in MetricsFactory, i.e. Counter.Config
+        // calls MetricsFactory.createCounter().
+
+        return config.create(this);
+    }
 }

--- a/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/BaseConfigTest.java
+++ b/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/BaseConfigTest.java
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.metrics.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+abstract class BaseConfigTest<C extends MetricConfig<?, C>> {
+
+    protected static final String CATEGORY = "CaTeGoRy";
+    protected static final String NAME = "NaMe";
+    protected static final String DESCRIPTION = "DeScRiPtIoN";
+    protected static final String UNIT = "UnIt";
+    protected static final String FORMAT = "FoRmAt";
+
+    protected abstract C create(String category, String name);
+
+    protected final C createBase() {
+        return create(CATEGORY, NAME);
+    }
+
+    protected final C createFull() {
+        return create(CATEGORY, NAME)
+                .withDescription(DESCRIPTION)
+                .withUnit(UNIT)
+                .withFormat(FORMAT);
+    }
+
+    @Test
+    @DisplayName("Constructor fails with illegal basic parameters")
+    void testBaseConstructorWithIllegalParameter() {
+        assertThatThrownBy(() -> create(null, NAME)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> create("", NAME)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> create(" \t\n", NAME)).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> create(CATEGORY, null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> create(CATEGORY, "")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> create(CATEGORY, " \t\n")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("Constructor initializes basic fields")
+    void testConstructorBaseFields() {
+        // when
+        final C config = create(CATEGORY, NAME);
+
+        // then
+        assertThat(config.getCategory()).isEqualTo(CATEGORY);
+        assertThat(config.getName()).isEqualTo(NAME);
+        assertThat(config.getDescription()).isEqualTo(NAME);
+        assertThat(config.getUnit()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Basic setters fail with illegal parameters")
+    void testBaseSettersWithIllegalParameters() {
+        // given
+        final C config = create(CATEGORY, NAME);
+
+        // then
+        assertThatThrownBy(() -> config.withDescription(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> config.withDescription("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> config.withDescription(" \t\n")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> config.withDescription(DESCRIPTION.repeat(50)))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> config.withUnit(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> config.withUnit("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> config.withUnit("\t\n")).isInstanceOf(IllegalArgumentException.class);
+
+        assertThatThrownBy(() -> config.withFormat(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> config.withFormat("")).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> config.withFormat("\t\n")).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("Basic setters store values")
+    void testBaseSetters() {
+        // when
+        C config = createFull();
+
+        // then
+        assertThat(config.getCategory()).isEqualTo(CATEGORY);
+        assertThat(config.getName()).isEqualTo(NAME);
+        assertThat(config.getDescription()).isEqualTo(DESCRIPTION);
+        assertThat(config.getUnit()).isEqualTo(UNIT);
+        assertThat(config.getFormat()).isEqualTo(FORMAT);
+    }
+
+    @Test
+    @DisplayName("toString contains basic values")
+    void testToStringBase() {
+        // when
+        final C config = createFull();
+
+        // then
+        assertThat(config.toString())
+                .contains(
+                        CATEGORY,
+                        NAME,
+                        DESCRIPTION,
+                        UNIT,
+                        FORMAT,
+                        config.getResultClass().getSimpleName());
+    }
+}

--- a/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/CounterConfigTest.java
+++ b/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/CounterConfigTest.java
@@ -2,89 +2,23 @@
 package com.swirlds.metrics.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class CounterConfigTest {
+class CounterConfigTest extends BaseConfigTest<Counter.Config> {
 
-    private static final String DEFAULT_FORMAT = "%d";
-
-    private static final String CATEGORY = "CaTeGoRy";
-    private static final String NAME = "NaMe";
-    private static final String DESCRIPTION = "DeScRiPtIoN";
-    private static final String UNIT = "UnIt";
+    @Override
+    protected Counter.Config create(String category, String name) {
+        return new Counter.Config(category, name);
+    }
 
     @Test
-    @DisplayName("Constructor should store values")
-    void testConstructor() {
+    @DisplayName("Constructor initializes custom format")
+    void testConstructorCustomFormat() {
         // when
-        final Counter.Config config = new Counter.Config(CATEGORY, NAME);
+        final Counter.Config config = createBase();
 
-        // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-    }
-
-    @Test
-    @DisplayName("Constructor should throw IAE when passing illegal parameters")
-    void testConstructorWithIllegalParameter() {
-        assertThatThrownBy(() -> new Counter.Config(null, NAME)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new Counter.Config("", NAME)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new Counter.Config(" \t\n", NAME)).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> new Counter.Config(CATEGORY, null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new Counter.Config(CATEGORY, "")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new Counter.Config(CATEGORY, " \t\n")).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void testSetters() {
-        // given
-        final Counter.Config config = new Counter.Config(CATEGORY, NAME);
-
-        // when
-        final Counter.Config result = config.withDescription(DESCRIPTION).withUnit(UNIT);
-
-        // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(DEFAULT_FORMAT);
-    }
-
-    @Test
-    void testSettersWithIllegalParameters() {
-        // given
-        final Counter.Config config = new Counter.Config(CATEGORY, NAME);
-        final String longDescription = DESCRIPTION.repeat(50);
-
-        // then
-        assertThatThrownBy(() -> config.withDescription(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withDescription("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(longDescription)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withUnit(null)).isInstanceOf(NullPointerException.class);
-    }
-
-    @Test
-    void testToString() {
-        // given
-        final Counter.Config config =
-                new Counter.Config(CATEGORY, NAME).withDescription(DESCRIPTION).withUnit(UNIT);
-
-        // then
-        assertThat(config.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT);
+        assertThat(config.getFormat()).isEqualTo(MetricConfig.NUMBER_FORMAT);
     }
 }

--- a/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/DoubleAccumulatorConfigTest.java
+++ b/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/DoubleAccumulatorConfigTest.java
@@ -7,113 +7,71 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoubleSupplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class DoubleAccumulatorConfigTest {
+class DoubleAccumulatorConfigTest extends BaseConfigTest<DoubleAccumulator.Config> {
 
-    private static final String DEFAULT_FORMAT = FloatFormats.FORMAT_11_3;
-
-    private static final String CATEGORY = "CaTeGoRy";
-    private static final String NAME = "NaMe";
-    private static final String DESCRIPTION = "DeScRiPtIoN";
-    private static final String UNIT = "UnIt";
-    private static final String FORMAT = "FoRmAt";
     private static final double EPSILON = 1e-6;
 
+    @Override
+    protected DoubleAccumulator.Config create(String category, String name) {
+        return new DoubleAccumulator.Config(category, name);
+    }
+
     @Test
-    @DisplayName("Constructor should store values")
-    void testConstructor() {
+    @DisplayName("Constructor initializes custom fields")
+    void testConstructorCustomFields() {
         // when
-        final DoubleAccumulator.Config config = new DoubleAccumulator.Config(CATEGORY, NAME);
+        final DoubleAccumulator.Config config = createBase();
 
         // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
+        assertThat(config.getFormat()).isEqualTo(FloatFormats.FORMAT_11_3);
         assertThat(config.getAccumulator().applyAsDouble(2.0, 3.0)).isEqualTo(Double.max(2.0, 3.0), within(EPSILON));
-        assertThat(config.getInitialValue()).isEqualTo(0.0, within(EPSILON));
+        assertThat(config.getInitializer().getAsDouble()).isEqualTo(0.0, within(EPSILON));
     }
 
     @Test
-    @DisplayName("Constructor should throw IAE when passing illegal parameters")
-    void testConstructorWithIllegalParameter() {
-        assertThatThrownBy(() -> new DoubleAccumulator.Config(null, NAME)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new DoubleAccumulator.Config("", NAME)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DoubleAccumulator.Config(" \t\n", NAME))
-                .isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> new DoubleAccumulator.Config(CATEGORY, null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new DoubleAccumulator.Config(CATEGORY, ""))
-                .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DoubleAccumulator.Config(CATEGORY, " \t\n"))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void testSetters() {
+    @DisplayName("Custom setters store values")
+    void testCustomSetters() {
         // given
         final DoubleBinaryOperator accumulator = mock(DoubleBinaryOperator.class);
-        final DoubleAccumulator.Config config = new DoubleAccumulator.Config(CATEGORY, NAME);
+        final DoubleSupplier initializer = mock(DoubleSupplier.class);
 
         // when
-        final DoubleAccumulator.Config result = config.withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withAccumulator(accumulator)
-                .withInitialValue(Math.PI);
+        final DoubleAccumulator.Config config1 =
+                createBase().withAccumulator(accumulator).withInitialValue(Math.PI);
+        final DoubleAccumulator.Config config2 =
+                createBase().withAccumulator(accumulator).withInitializer(initializer);
 
         // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-        assertThat(config.getAccumulator().applyAsDouble(2.0, 3.0)).isEqualTo(Double.max(2.0, 3.0), within(EPSILON));
-        assertThat(config.getInitialValue()).isEqualTo(0.0, within(EPSILON));
+        assertThat(config1.getAccumulator()).isEqualTo(accumulator);
+        assertThat(config1.getInitializer().getAsDouble()).isEqualTo(Math.PI, within(EPSILON));
 
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getAccumulator()).isEqualTo(accumulator);
-        assertThat(result.getInitialValue()).isEqualTo(Math.PI, within(EPSILON));
+        assertThat(config2.getAccumulator()).isEqualTo(accumulator);
+        assertThat(config2.getInitializer()).isEqualTo(initializer);
     }
 
     @Test
-    void testSettersWithIllegalParameters() {
+    @DisplayName("Custom setters fail with illegal parameters")
+    void testCustomSettersWithIllegalParameters() {
         // given
-        final DoubleAccumulator.Config config = new DoubleAccumulator.Config(CATEGORY, NAME);
-        final String longDescription = DESCRIPTION.repeat(50);
+        final DoubleAccumulator.Config config = createBase();
 
         // then
-        assertThatThrownBy(() -> config.withDescription(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withDescription("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(longDescription)).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> config.withUnit(null)).isInstanceOf(NullPointerException.class);
-
-        assertThatThrownBy(() -> config.withFormat(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withFormat("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withFormat(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-
         assertThatThrownBy(() -> config.withAccumulator(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> config.withInitializer(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void testToString() {
+    @DisplayName("toString contains custom values")
+    void testToStringCustom() {
         // given
-        final DoubleAccumulator.Config config = new DoubleAccumulator.Config(CATEGORY, NAME)
-                .withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitialValue(Math.PI);
-
+        final DoubleAccumulator.Config config1 = createFull().withInitialValue(Math.PI);
+        final DoubleAccumulator.Config config2 = createFull().withInitializer(() -> 42);
         // then
-        assertThat(config.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "3.1415");
+        assertThat(config1.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "3.1415");
+        assertThat(config2.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "42");
     }
 }

--- a/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/DoubleGaugeConfigTest.java
+++ b/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/DoubleGaugeConfigTest.java
@@ -2,104 +2,46 @@
 package com.swirlds.metrics.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.within;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class DoubleGaugeConfigTest {
-
-    private static final String DEFAULT_FORMAT = FloatFormats.FORMAT_11_3;
-
-    private static final String CATEGORY = "CaTeGoRy";
-    private static final String NAME = "NaMe";
-    private static final String DESCRIPTION = "DeScRiPtIoN";
-    private static final String UNIT = "UnIt";
-    private static final String FORMAT = "FoRmAt";
+class DoubleGaugeConfigTest extends BaseConfigTest<DoubleGauge.Config> {
 
     private static final double EPSILON = 1e-6;
 
+    @Override
+    protected DoubleGauge.Config create(String category, String name) {
+        return new DoubleGauge.Config(category, name);
+    }
+
     @Test
-    @DisplayName("Constructor should store values")
-    void testConstructor() {
+    @DisplayName("Constructor initializes custom fields")
+    void testConstructorCustomFields() {
         // when
-        final DoubleGauge.Config config = new DoubleGauge.Config(CATEGORY, NAME);
+        final DoubleGauge.Config config = createBase();
 
         // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
+        assertThat(config.getFormat()).isEqualTo(FloatFormats.FORMAT_11_3);
         assertThat(config.getInitialValue()).isEqualTo(0.0, within(EPSILON));
     }
 
     @Test
-    @DisplayName("Constructor should throw IAE when passing illegal parameters")
-    void testConstructorWithIllegalParameter() {
-        assertThatThrownBy(() -> new DoubleGauge.Config(null, NAME)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new DoubleGauge.Config("", NAME)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DoubleGauge.Config(" \t\n", NAME)).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> new DoubleGauge.Config(CATEGORY, null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new DoubleGauge.Config(CATEGORY, "")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new DoubleGauge.Config(CATEGORY, " \t\n"))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void testSetters() {
+    @DisplayName("Custom setters store values")
+    void testCustomSetters() {
         // given
-        final DoubleGauge.Config config = new DoubleGauge.Config(CATEGORY, NAME);
-
-        // when
-        final DoubleGauge.Config result = config.withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitialValue(Math.PI);
+        final DoubleGauge.Config config = createBase().withInitialValue(Math.PI);
 
         // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-        assertThat(config.getInitialValue()).isEqualTo(0.0, within(EPSILON));
-
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getInitialValue()).isEqualTo(Math.PI, within(EPSILON));
+        assertThat(config.getInitialValue()).isEqualTo(Math.PI, within(EPSILON));
     }
 
     @Test
-    void testSettersWithIllegalParameters() {
+    @DisplayName("toString contains custom values")
+    void testToStringCustom() {
         // given
-        final DoubleGauge.Config config = new DoubleGauge.Config(CATEGORY, NAME);
-        final String longDescription = DESCRIPTION.repeat(50);
-
-        // then
-        assertThatThrownBy(() -> config.withDescription(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withDescription("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(longDescription)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withUnit(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withFormat(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withFormat("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withFormat(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void testToString() {
-        // given
-        final DoubleGauge.Config config = new DoubleGauge.Config(CATEGORY, NAME)
-                .withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitialValue(Math.PI);
+        final DoubleGauge.Config config = createFull().withInitialValue(Math.PI);
 
         // then
         assertThat(config.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "3.1415");

--- a/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/IntegerAccumulatorConfigTest.java
+++ b/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/IntegerAccumulatorConfigTest.java
@@ -10,121 +10,63 @@ import java.util.function.IntSupplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class IntegerAccumulatorConfigTest {
+class IntegerAccumulatorConfigTest extends BaseConfigTest<IntegerAccumulator.Config> {
 
-    private static final String DEFAULT_FORMAT = "%d";
-
-    private static final String CATEGORY = "CaTeGoRy";
-    private static final String NAME = "NaMe";
-    private static final String DESCRIPTION = "DeScRiPtIoN";
-    private static final String UNIT = "UnIt";
-    private static final String FORMAT = "FoRmAt";
+    @Override
+    protected IntegerAccumulator.Config create(String category, String name) {
+        return new IntegerAccumulator.Config(category, name);
+    }
 
     @Test
-    @DisplayName("Constructor should store values")
-    void testConstructor() {
+    @DisplayName("Constructor initializes custom fields")
+    void testConstructorCustomFields() {
         // when
-        final IntegerAccumulator.Config config = new IntegerAccumulator.Config(CATEGORY, NAME);
+        final IntegerAccumulator.Config config = createBase();
 
         // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
+        assertThat(config.getFormat()).isEqualTo(MetricConfig.NUMBER_FORMAT);
         assertThat(config.getAccumulator().applyAsInt(2, 3)).isEqualTo(Integer.max(2, 3));
-        assertThat(config.getInitializer()).isNull();
-        assertThat(config.getInitialValue()).isZero();
+        assertThat(config.getInitializer().getAsInt()).isZero();
     }
 
     @Test
-    @DisplayName("Constructor should throw IAE when passing illegal parameters")
-    void testConstructorWithIllegalParameter() {
-        assertThatThrownBy(() -> new IntegerAccumulator.Config(null, NAME)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new IntegerAccumulator.Config("", NAME)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new IntegerAccumulator.Config(" \t\n", NAME))
-                .isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> new IntegerAccumulator.Config(CATEGORY, null))
-                .isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new IntegerAccumulator.Config(CATEGORY, ""))
-                .isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new IntegerAccumulator.Config(CATEGORY, " \t\n"))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void testSetters() {
+    @DisplayName("Custom setters store values")
+    void testCustomSetters() {
         // given
         final IntBinaryOperator accumulator = mock(IntBinaryOperator.class);
-        final IntegerAccumulator.Config config = new IntegerAccumulator.Config(CATEGORY, NAME);
         final IntSupplier initializer = mock(IntSupplier.class);
 
         // when
-        final IntegerAccumulator.Config result = config.withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withAccumulator(accumulator)
-                .withInitializer(initializer)
-                .withInitialValue(42);
+        final IntegerAccumulator.Config config1 =
+                createBase().withAccumulator(accumulator).withInitialValue(42);
+        final IntegerAccumulator.Config config2 =
+                createBase().withAccumulator(accumulator).withInitializer(initializer);
 
         // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-        assertThat(config.getAccumulator().applyAsInt(2, 3)).isEqualTo(Integer.max(2, 3));
-        assertThat(config.getInitializer()).isNull();
-        assertThat(config.getInitialValue()).isZero();
+        assertThat(config1.getAccumulator()).isEqualTo(accumulator);
+        assertThat(config1.getInitializer().getAsInt()).isEqualTo(42);
 
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getAccumulator()).isEqualTo(accumulator);
-        assertThat(result.getInitializer()).isEqualTo(initializer);
-        assertThat(result.getInitialValue()).isEqualTo(42);
+        assertThat(config2.getAccumulator()).isEqualTo(accumulator);
+        assertThat(config2.getInitializer()).isEqualTo(initializer);
     }
 
     @Test
-    void testSettersWithIllegalParameters() {
+    @DisplayName("Custom setters fail with illegal parameters")
+    void testCustomSettersWithIllegalParameters() {
         // given
-        final IntegerAccumulator.Config config = new IntegerAccumulator.Config(CATEGORY, NAME);
-        final String longDescription = DESCRIPTION.repeat(50);
+        final IntegerAccumulator.Config config = createBase();
 
         // then
-        assertThatThrownBy(() -> config.withDescription(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withDescription("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(longDescription)).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> config.withUnit(null)).isInstanceOf(NullPointerException.class);
-
-        assertThatThrownBy(() -> config.withFormat(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withFormat("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withFormat(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-
         assertThatThrownBy(() -> config.withAccumulator(null)).isInstanceOf(NullPointerException.class);
-
         assertThatThrownBy(() -> config.withInitializer(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void testToString() {
+    @DisplayName("toString contains custom values")
+    void testToStringCustom() {
         // given
-        final IntegerAccumulator.Config config1 = new IntegerAccumulator.Config(CATEGORY, NAME)
-                .withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitialValue(42);
-        final IntegerAccumulator.Config config2 = new IntegerAccumulator.Config(CATEGORY, NAME)
-                .withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitializer(() -> 3)
-                .withInitialValue(42);
+        final IntegerAccumulator.Config config1 = createFull().withInitialValue(42);
+        final IntegerAccumulator.Config config2 = createFull().withInitializer(() -> 3);
 
         // then
         assertThat(config1.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "42");

--- a/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/IntegerGaugeConfigTest.java
+++ b/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/IntegerGaugeConfigTest.java
@@ -2,103 +2,42 @@
 package com.swirlds.metrics.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class IntegerGaugeConfigTest {
+class IntegerGaugeConfigTest extends BaseConfigTest<IntegerGauge.Config> {
 
-    private static final String DEFAULT_FORMAT = "%d";
-
-    private static final String CATEGORY = "CaTeGoRy";
-    private static final String NAME = "NaMe";
-    private static final String DESCRIPTION = "DeScRiPtIoN";
-    private static final String UNIT = "UnIt";
-    private static final String FORMAT = "FoRmAt";
+    @Override
+    protected IntegerGauge.Config create(String category, String name) {
+        return new IntegerGauge.Config(category, name);
+    }
 
     @Test
-    @DisplayName("Constructor should store values")
-    void testConstructor() {
+    @DisplayName("Constructor initializes custom fields")
+    void testConstructorCustomFields() {
         // when
-        final IntegerGauge.Config config = new IntegerGauge.Config(CATEGORY, NAME);
+        final IntegerGauge.Config config = createBase();
 
         // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
+        assertThat(config.getFormat()).isEqualTo(MetricConfig.NUMBER_FORMAT);
         assertThat(config.getInitialValue()).isZero();
     }
 
     @Test
-    @DisplayName("Constructor should throw IAE when passing illegal parameters")
-    void testConstructorWithIllegalParameter() {
-        assertThatThrownBy(() -> new IntegerGauge.Config(null, NAME)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new IntegerGauge.Config("", NAME)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new IntegerGauge.Config(" \t\n", NAME)).isInstanceOf(IllegalArgumentException.class);
+    @DisplayName("Custom setters store values")
+    void testCustomSetters() {
+        // given
+        final IntegerGauge.Config config = createBase().withInitialValue(42);
 
-        assertThatThrownBy(() -> new IntegerGauge.Config(CATEGORY, null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new IntegerGauge.Config(CATEGORY, "")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new IntegerGauge.Config(CATEGORY, " \t\n"))
-                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(config.getInitialValue()).isEqualTo(42);
     }
 
     @Test
-    void testSetters() {
+    @DisplayName("toString contains custom values")
+    void testToStringCustom() {
         // given
-        final IntegerGauge.Config config = new IntegerGauge.Config(CATEGORY, NAME);
-
-        // when
-        final IntegerGauge.Config result = config.withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitialValue(42);
-
-        // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-        assertThat(config.getInitialValue()).isZero();
-
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getInitialValue()).isEqualTo(42);
-    }
-
-    @Test
-    void testSettersWithIllegalParameters() {
-        // given
-        final IntegerGauge.Config config = new IntegerGauge.Config(CATEGORY, NAME);
-        final String longDescription = DESCRIPTION.repeat(50);
-
-        // then
-        assertThatThrownBy(() -> config.withDescription(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withDescription("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(longDescription)).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> config.withUnit(null)).isInstanceOf(NullPointerException.class);
-
-        assertThatThrownBy(() -> config.withFormat(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withFormat("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withFormat(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void testToString() {
-        // given
-        final IntegerGauge.Config config = new IntegerGauge.Config(CATEGORY, NAME)
-                .withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitialValue(42);
+        final IntegerGauge.Config config = createFull().withInitialValue(42);
 
         // then
         assertThat(config.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "42");

--- a/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/LongAccumulatorConfigTest.java
+++ b/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/LongAccumulatorConfigTest.java
@@ -6,111 +6,67 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 
 import java.util.function.LongBinaryOperator;
+import java.util.function.LongSupplier;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class LongAccumulatorConfigTest {
+class LongAccumulatorConfigTest extends BaseConfigTest<LongAccumulator.Config> {
 
-    private static final String DEFAULT_FORMAT = "%d";
-
-    private static final String CATEGORY = "CaTeGoRy";
-    private static final String NAME = "NaMe";
-    private static final String DESCRIPTION = "DeScRiPtIoN";
-    private static final String UNIT = "UnIt";
-    private static final String FORMAT = "FoRmAt";
+    @Override
+    protected LongAccumulator.Config create(String category, String name) {
+        return new LongAccumulator.Config(category, name);
+    }
 
     @Test
-    @DisplayName("Constructor should store values")
-    void testConstructor() {
+    @DisplayName("Constructor initializes custom fields")
+    void testConstructorCustomFields() {
         // when
-        final LongAccumulator.Config config = new LongAccumulator.Config(CATEGORY, NAME);
+        final LongAccumulator.Config config = createBase();
 
         // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
         assertThat(config.getAccumulator().applyAsLong(2L, 3L)).isEqualTo(Long.max(2L, 3L));
-        assertThat(config.getInitialValue()).isZero();
+        assertThat(config.getInitializer().getAsLong()).isZero();
     }
 
     @Test
-    @DisplayName("Constructor should throw IAE when passing illegal parameters")
-    void testConstructorWithIllegalParameter() {
-        assertThatThrownBy(() -> new LongAccumulator.Config(null, NAME)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new LongAccumulator.Config("", NAME)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new LongAccumulator.Config(" \t\n", NAME))
-                .isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> new LongAccumulator.Config(CATEGORY, null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new LongAccumulator.Config(CATEGORY, "")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new LongAccumulator.Config(CATEGORY, " \t\n"))
-                .isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void testSetters() {
+    @DisplayName("Custom setters store values")
+    void testCustomSetters() {
         // given
         final LongBinaryOperator accumulator = mock(LongBinaryOperator.class);
-        final LongAccumulator.Config config = new LongAccumulator.Config(CATEGORY, NAME);
+        final LongSupplier initializer = mock(LongSupplier.class);
 
         // when
-        final LongAccumulator.Config result = config.withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withAccumulator(accumulator)
-                .withInitialValue(42L);
+        final LongAccumulator.Config config1 =
+                createBase().withAccumulator(accumulator).withInitialValue(42L);
+        final LongAccumulator.Config config2 =
+                createBase().withAccumulator(accumulator).withInitializer(initializer);
 
-        // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-        assertThat(config.getAccumulator().applyAsLong(2L, 3L)).isEqualTo(Long.max(2L, 3L));
-        assertThat(config.getInitialValue()).isZero();
+        assertThat(config1.getAccumulator()).isEqualTo(accumulator);
+        assertThat(config1.getInitializer().getAsLong()).isEqualTo(42L);
 
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getAccumulator()).isEqualTo(accumulator);
-        assertThat(result.getInitialValue()).isEqualTo(42L);
+        assertThat(config2.getAccumulator()).isEqualTo(accumulator);
+        assertThat(config2.getInitializer()).isEqualTo(initializer);
     }
 
     @Test
-    void testSettersWithIllegalParameters() {
+    @DisplayName("Custom setters fail with illegal parameters")
+    void testCustomSettersWithIllegalParameters() {
         // given
-        final LongAccumulator.Config config = new LongAccumulator.Config(CATEGORY, NAME);
-        final String longDescription = DESCRIPTION.repeat(50);
+        final LongAccumulator.Config config = createBase();
 
         // then
-        assertThatThrownBy(() -> config.withDescription(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withDescription("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(longDescription)).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> config.withUnit(null)).isInstanceOf(NullPointerException.class);
-
-        assertThatThrownBy(() -> config.withFormat(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withFormat("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withFormat(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-
         assertThatThrownBy(() -> config.withAccumulator(null)).isInstanceOf(NullPointerException.class);
+        assertThatThrownBy(() -> config.withInitializer(null)).isInstanceOf(NullPointerException.class);
     }
 
     @Test
-    void testToString() {
+    @DisplayName("toString contains custom values")
+    void testToStringCustom() {
         // given
-        final LongAccumulator.Config config = new LongAccumulator.Config(CATEGORY, NAME)
-                .withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitialValue(42L);
-
+        final LongAccumulator.Config config1 = createFull().withInitialValue(42L);
+        final LongAccumulator.Config config2 = createFull().withInitializer(() -> 3L);
         // then
-        assertThat(config.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "42");
+        assertThat(config1.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "42");
+        assertThat(config2.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "3");
     }
 }

--- a/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/LongGaugeConfigTest.java
+++ b/platform-sdk/swirlds-metrics-api/src/test/java/com/swirlds/metrics/api/LongGaugeConfigTest.java
@@ -2,102 +2,42 @@
 package com.swirlds.metrics.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-class LongGaugeConfigTest {
+class LongGaugeConfigTest extends BaseConfigTest<LongGauge.Config> {
 
-    private static final String DEFAULT_FORMAT = "%d";
-
-    private static final String CATEGORY = "CaTeGoRy";
-    private static final String NAME = "NaMe";
-    private static final String DESCRIPTION = "DeScRiPtIoN";
-    private static final String UNIT = "UnIt";
-    private static final String FORMAT = "FoRmAt";
+    @Override
+    protected LongGauge.Config create(String category, String name) {
+        return new LongGauge.Config(category, name);
+    }
 
     @Test
-    @DisplayName("Constructor should store values")
-    void testConstructor() {
+    @DisplayName("Constructor initializes custom fields")
+    void testConstructorCustomFields() {
         // when
-        final LongGauge.Config config = new LongGauge.Config(CATEGORY, NAME);
+        final LongGauge.Config config = createBase();
 
         // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
+        assertThat(config.getFormat()).isEqualTo(MetricConfig.NUMBER_FORMAT);
         assertThat(config.getInitialValue()).isZero();
     }
 
     @Test
-    @DisplayName("Constructor should throw IAE when passing illegal parameters")
-    void testConstructorWithIllegalParameter() {
-        assertThatThrownBy(() -> new LongGauge.Config(null, NAME)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new LongGauge.Config("", NAME)).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new LongGauge.Config(" \t\n", NAME)).isInstanceOf(IllegalArgumentException.class);
+    @DisplayName("Custom setters store values")
+    void testCustomSetters() {
+        // given
+        final LongGauge.Config config = createBase().withInitialValue(42);
 
-        assertThatThrownBy(() -> new LongGauge.Config(CATEGORY, null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> new LongGauge.Config(CATEGORY, "")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> new LongGauge.Config(CATEGORY, " \t\n")).isInstanceOf(IllegalArgumentException.class);
+        assertThat(config.getInitialValue()).isEqualTo(42);
     }
 
     @Test
-    void testSetters() {
+    @DisplayName("toString contains custom values")
+    void testToStringCustom() {
         // given
-        final LongGauge.Config config = new LongGauge.Config(CATEGORY, NAME);
-
-        // when
-        final LongGauge.Config result = config.withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitialValue(42L);
-
-        // then
-        assertThat(config.getCategory()).isEqualTo(CATEGORY);
-        assertThat(config.getName()).isEqualTo(NAME);
-        assertThat(config.getDescription()).isEqualTo(NAME);
-        assertThat(config.getUnit()).isEmpty();
-        assertThat(config.getFormat()).isEqualTo(DEFAULT_FORMAT);
-        assertThat(config.getInitialValue()).isZero();
-
-        assertThat(result.getCategory()).isEqualTo(CATEGORY);
-        assertThat(result.getName()).isEqualTo(NAME);
-        assertThat(result.getDescription()).isEqualTo(DESCRIPTION);
-        assertThat(result.getUnit()).isEqualTo(UNIT);
-        assertThat(result.getFormat()).isEqualTo(FORMAT);
-        assertThat(result.getInitialValue()).isEqualTo(42L);
-    }
-
-    @Test
-    void testSettersWithIllegalParameters() {
-        // given
-        final LongGauge.Config config = new LongGauge.Config(CATEGORY, NAME);
-        final String longDescription = DESCRIPTION.repeat(50);
-
-        // then
-        assertThatThrownBy(() -> config.withDescription(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withDescription("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withDescription(longDescription)).isInstanceOf(IllegalArgumentException.class);
-
-        assertThatThrownBy(() -> config.withUnit(null)).isInstanceOf(NullPointerException.class);
-
-        assertThatThrownBy(() -> config.withFormat(null)).isInstanceOf(NullPointerException.class);
-        assertThatThrownBy(() -> config.withFormat("")).isInstanceOf(IllegalArgumentException.class);
-        assertThatThrownBy(() -> config.withFormat(" \t\n")).isInstanceOf(IllegalArgumentException.class);
-    }
-
-    @Test
-    void testToString() {
-        // given
-        final LongGauge.Config config = new LongGauge.Config(CATEGORY, NAME)
-                .withDescription(DESCRIPTION)
-                .withUnit(UNIT)
-                .withFormat(FORMAT)
-                .withInitialValue(42L);
+        final LongGauge.Config config = createFull().withInitialValue(42);
 
         // then
         assertThat(config.toString()).contains(CATEGORY, NAME, DESCRIPTION, UNIT, FORMAT, "42");

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/AbstractMetric.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/AbstractMetric.java
@@ -105,14 +105,20 @@ public abstract class AbstractMetric implements SnapshotableMetric {
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
+    public final String toString() {
+        return selfToString().toString();
+    }
+
+    /**
+     * @return a {@link ToStringBuilder} for this metric
+     */
+    protected ToStringBuilder selfToString() {
         return new ToStringBuilder(this)
                 .append("category", category)
                 .append("name", name)
                 .append("description", description)
                 .append("unit", unit)
                 .append("format", format)
-                .append("dataType", getDataType())
-                .toString();
+                .append("dataType", getDataType());
     }
 }

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultCounter.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultCounter.java
@@ -63,10 +63,7 @@ public class DefaultCounter extends AbstractMetric implements Counter {
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", adder.sum())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", get());
     }
 }

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultDoubleAccumulator.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultDoubleAccumulator.java
@@ -22,12 +22,10 @@ public class DefaultDoubleAccumulator extends AbstractMetric implements DoubleAc
 
     public DefaultDoubleAccumulator(@NonNull final Config config) {
         super(config);
-        final double initialValue = config.getInitialValue();
-        final DoubleSupplier configInitializer = config.getInitializer();
 
-        this.accumulator = config.getAccumulator();
-        this.initializer = configInitializer != null ? configInitializer : () -> initialValue;
-        this.container = new AtomicDouble(this.initializer.getAsDouble());
+        accumulator = config.getAccumulator();
+        initializer = config.getInitializer();
+        container = new AtomicDouble(initializer.getAsDouble());
     }
 
     /**
@@ -72,10 +70,7 @@ public class DefaultDoubleAccumulator extends AbstractMetric implements DoubleAc
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", get())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", get());
     }
 }

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultDoubleGauge.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultDoubleGauge.java
@@ -58,10 +58,7 @@ public class DefaultDoubleGauge extends AbstractMetric implements DoubleGauge {
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", value.get())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", get());
     }
 }

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultIntegerAccumulator.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultIntegerAccumulator.java
@@ -23,10 +23,10 @@ public class DefaultIntegerAccumulator extends AbstractMetric implements Integer
 
     public DefaultIntegerAccumulator(@NonNull final Config config) {
         super(config);
-        this.accumulator = config.getAccumulator();
-        final int initialValue = config.getInitialValue();
-        this.initializer = config.getInitializer() != null ? config.getInitializer() : () -> initialValue;
-        this.container = new AtomicInteger(this.initializer.getAsInt());
+
+        accumulator = config.getAccumulator();
+        initializer = config.getInitializer();
+        container = new AtomicInteger(this.initializer.getAsInt());
     }
 
     /**
@@ -74,10 +74,7 @@ public class DefaultIntegerAccumulator extends AbstractMetric implements Integer
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", get())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", get());
     }
 }

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultIntegerGauge.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultIntegerGauge.java
@@ -19,7 +19,7 @@ public class DefaultIntegerGauge extends AbstractMetric implements IntegerGauge 
 
     public DefaultIntegerGauge(@NonNull final Config config) {
         super(config);
-        this.value = new AtomicInteger(config.getInitialValue());
+        value = new AtomicInteger(config.getInitialValue());
     }
 
     /**
@@ -59,10 +59,7 @@ public class DefaultIntegerGauge extends AbstractMetric implements IntegerGauge 
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", value.get())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", get());
     }
 }

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultLongAccumulator.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultLongAccumulator.java
@@ -23,12 +23,10 @@ public class DefaultLongAccumulator extends AbstractMetric implements LongAccumu
 
     public DefaultLongAccumulator(@NonNull final Config config) {
         super(config);
-        final long initialValue = config.getInitialValue();
-        final LongSupplier configInitializer = config.getInitializer();
 
-        this.accumulator = config.getAccumulator();
-        this.initializer = configInitializer != null ? configInitializer : () -> initialValue;
-        this.container = new AtomicLong(this.initializer.getAsLong());
+        accumulator = config.getAccumulator();
+        initializer = config.getInitializer();
+        container = new AtomicLong(this.initializer.getAsLong());
     }
 
     /**
@@ -76,10 +74,7 @@ public class DefaultLongAccumulator extends AbstractMetric implements LongAccumu
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", get())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", get());
     }
 }

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultLongGauge.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/com/swirlds/metrics/impl/DefaultLongGauge.java
@@ -19,7 +19,7 @@ public class DefaultLongGauge extends AbstractMetric implements LongGauge {
 
     public DefaultLongGauge(@NonNull final Config config) {
         super(config);
-        this.value = new AtomicLong(config.getInitialValue());
+        value = new AtomicLong(config.getInitialValue());
     }
 
     /**
@@ -59,10 +59,7 @@ public class DefaultLongGauge extends AbstractMetric implements LongGauge {
      * {@inheritDoc}
      */
     @Override
-    public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("value", value.get())
-                .toString();
+    protected ToStringBuilder selfToString() {
+        return super.selfToString().append("value", get());
     }
 }

--- a/platform-sdk/swirlds-metrics-impl/src/main/java/module-info.java
+++ b/platform-sdk/swirlds-metrics-impl/src/main/java/module-info.java
@@ -2,7 +2,7 @@
 module com.swirlds.metrics.impl {
     exports com.swirlds.metrics.impl;
 
+    requires transitive com.swirlds.base;
     requires transitive com.swirlds.metrics.api;
-    requires com.swirlds.base;
     requires static transitive com.github.spotbugs.annotations;
 }

--- a/platform-sdk/swirlds-metrics-impl/src/test/java/com/swirlds/metrics/impl/test/DefaultIntegerAccumulatorTest.java
+++ b/platform-sdk/swirlds-metrics-impl/src/test/java/com/swirlds/metrics/impl/test/DefaultIntegerAccumulatorTest.java
@@ -58,9 +58,9 @@ class DefaultIntegerAccumulatorTest {
         assertEquals(
                 DESCRIPTION, accumulator2.getDescription(), "The description was not set correctly in the constructor");
         assertEquals(FORMAT, accumulator2.getFormat(), "The format was not set correctly in the constructor");
-        assertEquals(3, accumulator2.getInitialValue(), "The initial value was not initialized correctly");
-        assertEquals(3, accumulator2.get(), "The value was not initialized correctly");
-        assertEquals(3, accumulator2.get(VALUE), "The value was not initialized correctly");
+        assertEquals(42, accumulator2.getInitialValue(), "The initial value was not initialized correctly");
+        assertEquals(42, accumulator2.get(), "The value was not initialized correctly");
+        assertEquals(42, accumulator2.get(VALUE), "The value was not initialized correctly");
         assertThat(accumulator2.getValueTypes()).containsExactly(VALUE);
     }
 


### PR DESCRIPTION
**Description**:
Make `MetricConfig` a mutable builder.

Today, `MetricConfig` is implemented to be an immutable class.
This doesn't make sense because config is used only once to getOrCreate a metric.

The builder pattern is used in many observability frameworks and will simplify extending `MetricConfig` with custom configuration without the requirement to implement `withDescription` and `withUnit` methods.

**Related issue(s)**: #19960

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
