### PR TITLE
chore: update hiero gradle conventions to v0.4.9

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-plugins { id("org.hiero.gradle.build") version "0.4.8" }
+plugins { id("org.hiero.gradle.build") version "0.4.9" }
 
 javaModules {
     // This "intermediate parent project" should be removed


### PR DESCRIPTION
**Description**:

Update hiero-gradle-conventions plugin to version 0.4.9. This increases the timeout on Maven Central publishing.

**Related Issue(s)**:

Fixes #20061
