### PR TITLE
chore: Report TCK regression test to CITR Detailed Test Reports Channel

### DIFF
--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -315,7 +315,7 @@ jobs:
       - name: Report Status to TCK Working Group
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
-          webhook: ${{ secrets.slack-report-webhook }}
+          webhook: ${{ secrets.slack-tck-report-webhook }}
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload.json
@@ -323,7 +323,7 @@ jobs:
       - name: Report Status to TCK Working Group
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
         with:
-          webhook: ${{ secrets.slack-report-webhook }}
+          webhook: ${{ secrets.slack-detailed-report-webhook }}
           webhook-type: incoming-webhook
           payload-templated: true
           payload-file-path: slack_payload.json

--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -15,7 +15,10 @@ on:
       access-token:
         description: "GitHub Access Token with write permissions to the repository."
         required: true
-      slack-report-webhook:
+      slack-tck-report-webhook:
+        description: "Slack Webhook URL for TCK Group Monitoring."
+        required: true
+      slack-detailed-report-webhook:
         description: "Slack Webhook URL for TCK Monitoring."
         required: true
 
@@ -308,6 +311,14 @@ jobs:
             ]
           }
           EOF
+
+      - name: Report Status to TCK Working Group
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.slack-report-webhook }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json
 
       - name: Report Status to TCK Working Group
         uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -194,7 +194,8 @@ jobs:
       custom-job-name: "SDK TCK Regression"
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
-      slack-report-webhook: ${{ secrets.SLACK_TCK_MONITOR_WEBHOOK }}
+      slack-tck-report-webhook: ${{ secrets.SLACK_TCK_MONITOR_WEBHOOK }}
+      slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
   tag-for-promotion:
     name: Tag as XTS-Passing

--- a/.github/workflows/zxf-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/zxf-dry-run-extended-test-suite.yaml
@@ -117,4 +117,5 @@ jobs:
       custom-job-name: "Dry-Run: SDK TCK Regression"
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
-      slack-report-webhook: ${{ secrets.SLACK_TCK_MONITOR_WEBHOOK }}
+      slack-tck-report-webhook: ${{ secrets.SLACK_TCK_MONITOR_WEBHOOK }}
+      slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}


### PR DESCRIPTION
## Description

This pull request updates Slack webhook configurations across multiple GitHub Actions workflows to improve clarity and functionality. The changes include renaming an existing webhook variable for consistency, adding a new webhook for detailed reporting, and incorporating a new Slack notification step in one of the workflows.

### Updates to Slack webhook configurations:

* [`.github/workflows/zxc-tck-regression.yaml`](diffhunk://#diff-276b3c78510bfe1ba0edc6d1c72256cf2d3c424c7b3733a999efb0f5c7b886cdL18-R21): Renamed `slack-report-webhook` to `slack-tck-report-webhook` and added a new `slack-detailed-report-webhook` input for detailed reporting.
* [`.github/workflows/zxcron-extended-test-suite.yaml`](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687L197-R198): Updated secrets to reflect the renamed `slack-tck-report-webhook` and added `slack-detailed-report-webhook` for detailed reporting.

### New Slack notification step:

* [`.github/workflows/zxc-tck-regression.yaml`](diffhunk://#diff-276b3c78510bfe1ba0edc6d1c72256cf2d3c424c7b3733a999efb0f5c7b886cdR322-R329): Added a step to report status to the TCK working group using the Slack GitHub Action. This step leverages the `slack-report-webhook` for notifications.

### Related Issue(s)

Closes #20017