### PR TITLE
build: update org.hiero.gradle.build to 0.4.8

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.4.7" }
+plugins { id("org.hiero.gradle.build") version "0.4.8" }
 
 javaModules {
     // This "intermediate parent project" should be removed


### PR DESCRIPTION
**Description**:

Includes: https://github.com/hiero-ledger/hiero-gradle-conventions/pull/239

To fix:
```
 > Failed to apply plugin 'org.hiero.gradle.feature.publish-artifactregistry'.
   > Repository with name 'sonatype' not found.
```
