### PR TITLE
ci: add identify release candidate workflow

### DIFF
--- a/.github/workflows/flow-identify-release-candidate.yaml
+++ b/.github/workflows/flow-identify-release-candidate.yaml
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "[Main] Identify and Tag Release Candidate"
+on:
+  workflow_dispatch:
+    inputs:
+      build-number:
+        description: "Build Number (ex: 43 = build-00043):"
+        type: string
+        required: true
+      release-version:
+        description: "Release Candidate Version (ex: 0.64.0)"
+        type: string
+        required: true
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+jobs:
+  identify-release-candidate:
+    name: Identify and Apply Release Candidate Tag
+    runs-on: hiero-network-node-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863 # v2.12.1
+        with:
+          egress-policy: audit
+
+      - name: Build Input Validation
+        id: validate
+        run: |
+          echo "The input is ${{ inputs.build-number }}"
+          if ! [[ "${{ inputs.build-number }}" =~ ^[0-9]+$ ]]; then
+            echo "Input is not a valid integer"
+            exit 1
+          fi
+          echo "Input is a valid integer: $(( ${{ inputs.build-number }} ))"
+
+          # 5-digit padding
+          padded_number="$(printf "%05d" "${{ inputs.build-number }}")"
+          echo "Padded number is: ${padded_number}"
+
+          # Add "build_" prefix to the padded number
+          build_tag="build-${padded_number}"
+          echo "Prefixed number is: ${build_tag}"
+
+          # Export to Github output and Github summary
+          echo "build-tag=${build_tag}" >> ${GITHUB_OUTPUT}
+          echo "Build Tag to Release: ${build_tag}" >> ${GITHUB_STEP_SUMMARY}
+
+      - name: Checkout Code
+        id: checkout_code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: "0"
+          ref: ${{ steps.validate.outputs.build-tag }}
+          token: ${{ secrets.GH_ACCESS_TOKEN }}
+
+      - name: Import GPG Key
+        uses: step-security/ghaction-import-gpg@c86c374c0659a6c2d1284bccf8af889e73ce8fe0 # v6.3.0
+        with:
+          git_commit_gpgsign: true
+          git_tag_gpgsign: true
+          git_user_signingkey: true
+          gpg_private_key: ${{ secrets.SVCS_GPG_KEY_CONTENTS }}
+          passphrase: ${{ secrets.SVCS_GPG_KEY_PASSPHRASE }}
+
+      - name: Install Semantic Version Tools
+        run: |
+          echo "::group::Download SemVer Binary"
+          sudo curl -L -o /usr/local/bin/semver https://raw.githubusercontent.com/fsaintjacques/semver-tool/master/src/semver
+          echo "::endgroup::"
+          echo "::group::Change SemVer Binary Permissions"
+          sudo chmod -v +x /usr/local/bin/semver
+          echo "::endgroup::"
+          echo "::group::Show SemVer Binary Version Info"
+          semver --version
+          echo "::endgroup::"
+
+      - name: Validate Semantic Version Input Structure
+        run: |
+          if semver validate "${RELEASE_VERSION}"; then
+            echo "Valid semver"
+          else
+            echo "Invalid semver provided"
+            exit 1
+          fi
+
+      - name: Extract Semantic Version
+        id: release-version
+        run: |
+          RELEASE_VERSION="$(semver get release "${{ inputs.release-version }}")"
+          echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
+
+      - name: Calculate Release Candidate Tag Value
+        id: calculated-tag
+        run: |
+          MAJOR=$(semver get major "${{ steps.release-version.outputs.version }}")
+          MINOR=$(semver get minor "${{ steps.release-version.outputs.version }}")
+          
+          NEW_TAG="release-candidate-${MAJOR}.${MINOR}"
+          echo "Release Candiate Tag: ${NEW_TAG}"
+          echo "candidate=${NEW_TAG}" >> "${GITHUB_OUTPUT}"
+
+      - name: Apply Release Candidate Tag
+        run: |
+          echo "Applying release candidate tag"
+          # git tag --annotate "${{ steps.calculated-tag.outputs.candidate }}" --message "${{ steps.calculated-tag.outputs.candidate }}"
+          echo "Applied tag ${{ steps.calculated-tag.outputs.candidate }}"
+          echo "Version Tag Applied: ${{ steps.calculated-tag.outputs.candidate_tag }}" >> ${GITHUB_STEP_SUMMARY}
+
+      - name: Push Release Candidate Tag to Remote
+        run: |
+          echo "Pushing release tag to remote"
+          git push origin tag "${{ steps.calculated-tag.outputs.candidate }}"
+          echo "Pushed new release tag to remote"


### PR DESCRIPTION
**Description**:

Create a new workflow to apply a release-candidate-version tag to a build ID tag. This will help us transition from release branches and primarily focus on the mainline instead.

**Related Issue(s)**:

Implements #20091

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
