### PR TITLE
fix: Keeping nonce updates after Ethereum Transactions when inside batch

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeCharging.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/FeeCharging.java
@@ -11,6 +11,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Map;
 import java.util.function.ObjLongConsumer;
 
 /**
@@ -128,6 +129,11 @@ public interface FeeCharging {
          */
         @Deprecated
         HandleContext.TransactionCategory category();
+
+        /**
+         * Replays the nonce increment for the given accounts after ethCall failures.
+         */
+        void replayNonceIncrement(Map<AccountID, Long> nonceIncrements);
     }
 
     /**
@@ -139,6 +145,14 @@ public interface FeeCharging {
      * @return the total fees charged
      */
     Fees charge(@NonNull Context ctx, @NonNull Validation validation, @NonNull Fees fees);
+
+    /**
+     * Increments the nonce for the given accounts in the replay context.
+     * This is used to ensure that the nonce is incremented for accounts that are charged fees.
+     *
+     * @param nonceIncrements a map of account IDs to their nonce values
+     */
+    void replayNonceIncrement(@NonNull Map<AccountID, Long> nonceIncrements);
 
     /**
      * Refunds the fees for the given validation in the given context.

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/NoopFeeCharging.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/NoopFeeCharging.java
@@ -11,6 +11,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Map;
 
 /**
  * A fee charging strategy that validates all scenarios and charges no fees.
@@ -42,6 +43,11 @@ public enum NoopFeeCharging implements FeeCharging {
         requireNonNull(validation);
         requireNonNull(fees);
         return Fees.FREE;
+    }
+
+    @Override
+    public void replayNonceIncrement(@NonNull Map<AccountID, Long> nonceIncrements) {
+        // No-op
     }
 
     @Override

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleContext.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/HandleContext.java
@@ -163,6 +163,11 @@ public interface HandleContext {
              * Batch inner transaction bytes. Used to prehandle inner transaction while dispatching them.
              */
             INNER_TRANSACTION_BYTES,
+            /**
+             * A callback to be invoked to increment the nonce of the payer account.
+             * This is used to ensure that the nonce is incremented when ethereum transaction fails inside a batch.
+             */
+            ETHEREUM_NONCE_INCREMENT_CALLBACK
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/AppFeeCharging.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/AppFeeCharging.java
@@ -28,6 +28,7 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.workflows.SolvencyPreCheck;
 import com.hedera.node.app.workflows.handle.dispatch.ValidationResult;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -96,6 +97,11 @@ public class AppFeeCharging implements FeeCharging {
             case USER, NODE -> ctx.charge(ctx.payerId(), feesToCharge, ctx.nodeAccountId(), null);
             default -> ctx.charge(ctx.payerId(), feesToCharge, null);
         };
+    }
+
+    @Override
+    public void replayNonceIncrement(@NonNull Map<AccountID, Long> nonceIncrements) {
+        // No-op, as the app does not support nonce increments.
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeAccumulator.java
@@ -11,6 +11,7 @@ import com.hedera.node.app.spi.workflows.record.StreamBuilder;
 import com.hedera.node.app.workflows.handle.stack.SavepointStackImpl;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Map;
 import java.util.function.LongConsumer;
 import java.util.function.ObjLongConsumer;
 
@@ -100,5 +101,15 @@ public class FeeAccumulator {
         requireNonNull(nodeAccountId);
         requireNonNull(fees);
         tokenApi.refundFees(payerId, nodeAccountId, fees, feeStreamBuilder, onNodeFeeRefunded);
+    }
+
+    /**
+     * Sets the nonce of a given account to the given value, effectively replaying a nonce increment after failure.
+     *
+     * @param nonceIncrements A map of account IDs to their respective nonce value.
+     */
+    public void replayNonceIncrement(@NonNull Map<AccountID, Long> nonceIncrements) {
+        requireNonNull(nonceIncrements);
+        nonceIncrements.forEach(tokenApi::setNonce);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/Dispatch.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/Dispatch.java
@@ -25,6 +25,7 @@ import com.swirlds.state.lifecycle.info.NodeInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.ObjLongConsumer;
 
@@ -244,6 +245,12 @@ public interface Dispatch extends FeeCharging.Context {
         requireNonNull(fees);
         requireNonNull(nodeAccountId);
         feeAccumulator().refundFees(payerId, fees, nodeAccountId);
+    }
+
+    @Override
+    default void replayNonceIncrement(@NonNull final Map<AccountID, Long> nonceIncrements) {
+        requireNonNull(nonceIncrements);
+        feeAccumulator().replayNonceIncrement(nonceIncrements);
     }
 
     @Override

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleFeeCharging.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/ScheduleFeeCharging.java
@@ -12,6 +12,7 @@ import com.hedera.node.app.spi.fees.FeeCharging;
 import com.hedera.node.app.spi.fees.Fees;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -53,6 +54,11 @@ public class ScheduleFeeCharging implements FeeCharging {
         requireNonNull(validation);
         requireNonNull(fees);
         return service.baseFeeCharging().charge(ctx, validation, fees.onlyServiceComponent());
+    }
+
+    @Override
+    public void replayNonceIncrement(@NonNull Map<AccountID, Long> nonceIncrements) {
+        // No-op, as the schedule service does not handle nonce increments
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyWorldUpdater.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyWorldUpdater.java
@@ -310,7 +310,6 @@ public class ProxyWorldUpdater implements HederaWorldUpdater {
             @NonNull final Address deleted, @NonNull final Address beneficiary, @NonNull final MessageFrame frame) {
         evmFrameState.trackSelfDestructBeneficiary(deleted, beneficiary, frame);
     }
-    ;
 
     /**
      * {@inheritDoc}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/impl/EthereumTransactionTranslator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/impl/EthereumTransactionTranslator.java
@@ -26,8 +26,6 @@ import java.util.List;
  */
 public class EthereumTransactionTranslator implements BlockTransactionPartsTranslator {
     private static final String PRE_NONCE_ERROR_MESSAGE = "0x5452414e53414354494f4e5f4f56455253495a45";
-    private static final String TEMPORARY_SPECIAL_CASE =
-            "AtomicBatchEthereumCallKeysTest.precompileCallFailsWhenSignatureMissingFromBothEthereumAndHederaTxn";
 
     @Override
     public SingleTransactionRecord translate(
@@ -83,14 +81,10 @@ public class EthereumTransactionTranslator implements BlockTransactionPartsTrans
                                                             derivedBuilder, remainingStateChanges);
                                                 }
                                                 if (!PRE_NONCE_ERROR_MESSAGE.equals(txCallResult.errorMessage())) {
-                                                    if (TEMPORARY_SPECIAL_CASE.equals(parts.memo())) {
-                                                        derivedBuilder.signerNonce(1L);
-                                                    } else {
-                                                        baseTranslator.addSignerNonce(
-                                                                txCallResult.senderId(),
-                                                                derivedBuilder,
-                                                                remainingStateChanges);
-                                                    }
+                                                    baseTranslator.addSignerNonce(
+                                                            txCallResult.senderId(),
+                                                            derivedBuilder,
+                                                            remainingStateChanges);
                                                 }
                                                 final var fnResult = derivedBuilder.build();
                                                 recordBuilder.contractCallResult(fnResult);
@@ -153,7 +147,6 @@ public class EthereumTransactionTranslator implements BlockTransactionPartsTrans
                                     receiptBuilder.contractID(result.contractID());
                                 }
                             });
-                    if (ethTxData != null) {}
                 },
                 remainingStateChanges,
                 followingUnitTraces);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -2076,6 +2076,28 @@ public class UtilVerbs {
     }
 
     /**
+     * Validates that the gas charge for an inner transaction (inside Atomic Batch)
+     * is within the allowedPercentDiff of expected gas in USD.
+     *
+     * @param txn txn to be validated
+     * @param expectedUsdForGas expected gas charge in usd
+     * @param allowedPercentDiff allowed percentage difference
+     */
+    public static CustomSpecAssert validateChargedUsdForGasOnlyForInnerTxn(
+            String txn, String parent, double expectedUsdForGas, double allowedPercentDiff) {
+        return assertionsHold((spec, assertLog) -> {
+            final var gasCharged = getChargedGasForInnerTxn(spec, txn, parent);
+            assertEquals(
+                    expectedUsdForGas,
+                    gasCharged,
+                    (allowedPercentDiff / 100.0) * expectedUsdForGas,
+                    String.format(
+                            "%s gas charge (%s) more than %.2f percent different than expected!",
+                            sdec(expectedUsdForGas, 4), txn, allowedPercentDiff));
+        });
+    }
+
+    /**
      * Validates that an amount is within a certain percentage of an expected value.
      * @param expected expected value
      * @param actual actual value
@@ -2669,6 +2691,31 @@ public class UtilVerbs {
                 / ONE_HBAR
                 / rcd.getReceipt().getExchangeRate().getCurrentRate().getHbarEquiv()
                 * rcd.getReceipt().getExchangeRate().getCurrentRate().getCentEquiv()
+                / 100;
+    }
+
+    /**
+     * Returns the charged gas for an inner transaction (inside Atomic Batch) in USD, assuming a standard cost of
+     * 71 tinybars per gas unit.
+     *
+     * @param spec the spec
+     * @param txn the transaction
+     * @return the charged gas in USD
+     */
+    private static double getChargedGasForInnerTxn(
+            @NonNull final HapiSpec spec, @NonNull final String txn, @NonNull final String parent) {
+        requireNonNull(spec);
+        requireNonNull(txn);
+        var subOp = getTxnRecord(txn).logged();
+        var parentOp = getTxnRecord(parent);
+        allRunFor(spec, subOp, parentOp);
+        final var rcd = subOp.getResponseRecord();
+        final var parentRcd = parentOp.getResponseRecord();
+        final var gasUsed = rcd.getContractCallResult().getGasUsed();
+        return (gasUsed * 71.0)
+                / ONE_HBAR
+                / parentRcd.getReceipt().getExchangeRate().getCurrentRate().getHbarEquiv()
+                * parentRcd.getReceipt().getExchangeRate().getCurrentRate().getCentEquiv()
                 / 100;
     }
 


### PR DESCRIPTION
**Description**:
Keep nonce updates for failed Ethereum Transactions when executed inside of a AtomicBatch.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
