### PR TITLE
chore: Modify defaults on SDPT controller to align with 1hr smoke test

### DIFF
--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       test-asset:
         required: true
-        default: "Latitude3"
+        default: "Latitude4"
         description: "Performance test on given namespace"
         type: choice
         options:
@@ -64,12 +64,12 @@ on:
         type: string
       crypto-bench-merkle-db-test-params:
         required: true
-        default: "-p maxKey=500000000 -p numRecords=100000 -p keySize=24 -p recordSize=1024 -p numFiles=6000"
+        default: "-p maxKey=500000000 -p numRecords=100000 -p keySize=24 -p recordSize=1024 -p numFiles=60"
         description: "Test params"
         type: string
       disable-notifications:
         required: false
-        default: false
+        default: true
         type: boolean
         description: "If true, skip tag and notifications"
 


### PR DESCRIPTION
**Description**:

This pull request updates the default values for several inputs in the `.github/workflows/zxf-single-day-performance-test-controller.yaml` file to adjust testing parameters and behavior.

Changes to default input values:

* Updated the `test-asset` default value from `"Latitude3"` to `"Latitude4"`.
* Adjusted the `crypto-bench-merkle-db-test-params` default value by reducing the `numFiles` parameter from `6000` to `60`.
* Changed the `disable-notifications` default value from `false` to `true` to skip tags and notifications by default.

**Related issue(s)**:

Closes #20010

**Notes for reviewer**:

<img width="309" alt="image" src="https://github.com/user-attachments/assets/02599925-a74a-458f-898d-da4de4d0e742" />

