### PR TITLE
test: Edge cases - Smart Contracts Service Tests Part 4

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm46ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm46ValidationSuite.java
@@ -80,7 +80,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
-// This test cases are direct copies of Evm38ValidationSuite. The difference here is that
+// This test cases are direct copies of Evm46ValidationSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm50ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm50ValidationSuite.java
@@ -24,7 +24,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
-// This test cases are direct copies of Evm38ValidationSuite. The difference here is that
+// This test cases are direct copies of Evm50ValidationSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicAliasTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicAliasTest.java
@@ -1,0 +1,217 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.hips.batch;
+
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.anyResult;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.isLiteralResult;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.createHollow;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withAddressOfKey;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withLongZeroAddress;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
+import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountUpdateSuite.ALIAS;
+import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.dsl.annotations.Account;
+import com.hedera.services.bdd.spec.dsl.annotations.Contract;
+import com.hedera.services.bdd.spec.dsl.entities.SpecAccount;
+import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+
+// This test cases are direct copies of CreateWithAliasDisabledTest. The difference here is that
+// we are wrapping the operations in an atomic batch to confirm that everything works as expected.
+@Tag(SMART_CONTRACT)
+@DisplayName("hip632ViewFunctions")
+@HapiTestLifecycle
+class AtomicAliasTest {
+
+    @Contract(contract = "HRC632Contract", creationGas = 2_000_000L)
+    static SpecContract hrc632Contract;
+
+    @Account(maxAutoAssociations = 10, tinybarBalance = ONE_MILLION_HBARS)
+    static SpecAccount alice;
+
+    com.esaulpaugh.headlong.abi.Address nonExtantAccount =
+            com.esaulpaugh.headlong.abi.Address.wrap("0x0000000000000000000000000000000000000000");
+    com.esaulpaugh.headlong.abi.Address nonExtantAlias =
+            com.esaulpaugh.headlong.abi.Address.wrap("0x0123456789012345678901234567890123456789");
+
+    private static final String BATCH_OPERATOR = "batchOperator";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of(
+                "atomicBatch.isEnabled",
+                "true",
+                "atomicBatch.maxNumberOfTransactions",
+                "50",
+                "contracts.throttle.throttleByGas",
+                "false",
+                "cryptoCreateWithAlias.enabled",
+                "false"));
+        testLifecycle.doAdhoc(
+                newKeyNamed(ALIAS).shape(SECP_256K1_SHAPE),
+                createHollow(1, i -> ALIAS),
+                withOpContext((spec, opLog) -> updateSpecFor(spec, ALIAS)));
+        testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
+    }
+
+    @Nested
+    @DisplayName("isValidAlias")
+    class IsValidAliasTest {
+
+        private static final String IS_VALID_ALIAS_CALL = "isValidAliasCall";
+
+        @HapiTest
+        @DisplayName("returns true for a regular account")
+        public Stream<DynamicTest> isValidAliasRegularAccount() {
+            return hapiTest(hrc632Contract
+                    .call(IS_VALID_ALIAS_CALL, alice)
+                    .wrappedInBatchOperation(BATCH_OPERATOR)
+                    .gas(1_000_000L)
+                    .andAssert(txn -> txn.hasResults(
+                            anyResult(),
+                            resultWith()
+                                    .resultThruAbi(
+                                            getABIFor(FUNCTION, IS_VALID_ALIAS_CALL, hrc632Contract.name()),
+                                            isLiteralResult(new Object[] {Boolean.TRUE})))));
+        }
+
+        @HapiTest
+        @DisplayName("returns true for a account with valid alias")
+        public Stream<DynamicTest> isValidAliasAliasAccount() {
+            return hapiTest(withAddressOfKey(ALIAS, aliasAddress -> hrc632Contract
+                    .call(IS_VALID_ALIAS_CALL, aliasAddress)
+                    .wrappedInBatchOperation(BATCH_OPERATOR)
+                    .gas(1_000_000L)
+                    .andAssert(txn -> txn.hasResults(
+                            anyResult(),
+                            resultWith()
+                                    .resultThruAbi(
+                                            getABIFor(FUNCTION, IS_VALID_ALIAS_CALL, hrc632Contract.name()),
+                                            isLiteralResult(new Object[] {Boolean.TRUE}))))));
+        }
+
+        @HapiTest
+        @DisplayName("returns false for a non extant account")
+        public Stream<DynamicTest> isValidAliasNonExtantAccount() {
+            return hapiTest(hrc632Contract
+                    .call(IS_VALID_ALIAS_CALL, nonExtantAccount)
+                    .wrappedInBatchOperation(BATCH_OPERATOR)
+                    .gas(1_000_000L)
+                    .andAssert(txn -> txn.hasResults(
+                            anyResult(),
+                            resultWith()
+                                    .resultThruAbi(
+                                            getABIFor(FUNCTION, IS_VALID_ALIAS_CALL, hrc632Contract.name()),
+                                            isLiteralResult(new Object[] {Boolean.FALSE})))));
+        }
+
+        @HapiTest
+        @DisplayName("returns false for a non extant alias")
+        public Stream<DynamicTest> isValidAliasNonExtantAlias() {
+            return hapiTest(hrc632Contract
+                    .call(IS_VALID_ALIAS_CALL, nonExtantAlias)
+                    .wrappedInBatchOperation(BATCH_OPERATOR)
+                    .gas(1_000_000L)
+                    .andAssert(txn -> txn.hasResults(
+                            anyResult(),
+                            resultWith()
+                                    .resultThruAbi(
+                                            getABIFor(FUNCTION, IS_VALID_ALIAS_CALL, hrc632Contract.name()),
+                                            isLiteralResult(new Object[] {Boolean.FALSE})))));
+        }
+    }
+
+    @Nested
+    @DisplayName("getEvmAddressAlias")
+    class GetEvmAddressAliasTest {
+
+        private static final String GET_EVM_ADDRESS_ALIAS_CALL = "getEvmAddressAliasCall";
+
+        @HapiTest
+        @DisplayName("succeeds for account with valid alias")
+        public Stream<DynamicTest> evmAddressAliasGivenGoodAccount() {
+            return hapiTest(withLongZeroAddress(ALIAS, aliasAddress -> hrc632Contract
+                    .call(GET_EVM_ADDRESS_ALIAS_CALL, aliasAddress)
+                    .wrappedInBatchOperation(BATCH_OPERATOR)
+                    .gas(1_000_000L)));
+        }
+
+        @HapiTest
+        @DisplayName("reverts when given non extant evm address")
+        public Stream<DynamicTest> evmAddressAliasGivenNonExtantAlias() {
+            return hapiTest(hrc632Contract
+                    .call(GET_EVM_ADDRESS_ALIAS_CALL, nonExtantAlias)
+                    .wrappedInBatchOperation(BATCH_OPERATOR, OK, INNER_TRANSACTION_FAILED)
+                    .gas(1_000_000L)
+                    .andAssert(txn -> txn.hasKnownStatus(CONTRACT_REVERT_EXECUTED)));
+        }
+
+        @HapiTest
+        @DisplayName("reverts when given non extant long zero address")
+        public Stream<DynamicTest> evmAddressAliasGivenNonExtantLongZero() {
+            return hapiTest(hrc632Contract
+                    .call(GET_EVM_ADDRESS_ALIAS_CALL, nonExtantAccount)
+                    .wrappedInBatchOperation(BATCH_OPERATOR, OK, INNER_TRANSACTION_FAILED)
+                    .gas(1_000_000L)
+                    .andAssert(txn -> txn.hasKnownStatus(CONTRACT_REVERT_EXECUTED)));
+        }
+    }
+
+    @Nested
+    @DisplayName("getHederaAccountNumAlias")
+    class GetHederaAccountNumAliasTest {
+
+        private static final String GET_HEDERA_ACCOUNT_NUM_ALIAS_CALL = "getHederaAccountNumAliasCall";
+
+        @HapiTest
+        @DisplayName("succeeds for account with valid alias")
+        public Stream<DynamicTest> hederaAccountNumAliasGivenGoodAccount() {
+            return hapiTest(withAddressOfKey(ALIAS, aliasAddress -> hrc632Contract
+                    .call(GET_HEDERA_ACCOUNT_NUM_ALIAS_CALL, aliasAddress)
+                    .wrappedInBatchOperation(BATCH_OPERATOR)
+                    .gas(1_000_000L)));
+        }
+
+        @HapiTest
+        @DisplayName("reverts when given non extant evm address")
+        public Stream<DynamicTest> hederaAccountNumAliasGivenNonExtantAlias() {
+            return hapiTest(hrc632Contract
+                    .call(GET_HEDERA_ACCOUNT_NUM_ALIAS_CALL, nonExtantAlias)
+                    .wrappedInBatchOperation(BATCH_OPERATOR, OK, INNER_TRANSACTION_FAILED)
+                    .gas(1_000_000L)
+                    .andAssert(txn -> txn.hasKnownStatus(CONTRACT_REVERT_EXECUTED)));
+        }
+
+        @HapiTest
+        @DisplayName("reverts when given non extant long zero address")
+        public Stream<DynamicTest> hederaAccountNumAliasGivenNonExtantLongZero() {
+            return hapiTest(hrc632Contract
+                    .call(GET_HEDERA_ACCOUNT_NUM_ALIAS_CALL, nonExtantAccount)
+                    .wrappedInBatchOperation(BATCH_OPERATOR, OK, INNER_TRANSACTION_FAILED)
+                    .gas(1_000_000L)
+                    .andAssert(txn -> txn.hasKnownStatus(CONTRACT_REVERT_EXECUTED)));
+        }
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicCreateWithAliasDisabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicCreateWithAliasDisabledTest.java
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.hips.batch;
+
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.keys.KeyShape.SECP256K1;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumContractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.FIVE_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
+import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
+import static com.hedera.services.bdd.suites.contract.Utils.asSolidityAddress;
+import static com.hedera.services.bdd.suites.contract.ethereum.EthereumSuite.GAS_LIMIT;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.PAY_RECEIVABLE_CONTRACT;
+import static com.hedera.services.bdd.suites.contract.leaky.LeakyContractTestsSuite.GAS_TO_OFFER;
+import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.AUTO_RENEW_PERIOD;
+import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.CREATE_TOKEN_WITH_ALL_CUSTOM_FEES_AVAILABLE;
+import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.DEFAULT_AMOUNT_TO_SEND;
+import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.ECDSA_KEY;
+import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.EXISTING_TOKEN;
+import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.FIRST_CREATE_TXN;
+import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.TOKEN_CREATE_CONTRACT;
+import static com.hedera.services.bdd.suites.crypto.CryptoCreateSuite.ACCOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CUSTOM_FEE_COLLECTOR;
+
+import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts;
+import com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts;
+import com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.ArrayUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
+
+// This test cases are direct copies of CreateWithAliasDisabledTest. The difference here is that
+// we are wrapping the operations in an atomic batch to confirm that everything works as expected.
+
+/**
+ * Tests expected behavior when the {@code cryptoCreateWithAlias.enabled} feature flag is off for
+ * <a href="https://hips.hedera.com/hip/hip-583">HIP-583, "Expand alias support in CryptoCreate &amp; CryptoTransfer Transactions"</a>.
+ */
+@HapiTestLifecycle
+public class AtomicCreateWithAliasDisabledTest {
+
+    private static final String BATCH_OPERATOR = "batchOperator";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of(
+                "atomicBatch.isEnabled",
+                "true",
+                "atomicBatch.maxNumberOfTransactions",
+                "50",
+                "contracts.throttle.throttleByGas",
+                "false",
+                "cryptoCreateWithAlias.enabled",
+                "false"));
+        testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> etx026AccountWithoutAliasCanMakeEthTxnsDueToAutomaticAliasCreation() {
+        final String ACCOUNT = "account";
+        return hapiTest(
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(ACCOUNT).key(SECP_256K1_SOURCE_KEY).balance(ONE_HUNDRED_HBARS),
+                atomicBatch(ethereumContractCreate(PAY_RECEIVABLE_CONTRACT)
+                                .type(EthTxData.EthTransactionType.EIP1559)
+                                .signingWith(SECP_256K1_SOURCE_KEY)
+                                .payingWith(ACCOUNT)
+                                .maxGasAllowance(FIVE_HBARS)
+                                .nonce(0)
+                                .gasLimit(GAS_LIMIT)
+                                .hasKnownStatus(INVALID_ACCOUNT_ID)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> createTokenWithInvalidFeeCollector() {
+        return hapiTest(
+                newKeyNamed(ECDSA_KEY).shape(SECP256K1),
+                cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS).key(ECDSA_KEY),
+                uploadInitCode(TOKEN_CREATE_CONTRACT),
+                contractCreate(TOKEN_CREATE_CONTRACT).gas(4_000_000L),
+                tokenCreate(EXISTING_TOKEN),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        atomicBatch(contractCall(
+                                                TOKEN_CREATE_CONTRACT,
+                                                CREATE_TOKEN_WITH_ALL_CUSTOM_FEES_AVAILABLE,
+                                                spec.registry()
+                                                        .getKey(ECDSA_KEY)
+                                                        .getECDSASecp256K1()
+                                                        .toByteArray(),
+                                                HapiParserUtil.asHeadlongAddress((byte[])
+                                                        ArrayUtils.toPrimitive(asSolidityAddress(spec, 15252L))),
+                                                HapiParserUtil.asHeadlongAddress(asAddress(
+                                                        spec.registry().getTokenID(EXISTING_TOKEN))),
+                                                HapiParserUtil.asHeadlongAddress(asAddress(
+                                                        spec.registry().getAccountID(ACCOUNT))),
+                                                AUTO_RENEW_PERIOD)
+                                        .via(FIRST_CREATE_TXN)
+                                        .gas(GAS_TO_OFFER)
+                                        .sending(DEFAULT_AMOUNT_TO_SEND)
+                                        .payingWith(ACCOUNT)
+                                        .refusingEthConversion()
+                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED))),
+                getTxnRecord(FIRST_CREATE_TXN).andAllChildRecords().logged(),
+                getAccountBalance(ACCOUNT).logged(),
+                getAccountBalance(TOKEN_CREATE_CONTRACT).logged(),
+                getContractInfo(TOKEN_CREATE_CONTRACT).logged(),
+                childRecordsCheck(
+                        FIRST_CREATE_TXN,
+                        CONTRACT_REVERT_EXECUTED,
+                        TransactionRecordAsserts.recordWith()
+                                .status(INVALID_CUSTOM_FEE_COLLECTOR)
+                                .contractCallResult(ContractFnResultAsserts.resultWith()
+                                        .error(INVALID_CUSTOM_FEE_COLLECTOR.name()))));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicIsAuthorizedTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicIsAuthorizedTest.java
@@ -1,0 +1,1075 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.hips.batch;
+
+import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPrivateKey;
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.keys.KeyShape.ED25519;
+import static com.hedera.services.bdd.spec.keys.KeyShape.SIMPLE;
+import static com.hedera.services.bdd.spec.keys.KeyShape.listOf;
+import static com.hedera.services.bdd.spec.keys.KeyShape.sigs;
+import static com.hedera.services.bdd.spec.keys.SigControl.ANY;
+import static com.hedera.services.bdd.spec.keys.SigControl.ED25519_ON;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.getEcdsaPrivateKeyFromSpec;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.getEd25519PrivateKeyFromSpec;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyListNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newThresholdKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
+import static com.hedera.services.bdd.suites.contract.Utils.idAsHeadlongAddress;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE_TYPE_MISMATCHING_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
+import com.esaulpaugh.headlong.abi.Address;
+import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.SignaturePair;
+import com.hedera.node.app.hapi.utils.SignatureGenerator;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.keys.KeyShape;
+import com.hedera.services.bdd.spec.keys.RepeatableKeyGenerator;
+import com.hedera.services.bdd.suites.utils.contracts.BoolResult;
+import com.hedera.services.bdd.utils.Signing;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.bouncycastle.jcajce.provider.digest.Keccak;
+import org.bouncycastle.jcajce.provider.digest.SHA384.Digest;
+import org.hiero.base.utility.CommonUtils;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Tag;
+
+// This test cases are direct copies of IsAuthorizedTest. The difference here is that
+// we are wrapping the operations in an atomic batch to confirm that everything works as expected.
+
+/**
+ * Tests expected behavior of the HRC-632 {@code isAuthorizedRaw(address,bytes,bytes)} function
+ * when the {@code contracts.systemContract.accountService.isAuthorizedRawEnabled} feature flag is on (which is
+ * true by default in  the current release.)
+ */
+@Tag(SMART_CONTRACT)
+@HapiTestLifecycle
+@SuppressWarnings("java:S1192") // "String literals should not be duplicated" - would impair readability here
+public class AtomicIsAuthorizedTest {
+
+    public static final String ACCOUNT = "account";
+    public static final String ANOTHER_ACCOUNT = "anotherAccount";
+
+    private static final String ECDSA_KEY = "ecdsaKey";
+    private static final String ECDSA_KEY_ANOTHER = "ecdsaKeyAnother";
+    private static final String ED25519_KEY = "ed25519Key";
+    private static final String THRESHOLD_KEY = "ThreshKey";
+    private static final String KEY_LIST = "ListKeys";
+
+    private static final KeyShape THRESHOLD_KEY_SHAPE = KeyShape.threshOf(1, ED25519, SIMPLE);
+    private static final KeyShape KEY_LIST_SHAPE = listOf(ED25519, SIMPLE);
+
+    private static final String HRC632_CONTRACT = "HRC632Contract";
+    private static final String CONTRACTS_SYSTEM_CONTRACT_ACCOUNT_SERVICE_IS_AUTHORIZED_RAW_ENABLED =
+            "contracts.systemContract.accountService.isAuthorizedRawEnabled";
+    private static final String CONTRACTS_SYSTEM_CONTRACT_ACCOUNT_SERVICE_IS_AUTHORIZED_ENABLED =
+            "contracts.systemContract.accountService.isAuthorizedRawEnabled";
+
+    private static final String BATCH_OPERATOR = "batchOperator";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of(
+                "atomicBatch.isEnabled",
+                "true",
+                "atomicBatch.maxNumberOfTransactions",
+                "50",
+                "contracts.throttle.throttleByGas",
+                "false",
+                "cryptoCreateWithAlias.enabled",
+                "false"));
+        testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
+    }
+
+    @Nested
+    @DisplayName("IsAuthorizedRaw")
+    class IsAuthorizedRawTests {
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawECDSAHappyPath() {
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+
+                        final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var addressBytes = recoverAddressFromPrivateKey(privateKey);
+                        final var signedBytes = Signing.signMessage(messageHash, privateKey);
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                asHeadlongAddress(addressBytes),
+                                                messageHash,
+                                                signedBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawECDSAInsufficientGas() {
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+
+                        final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var addressBytes = recoverAddressFromPrivateKey(privateKey);
+                        final var signedBytes = Signing.signMessage(messageHash, privateKey);
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                asHeadlongAddress(addressBytes),
+                                                messageHash,
+                                                signedBytes)
+                                        .via("authorizeCall")
+                                        .hasPrecheck(INSUFFICIENT_GAS)
+                                        .gas(1L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasPrecheck(INSUFFICIENT_GAS);
+                        allRunFor(spec, call);
+                    }));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawECDSADifferentHash() {
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+                        final var differentHash = new Keccak.Digest256().digest("submit1".getBytes());
+
+                        final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var addressBytes = recoverAddressFromPrivateKey(privateKey);
+                        final var signedBytes = Signing.signMessage(messageHash, privateKey);
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                asHeadlongAddress(addressBytes),
+                                                differentHash,
+                                                signedBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(false)))));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawECDSAInvalidVValue() {
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+
+                        final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var addressBytes = recoverAddressFromPrivateKey(privateKey);
+                        final var signature = Signing.signMessage(messageHash, privateKey);
+                        signature[signature.length - 1] = (byte) 2;
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                asHeadlongAddress(addressBytes),
+                                                messageHash,
+                                                signature)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(false)))));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawECDSAInvalidSignatureLength() {
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+
+                        final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var addressBytes = recoverAddressFromPrivateKey(privateKey);
+                        final byte[] invalidSignature = new byte[64];
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                asHeadlongAddress(addressBytes),
+                                                messageHash,
+                                                invalidSignature)
+                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED);
+                        allRunFor(spec, call);
+                    }),
+                    childRecordsCheck(
+                            "authorizeCall",
+                            CONTRACT_REVERT_EXECUTED,
+                            recordWith().status(INVALID_SIGNATURE_TYPE_MISMATCHING_KEY)));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawEDHappyPath() {
+            final AtomicReference<Address> accountNum = new AtomicReference<>();
+
+            return hapiTest(
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(ED25519_KEY)
+                            .exposingCreatedIdTo(id -> accountNum.set(idAsHeadlongAddress(id))),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Digest().digest("submit".getBytes());
+
+                        final var edKey = spec.registry().getKey(ED25519_KEY);
+                        final var privateKey = spec.keys()
+                                .getEd25519PrivateKey(
+                                        CommonUtils.hex(edKey.toByteArray()).substring(4));
+                        final var signedBytes = SignatureGenerator.signBytes(messageHash, privateKey);
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                accountNum.get(),
+                                                messageHash,
+                                                signedBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawEDDifferentHash() {
+            final AtomicReference<Address> accountNum = new AtomicReference<>();
+
+            return hapiTest(
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(ED25519_KEY)
+                            .exposingCreatedIdTo(id -> accountNum.set(idAsHeadlongAddress(id))),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var differentHash = new Digest().digest("submit1".getBytes());
+
+                        final var edKey = spec.registry().getKey(ED25519_KEY);
+                        final var privateKey = spec.keys()
+                                .getEd25519PrivateKey(
+                                        CommonUtils.hex(edKey.toByteArray()).substring(4));
+                        final var signedBytes = SignatureGenerator.signBytes(messageHash, privateKey);
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                accountNum.get(),
+                                                differentHash,
+                                                signedBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(false)))));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawEDInsufficientGas() {
+            final AtomicReference<Address> accountNum = new AtomicReference<>();
+
+            return hapiTest(
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(ED25519_KEY)
+                            .exposingCreatedIdTo(id -> accountNum.set(idAsHeadlongAddress(id))),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Digest().digest("submit".getBytes());
+
+                        final var edKey = spec.registry().getKey(ED25519_KEY);
+                        final var privateKey = spec.keys()
+                                .getEd25519PrivateKey(
+                                        CommonUtils.hex(edKey.toByteArray()).substring(4));
+                        final var signedBytes = SignatureGenerator.signBytes(messageHash, privateKey);
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                accountNum.get(),
+                                                messageHash,
+                                                signedBytes)
+                                        .via("authorizeCall")
+                                        .hasPrecheck(INSUFFICIENT_GAS)
+                                        .gas(1L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasPrecheck(INSUFFICIENT_GAS);
+                        allRunFor(spec, call);
+                    }));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawEDInvalidSignatureAddressPairsFails() {
+            final AtomicReference<Address> accountNum = new AtomicReference<>();
+
+            return hapiTest(
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(ED25519_KEY)
+                            .exposingCreatedIdTo(id -> accountNum.set(idAsHeadlongAddress(id))),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+
+                        final var callECSigWithLongZero = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                accountNum.get(),
+                                                messageHash,
+                                                new byte[65])
+                                        .via("authorizeCallECWithLongZero")
+                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED);
+                        final var callECWithInvalidSignature = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                accountNum.get(),
+                                                messageHash,
+                                                new byte[63])
+                                        .via("authorizeCallECWithInvalidSignature")
+                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED);
+                        allRunFor(spec, callECSigWithLongZero, callECWithInvalidSignature);
+                    }),
+                    childRecordsCheck(
+                            "authorizeCallECWithLongZero",
+                            CONTRACT_REVERT_EXECUTED,
+                            recordWith().status(INVALID_ACCOUNT_ID)),
+                    childRecordsCheck(
+                            "authorizeCallECWithInvalidSignature",
+                            CONTRACT_REVERT_EXECUTED,
+                            recordWith().status(INVALID_TRANSACTION_BODY)));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawAliasWithECFails() {
+            final AtomicReference<Address> accountNum = new AtomicReference<>();
+
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(ECDSA_KEY)
+                            .exposingCreatedIdTo(id -> accountNum.set(idAsHeadlongAddress(id))),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var signedBytes = Signing.signMessage(messageHash, privateKey);
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                accountNum.get(),
+                                                messageHash,
+                                                signedBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED);
+                        allRunFor(spec, call);
+                    }),
+                    childRecordsCheck(
+                            "authorizeCall",
+                            CONTRACT_REVERT_EXECUTED,
+                            recordWith().status(INVALID_TRANSACTION_BODY)));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawEDWithComplexKeysFails() {
+            final AtomicReference<Address> accountNum = new AtomicReference<>();
+            final AtomicReference<Address> accountAnotherNum = new AtomicReference<>();
+            return hapiTest(
+                    newKeyNamed(THRESHOLD_KEY).shape(THRESHOLD_KEY_SHAPE.signedWith(sigs(ED25519_ON, ANY))),
+                    newKeyNamed(KEY_LIST).shape(KEY_LIST_SHAPE.signedWith(sigs(ED25519_ON, ANY))),
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(THRESHOLD_KEY)
+                            .exposingCreatedIdTo(id -> accountNum.set(idAsHeadlongAddress(id))),
+                    cryptoCreate(ANOTHER_ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(KEY_LIST)
+                            .exposingCreatedIdTo(id -> accountAnotherNum.set(idAsHeadlongAddress(id))),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var edKey = spec.registry().getKey(ED25519_KEY);
+                        final var privateKey = spec.keys()
+                                .getEd25519PrivateKey(
+                                        CommonUtils.hex(edKey.toByteArray()).substring(4));
+                        final var signedBytes = SignatureGenerator.signBytes(messageHash, privateKey);
+
+                        final var callWithThreshold = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                accountNum.get(),
+                                                messageHash,
+                                                signedBytes)
+                                        .via("authorizeCallWithThreshold")
+                                        .gas(2_000_000L)
+                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED);
+
+                        final var callWithKeyList = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                accountAnotherNum.get(),
+                                                messageHash,
+                                                signedBytes)
+                                        .via("authorizeCallWithKeyList")
+                                        .gas(2_000_000L)
+                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED);
+                        allRunFor(spec, callWithThreshold, callWithKeyList);
+                    }),
+                    childRecordsCheck(
+                            "authorizeCallWithThreshold",
+                            CONTRACT_REVERT_EXECUTED,
+                            recordWith().status(INVALID_TRANSACTION_BODY)),
+                    childRecordsCheck(
+                            "authorizeCallWithKeyList",
+                            CONTRACT_REVERT_EXECUTED,
+                            recordWith().status(INVALID_TRANSACTION_BODY)));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawAccountAndSignatureKeysCombinations() {
+            final AtomicReference<Address> accountNum = new AtomicReference<>();
+
+            return hapiTest(
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    newKeyNamed(ECDSA_KEY_ANOTHER).shape(SECP_256K1_SHAPE),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY_ANOTHER, ONE_HUNDRED_HBARS)),
+                    cryptoCreate(ACCOUNT).balance(ONE_MILLION_HBARS).key(ED25519_KEY),
+                    cryptoCreate(ANOTHER_ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(ED25519_KEY)
+                            .exposingCreatedIdTo(id -> accountNum.set(idAsHeadlongAddress(id))),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var messageHash = new Digest().digest("submit".getBytes());
+                        final var messageHash32Bytes = new Keccak.Digest256().digest("submit".getBytes());
+
+                        // Sign message with ED25519
+                        final var edKey = spec.registry().getKey(ED25519_KEY);
+                        final var privateKey = spec.keys()
+                                .getEd25519PrivateKey(
+                                        CommonUtils.hex(edKey.toByteArray()).substring(4));
+                        final var signedBytes = SignatureGenerator.signBytes(messageHash, privateKey);
+
+                        // Sign message with ECDSA
+                        final var privateKeyECDSA = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var privateKeyECDSAAnother = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY_ANOTHER);
+                        final var addressBytes = recoverAddressFromPrivateKey(privateKeyECDSAAnother);
+                        final var signedBytesECDSA = Signing.signMessage(messageHash32Bytes, privateKeyECDSA);
+
+                        // Perform test calls
+                        final var callECDSADifferent = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                asHeadlongAddress(addressBytes),
+                                                messageHash32Bytes,
+                                                signedBytesECDSA)
+                                        .via("callSignatureWithDifferentAddressECDSAKey")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+
+                        final var callWithDifferentAccountsWithSameKey = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                accountNum.get(),
+                                                messageHash,
+                                                signedBytes)
+                                        .via("callWithDifferentAccountsWithSameKey")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+
+                        final var callECKeyEDSignature = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedRawCall",
+                                                asHeadlongAddress(addressBytes),
+                                                messageHash,
+                                                signedBytes)
+                                        .via("callWithECKeyAddressForEDSignature")
+                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED);
+                        allRunFor(spec, callECDSADifferent, callWithDifferentAccountsWithSameKey, callECKeyEDSignature);
+                    }),
+                    getTxnRecord("callSignatureWithDifferentAddressECDSAKey")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(false)))),
+                    getTxnRecord("callWithDifferentAccountsWithSameKey")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))),
+                    childRecordsCheck(
+                            "callWithECKeyAddressForEDSignature",
+                            CONTRACT_REVERT_EXECUTED,
+                            recordWith().status(INVALID_SIGNATURE_TYPE_MISMATCHING_KEY)));
+        }
+
+        // FUTURE: Note the difference in returned status between the EC tests and the ED tests:
+        // INSUFFICIENT_GAS vs CONTRACT_REVERT_EXECUTED.  This has to do with whether the tests run out
+        // of gas before/after the `isAuthorizedRaw` call, or within it.  And it also shows up in whether
+        // there is a child record for the method call.  The question is: Given that this difference is
+        // visible to callers, is it acceptable?  Question will become more important as more system
+        // contract methods gain individual gas fees.
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawECDSACheckGasRequirements() {
+
+            // Intrinsic gas is 21_000, ECRECOVER is 3_000, but there's also the contract itself that we're calling
+
+            record TestCase(long gasAmount, ResponseCodeEnum status) {}
+
+            final var testCases = new ArrayList<TestCase>(List.of(new TestCase(100000, SUCCESS)));
+            for (long g = 28000; g < 34000; g += 1000) {
+                testCases.add(new TestCase(g, INSUFFICIENT_GAS));
+            }
+            for (long g = 34000; g < 34300; g += 100) {
+                testCases.add(new TestCase(g, INSUFFICIENT_GAS));
+            }
+            for (long g = 34300; g < 35000; g += 100) {
+                testCases.add(new TestCase(g, SUCCESS));
+            }
+            for (long g = 35000; g < 40000; g += 1000) {
+                testCases.add(new TestCase(g, SUCCESS));
+            }
+
+            final var dynamicTests = new ArrayList<Stream<DynamicTest>>(testCases.size());
+            for (final var testCase : testCases) {
+                final var testName = "isAuthorizedRawECDSACheckGasRequirements with %d gas, expecting %s"
+                        .formatted(testCase.gasAmount(), testCase.status());
+                final var recordName = "authorizeCallEC-%d".formatted(testCase.gasAmount());
+
+                final var throughWhen = defaultHapiSpec(testName)
+                        .given(
+                                overriding(CONTRACTS_SYSTEM_CONTRACT_ACCOUNT_SERVICE_IS_AUTHORIZED_RAW_ENABLED, "true"),
+                                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                                uploadInitCode(HRC632_CONTRACT),
+                                contractCreate(HRC632_CONTRACT))
+                        .when(withOpContext((spec, opLog) -> {
+                            final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+
+                            final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                            final var addressBytes = recoverAddressFromPrivateKey(privateKey);
+                            final var signedBytes = Signing.signMessage(messageHash, privateKey);
+
+                            var call = atomicBatch(contractCall(
+                                                    HRC632_CONTRACT,
+                                                    "isAuthorizedRawCall",
+                                                    asHeadlongAddress(addressBytes),
+                                                    messageHash,
+                                                    signedBytes)
+                                            .via(recordName)
+                                            .gas(testCase.gasAmount())
+                                            .batchKey(BATCH_OPERATOR))
+                                    .payingWith(BATCH_OPERATOR)
+                                    .hasKnownStatusFrom(SUCCESS, INNER_TRANSACTION_FAILED);
+                            allRunFor(spec, call);
+                        }));
+                final var hapiSpec = testCase.status() == SUCCESS
+                        ? throughWhen.then(getTxnRecord(recordName)
+                                .hasPriority(recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))))
+                        : throughWhen.then(getTxnRecord(recordName)
+                                .hasPriority(recordWith()
+                                        .status(INSUFFICIENT_GAS)
+                                        .contractCallResult(resultWith().gasUsed(testCase.gasAmount()))));
+                dynamicTests.add(hapiSpec);
+            }
+
+            return dynamicTests.stream().reduce(Stream::concat).get();
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> isAuthorizedRawED25519CheckGasRequirements() {
+
+            // Intrinsic gas is 21_000, hard-coded verification charge is 1_500_000, but there's also the contract
+            // itself
+            // that we're calling - allow 55K gas (actually, determined empirically)
+
+            final long GAS_BURNT_IN_ADDITION_TO_IS_AUTHORIZED_RAW_ALLOWANCE = 55_000L;
+
+            record TestCase(long gasAmount, ResponseCodeEnum status) {}
+
+            final var testCases = new ArrayList<TestCase>();
+            for (long g = 1_550_000; g < 1_554_000; g += 1000) {
+                testCases.add(new TestCase(g, INSUFFICIENT_GAS));
+            }
+            for (long g = 1_554_000; g < 1_554_500; g += 100) {
+                testCases.add(new TestCase(g, INSUFFICIENT_GAS));
+            }
+            for (long g = 1_554_500; g < 1_555_000; g += 100) {
+                testCases.add(new TestCase(g, SUCCESS));
+            }
+            for (long g = 1_555_000; g < 1_560_000; g += 1000) {
+                testCases.add(new TestCase(g, SUCCESS));
+            }
+
+            final var dynamicTests = new ArrayList<Stream<DynamicTest>>(testCases.size());
+            for (final var testCase : testCases) {
+                final var testName = "isAuthorizedRawED25519CheckGasRequirements with %d gas, expecting %s"
+                        .formatted(testCase.gasAmount(), testCase.status());
+                final var recordName = "authorizeCallED-%d".formatted(testCase.gasAmount());
+
+                final AtomicReference<Address> accountNum = new AtomicReference<>();
+
+                final var throughWhen = defaultHapiSpec(testName)
+                        .given(
+                                newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                                cryptoCreate(ACCOUNT)
+                                        .balance(ONE_MILLION_HBARS)
+                                        .key(ED25519_KEY)
+                                        .exposingCreatedIdTo(id -> accountNum.set(idAsHeadlongAddress(id))),
+                                uploadInitCode(HRC632_CONTRACT),
+                                contractCreate(HRC632_CONTRACT))
+                        .when(withOpContext((spec, opLog) -> {
+                            final var messageHash = new Digest().digest("submit".getBytes());
+
+                            final var edKey = spec.registry().getKey(ED25519_KEY);
+                            final var privateKey = spec.keys()
+                                    .getEd25519PrivateKey(
+                                            CommonUtils.hex(edKey.toByteArray()).substring(4));
+                            final var signedBytes = SignatureGenerator.signBytes(messageHash, privateKey);
+
+                            var call = atomicBatch(contractCall(
+                                                    HRC632_CONTRACT,
+                                                    "isAuthorizedRawCall",
+                                                    accountNum.get(),
+                                                    messageHash,
+                                                    signedBytes)
+                                            .via(recordName)
+                                            .gas(testCase.gasAmount())
+                                            .batchKey(BATCH_OPERATOR))
+                                    .payingWith(BATCH_OPERATOR)
+                                    .hasKnownStatusFrom(SUCCESS, INNER_TRANSACTION_FAILED);
+                            allRunFor(spec, call);
+                        }));
+                final var hapiSpec = testCase.status() == SUCCESS
+                        ? throughWhen.then(getTxnRecord(recordName)
+                                .hasPriority(recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))))
+                        : throughWhen.then(childRecordsCheck(
+                                recordName,
+                                CONTRACT_REVERT_EXECUTED,
+                                recordWith()
+                                        .status(INSUFFICIENT_GAS)
+                                        .contractCallResult(resultWith()
+                                                .gasUsedIsInRange(
+                                                        (testCase.gasAmount()
+                                                                - GAS_BURNT_IN_ADDITION_TO_IS_AUTHORIZED_RAW_ALLOWANCE),
+                                                        testCase.gasAmount()))));
+                dynamicTests.add(hapiSpec);
+            }
+
+            return dynamicTests.stream().reduce(Stream::concat).get();
+        }
+    }
+
+    @Nested
+    @DisplayName("IsAuthorizedTests")
+    class IsAuthorizedTests {
+
+        @HapiTest
+        final Stream<DynamicTest> ecdsaHappyPath() {
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ECDSA_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var message = "submit".getBytes();
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+                        final var privateKey = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var publicKey = spec.registry().getKey(ECDSA_KEY).getECDSASecp256K1();
+                        final var addressBytes = recoverAddressFromPrivateKey(privateKey);
+                        final var signedBytes = Signing.signMessage(messageHash, privateKey);
+
+                        final var signatureMap = SignatureMap.newBuilder()
+                                .sigPair(SignaturePair.newBuilder()
+                                        .ecdsaSecp256k1(Bytes.wrap(signedBytes))
+                                        .pubKeyPrefix(Bytes.wrap(publicKey.toByteArray()))
+                                        .build())
+                                .build();
+
+                        final var signatureMapBytes =
+                                SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray();
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedCall",
+                                                asHeadlongAddress(addressBytes),
+                                                message,
+                                                signatureMapBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> ed25519HappyPath() {
+            final AtomicReference<AccountID> accountNum = new AtomicReference<>();
+            return hapiTest(
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(ED25519_KEY)
+                            .exposingCreatedIdTo(accountNum::set),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ED25519_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var message = "submit".getBytes();
+                        final var privateKey = getEd25519PrivateKeyFromSpec(spec, ED25519_KEY);
+                        final var publicKey =
+                                spec.registry().getKey(ED25519_KEY).getEd25519();
+                        final var signedBytes = SignatureGenerator.signBytes(message, privateKey);
+                        final var signatureMap = SignatureMap.newBuilder()
+                                .sigPair(SignaturePair.newBuilder()
+                                        .ed25519(Bytes.wrap(signedBytes))
+                                        .pubKeyPrefix(Bytes.wrap(publicKey.toByteArray()))
+                                        .build())
+                                .build();
+                        final var signatureMapBytes =
+                                SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray();
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedCall",
+                                                asHeadlongAddress(asAddress(accountNum.get())),
+                                                message,
+                                                signatureMapBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> keyListHappyPath() {
+            final AtomicReference<AccountID> accountNum = new AtomicReference<>();
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    newKeyListNamed(KEY_LIST, List.of(ECDSA_KEY, ED25519_KEY)),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(KEY_LIST)
+                            .exposingCreatedIdTo(accountNum::set),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ED25519_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var message = "submit".getBytes();
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+                        final var privateKeyEcdsa = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var publicKeyEcdsa =
+                                spec.registry().getKey(ECDSA_KEY).getECDSASecp256K1();
+                        final var addressBytesEcdsa = recoverAddressFromPrivateKey(privateKeyEcdsa);
+                        final var signedBytesEcdsa = Signing.signMessage(messageHash, privateKeyEcdsa);
+
+                        final var privateKeyEd = getEd25519PrivateKeyFromSpec(spec, ED25519_KEY);
+                        final var publicKeyEd =
+                                spec.registry().getKey(ED25519_KEY).getEd25519();
+                        final var signedBytesEd = SignatureGenerator.signBytes(message, privateKeyEd);
+                        final var signatureMap = SignatureMap.newBuilder()
+                                .sigPair(List.of(
+                                        SignaturePair.newBuilder()
+                                                .ed25519(Bytes.wrap(signedBytesEd))
+                                                .pubKeyPrefix(Bytes.wrap(publicKeyEd.toByteArray()))
+                                                .build(),
+                                        SignaturePair.newBuilder()
+                                                .ecdsaSecp256k1(Bytes.wrap(signedBytesEcdsa))
+                                                .pubKeyPrefix(Bytes.wrap(publicKeyEcdsa.toByteArray()))
+                                                .build()))
+                                .build();
+                        final var signatureMapBytes =
+                                SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray();
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedCall",
+                                                asHeadlongAddress(asAddress(accountNum.get())),
+                                                message,
+                                                signatureMapBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> thresholdKey1of2HappyPath() {
+            final AtomicReference<AccountID> accountNum = new AtomicReference<>();
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    newThresholdKeyNamed(THRESHOLD_KEY, 1, List.of(ECDSA_KEY, ED25519_KEY)),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(THRESHOLD_KEY)
+                            .exposingCreatedIdTo(accountNum::set),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ED25519_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var message = "submit".getBytes();
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+                        final var privateKeyEcdsa = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var publicKeyEcdsa =
+                                spec.registry().getKey(ECDSA_KEY).getECDSASecp256K1();
+                        final var addressBytesEcdsa = recoverAddressFromPrivateKey(privateKeyEcdsa);
+                        final var signedBytesEcdsa = Signing.signMessage(messageHash, privateKeyEcdsa);
+
+                        final var privateKeyEd = getEd25519PrivateKeyFromSpec(spec, ED25519_KEY);
+                        final var publicKeyEd =
+                                spec.registry().getKey(ED25519_KEY).getEd25519();
+                        final var signedBytesEd = SignatureGenerator.signBytes(message, privateKeyEd);
+                        final var signatureMap = SignatureMap.newBuilder()
+                                .sigPair(List.of(
+                                        //                                        SignaturePair.newBuilder()
+                                        //
+                                        // .ed25519(Bytes.wrap(signedBytesEd))
+                                        //
+                                        // .pubKeyPrefix(Bytes.wrap(publicKeyEd.toByteArray()))
+                                        //                                                .build(),
+                                        SignaturePair.newBuilder()
+                                                .ecdsaSecp256k1(Bytes.wrap(signedBytesEcdsa))
+                                                .pubKeyPrefix(Bytes.wrap(publicKeyEcdsa.toByteArray()))
+                                                .build()))
+                                .build();
+                        final var signatureMapBytes =
+                                SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray();
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedCall",
+                                                asHeadlongAddress(asAddress(accountNum.get())),
+                                                message,
+                                                signatureMapBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))));
+        }
+
+        @HapiTest
+        final Stream<DynamicTest> thresholdKey2of2HappyPath() {
+            final AtomicReference<AccountID> accountNum = new AtomicReference<>();
+            return hapiTest(
+                    newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE).generator(new RepeatableKeyGenerator()),
+                    newKeyNamed(ED25519_KEY).shape(ED25519).generator(new RepeatableKeyGenerator()),
+                    newThresholdKeyNamed(THRESHOLD_KEY, 2, List.of(ECDSA_KEY, ED25519_KEY)),
+                    cryptoCreate(ACCOUNT)
+                            .balance(ONE_MILLION_HBARS)
+                            .key(THRESHOLD_KEY)
+                            .exposingCreatedIdTo(accountNum::set),
+                    cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, ED25519_KEY, ONE_HUNDRED_HBARS)),
+                    uploadInitCode(HRC632_CONTRACT),
+                    contractCreate(HRC632_CONTRACT),
+                    withOpContext((spec, opLog) -> {
+                        final var message = "submit".getBytes();
+                        final var messageHash = new Keccak.Digest256().digest("submit".getBytes());
+                        final var privateKeyEcdsa = getEcdsaPrivateKeyFromSpec(spec, ECDSA_KEY);
+                        final var publicKeyEcdsa =
+                                spec.registry().getKey(ECDSA_KEY).getECDSASecp256K1();
+                        final var addressBytesEcdsa = recoverAddressFromPrivateKey(privateKeyEcdsa);
+                        final var signedBytesEcdsa = Signing.signMessage(messageHash, privateKeyEcdsa);
+
+                        final var privateKeyEd = getEd25519PrivateKeyFromSpec(spec, ED25519_KEY);
+                        final var publicKeyEd =
+                                spec.registry().getKey(ED25519_KEY).getEd25519();
+                        final var signedBytesEd = SignatureGenerator.signBytes(message, privateKeyEd);
+                        final var signatureMap = SignatureMap.newBuilder()
+                                .sigPair(List.of(
+                                        SignaturePair.newBuilder()
+                                                .ed25519(Bytes.wrap(signedBytesEd))
+                                                .pubKeyPrefix(Bytes.wrap(publicKeyEd.toByteArray()))
+                                                .build(),
+                                        SignaturePair.newBuilder()
+                                                .ecdsaSecp256k1(Bytes.wrap(signedBytesEcdsa))
+                                                .pubKeyPrefix(Bytes.wrap(publicKeyEcdsa.toByteArray()))
+                                                .build()))
+                                .build();
+                        final var signatureMapBytes =
+                                SignatureMap.PROTOBUF.toBytes(signatureMap).toByteArray();
+
+                        final var call = atomicBatch(contractCall(
+                                                HRC632_CONTRACT,
+                                                "isAuthorizedCall",
+                                                asHeadlongAddress(asAddress(accountNum.get())),
+                                                message,
+                                                signatureMapBytes)
+                                        .via("authorizeCall")
+                                        .gas(2_000_000L)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR);
+                        allRunFor(spec, call);
+                    }),
+                    getTxnRecord("authorizeCall")
+                            .hasPriority(recordWith()
+                                    .status(SUCCESS)
+                                    .contractCallResult(resultWith().contractCallResult(BoolResult.flag(true)))));
+        }
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/batch/AtomicLeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/batch/AtomicLeakyContractTestsSuite.java
@@ -1,0 +1,1299 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.leaky.batch;
+
+import static com.google.protobuf.ByteString.EMPTY;
+import static com.hedera.node.app.hapi.utils.EthSigsUtils.recoverAddressFromPubKey;
+import static com.hedera.services.bdd.junit.ContextRequirement.FEE_SCHEDULE_OVERRIDES;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asContract;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts.resultWith;
+import static com.hedera.services.bdd.spec.assertions.ContractInfoAsserts.contractWith;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.contractCallLocal;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getContractInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenNftInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCallWithFunctionAbi;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCustomCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCallWithFunctionAbi;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uncheckedSubmit;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadSingleInitCode;
+import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddress;
+import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.asHeadlongAddressArray;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingUnique;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.SidecarVerbs.expectContractActionSidecarFor;
+import static com.hedera.services.bdd.spec.utilops.SidecarVerbs.expectContractStateChangesSidecarFor;
+import static com.hedera.services.bdd.spec.utilops.SidecarVerbs.sidecarValidation;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.childRecordsCheck;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.emptyChildRecordsCheck;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.inParallel;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingTwo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.reduceFeeFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_CONTRACT_SENDER;
+import static com.hedera.services.bdd.suites.HapiSuite.EMPTY_KEY;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
+import static com.hedera.services.bdd.suites.HapiSuite.THREE_MONTHS_IN_SECONDS;
+import static com.hedera.services.bdd.suites.HapiSuite.TOKEN_TREASURY;
+import static com.hedera.services.bdd.suites.contract.Utils.FunctionType.FUNCTION;
+import static com.hedera.services.bdd.suites.contract.Utils.asAddress;
+import static com.hedera.services.bdd.suites.contract.Utils.asHexedAddress;
+import static com.hedera.services.bdd.suites.contract.Utils.asHexedSolidityAddress;
+import static com.hedera.services.bdd.suites.contract.Utils.asSolidityAddress;
+import static com.hedera.services.bdd.suites.contract.Utils.getABIFor;
+import static com.hedera.services.bdd.suites.contract.Utils.mirrorAddrWith;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.ACCOUNT_INFO;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.ACCOUNT_INFO_AFTER_CALL;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.CALL_TX;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.CALL_TX_REC;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.CONTRACT_FROM;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.DEPOSIT;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.PAY_RECEIVABLE_CONTRACT;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.SIMPLE_UPDATE_CONTRACT;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.TRANSFERRING_CONTRACT;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.TRANSFER_TO_CALLER;
+import static com.hedera.services.bdd.suites.contract.hapi.ContractCreateSuite.EMPTY_CONSTRUCTOR_CONTRACT;
+import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.TOKEN_NAME;
+import static com.hedera.services.bdd.suites.contract.precompile.ERCPrecompileSuite.NAME_TXN;
+import static com.hedera.services.bdd.suites.contract.traceability.EncodingUtils.formattedAssertionValue;
+import static com.hedera.services.bdd.suites.crypto.AutoAccountCreationSuite.LAZY_MEMO;
+import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
+import static com.hedera.services.bdd.suites.crypto.CryptoApproveAllowanceSuite.ADMIN_KEY;
+import static com.hedera.services.bdd.suites.utils.contracts.AddressResult.hexedAddress;
+import static com.hedera.services.bdd.suites.utils.contracts.precompile.HTSPrecompileResult.htsPrecompileResult;
+import static com.hedera.services.stream.proto.ContractActionType.CALL;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_REVERT_EXECUTED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRACT_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SOLIDITY_ADDRESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CHILD_RECORDS_EXCEEDED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_GAS_LIMIT_EXCEEDED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
+import static org.hyperledger.besu.datatypes.Address.contractAddress;
+import static org.hyperledger.besu.datatypes.Address.fromHexString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.BytesValue;
+import com.hedera.node.app.hapi.utils.contracts.ParsingConstants.FunctionType;
+import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
+import com.hedera.node.app.hapi.utils.fee.FeeBuilder;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.spec.HapiPropertySource;
+import com.hedera.services.bdd.spec.HapiSpecOperation;
+import com.hedera.services.bdd.spec.assertions.ContractInfoAsserts;
+import com.hedera.services.bdd.spec.assertions.StateChange;
+import com.hedera.services.bdd.spec.assertions.StorageChange;
+import com.hedera.services.bdd.spec.queries.QueryVerbs;
+import com.hedera.services.bdd.spec.queries.meta.HapiGetTxnRecord;
+import com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil;
+import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
+import com.hedera.services.bdd.suites.contract.Utils;
+import com.hedera.services.stream.proto.CallOperationType;
+import com.hedera.services.stream.proto.ContractAction;
+import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.HederaFunctionality;
+import com.hederahashgraph.api.proto.java.TokenID;
+import com.hederahashgraph.api.proto.java.TokenSupplyType;
+import com.hederahashgraph.api.proto.java.TokenType;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.hiero.base.utility.CommonUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Order;
+
+// This test cases are direct copies of LeakyContractTestsSuite. The difference here is that
+// we are wrapping the operations in an atomic batch to confirm that everything works as expected.
+@SuppressWarnings("java:S1192") // "string literal should not be duplicated" - this rule makes test suites worse
+@OrderedInIsolation
+@HapiTestLifecycle
+public class AtomicLeakyContractTestsSuite {
+
+    public static final String CREATE_TX = "createTX";
+    public static final String CREATE_TX_REC = "createTXRec";
+    public static final String FALSE = "false";
+    public static final int GAS_TO_OFFER = 2_000_000;
+    public static final String SENDER = "yahcliSender";
+    public static final String RECEIVER = "yahcliReceiver";
+    private static final String FUNGIBLE_TOKEN = "fungibleToken";
+    private static final String NON_FUNGIBLE_TOKEN = "nonFungibleToken";
+    private static final String MULTI_KEY = "purpose";
+    private static final String ACCOUNT = "anybody";
+    public static final String RECIPIENT = "recipient";
+    private static final String FIRST = "FIRST";
+    private static final ByteString FIRST_META = ByteString.copyFrom(FIRST.getBytes(StandardCharsets.UTF_8));
+    public static final String ERC_20_CONTRACT = "ERC20Contract";
+    private static final String TRANSFER_TXN = "transferTxn";
+    public static final String TRANSFER = "transfer";
+    private static final String NF_TOKEN = "nfToken";
+    private static final String MULTI_KEY_NAME = "multiKey";
+    private static final String A_CIVILIAN = "aCivilian";
+    private static final String B_CIVILIAN = "bCivilian";
+    private static final String GET_APPROVED = "outerGetApproved";
+    private static final String GET_BALANCE_OF = "getBalanceOf";
+    private static final String SOME_ERC_721_SCENARIOS = "SomeERC721Scenarios";
+    private static final String GET_OWNER_OF = "getOwnerOf";
+    private static final String MISSING_TOKEN = "MISSING_TOKEN";
+    private static final String WITH_SPENDER = "WITH_SPENDER";
+    private static final String DO_SPECIFIC_APPROVAL = "doSpecificApproval";
+    public static final String GET_BYTECODE = "getBytecode";
+    public static final String CONTRACT_REPORTED_LOG_MESSAGE = "Contract reported TestContract initcode is {} bytes";
+    public static final String DEPLOY = "deploy";
+    private static final long NONEXISTENT_CONTRACT_NUM = 1_234_567_890L;
+    private static final String BATCH_OPERATOR = "batchOperator";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of(
+                "atomicBatch.isEnabled",
+                "true",
+                "atomicBatch.maxNumberOfTransactions",
+                "50",
+                "contracts.throttle.throttleByGas",
+                "false",
+                "cryptoCreateWithAlias.enabled",
+                "false"));
+        testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
+    }
+
+    @HapiTest
+    @Order(27)
+    final Stream<DynamicTest> transferErc20TokenFromErc721TokenFails() {
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                cryptoCreate(ACCOUNT).balance(100 * ONE_MILLION_HBARS),
+                cryptoCreate(RECIPIENT),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(NON_FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(MULTI_KEY)
+                        .supplyKey(MULTI_KEY),
+                mintToken(NON_FUNGIBLE_TOKEN, List.of(FIRST_META)),
+                tokenAssociate(ACCOUNT, List.of(NON_FUNGIBLE_TOKEN)),
+                tokenAssociate(RECIPIENT, List.of(NON_FUNGIBLE_TOKEN)),
+                cryptoTransfer(movingUnique(NON_FUNGIBLE_TOKEN, 1).between(TOKEN_TREASURY, ACCOUNT))
+                        .payingWith(ACCOUNT),
+                uploadInitCode(ERC_20_CONTRACT),
+                contractCreate(ERC_20_CONTRACT),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        atomicBatch(contractCall(
+                                                ERC_20_CONTRACT,
+                                                TRANSFER,
+                                                HapiParserUtil.asHeadlongAddress(asAddress(
+                                                        spec.registry().getTokenID(NON_FUNGIBLE_TOKEN))),
+                                                HapiParserUtil.asHeadlongAddress(asAddress(
+                                                        spec.registry().getAccountID(RECIPIENT))),
+                                                BigInteger.TWO)
+                                        .payingWith(ACCOUNT)
+                                        .alsoSigningWithFullPrefix(MULTI_KEY)
+                                        .via(TRANSFER_TXN)
+                                        .gas(GAS_TO_OFFER)
+                                        .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED))),
+                getTxnRecord(TRANSFER_TXN).andAllChildRecords());
+    }
+
+    @Order(35)
+    @LeakyHapiTest(requirement = FEE_SCHEDULE_OVERRIDES)
+    final Stream<DynamicTest> getErc20TokenNameExceedingLimits() {
+        final var REDUCED_NETWORK_FEE = 1L;
+        final var REDUCED_NODE_FEE = 1L;
+        final var REDUCED_SERVICE_FEE = 1L;
+        final var INIT_ACCOUNT_BALANCE = 100 * ONE_HUNDRED_HBARS;
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                cryptoCreate(ACCOUNT).balance(INIT_ACCOUNT_BALANCE),
+                cryptoCreate(TOKEN_TREASURY),
+                tokenCreate(FUNGIBLE_TOKEN)
+                        .tokenType(TokenType.FUNGIBLE_COMMON)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .initialSupply(5)
+                        .name(TOKEN_NAME)
+                        .treasury(TOKEN_TREASURY)
+                        .adminKey(MULTI_KEY)
+                        .supplyKey(MULTI_KEY),
+                uploadInitCode(ERC_20_CONTRACT),
+                contractCreate(ERC_20_CONTRACT),
+                balanceSnapshot("accountSnapshot", ACCOUNT),
+                reduceFeeFor(
+                        HederaFunctionality.ContractCall, REDUCED_NODE_FEE, REDUCED_NETWORK_FEE, REDUCED_SERVICE_FEE),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        atomicBatch(contractCall(
+                                                ERC_20_CONTRACT,
+                                                "nameNTimes",
+                                                asHeadlongAddress(asHexedAddress(
+                                                        spec.registry().getTokenID(FUNGIBLE_TOKEN))),
+                                                BigInteger.valueOf(51))
+                                        .payingWith(ACCOUNT)
+                                        .via(NAME_TXN)
+                                        .gas(4_000_000)
+                                        .hasKnownStatus(MAX_CHILD_RECORDS_EXCEEDED)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED))),
+                getTxnRecord(NAME_TXN)
+                        .andAllChildRecords()
+                        .logged()
+                        .hasPriority(recordWith()
+                                .contractCallResult(resultWith()
+                                        .error(Bytes.of(MAX_CHILD_RECORDS_EXCEEDED
+                                                        .name()
+                                                        .getBytes())
+                                                .toHexString())
+                                        .gasUsed(4_000_000))));
+    }
+
+    @HapiTest
+    @Order(2)
+    final Stream<DynamicTest> payerCannotOverSendValue() {
+        final var payerBalance = 666 * ONE_HBAR;
+        final var overdraftAmount = payerBalance + ONE_HBAR;
+        final var overAmbitiousPayer = "overAmbitiousPayer";
+        final var uncheckedCC = "uncheckedCC";
+        return hapiTest(
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                contractCreate(PAY_RECEIVABLE_CONTRACT).adminKey(THRESHOLD),
+                cryptoCreate(overAmbitiousPayer).balance(payerBalance),
+                contractCall(PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(overdraftAmount))
+                        .payingWith(overAmbitiousPayer)
+                        .sending(overdraftAmount)
+                        .hasPrecheck(INSUFFICIENT_PAYER_BALANCE),
+                usableTxnIdNamed(uncheckedCC).payerId(overAmbitiousPayer),
+                uncheckedSubmit(atomicBatch(contractCall(
+                                                PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(overdraftAmount))
+                                        .txnId(uncheckedCC)
+                                        .payingWith(overAmbitiousPayer)
+                                        .sending(overdraftAmount)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR))
+                        .payingWith(GENESIS),
+                sleepFor(1_000),
+                getReceipt(uncheckedCC)
+                        // Mod-service and mono-service use these mostly interchangeably
+                        .hasPriorityStatusFrom(INSUFFICIENT_PAYER_BALANCE, INSUFFICIENT_ACCOUNT_BALANCE)
+                        .logged());
+    }
+
+    @HapiTest
+    @Order(0)
+    final Stream<DynamicTest> transferToCaller() {
+        final var transferTxn = TRANSFER_TXN;
+        final var sender = "sender";
+        return hapiTest(
+                uploadInitCode(TRANSFERRING_CONTRACT),
+                contractCreate(TRANSFERRING_CONTRACT).balance(10_000L),
+                cryptoCreate(sender).balance(ONE_HUNDRED_HBARS),
+                getAccountInfo(sender).savingSnapshot(ACCOUNT_INFO).payingWith(GENESIS),
+                withOpContext((spec, log) -> {
+                    var transferCall = atomicBatch(
+                                    contractCall(TRANSFERRING_CONTRACT, TRANSFER_TO_CALLER, BigInteger.valueOf(10))
+                                            .payingWith(sender)
+                                            .via(transferTxn)
+                                            .logged()
+                                            .batchKey(BATCH_OPERATOR))
+                            .payingWith(BATCH_OPERATOR);
+
+                    var saveTxnRecord = getTxnRecord(transferTxn)
+                            .saveTxnRecordToRegistry("txn")
+                            .payingWith(GENESIS);
+                    var saveAccountInfoAfterCall = getAccountInfo(sender)
+                            .savingSnapshot(ACCOUNT_INFO_AFTER_CALL)
+                            .payingWith(GENESIS);
+                    var saveContractInfo =
+                            getContractInfo(TRANSFERRING_CONTRACT).saveToRegistry(CONTRACT_FROM);
+
+                    allRunFor(spec, transferCall, saveTxnRecord, saveAccountInfoAfterCall, saveContractInfo);
+                }),
+                assertionsHold((spec, opLog) -> {
+                    final var fee = spec.registry().getTransactionRecord("txn").getTransactionFee();
+                    final var accountBalanceBeforeCall =
+                            spec.registry().getAccountInfo(ACCOUNT_INFO).getBalance();
+                    final var accountBalanceAfterCall = spec.registry()
+                            .getAccountInfo(ACCOUNT_INFO_AFTER_CALL)
+                            .getBalance();
+                    assertEquals(accountBalanceAfterCall, accountBalanceBeforeCall - fee + 10L);
+                }),
+                sourcing(() -> getContractInfo(TRANSFERRING_CONTRACT)
+                        .has(contractWith().balance(10_000L - 10L))));
+    }
+
+    @LeakyHapiTest(overrides = {"contracts.maxRefundPercentOfGasLimit"})
+    @Order(14)
+    final Stream<DynamicTest> maxRefundIsMaxGasRefundConfiguredWhenTXGasPriceIsSmaller() {
+        return hapiTest(
+                overriding("contracts.maxRefundPercentOfGasLimit", "5"),
+                uploadInitCode(SIMPLE_UPDATE_CONTRACT),
+                contractCreate(SIMPLE_UPDATE_CONTRACT).gas(300_000L),
+                atomicBatch(contractCall(SIMPLE_UPDATE_CONTRACT, "set", BigInteger.valueOf(5), BigInteger.valueOf(42))
+                                .gas(300_000L)
+                                .via(CALL_TX)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                withOpContext((spec, ignore) -> {
+                    final var subop01 = getTxnRecord(CALL_TX).saveTxnRecordToRegistry(CALL_TX_REC);
+                    allRunFor(spec, subop01);
+
+                    final var gasUsed = spec.registry()
+                            .getTransactionRecord(CALL_TX_REC)
+                            .getContractCallResult()
+                            .getGasUsed();
+                    assertEquals(285000, gasUsed);
+                }));
+    }
+
+    @SuppressWarnings("java:S5960")
+    @LeakyHapiTest(overrides = {"ledger.autoRenewPeriod.maxDuration", "entities.maxLifetime"})
+    final Stream<DynamicTest> contractCreationStoragePriceMatchesFinalExpiry() {
+        final var toyMaker = "ToyMaker";
+        final var createIndirectly = "CreateIndirectly";
+        final var normalPayer = "normalPayer";
+        final var longLivedPayer = "longLivedPayer";
+        final var longLifetime = 100 * 7776000L;
+        final AtomicLong normalPayerGasUsed = new AtomicLong();
+        final AtomicLong longLivedPayerGasUsed = new AtomicLong();
+        final AtomicReference<byte[]> toyMakerMirror = new AtomicReference<>();
+        return hapiTest(
+                overridingTwo(
+                        "ledger.autoRenewPeriod.maxDuration", "" + longLifetime,
+                        "entities.maxLifetime", "" + longLifetime),
+                cryptoCreate(normalPayer),
+                cryptoCreate(longLivedPayer).autoRenewSecs(longLifetime - 12345),
+                uploadInitCode(toyMaker, createIndirectly),
+                contractCreate(toyMaker).exposingContractIdTo(id -> toyMakerMirror.set(asSolidityAddress(id))),
+                sourcing(() -> contractCreate(createIndirectly)
+                        .autoRenewSecs(longLifetime - 12345)
+                        .payingWith(GENESIS)),
+                atomicBatch(contractCall(toyMaker, "make")
+                                .payingWith(normalPayer)
+                                .exposingGasTo((status, gasUsed) -> normalPayerGasUsed.set(gasUsed))
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                atomicBatch(contractCall(toyMaker, "make")
+                                .payingWith(longLivedPayer)
+                                .exposingGasTo((status, gasUsed) -> longLivedPayerGasUsed.set(gasUsed))
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                assertionsHold((spec, opLog) -> assertEquals(
+                        normalPayerGasUsed.get(),
+                        longLivedPayerGasUsed.get(),
+                        "Payer expiry should not affect create storage" + " cost")),
+                // Verify that we are still charged a "typical" amount despite the payer and
+                // the original sender contract having extremely long expiry dates
+                sourcing(() -> contractCall(createIndirectly, "makeOpaquely", asHeadlongAddress(toyMakerMirror.get()))
+                        .payingWith(longLivedPayer)));
+    }
+
+    @LeakyHapiTest(overrides = {"contracts.maxGasPerSec"})
+    final Stream<DynamicTest> gasLimitOverMaxGasLimitFailsPrecheck() {
+        return hapiTest(
+                uploadInitCode(SIMPLE_UPDATE_CONTRACT),
+                uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),
+                contractCreate(SIMPLE_UPDATE_CONTRACT).gas(300_000L),
+                overriding("contracts.maxGasPerSec", "100"),
+                atomicBatch(contractCall(SIMPLE_UPDATE_CONTRACT, "set", BigInteger.valueOf(5), BigInteger.valueOf(42))
+                                .gas(23_000L)
+                                .hasPrecheck(MAX_GAS_LIMIT_EXCEEDED)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED),
+                contractCreate(EMPTY_CONSTRUCTOR_CONTRACT).gas(1_000_000L).hasPrecheck(MAX_GAS_LIMIT_EXCEEDED));
+    }
+
+    @HapiTest
+    @Order(5)
+    final Stream<DynamicTest> transferZeroHbarsToCaller() {
+        final var transferTxn = TRANSFER_TXN;
+        return hapiTest(
+                uploadInitCode(TRANSFERRING_CONTRACT),
+                contractCreate(TRANSFERRING_CONTRACT).balance(10_000L),
+                getAccountInfo(DEFAULT_CONTRACT_SENDER)
+                        .savingSnapshot(ACCOUNT_INFO)
+                        .payingWith(GENESIS),
+                withOpContext((spec, log) -> {
+                    var transferCall = atomicBatch(
+                                    contractCall(TRANSFERRING_CONTRACT, TRANSFER_TO_CALLER, BigInteger.ZERO)
+                                            .payingWith(DEFAULT_CONTRACT_SENDER)
+                                            .via(transferTxn)
+                                            .logged()
+                                            .batchKey(BATCH_OPERATOR))
+                            .payingWith(BATCH_OPERATOR);
+
+                    var saveTxnRecord = getTxnRecord(transferTxn)
+                            .saveTxnRecordToRegistry("txn_registry")
+                            .payingWith(GENESIS);
+                    var saveAccountInfoAfterCall = getAccountInfo(DEFAULT_CONTRACT_SENDER)
+                            .savingSnapshot(ACCOUNT_INFO_AFTER_CALL)
+                            .payingWith(GENESIS);
+                    var saveContractInfo =
+                            getContractInfo(TRANSFERRING_CONTRACT).saveToRegistry(CONTRACT_FROM);
+
+                    allRunFor(spec, transferCall, saveTxnRecord, saveAccountInfoAfterCall, saveContractInfo);
+                }),
+                assertionsHold((spec, opLog) -> {
+                    final var fee =
+                            spec.registry().getTransactionRecord("txn_registry").getTransactionFee();
+                    final var accountBalanceBeforeCall =
+                            spec.registry().getAccountInfo(ACCOUNT_INFO).getBalance();
+                    final var accountBalanceAfterCall = spec.registry()
+                            .getAccountInfo(ACCOUNT_INFO_AFTER_CALL)
+                            .getBalance();
+                    final var contractBalanceAfterCall =
+                            spec.registry().getContractInfo(CONTRACT_FROM).getBalance();
+
+                    assertEquals(accountBalanceAfterCall, accountBalanceBeforeCall - fee);
+                    assertEquals(contractBalanceAfterCall, 10_000L);
+                }));
+    }
+
+    @Order(1)
+    @LeakyHapiTest(overrides = {"contracts.maxRefundPercentOfGasLimit"})
+    final Stream<DynamicTest> resultSizeAffectsFees() {
+        final var contract = "VerboseDeposit";
+        final var TRANSFER_AMOUNT = 1_000L;
+        BiConsumer<TransactionRecord, Logger> resultSizeFormatter = (rcd, txnLog) -> {
+            final var result = rcd.getContractCallResult();
+            txnLog.info(
+                    "Contract call result FeeBuilder size = {}, fee = {}, result is"
+                            + " [self-reported size = {}, '{}']",
+                    () -> FeeBuilder.getContractFunctionSize(result),
+                    rcd::getTransactionFee,
+                    result.getContractCallResult()::size,
+                    result::getContractCallResult);
+            txnLog.info("  Literally :: {}", result);
+        };
+
+        return hapiTest(
+                overriding("contracts.maxRefundPercentOfGasLimit", "100"),
+                uploadInitCode(contract),
+                contractCreate(contract),
+                atomicBatch(contractCall(contract, DEPOSIT, TRANSFER_AMOUNT, 0L, "So we out-danced thought...")
+                                .via("noLogsCallTxn")
+                                .sending(TRANSFER_AMOUNT)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                atomicBatch(contractCall(contract, DEPOSIT, TRANSFER_AMOUNT, 5L, "So we out-danced thought...")
+                                .via("loggedCallTxn")
+                                .sending(TRANSFER_AMOUNT)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                assertionsHold((spec, assertLog) -> {
+                    HapiGetTxnRecord noLogsLookup =
+                            QueryVerbs.getTxnRecord("noLogsCallTxn").loggedWith(resultSizeFormatter);
+                    HapiGetTxnRecord logsLookup =
+                            QueryVerbs.getTxnRecord("loggedCallTxn").loggedWith(resultSizeFormatter);
+                    allRunFor(spec, noLogsLookup, logsLookup);
+                    final var unloggedRecord =
+                            noLogsLookup.getResponse().getTransactionGetRecord().getTransactionRecord();
+                    final var loggedRecord =
+                            logsLookup.getResponse().getTransactionGetRecord().getTransactionRecord();
+                    assertLog.info("Fee for logged record   = {}", loggedRecord::getTransactionFee);
+                    assertLog.info("Fee for unlogged record = {}", unloggedRecord::getTransactionFee);
+                    Assertions.assertNotEquals(
+                            unloggedRecord.getTransactionFee(),
+                            loggedRecord.getTransactionFee(),
+                            "Result size should change the txn fee!");
+                }));
+    }
+
+    @HapiTest
+    @Order(8)
+    final Stream<DynamicTest> autoAssociationSlotsAppearsInInfo() {
+        final int maxAutoAssociations = 100;
+        final String CONTRACT = "Multipurpose";
+
+        return hapiTest(
+                newKeyNamed(ADMIN_KEY),
+                uploadInitCode(CONTRACT),
+                atomicBatch(contractCreate(CONTRACT)
+                                .adminKey(ADMIN_KEY)
+                                .maxAutomaticTokenAssociations(maxAutoAssociations)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                getContractInfo(CONTRACT)
+                        .has(ContractInfoAsserts.contractWith().maxAutoAssociations(maxAutoAssociations)));
+    }
+
+    @Order(16)
+    @LeakyHapiTest(overrides = {"contracts.maxRefundPercentOfGasLimit"})
+    final Stream<DynamicTest> createMaxRefundIsMaxGasRefundConfiguredWhenTXGasPriceIsSmaller() {
+        return hapiTest(
+                overriding("contracts.maxRefundPercentOfGasLimit", "5"),
+                uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),
+                atomicBatch(contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
+                                .gas(300_000L)
+                                .via(CREATE_TX)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                withOpContext((spec, ignore) -> {
+                    final var subop01 = getTxnRecord(CREATE_TX).saveTxnRecordToRegistry(CREATE_TX_REC);
+                    allRunFor(spec, subop01);
+
+                    final var gasUsed = spec.registry()
+                            .getTransactionRecord(CREATE_TX_REC)
+                            .getContractCreateResult()
+                            .getGasUsed();
+                    assertEquals(285_000L, gasUsed);
+                }));
+    }
+
+    @Order(11)
+    @LeakyHapiTest(overrides = {"contracts.maxRefundPercentOfGasLimit"})
+    final Stream<DynamicTest> createMinChargeIsTXGasUsedByContractCreate() {
+        return hapiTest(
+                overriding("contracts.maxRefundPercentOfGasLimit", "100"),
+                uploadInitCode(EMPTY_CONSTRUCTOR_CONTRACT),
+                atomicBatch(contractCreate(EMPTY_CONSTRUCTOR_CONTRACT)
+                                .gas(300_000L)
+                                .via(CREATE_TX)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                withOpContext((spec, ignore) -> {
+                    final var subop01 = getTxnRecord(CREATE_TX).saveTxnRecordToRegistry(CREATE_TX_REC);
+                    allRunFor(spec, subop01);
+
+                    final var gasUsed = spec.registry()
+                            .getTransactionRecord(CREATE_TX_REC)
+                            .getContractCreateResult()
+                            .getGasUsed();
+                    assertTrue(gasUsed > 0L);
+                }));
+    }
+
+    @HapiTest
+    @Order(3)
+    final Stream<DynamicTest> propagatesNestedCreations() {
+        final var call = "callTxn";
+        final var creation = "createTxn";
+        final var contract = "NestedCreations";
+
+        final var adminKey = "adminKey";
+        final var entityMemo = "JUST DO IT";
+        final var customAutoRenew = 7776001L;
+        final AtomicLong childNum = new AtomicLong();
+        final AtomicLong grandChildNum = new AtomicLong();
+        final AtomicReference<ByteString> expectedChildAddress = new AtomicReference<>();
+        final AtomicReference<ByteString> expectedParentAddress = new AtomicReference<>();
+
+        return hapiTest(
+                newKeyNamed(adminKey),
+                uploadInitCode(contract),
+                contractCreate(contract)
+                        .stakedNodeId(0)
+                        .adminKey(adminKey)
+                        .entityMemo(entityMemo)
+                        .autoRenewSecs(customAutoRenew)
+                        .via(creation),
+                atomicBatch(contractCall(contract, "propagate")
+                                .gas(4_000_000L)
+                                .via(call)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                withOpContext((spec, opLog) -> {
+                    final var parentNum = spec.registry().getContractId(contract);
+
+                    final var expectedParentContractAddress = asHeadlongAddress(asSolidityAddress(parentNum))
+                            .toString()
+                            .toLowerCase()
+                            .substring(2);
+                    expectedParentAddress.set(ByteString.copyFrom(CommonUtils.unhex(expectedParentContractAddress)));
+
+                    final var expectedChildContractAddress =
+                            contractAddress(fromHexString(expectedParentContractAddress), 1L);
+                    final var expectedGrandChildContractAddress = contractAddress(expectedChildContractAddress, 1L);
+                    childNum.set(parentNum.getContractNum() + 1L);
+                    expectedChildAddress.set(ByteString.copyFrom(expectedChildContractAddress.toArray()));
+                    grandChildNum.set(parentNum.getContractNum() + 2L);
+
+                    final var parentContractInfo =
+                            getContractInfo(contract).has(contractWith().addressOrAlias(expectedParentContractAddress));
+                    final var childContractInfo = getContractInfo(String.valueOf(childNum.get()))
+                            .has(contractWith().addressOrAlias(expectedChildContractAddress.toUnprefixedHexString()));
+                    final var grandChildContractInfo = getContractInfo(String.valueOf(grandChildNum.get()))
+                            .has(contractWith()
+                                    .addressOrAlias(expectedGrandChildContractAddress.toUnprefixedHexString()))
+                            .logged();
+
+                    allRunFor(spec, parentContractInfo, childContractInfo, grandChildContractInfo);
+                }),
+                sourcing(() -> childRecordsCheck(
+                        call,
+                        SUCCESS,
+                        recordWith()
+                                .contractCreateResult(resultWith().create1EvmAddress(expectedParentAddress.get(), 1L))
+                                .status(SUCCESS),
+                        recordWith()
+                                .contractCreateResult(resultWith().create1EvmAddress(expectedChildAddress.get(), 1L))
+                                .status(SUCCESS))),
+                sourcing(() -> getContractInfo(String.valueOf(childNum.get()))
+                        .logged()
+                        .has(contractWith().propertiesInheritedFrom(contract))));
+    }
+
+    @LeakyHapiTest(overrides = {"contracts.maxRefundPercentOfGasLimit"})
+    final Stream<DynamicTest> temporarySStoreRefundTest() {
+        final var contract = "TemporarySStoreRefund";
+        return hapiTest(
+                overriding("contracts.maxRefundPercentOfGasLimit", "100"),
+                uploadInitCode(contract),
+                contractCreate(contract).gas(500_000L),
+                atomicBatch(contractCall(contract, "holdTemporary", BigInteger.valueOf(10))
+                                .via("tempHoldTx")
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                atomicBatch(contractCall(contract, "holdPermanently", BigInteger.valueOf(10))
+                                .via("permHoldTx")
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                withOpContext((spec, opLog) -> {
+                    final var subop01 = getTxnRecord("tempHoldTx")
+                            .saveTxnRecordToRegistry("tempHoldTxRec")
+                            .logged();
+                    final var subop02 = getTxnRecord("permHoldTx")
+                            .saveTxnRecordToRegistry("permHoldTxRec")
+                            .logged();
+
+                    CustomSpecAssert.allRunFor(spec, subop01, subop02);
+
+                    final var gasUsedForTemporaryHoldTx = spec.registry()
+                            .getTransactionRecord("tempHoldTxRec")
+                            .getContractCallResult()
+                            .getGasUsed();
+                    final var gasUsedForPermanentHoldTx = spec.registry()
+                            .getTransactionRecord("permHoldTxRec")
+                            .getContractCallResult()
+                            .getGasUsed();
+
+                    Assertions.assertTrue(gasUsedForTemporaryHoldTx < 35000L);
+                    Assertions.assertTrue(gasUsedForPermanentHoldTx > 40000L);
+                }));
+    }
+
+    @HapiTest
+    @Order(6)
+    final Stream<DynamicTest> canCallPendingContractSafely() {
+        final var numSlots = 64L;
+        final var createBurstSize = 500;
+        final long[] targets = {19, 24};
+        final AtomicLong createdFileNum = new AtomicLong();
+        final var callTxn = "callTxn";
+        final var contract = "FibonacciPlus";
+        final var expiry = Instant.now().getEpochSecond() + 7776000;
+
+        return hapiTest(
+                uploadSingleInitCode(contract, expiry, GENESIS, createdFileNum::set),
+                inParallel(IntStream.range(0, createBurstSize)
+                        .mapToObj(i -> atomicBatch(contractCustomCreate(contract, String.valueOf(i), numSlots)
+                                        .fee(ONE_HUNDRED_HBARS)
+                                        .gas(800_000L)
+                                        .payingWith(GENESIS)
+                                        .noLogging()
+                                        .deferStatusResolution()
+                                        .bytecode(contract)
+                                        .adminKey(THRESHOLD)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR))
+                        .toArray(HapiSpecOperation[]::new)),
+                sourcing(() -> contractCallWithFunctionAbi(
+                                "0.0." + (createdFileNum.get() + createBurstSize),
+                                getABIFor(FUNCTION, "addNthFib", contract),
+                                targets,
+                                12L)
+                        .payingWith(GENESIS)
+                        .gas(300_000L)
+                        .via(callTxn)));
+    }
+
+    // @LeakyHapiTest(overrides = {"contracts.evm.version"}) This will be fixed in
+    // https://github.com/hiero-ledger/hiero-consensus-node/issues/19993
+    final Stream<DynamicTest> evmLazyCreateViaSolidityCall() {
+        final var LAZY_CREATE_CONTRACT = "NestedLazyCreateContract";
+        final var ECDSA_KEY = "ECDSAKey";
+        final var callLazyCreateFunction = "nestedLazyCreateThenSendMore";
+        final var revertingCallLazyCreateFunction = "nestedLazyCreateThenRevert";
+        final var depositAmount = 1000;
+        final var mirrorTxn = "mirrorTxn";
+        final var revertingTxn = "revertingTxn";
+        final var payTxn = "payTxn";
+        final var evmAddressOfChildContract = new AtomicReference<BytesValue>();
+
+        return hapiTest(
+                sidecarValidation(),
+                overriding("contracts.evm.version", "v0.34"),
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                uploadInitCode(LAZY_CREATE_CONTRACT),
+                atomicBatch(contractCreate(LAZY_CREATE_CONTRACT)
+                                .via(CALL_TX_REC)
+                                .gas(6_000_000L)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                getTxnRecord(CALL_TX_REC).andAllChildRecords().logged().exposingAllTo(records -> {
+                    final var lastChildResult = records.getLast().getContractCreateResult();
+                    evmAddressOfChildContract.set(lastChildResult.getEvmAddress());
+                }),
+                withOpContext((spec, opLog) -> {
+                    final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
+                    final var keyBytes = ecdsaKey.getECDSASecp256K1().toByteArray();
+                    final var address = asHeadlongAddress(recoverAddressFromPubKey(keyBytes));
+                    final var evmAddress = ByteString.copyFrom(recoverAddressFromPubKey(keyBytes));
+                    allRunFor(
+                            spec,
+                            // given invalid address that's not derived from an ECDSA key, should revert the transaction
+                            atomicBatch(contractCall(
+                                                    LAZY_CREATE_CONTRACT,
+                                                    callLazyCreateFunction,
+                                                    mirrorAddrWith(spec, NONEXISTENT_CONTRACT_NUM))
+                                            .sending(depositAmount)
+                                            .via(mirrorTxn)
+                                            .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                            .gas(6_000_000)
+                                            .batchKey(BATCH_OPERATOR))
+                                    .payingWith(BATCH_OPERATOR)
+                                    .hasKnownStatus(INNER_TRANSACTION_FAILED),
+                            emptyChildRecordsCheck(mirrorTxn, CONTRACT_REVERT_EXECUTED),
+                            getAccountInfo(String.valueOf(NONEXISTENT_CONTRACT_NUM))
+                                    .hasCostAnswerPrecheck(INVALID_ACCOUNT_ID),
+                            // given a reverting contract call, should also revert the hollow account creation
+                            atomicBatch(contractCall(LAZY_CREATE_CONTRACT, revertingCallLazyCreateFunction, address)
+                                            .sending(depositAmount)
+                                            .via(revertingTxn)
+                                            .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                            .gas(6_000_000)
+                                            .batchKey(BATCH_OPERATOR))
+                                    .payingWith(BATCH_OPERATOR)
+                                    .hasKnownStatus(INNER_TRANSACTION_FAILED),
+                            emptyChildRecordsCheck(revertingTxn, CONTRACT_REVERT_EXECUTED),
+                            getAliasedAccountInfo(evmAddress).hasCostAnswerPrecheck(INVALID_ACCOUNT_ID),
+                            // given a valid address that is derived from an ECDSA key, should create hollow account
+                            atomicBatch(contractCall(LAZY_CREATE_CONTRACT, callLazyCreateFunction, address)
+                                            .via(payTxn)
+                                            .sending(depositAmount)
+                                            .hasKnownStatus(SUCCESS)
+                                            .gas(6_000_000)
+                                            .batchKey(BATCH_OPERATOR))
+                                    .payingWith(BATCH_OPERATOR),
+                            childRecordsCheck(
+                                    payTxn,
+                                    SUCCESS,
+                                    recordWith().status(SUCCESS).memo(LAZY_MEMO)),
+                            getAliasedAccountInfo(ECDSA_KEY)
+                                    .has(accountWith()
+                                            .key(EMPTY_KEY)
+                                            .autoRenew(THREE_MONTHS_IN_SECONDS)
+                                            .receiverSigReq(false)
+                                            .memo(LAZY_MEMO)
+                                            .evmAddress(evmAddress)
+                                            .balance(depositAmount)));
+                }),
+                withOpContext((spec, opLog) -> {
+                    final var getTxnRecord =
+                            getTxnRecord(payTxn).andAllChildRecords().logged();
+                    allRunFor(spec, getTxnRecord);
+
+                    final var childRecord = getTxnRecord.getFirstNonStakingChildRecord();
+                    final var lazyAccountId = childRecord.getReceipt().getAccountID();
+                    final var lazyAccountName = "lazy";
+                    spec.registry().saveAccountId(lazyAccountName, lazyAccountId);
+
+                    allRunFor(
+                            spec,
+                            getAccountBalance(lazyAccountName).hasTinyBars(depositAmount),
+                            expectContractStateChangesSidecarFor(
+                                    payTxn,
+                                    List.of(StateChange.stateChangeFor(LAZY_CREATE_CONTRACT)
+                                            .withStorageChanges(StorageChange.onlyRead(
+                                                    formattedAssertionValue(0L),
+                                                    evmAddressOfChildContract
+                                                            .get()
+                                                            .getValue())))),
+                            expectContractActionSidecarFor(
+                                    payTxn,
+                                    List.of(ContractAction.newBuilder()
+                                            .setCallType(CALL)
+                                            .setCallDepth(1)
+                                            .setCallOperationType(CallOperationType.OP_CALL)
+                                            .setCallingContract(spec.registry().getContractId(LAZY_CREATE_CONTRACT))
+                                            .setRecipientAccount(lazyAccountId)
+                                            .setOutput(EMPTY)
+                                            .setGas(5_832_424)
+                                            .setValue(depositAmount / 4)
+                                            .build())));
+                }));
+    }
+
+    @LeakyHapiTest(overrides = {"consensus.handle.maxFollowingRecords", "contracts.evm.version"})
+    final Stream<DynamicTest> evmLazyCreateViaSolidityCallTooManyCreatesFails() {
+        final var LAZY_CREATE_CONTRACT = "NestedLazyCreateContract";
+        final var ECDSA_KEY = "ECDSAKey";
+        final var ECDSA_KEY2 = "ECDSAKey2";
+        final var createTooManyHollowAccounts = "createTooManyHollowAccounts";
+        final var depositAmount = 1000;
+        return hapiTest(
+                overridingTwo("consensus.handle.maxFollowingRecords", "1", "contracts.evm.version", "v0.34"),
+                newKeyNamed(ECDSA_KEY).shape(SECP_256K1_SHAPE),
+                newKeyNamed(ECDSA_KEY2).shape(SECP_256K1_SHAPE),
+                uploadInitCode(LAZY_CREATE_CONTRACT),
+                contractCreate(LAZY_CREATE_CONTRACT).via(CALL_TX_REC).gas(2_000_000),
+                getTxnRecord(CALL_TX_REC).andAllChildRecords().logged(),
+                withOpContext((spec, opLog) -> {
+                    final var ecdsaKey = spec.registry().getKey(ECDSA_KEY);
+                    final var tmp = ecdsaKey.getECDSASecp256K1().toByteArray();
+                    final var addressBytes = recoverAddressFromPubKey(tmp);
+                    final var ecdsaKey2 = spec.registry().getKey(ECDSA_KEY2);
+                    final var tmp2 = ecdsaKey2.getECDSASecp256K1().toByteArray();
+                    final var addressBytes2 = recoverAddressFromPubKey(tmp2);
+                    allRunFor(
+                            spec,
+                            atomicBatch(contractCall(LAZY_CREATE_CONTRACT, createTooManyHollowAccounts, (Object)
+                                                    asHeadlongAddressArray(addressBytes, addressBytes2))
+                                            .sending(depositAmount)
+                                            .via(TRANSFER_TXN)
+                                            .gas(6_000_000)
+                                            .hasKnownStatus(MAX_CHILD_RECORDS_EXCEEDED)
+                                            .batchKey(BATCH_OPERATOR))
+                                    .payingWith(BATCH_OPERATOR)
+                                    .hasKnownStatus(INNER_TRANSACTION_FAILED),
+                            getAliasedAccountInfo(ecdsaKey.toByteString())
+                                    .logged()
+                                    .hasCostAnswerPrecheck(INVALID_ACCOUNT_ID),
+                            getAliasedAccountInfo(ecdsaKey2.toByteString())
+                                    .logged()
+                                    .hasCostAnswerPrecheck(INVALID_ACCOUNT_ID));
+                }),
+                emptyChildRecordsCheck(TRANSFER_TXN, MAX_CHILD_RECORDS_EXCEEDED));
+    }
+
+    @Order(30)
+    @LeakyHapiTest(overrides = {"contracts.nonces.externalization.enabled"})
+    final Stream<DynamicTest> shouldReturnNullWhenContractsNoncesExternalizationFlagIsDisabled() {
+        final var contract = "NoncesExternalization";
+        final var payer = "payer";
+
+        return hapiTest(
+                overriding("contracts.nonces.externalization.enabled", "false"),
+                cryptoCreate(payer).balance(10 * ONE_HUNDRED_HBARS),
+                uploadInitCode(contract),
+                atomicBatch(contractCreate(contract)
+                                .logged()
+                                .gas(1_000_000L)
+                                .via("txn")
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                withOpContext((spec, opLog) -> {
+                    HapiGetTxnRecord op = getTxnRecord("txn")
+                            .logged()
+                            .hasPriority(recordWith()
+                                    .contractCreateResult(resultWith()
+                                            .contractWithNonce(spec.registry().getContractId(contract), null)));
+                    allRunFor(spec, op);
+                }));
+    }
+
+    @Order(31)
+    @LeakyHapiTest(overrides = {"contracts.evm.version"})
+    final Stream<DynamicTest> someErc721GetApprovedScenariosPass() {
+        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> zTokenMirrorAddr = new AtomicReference<>();
+
+        return hapiTest(
+                overriding("contracts.evm.version", "v0.38"),
+                newKeyNamed(MULTI_KEY_NAME),
+                cryptoCreate(A_CIVILIAN).exposingCreatedIdTo(id -> aCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                uploadInitCode(SOME_ERC_721_SCENARIOS),
+                contractCreate(SOME_ERC_721_SCENARIOS).adminKey(MULTI_KEY_NAME).gas(2_000_000L),
+                tokenCreate(NF_TOKEN)
+                        .supplyKey(MULTI_KEY_NAME)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .treasury(SOME_ERC_721_SCENARIOS)
+                        .initialSupply(0)
+                        .exposingCreatedIdTo(idLit ->
+                                tokenMirrorAddr.set(asHexedSolidityAddress(HapiPropertySource.asToken(idLit)))),
+                mintToken(
+                        NF_TOKEN,
+                        List.of(
+                                // 1
+                                ByteString.copyFromUtf8("A"),
+                                // 2
+                                ByteString.copyFromUtf8("B"))),
+                tokenAssociate(A_CIVILIAN, NF_TOKEN),
+                withOpContext((spec, opLog) -> {
+                    zCivilianMirrorAddr.set(asHexedSolidityAddress(
+                            AccountID.newBuilder().setAccountNum(666_666_666L).build()));
+                    zTokenMirrorAddr.set(asHexedSolidityAddress(
+                            TokenID.newBuilder().setTokenNum(666_666L).build()));
+                }),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_APPROVED,
+                                        asHeadlongAddress(zTokenMirrorAddr.get()),
+                                        BigInteger.ONE)
+                                .via(MISSING_TOKEN)
+                                .gas(1_000_000)
+                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED)),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        DO_SPECIFIC_APPROVAL,
+                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                        asHeadlongAddress(aCivilianMirrorAddr.get()),
+                                        BigInteger.ONE)
+                                .gas(1_000_000)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_APPROVED,
+                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                        BigInteger.valueOf(55))
+                                .via("MISSING_SERIAL")
+                                .gas(1_000_000)
+                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED)),
+                getTokenNftInfo(NF_TOKEN, 1L).logged(),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_APPROVED,
+                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                        BigInteger.TWO)
+                                .via("MISSING_SPENDER")
+                                .gas(1_000_000)
+                                .hasKnownStatus(SUCCESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_APPROVED,
+                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                        BigInteger.ONE)
+                                .via(WITH_SPENDER)
+                                .gas(1_000_000)
+                                .hasKnownStatus(SUCCESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)),
+                getTxnRecord(WITH_SPENDER).andAllChildRecords().logged(),
+                sourcing(() -> contractCallLocal(
+                                SOME_ERC_721_SCENARIOS,
+                                GET_APPROVED,
+                                asHeadlongAddress(tokenMirrorAddr.get()),
+                                BigInteger.ONE)
+                        .logged()
+                        .gas(1_000_000)
+                        .has(resultWith().contractCallResult(hexedAddress(aCivilianMirrorAddr.get())))),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        childRecordsCheck(
+                                "MISSING_SPENDER",
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(FunctionType.ERC_GET_APPROVED)
+                                                        .withSpender(new byte[0])))),
+                        childRecordsCheck(
+                                WITH_SPENDER,
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(FunctionType.ERC_GET_APPROVED)
+                                                        .withSpender(asAddress(
+                                                                spec.registry().getAccountID(A_CIVILIAN)))))))));
+    }
+
+    @Order(33)
+    @LeakyHapiTest(overrides = {"contracts.evm.version"})
+    final Stream<DynamicTest> someErc721BalanceOfScenariosPass() {
+        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> bCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> zTokenMirrorAddr = new AtomicReference<>();
+
+        return hapiTest(
+                overriding("contracts.evm.version", "v0.38"),
+                newKeyNamed(MULTI_KEY_NAME),
+                cryptoCreate(A_CIVILIAN).exposingCreatedIdTo(id -> aCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                cryptoCreate(B_CIVILIAN).exposingCreatedIdTo(id -> bCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                uploadInitCode(SOME_ERC_721_SCENARIOS),
+                contractCreate(SOME_ERC_721_SCENARIOS).adminKey(MULTI_KEY_NAME).gas(2_000_000),
+                tokenCreate(NF_TOKEN)
+                        .supplyKey(MULTI_KEY_NAME)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .treasury(SOME_ERC_721_SCENARIOS)
+                        .initialSupply(0)
+                        .exposingCreatedIdTo(idLit ->
+                                tokenMirrorAddr.set(asHexedSolidityAddress(HapiPropertySource.asToken(idLit)))),
+                mintToken(
+                        NF_TOKEN,
+                        List.of(
+                                // 1
+                                ByteString.copyFromUtf8("A"),
+                                // 2
+                                ByteString.copyFromUtf8("B"))),
+                tokenAssociate(A_CIVILIAN, NF_TOKEN),
+                cryptoTransfer(movingUnique(NF_TOKEN, 1L, 2L).between(SOME_ERC_721_SCENARIOS, A_CIVILIAN)),
+                withOpContext((spec, opLog) -> zTokenMirrorAddr.set(asHexedSolidityAddress(
+                        TokenID.newBuilder().setTokenNum(666_666L).build()))),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_BALANCE_OF,
+                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                        asHeadlongAddress(aCivilianMirrorAddr.get()))
+                                .via("BALANCE_OF")
+                                .gas(1_000_000)
+                                .hasKnownStatus(SUCCESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_BALANCE_OF,
+                                        asHeadlongAddress(zTokenMirrorAddr.get()),
+                                        asHeadlongAddress(aCivilianMirrorAddr.get()))
+                                .via(MISSING_TOKEN)
+                                .gas(1_000_000)
+                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED)),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_BALANCE_OF,
+                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                        asHeadlongAddress(bCivilianMirrorAddr.get()))
+                                .via("NOT_ASSOCIATED")
+                                .gas(1_000_000)
+                                .hasKnownStatus(SUCCESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)),
+                childRecordsCheck(
+                        "BALANCE_OF",
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(FunctionType.ERC_BALANCE)
+                                                .withBalance(2)))),
+                childRecordsCheck(
+                        "NOT_ASSOCIATED",
+                        SUCCESS,
+                        recordWith()
+                                .status(SUCCESS)
+                                .contractCallResult(resultWith()
+                                        .contractCallResult(htsPrecompileResult()
+                                                .forFunction(FunctionType.ERC_BALANCE)
+                                                .withBalance(0)))));
+    }
+
+    @Order(32)
+    @LeakyHapiTest(overrides = {"contracts.evm.version"})
+    final Stream<DynamicTest> someErc721OwnerOfScenariosPass() {
+        final AtomicReference<String> tokenMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> aCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> zCivilianMirrorAddr = new AtomicReference<>();
+        final AtomicReference<String> zTokenMirrorAddr = new AtomicReference<>();
+
+        return hapiTest(
+                overriding("contracts.evm.version", "v0.38"),
+                newKeyNamed(MULTI_KEY_NAME),
+                cryptoCreate(A_CIVILIAN).exposingCreatedIdTo(id -> aCivilianMirrorAddr.set(asHexedSolidityAddress(id))),
+                uploadInitCode(SOME_ERC_721_SCENARIOS),
+                contractCreate(SOME_ERC_721_SCENARIOS).adminKey(MULTI_KEY_NAME).gas(2_000_000),
+                tokenCreate(NF_TOKEN)
+                        .supplyKey(MULTI_KEY_NAME)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .treasury(SOME_ERC_721_SCENARIOS)
+                        .initialSupply(0)
+                        .exposingCreatedIdTo(idLit ->
+                                tokenMirrorAddr.set(asHexedSolidityAddress(HapiPropertySource.asToken(idLit)))),
+                mintToken(
+                        NF_TOKEN,
+                        List.of(
+                                // 1
+                                ByteString.copyFromUtf8("A"),
+                                // 2
+                                ByteString.copyFromUtf8("B"))),
+                tokenAssociate(A_CIVILIAN, NF_TOKEN),
+                withOpContext((spec, opLog) -> {
+                    zCivilianMirrorAddr.set(asHexedSolidityAddress(
+                            AccountID.newBuilder().setAccountNum(666_666_666L).build()));
+                    zTokenMirrorAddr.set(asHexedSolidityAddress(
+                            TokenID.newBuilder().setTokenNum(666_666L).build()));
+                }),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_OWNER_OF,
+                                        asHeadlongAddress(zTokenMirrorAddr.get()),
+                                        BigInteger.ONE)
+                                .via(MISSING_TOKEN)
+                                .gas(1_000_000)
+                                .hasKnownStatus(INVALID_SOLIDITY_ADDRESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED)),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_OWNER_OF,
+                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                        BigInteger.valueOf(55))
+                                .gas(1_000_000)
+                                .hasKnownStatus(CONTRACT_REVERT_EXECUTED)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED)),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_OWNER_OF,
+                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                        BigInteger.TWO)
+                                .via("TREASURY_OWNER")
+                                .gas(1_000_000)
+                                .hasKnownStatus(SUCCESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)),
+                cryptoTransfer(movingUnique(NF_TOKEN, 1L).between(SOME_ERC_721_SCENARIOS, A_CIVILIAN)),
+                sourcing(() -> atomicBatch(contractCall(
+                                        SOME_ERC_721_SCENARIOS,
+                                        GET_OWNER_OF,
+                                        asHeadlongAddress(tokenMirrorAddr.get()),
+                                        BigInteger.ONE)
+                                .via("CIVILIAN_OWNER")
+                                .gas(1_000_000)
+                                .hasKnownStatus(SUCCESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        childRecordsCheck(
+                                "TREASURY_OWNER",
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(FunctionType.ERC_OWNER)
+                                                        .withOwner(asAddress(
+                                                                spec.registry()
+                                                                        .getAccountID(SOME_ERC_721_SCENARIOS)))))),
+                        childRecordsCheck(
+                                "CIVILIAN_OWNER",
+                                SUCCESS,
+                                recordWith()
+                                        .status(SUCCESS)
+                                        .contractCallResult(resultWith()
+                                                .contractCallResult(htsPrecompileResult()
+                                                        .forFunction(FunctionType.ERC_GET_APPROVED)
+                                                        .withSpender(asAddress(
+                                                                spec.registry().getAccountID(A_CIVILIAN)))))))));
+    }
+
+    @Order(34)
+    @LeakyHapiTest(overrides = {"contracts.evm.version"})
+    final Stream<DynamicTest> callToNonExistingContractFailsGracefullyInV038() {
+        return hapiTest(
+                overriding("contracts.evm.version", "v0.38"),
+                withOpContext((spec, ctxLog) -> spec.registry().saveContractId("invalid", asContract("0.0.100000001"))),
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS)),
+                withOpContext((spec, opLog) -> updateSpecFor(spec, SECP_256K1_SOURCE_KEY)),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        atomicBatch(ethereumCallWithFunctionAbi(
+                                                false,
+                                                "invalid",
+                                                getABIFor(Utils.FunctionType.FUNCTION, "totalSupply", "ERC20ABI"))
+                                        .type(EthTxData.EthTransactionType.EIP1559)
+                                        .signingWith(SECP_256K1_SOURCE_KEY)
+                                        .payingWith(RELAYER)
+                                        .via("invalidContractCallTxn")
+                                        .nonce(0)
+                                        .gasPrice(0L)
+                                        .gasLimit(1_000_000L)
+                                        .hasPrecheck(INVALID_CONTRACT_ID)
+                                        .batchKey(BATCH_OPERATOR))
+                                .payingWith(BATCH_OPERATOR)
+                                .hasKnownStatus(INNER_TRANSACTION_FAILED))));
+    }
+
+    @Order(38)
+    @LeakyHapiTest
+    final Stream<DynamicTest> invalidContractCallFailsInV038() {
+        final var function = getABIFor(FUNCTION, "getIndirect", "CreateTrivial");
+
+        return hapiTest(
+                overriding("contracts.evm.version", "v0.38"),
+                withOpContext((spec, ctxLog) -> spec.registry().saveContractId("invalid", asContract("0.0.100000001"))),
+                atomicBatch(contractCallWithFunctionAbi("invalid", function)
+                                .hasKnownStatus(INVALID_CONTRACT_ID)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/batch/AtomicLeakyEthereumTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/batch/AtomicLeakyEthereumTestsSuite.java
@@ -1,0 +1,191 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.leaky.batch;
+
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.keys.KeyFactory.KeyType.THRESHOLD;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.ethereumCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
+import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.math.BigInteger;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+// This test cases are direct copies of LeakyEthereumTestsSuite. The difference here is that
+// we are wrapping the operations in an atomic batch to confirm that everything works as expected.
+@Tag(SMART_CONTRACT)
+@SuppressWarnings("java:S5960")
+@HapiTestLifecycle
+@Disabled // This will be enabled once https://github.com/hiero-ledger/hiero-consensus-node/issues/19901 is fixed
+public class AtomicLeakyEthereumTestsSuite {
+
+    private static final String PAY_RECEIVABLE_CONTRACT = "PayReceivable";
+    private static final String BATCH_OPERATOR = "batchOperator";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.overrideInClass(Map.of(
+                "atomicBatch.isEnabled",
+                "true",
+                "atomicBatch.maxNumberOfTransactions",
+                "50",
+                "contracts.throttle.throttleByGas",
+                "false",
+                "cryptoCreateWithAlias.enabled",
+                "false"));
+        testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
+    }
+
+    // test unprotected legacy ethereum transactions before EIP155
+    // this tests the behaviour when the `v` field is 27 or 28
+    // in this case the passed chainId = 0 so ETX is before EIP155
+    // and so `v` is calculated -> v = {0,1} + 27
+    // source: https://eips.ethereum.org/EIPS/eip-155
+    @LeakyHapiTest(overrides = {"contracts.chainId"})
+    final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155() {
+        final String DEPOSIT = "deposit";
+        final long depositAmount = 20_000L;
+        final Integer chainId = 0;
+
+        return hapiTest(
+                overriding("contracts.chainId", "" + chainId),
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                        .via("autoAccount"),
+                getTxnRecord("autoAccount").andAllChildRecords(),
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                contractCreate(PAY_RECEIVABLE_CONTRACT).adminKey(THRESHOLD),
+                atomicBatch(ethereumCall(PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(depositAmount))
+                                .type(EthTransactionType.LEGACY_ETHEREUM)
+                                .signingWith(SECP_256K1_SOURCE_KEY)
+                                .payingWith(RELAYER)
+                                .via("legacyBeforeEIP155")
+                                .nonce(0)
+                                .chainId(chainId)
+                                .gasPrice(50L)
+                                .maxPriorityGas(2L)
+                                .gasLimit(1_000_000L)
+                                .sending(depositAmount)
+                                .hasKnownStatus(ResponseCodeEnum.SUCCESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        getTxnRecord("legacyBeforeEIP155")
+                                .logged()
+                                .hasPriority(recordWith().status(SUCCESS)))));
+    }
+
+    /**
+     * test unprotected legacy ethereum transactions before EIP155
+     * When using a `CHAIN_ID` represented as a BigInteger, an additional byte is required
+     * to store the sign information (indicating whether the value is positive or negative),
+     * if there is no free bit available for this information, as in values like 11155111.
+     */
+    @LeakyHapiTest(overrides = {"contracts.chainId"})
+    /* default */ final Stream<DynamicTest> legacyUnprotectedEtxBeforeEIP155WithChainIdHavingExtraByteForSign() {
+        final var deposit = "deposit";
+        final var depositAmount = 20_000L;
+        final var chainId = 11_155_111;
+
+        return hapiTest(
+                overriding("contracts.chainId", "" + chainId),
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                        .via("autoAccount"),
+                getTxnRecord("autoAccount").andAllChildRecords(),
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                contractCreate(PAY_RECEIVABLE_CONTRACT).adminKey(THRESHOLD),
+                atomicBatch(ethereumCall(PAY_RECEIVABLE_CONTRACT, deposit, BigInteger.valueOf(depositAmount))
+                                .type(EthTransactionType.LEGACY_ETHEREUM)
+                                .signingWith(SECP_256K1_SOURCE_KEY)
+                                .payingWith(RELAYER)
+                                .via("legacyBeforeEIP155")
+                                .nonce(0)
+                                .chainId(chainId)
+                                .gasPrice(50L)
+                                .maxPriorityGas(2L)
+                                .gasLimit(1_000_000L)
+                                .sending(depositAmount)
+                                .hasKnownStatus(ResponseCodeEnum.SUCCESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        getTxnRecord("legacyBeforeEIP155")
+                                .logged()
+                                .hasPriority(recordWith().status(SUCCESS)))));
+    }
+
+    // test legacy ethereum transactions after EIP155
+    // this tests the behaviour when the `v` field is 37 or 38
+    // in this case the passed chainId = 1 so ETX is after EIP155
+    // and so `v` is calculated -> v = {0,1} + CHAIN_ID * 2 + 35
+    // source: https://eips.ethereum.org/EIPS/eip-155
+    @LeakyHapiTest(overrides = {"contracts.chainId"})
+    final Stream<DynamicTest> legacyEtxAfterEIP155() {
+        final String DEPOSIT = "deposit";
+        final long depositAmount = 20_000L;
+        final Integer chainId = 1;
+
+        return hapiTest(
+                overriding("contracts.chainId", "" + chainId),
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(6 * ONE_MILLION_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, SECP_256K1_SOURCE_KEY, ONE_HUNDRED_HBARS))
+                        .via("autoAccount"),
+                getTxnRecord("autoAccount").andAllChildRecords(),
+                uploadInitCode(PAY_RECEIVABLE_CONTRACT),
+                contractCreate(PAY_RECEIVABLE_CONTRACT).adminKey(THRESHOLD),
+                overriding("contracts.chainId", "" + chainId),
+                atomicBatch(ethereumCall(PAY_RECEIVABLE_CONTRACT, DEPOSIT, BigInteger.valueOf(depositAmount))
+                                .type(EthTransactionType.LEGACY_ETHEREUM)
+                                .signingWith(SECP_256K1_SOURCE_KEY)
+                                .payingWith(RELAYER)
+                                .via("legacyAfterEIP155")
+                                .nonce(0)
+                                .chainId(chainId)
+                                .gasPrice(50L)
+                                .maxPriorityGas(2L)
+                                .gasLimit(1_000_000L)
+                                .sending(depositAmount)
+                                .hasKnownStatus(ResponseCodeEnum.SUCCESS)
+                                .batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR),
+                withOpContext((spec, opLog) -> allRunFor(
+                        spec,
+                        getTxnRecord("legacyAfterEIP155")
+                                .logged()
+                                .hasPriority(recordWith().status(SUCCESS)))));
+    }
+}


### PR DESCRIPTION
**Description**:
* Add Contract HAPI tests wrapped inside an atomic batch
* Extend the HAPI framework to make the `CallContractOperation` object work with atomic batch

**Related issue(s)**:

Fixes #19760