### PR TITLE
ci: remove NLG repo checkout from CITR workflow

### DIFF
--- a/.github/workflows/zxc-execute-performance-test.yaml
+++ b/.github/workflows/zxc-execute-performance-test.yaml
@@ -69,7 +69,6 @@ env:
   NLG_VERSION: 0.3.2
   #if needed to re-build NLG from branch:
   NLG_REBUILD: false
-  NLG_BRANCH: main
 
 defaults:
   run:

--- a/.github/workflows/zxc-execute-performance-test.yaml
+++ b/.github/workflows/zxc-execute-performance-test.yaml
@@ -67,8 +67,6 @@ env:
   GS_ROOT_HTTPS: https://perf.analytics.eng.hashgraph.io/ephemeral/test_runs
   #Release version from jFrog
   NLG_VERSION: 0.3.2
-  #if needed to re-build NLG from branch:
-  NLG_REBUILD: false
 
 defaults:
   run:

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -324,13 +324,6 @@ jobs:
       - name: Move to Github Workspace
         run: cd "${{ github.workspace }}"
 
-      - name: Build network-load-generator
-        run: |
-          cd network-load-generator
-          ./gradlew --no-daemon clean assemble
-          cd build/libs
-          tar cvf /tmp/NLG.tar lib network-load-generator-*.jar
-
       - name: Prepare NLG parameters
         run: |
           set +x

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -75,8 +75,6 @@ env:
   GS_ROOT_HTTPS: https://perf.analytics.eng.hashgraph.io/ephemeral/test_runs
   #Release version from jFrog
   NLG_VERSION: 0.3.2
-  #if needed to re-build NLG from branch:
-  NLG_REBUILD: false
 
 jobs:
   performance-tests-start:
@@ -359,14 +357,6 @@ jobs:
           # Copy run version
           echo "run_number=${{ github.run_number }}" | tee -a "${{ github.workspace }}"/version_run.txt
           sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ env.namespace }}" cp "${{ github.workspace }}"/version_run.txt ${nlgpod}:/app/
-
-      - name: Update NLG code with local build
-        if: ${{ env.NLG_REBUILD == 'true' }}
-        run: |
-          cd "${{ github.workspace }}"
-          nlgpod=`sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ env.namespace }}" get pods | grep nlg-network-load-generator| awk '{print $1}'`
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ env.namespace }}" cp /tmp/NLG.tar ${nlgpod}:/app/
-          sh "${{ github.workspace }}"/.github/workflows/support/citr/kubectlt -n "${{ env.namespace }}" exec ${nlgpod} -c nlg -- bash -c "cd /app; rm -rf lib network-load-generator-*.jar; ls -l; tar xvf NLG.tar; ls -l"
 
       - name: Build swirlds-benchmark-CryptoBenchMerkleDb.transferPrefetch
         run: |

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -51,9 +51,6 @@ on:
         description: "Test params"
         type: string
     secrets:
-      nlg-access-token:
-        required: true
-        description: "GitHub token for network-load-generator repo"
       perf-analysis-access-token:
         required: true
         description: "GitHub token for performance-analysis-automation repo"
@@ -80,7 +77,6 @@ env:
   NLG_VERSION: 0.3.2
   #if needed to re-build NLG from branch:
   NLG_REBUILD: false
-  NLG_BRANCH: main
 
 jobs:
   performance-tests-start:
@@ -120,14 +116,6 @@ jobs:
           repository: hiero-ledger/solo
           path: solo
           ref: ${{ env.run_soloversion }}
-
-      - name: Checkout network-load-generator repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          repository: hashgraph/network-load-generator
-          path: network-load-generator
-          ref: ${{ env.NLG_BRANCH }}
-          token: ${{ secrets.nlg-access-token }}
 
       - name: Checkout performance-analysis-automation repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -143,7 +143,6 @@ jobs:
       crypto-bench-merkle-db-test-params: "${{ inputs.crypto-bench-merkle-db-test-params }}"
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
-      nlg-access-token: ${{ secrets.CITR_NLG_ACCESS_TOKEN }}
       perf-analysis-access-token: ${{ secrets.PERF_ANALYSIS_TOKEN }}
 
   tag-sdpt-passing:


### PR DESCRIPTION
**Description**:

Remove the Network Load Generator repo checkout step from CITR workflow.

**Related Issue(s)**:

Fixes #19925
