### PR TITLE
fix(18458): Pces file writer rollback

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
@@ -99,6 +99,6 @@ public record PcesConfig(
         @ConfigProperty(defaultValue = "1ms") Duration replayHealthThreshold,
         @ConfigProperty(defaultValue = "true") boolean limitReplayFrequency,
         @ConfigProperty(defaultValue = "5000") int maxEventReplayFrequency,
-        @ConfigProperty(defaultValue = "EVERY_EVENT") FileSyncOption inlinePcesSyncOption,
-        @ConfigProperty(defaultValue = "FILE_CHANNEL_SYNC") PcesFileWriterType pcesFileWriterType,
+        @ConfigProperty(defaultValue = "EVERY_SELF_EVENT") FileSyncOption inlinePcesSyncOption,
+        @ConfigProperty(defaultValue = "OUTPUT_STREAM") PcesFileWriterType pcesFileWriterType,
         @ConfigProperty(defaultValue = "OUTPUT_STREAM") PcesFileWriterType macPcesFileWriterType) {}


### PR DESCRIPTION
Description:
In https://github.com/hiero-ledger/hiero-consensus-node/issues/18458, we changed how we write events into the pces files (we now sync on every event and write using the strongest available guarantee). It produced an increased i/o activity on the disks.
This configuration rolls back the change.

Related issue(s):

Reverts https://github.com/hiero-ledger/hiero-consensus-node/pull/19067