### PR TITLE
fix: Pces file writer rollback v63

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
@@ -97,5 +97,5 @@ public record PcesConfig(
         @ConfigProperty(defaultValue = "1ms") Duration replayHealthThreshold,
         @ConfigProperty(defaultValue = "true") boolean limitReplayFrequency,
         @ConfigProperty(defaultValue = "5000") int maxEventReplayFrequency,
-        @ConfigProperty(defaultValue = "EVERY_SELF_EVENT") FileSyncOption inlinePcesSyncOption,
+        @ConfigProperty(defaultValue = "EVERY_EVENT") FileSyncOption inlinePcesSyncOption,
         @ConfigProperty(defaultValue = "OUTPUT_STREAM") PcesFileWriterType pcesFileWriterType) {}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
@@ -97,5 +97,5 @@ public record PcesConfig(
         @ConfigProperty(defaultValue = "1ms") Duration replayHealthThreshold,
         @ConfigProperty(defaultValue = "true") boolean limitReplayFrequency,
         @ConfigProperty(defaultValue = "5000") int maxEventReplayFrequency,
-        @ConfigProperty(defaultValue = "EVERY_EVENT") FileSyncOption inlinePcesSyncOption,
-        @ConfigProperty(defaultValue = "FILE_CHANNEL_SYNC") PcesFileWriterType pcesFileWriterType) {}
+        @ConfigProperty(defaultValue = "EVERY_SELF_EVENT") FileSyncOption inlinePcesSyncOption,
+        @ConfigProperty(defaultValue = "OUTPUT_STREAM") PcesFileWriterType pcesFileWriterType) {}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
@@ -97,5 +97,5 @@ public record PcesConfig(
         @ConfigProperty(defaultValue = "1ms") Duration replayHealthThreshold,
         @ConfigProperty(defaultValue = "true") boolean limitReplayFrequency,
         @ConfigProperty(defaultValue = "5000") int maxEventReplayFrequency,
-        @ConfigProperty(defaultValue = "EVERY_EVENT") FileSyncOption inlinePcesSyncOption,
+        @ConfigProperty(defaultValue = "EVERY_SELF_EVENT") FileSyncOption inlinePcesSyncOption,
         @ConfigProperty(defaultValue = "OUTPUT_STREAM") PcesFileWriterType pcesFileWriterType) {}


### PR DESCRIPTION
**Description**:
Restoring Pces filewriter configuration to write only on selfEvents using outputStream

**Related issue(s)**:

Fixes #