### PR TITLE
chore: Move resetCNlogs.sh to CN

### DIFF
--- a/.github/workflows/support/citr/resetCNlogs.sh
+++ b/.github/workflows/support/citr/resetCNlogs.sh
@@ -1,0 +1,11 @@
+NAMESPACE=$1
+NODE_ROOT=/opt/hgcapp/services-hedera/HapiApp2.0
+LOG_DIR=$NODE_ROOT/output
+
+
+NofNodes=`kubectl -n ${NAMESPACE} get pods | grep 'network-node' | wc -l`
+
+for i in `seq 1 1 $NofNodes`
+do
+  kubectl -n ${NAMESPACE} exec -it network-node${i}-0 -c root-container -- bash -c "find $LOG_DIR -type f -name '*.log' -exec truncate -c -s 0 {} \;"
+done

--- a/.github/workflows/zxc-execute-performance-test.yaml
+++ b/.github/workflows/zxc-execute-performance-test.yaml
@@ -386,4 +386,4 @@ jobs:
           echo Done: see results in "${{ steps.gs_https_url.outputs.url }}"
 
           echo "Truncating logs for next test..."
-          sh "${{ github.workspace }}"/paa_scripts/node_control/resetCNlogs.sh "${{ env.namespace }}"
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/resetCNlogs.sh "${{ env.namespace }}"

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -584,7 +584,7 @@ jobs:
           echo Done: see results in "${{ env.GS_ROOT_HTTPS }}/${{ env.RUN_HCN_VERSION }}_${{ env.run_namespace }}_${{ github.run_number }}/create_accounts"
 
           echo "Truncating logs for next test..."
-          sh "${{ github.workspace }}"/paa_scripts/node_control/resetCNlogs.sh "${{ env.namespace }}"
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/resetCNlogs.sh "${{ env.namespace }}"
 
       - name: Start test
         run: |
@@ -1044,7 +1044,7 @@ jobs:
           echo Done: see results in "${{ env.GS_ROOT_HTTPS }}/${{ env.RUN_HCN_VERSION }}_${{ env.run_namespace }}_${{ github.run_number }}/report/${{ env.run_NLG_Test }}"
 
           echo "Truncating logs for next test..."
-          sh "${{ github.workspace }}"/paa_scripts/node_control/resetCNlogs.sh "${{ env.namespace }}"
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/resetCNlogs.sh "${{ env.namespace }}"
 
       - name: Records logs of CryptoBenchMerkleDb
         run: |
@@ -1091,7 +1091,7 @@ jobs:
           echo Done: see results in "${{ env.GS_ROOT_HTTPS }}/${{ env.RUN_HCN_VERSION }}_${{ env.run_namespace }}_${{ github.run_number }}/report/CryptoBenchMerkleDb"
 
           echo "Truncating logs for next test..."
-          sh "${{ github.workspace }}"/paa_scripts/node_control/resetCNlogs.sh "${{ env.namespace }}"
+          sh "${{ github.workspace }}"/.github/workflows/support/citr/resetCNlogs.sh "${{ env.namespace }}"
 
   performance-HCSLoadTest:
     needs:


### PR DESCRIPTION
## Description

Moves the `resetCNlogs.sh` script from performance analsysis automation to CN

### Related Issue(s)

closes #19899