### PR TITLE
chore: Update CODEOWNERS for SC contributions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,14 +16,6 @@
 /hedera-state-validator                         @hiero-ledger/hiero-consensus-node-foundation-codeowners
 
 #########################
-##### HAPI protobuf #####
-#########################
-
-/hapi/                                          @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners @hiero-ledger/hiero-consensus-node-consensus-codeowners
-/hapi/hedera-protobufs/services                 @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners @jsync-swirlds @hiero-ledger/hiero-mirror-node-maintainers
-
-
-#########################
 ##### Hedera Node  ######
 #########################
 
@@ -51,6 +43,7 @@
 /hedera-node/hedera-util*/                      @hiero-ledger/hiero-consensus-node-execution-codeowners
 /hedera-node/hedera-staking*/                   @hiero-ledger/hiero-consensus-node-execution-codeowners
 /hedera-node/test-clients/                      @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
+/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/  @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
 
 # Documentation
 /hedera-node/docs/design/services/smart-contract-service    @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
@@ -94,7 +87,11 @@
 ####################
 #####   HAPI  ######
 ####################
+
 /hapi/                                              @hiero-ledger/hiero-consensus-node-consensus-codeowners @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners
+
+# Protobuf
+/hapi/hedera-protobuf-java-api/src/main/proto/services/ @hiero-ledger/hiero-consensus-node-execution-codeowners @hiero-ledger/hiero-consensus-node-smart-contract-codeowners @jsync-swirlds @hiero-ledger/hiero-mirror-node-maintainers
 
 # Documentation
 /platform-sdk/docs/platformWiki.md                  @hiero-ledger/hiero-consensus-node-consensus-codeowners @hiero-ledger/hiero-consensus-node-foundation-codeowners

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/AtomicSmartContractServiceFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/AtomicSmartContractServiceFeesTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.services.bdd.suites.fees;
+package com.hedera.services.bdd.suites.contract.fees;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/SmartContractServiceFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/SmartContractServiceFeesTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.services.bdd.suites.fees;
+package com.hedera.services.bdd.suites.contract.fees;
 
 import static com.hedera.services.bdd.junit.EmbeddedReason.NEEDS_STATE_ACCESS;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hip906/HbarAllowanceApprovalTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hip906/HbarAllowanceApprovalTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.services.bdd.suites.hip906;
+package com.hedera.services.bdd.suites.contract.hip906;
 
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asEntityString;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/ContractRecordsSanityCheckSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/ContractRecordsSanityCheckSuite.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.hedera.services.bdd.suites.records;
+package com.hedera.services.bdd.suites.contract.records;
 
 import static com.hedera.services.bdd.junit.ContextRequirement.SYSTEM_ACCOUNT_BALANCES;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StakingSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/StakingSuite.java
@@ -39,7 +39,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.STAKING_REWARD;
 import static com.hedera.services.bdd.suites.HapiSuite.TINY_PARTS_PER_WHOLE;
-import static com.hedera.services.bdd.suites.records.ContractRecordsSanityCheckSuite.PAYABLE_CONTRACT;
+import static com.hedera.services.bdd.suites.contract.records.ContractRecordsSanityCheckSuite.PAYABLE_CONTRACT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_STAKING_ID;
 
 import com.hedera.services.bdd.junit.HapiTest;
@@ -75,7 +75,7 @@ public class StakingSuite {
     private static final long STAKING_PERIOD_MINS = 1L;
 
     @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) throws Throwable {
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         testLifecycle.doAdhoc(
                 overridingThree(
                         "staking.startThreshold", "" + 10 * ONE_HBAR,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/SteadyStateThrottlingTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/SteadyStateThrottlingTest.java
@@ -30,7 +30,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.TOKEN_TREASURY;
-import static com.hedera.services.bdd.suites.records.ContractRecordsSanityCheckSuite.PAYABLE_CONTRACT;
+import static com.hedera.services.bdd.suites.contract.records.ContractRecordsSanityCheckSuite.PAYABLE_CONTRACT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOPIC_ID;


### PR DESCRIPTION
**Description**:
Occasionally services code owners are requested to review PR for which are non applicable to their ownership which slows down development time for SC contributors.

**Related issue(s)**:

Fixes [#17322](https://github.com/hiero-ledger/hiero-consensus-node/issues/17322)

**Notes for reviewer**:
- `##### HAPI protobuf #####` remove because of duplication
- `# Protobuf` fixed (changed to real folder) and moved to `#####   HAPI  ######` block
- doc ownership was already changed by https://github.com/hiero-ledger/hiero-consensus-node/commit/02ba8dfd2a5b208598ad5605f1fe417c40a01eda
- SC tests movement is not a great change as I think, because any change in "test utils" or "test core" will still cause execution team to review. But I grouped what is possible

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
