### PR TITLE
chore: Basic Capabilities API for Otter

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Capability.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Capability.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures;
+
+/**
+ * Capabilities that a test may require and is not supported by all environments.
+ */
+public enum Capability {
+
+    /**
+     * The test requires the ability to reconnect a node to the network.
+     */
+    RECONNECT
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/OtterTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/OtterTest.java
@@ -19,4 +19,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @Retention(RetentionPolicy.RUNTIME)
 @TestTemplate
 @ExtendWith({OtterTestExtension.class})
-public @interface OtterTest {}
+public @interface OtterTest {
+
+    /**
+     * Specifies the capabilities required by the test. If an environment does not support all of the required capabilities, the test will be disabled.
+     *
+     * @return an array of required capabilities
+     */
+    Capability[] requires() default {};
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerTestEnvironment.java
@@ -2,6 +2,8 @@
 package org.hiero.otter.fixtures.container;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
+import org.hiero.otter.fixtures.Capability;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
@@ -12,6 +14,8 @@ import org.hiero.otter.fixtures.internal.RegularTimeManager;
  * Implementation of {@link TestEnvironment} for tests running on a container network.
  */
 public class ContainerTestEnvironment implements TestEnvironment {
+
+    public static final Set<Capability> CAPABILITIES = Set.of(Capability.RECONNECT);
 
     private final ContainerNetwork network;
     private final RegularTimeManager timeManager = new RegularTimeManager();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -12,10 +12,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.constructable.ConstructableRegistry;
 import org.hiero.base.constructable.ConstructableRegistryException;
+import org.hiero.otter.fixtures.Capability;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
@@ -30,6 +32,7 @@ import org.hiero.otter.fixtures.logging.internal.InMemoryAppender;
  */
 public class TurtleTestEnvironment implements TestEnvironment {
 
+    public static final Set<Capability> CAPABILITIES = Set.of();
     private static final Logger log = LogManager.getLogger(TurtleTestEnvironment.class);
 
     static final String APP_NAME = "otter";


### PR DESCRIPTION
**Description**:

This PR adds a basic Capabilities API to the Otter framework. Required capabilities can be defined like so:

```
@OtterTest(requires = Capability.RECONNECT)
void testFoo(@NonNull final TestEnvironment env) {...}
```


**Related issue(s)**:

Fixes #19803 