### PR TITLE
chore: Isolate responsibility for stake period boundary side effects

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/NodeRewardManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/NodeRewardManager.java
@@ -196,6 +196,7 @@ public class NodeRewardManager {
         final var nodeRewardStore = new WritableNodeRewardsStoreImpl(writableStates);
         // Don't try to pay rewards in the genesis edge case when LastNodeRewardsPaymentTime.NEVER
         if (lastNodeRewardsPaymentTime == LastNodeRewardsPaymentTime.PREVIOUS_PERIOD) {
+            log.info("Considering paying node rewards for the last staking period at {}", asTimestamp(now));
             // Identify the nodes active in the last staking period
             final var rosterStore = new ReadableRosterStoreImpl(state.getReadableStates(RosterService.NAME));
             final var currentRoster =

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -890,23 +890,6 @@ public class HandleWorkflow {
     }
 
     /**
-     * Processes any side effects of crossing a stake period boundary.
-     *
-     * @param parentTxn the user transaction that crossed the boundary
-     */
-    private void processStakePeriodChanges(@NonNull final ParentTxn parentTxn) {
-        try {
-            stakePeriodChanges.process(
-                    parentTxn.stack(), parentTxn.tokenContextImpl(), streamMode, blockStreamManager.lastHandleTime());
-        } catch (final Exception e) {
-            // We don't propagate a failure here to avoid a catastrophic scenario
-            // where we are "stuck" trying to process node stake updates and never
-            // get back to user transactions
-            logger.error("Failed to process stake period changes", e);
-        }
-    }
-
-    /**
      * Configure the TSS callbacks for the given state.
      *
      * @param state the latest state

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -742,7 +742,7 @@ public class HandleWorkflow {
                 }
 
                 final var dispatch = parentTxnFactory.createDispatch(parentTxn, exchangeRateManager.exchangeRates());
-                advanceTimeFor(parentTxn, dispatch);
+                stakePeriodChanges.advanceTimeTo(parentTxn, true);
                 logPreDispatch(parentTxn);
                 if (parentTxn.type() == POST_UPGRADE_TRANSACTION) {
                     logger.info("Doing post-upgrade setup @ {}", parentTxn.consensusNow());
@@ -794,7 +794,7 @@ public class HandleWorkflow {
         final var baseBuilder = baseBuilderFor(executableTxn, scheduledTxn);
         final var dispatch =
                 parentTxnFactory.createDispatch(scheduledTxn, baseBuilder, executableTxn.keyVerifier(), SCHEDULED);
-        advanceTimeFor(scheduledTxn, dispatch);
+        stakePeriodChanges.advanceTimeTo(scheduledTxn, true);
         try {
             dispatchProcessor.processDispatch(dispatch);
             final var handleOutput = scheduledTxn
@@ -810,23 +810,6 @@ public class HandleWorkflow {
             logger.error("{} - exception thrown while handling scheduled transaction", ALERT_MESSAGE, e);
             return HandleOutput.failInvalidStreamItems(
                     scheduledTxn, exchangeRateManager.exchangeRates(), streamMode, recordCache);
-        }
-    }
-
-    /**
-     * Manages time-based side effects for the given user transaction and dispatch.
-     *
-     * @param parentTxn the user transaction to manage time for
-     * @param dispatch the dispatch to manage time for
-     */
-    private void advanceTimeFor(@NonNull final ParentTxn parentTxn, @NonNull final Dispatch dispatch) {
-        // WARNING: The check below relies on the BlockStreamManager's last-handled time not being updated yet,
-        // so we must not call setLastHandleTime() until after them
-        processStakePeriodChanges(parentTxn, dispatch);
-        blockStreamManager.setLastHandleTime(parentTxn.consensusNow());
-        if (streamMode != BLOCKS) {
-            // This updates consTimeOfLastHandledTxn as a side effect
-            blockRecordManager.advanceConsensusClock(parentTxn.consensusNow(), parentTxn.state());
         }
     }
 
@@ -910,16 +893,11 @@ public class HandleWorkflow {
      * Processes any side effects of crossing a stake period boundary.
      *
      * @param parentTxn the user transaction that crossed the boundary
-     * @param dispatch the dispatch for the user transaction that crossed the boundary
      */
-    private void processStakePeriodChanges(@NonNull final ParentTxn parentTxn, @NonNull final Dispatch dispatch) {
+    private void processStakePeriodChanges(@NonNull final ParentTxn parentTxn) {
         try {
             stakePeriodChanges.process(
-                    dispatch,
-                    parentTxn.stack(),
-                    parentTxn.tokenContextImpl(),
-                    streamMode,
-                    blockStreamManager.lastHandleTime());
+                    parentTxn.stack(), parentTxn.tokenContextImpl(), streamMode, blockStreamManager.lastHandleTime());
         } catch (final Exception e) {
             // We don't propagate a failure here to avoid a catastrophic scenario
             // where we are "stuck" trying to process node stake updates and never

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemTransactionsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemTransactionsTest.java
@@ -117,6 +117,9 @@ class SystemTransactionsTest {
     @Mock
     private StartupNetworks startupNetworks;
 
+    @Mock
+    private StakePeriodChanges stakePeriodChanges;
+
     @LoggingSubject
     private SystemTransactions subject;
 
@@ -144,7 +147,8 @@ class SystemTransactionsTest {
                 blockStreamManager,
                 exchangeRateManager,
                 recordCache,
-                startupNetworks);
+                startupNetworks,
+                stakePeriodChanges);
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -308,7 +308,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     /**
      * Gives a pretend state signature transaction.
      */
-    private byte[] mockStateSignatureTxn() {
+    protected byte[] mockStateSignatureTxn() {
         return hedera.encodeSystemTransaction(com.hedera.hapi.platform.event.StateSignatureTransaction.newBuilder()
                         .round(1L)
                         .hash(Bytes.wrap(new byte[48]))

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
@@ -185,6 +185,13 @@ public class RepeatableEmbeddedHedera extends AbstractEmbeddedHedera implements 
         }
     }
 
+    /**
+     * Handles a round with no user transactions.
+     */
+    public void handleRoundWithNoUserTransactions() {
+        handleRoundWith(mockStateSignatureTxn());
+    }
+
     private class SynchronousFakePlatform extends AbstractFakePlatform implements Platform {
         private FakeEvent lastCreatedEvent;
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip1064Tests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip1064Tests.java
@@ -1,11 +1,16 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.suites.integration;
 
+import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_TRANSFER;
+import static com.hedera.hapi.node.base.HederaFunctionality.NODE_STAKE_UPDATE;
 import static com.hedera.hapi.util.HapiUtils.asInstant;
 import static com.hedera.node.app.hapi.utils.CommonPbjConverters.toPbj;
+import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_STATE_ACCESS;
 import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION;
 import static com.hedera.services.bdd.junit.TestTags.INTEGRATION;
+import static com.hedera.services.bdd.junit.hedera.ExternalPath.BLOCK_STREAMS_DIR;
 import static com.hedera.services.bdd.junit.hedera.embedded.EmbeddedMode.REPEATABLE;
+import static com.hedera.services.bdd.junit.support.BlockStreamAccess.blockFrom;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
@@ -14,6 +19,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeUpdate;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.mutateSingleton;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doWithStartupConfig;
@@ -28,12 +34,18 @@ import static com.hedera.services.bdd.suites.HapiSuite.CIVILIAN_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.NODE_REWARD;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.TINY_PARTS_PER_WHOLE;
 import static com.hederahashgraph.api.proto.java.HederaFunctionality.CryptoTransfer;
+import static java.util.Comparator.comparing;
 import static java.util.stream.Collectors.toMap;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.state.token.NodeActivity;
 import com.hedera.hapi.node.state.token.NodeRewards;
 import com.hedera.node.app.hapi.utils.forensics.RecordStreamEntry;
@@ -42,7 +54,9 @@ import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyRepeatableHapiTest;
 import com.hedera.services.bdd.junit.RepeatableHapiTest;
 import com.hedera.services.bdd.junit.TargetEmbeddedMode;
+import com.hedera.services.bdd.junit.support.BlockStreamAccess;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
+import com.hedera.services.bdd.junit.support.translators.inputs.TransactionParts;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
@@ -52,14 +66,21 @@ import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.spec.utilops.streams.assertions.VisibleItemsValidator;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+import java.util.function.LongConsumer;
 import java.util.function.LongSupplier;
 import java.util.stream.Stream;
+import org.hiero.base.concurrent.interrupt.Uninterruptable;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.MethodOrderer;
@@ -633,16 +654,79 @@ public class RepeatableHip1064Tests {
                 doingContextual(TxnUtils::triggerAndCloseAtLeastOneFileIfNotInterrupted));
     }
 
+    @Order(7)
+    @RepeatableHapiTest(value = {NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION, NEEDS_STATE_ACCESS})
+    Stream<DynamicTest> nodeRewardPaymentsAlsoTriggersStakePeriodBoundarySideEffects() {
+        final AtomicLong highestBlockBeforeEmptyRound = new AtomicLong();
+        return hapiTest(
+                // Ensure a node is not declining rewards and there is a 801 balance
+                nodeUpdate("0").declineReward(true),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, NODE_REWARD, ONE_MILLION_HBARS)),
+                waitUntilStartOfNextStakingPeriod(1),
+                sleepForBlockPeriod(),
+                // Record the highest block number now
+                exposeLatestBlockNumber(highestBlockBeforeEmptyRound::set, Duration.ofSeconds(1)),
+                // Start a new block with a round w/o user transactions
+                doingContextual(spec -> spec.repeatableEmbeddedHederaOrThrow().handleRoundWithNoUserTransactions()),
+                sleepForBlockPeriod(),
+                // Finish the block with another round w/o user transaction
+                doingContextual(spec -> spec.repeatableEmbeddedHederaOrThrow().handleRoundWithNoUserTransactions()),
+                exposeLatestBlock(
+                        b -> {
+                            final var number =
+                                    b.items().getFirst().blockHeaderOrThrow().number();
+                            assertEquals(
+                                    highestBlockBeforeEmptyRound.get() + 1,
+                                    number,
+                                    "New block should have been created");
+                            final var rewardPayment = findFirst(b, CRYPTO_TRANSFER);
+                            assertTrue(
+                                    rewardPayment.isPresent(), "Node rewards payment should be present in the block");
+                            final var nodeStakeUpdate = findFirst(b, NODE_STAKE_UPDATE);
+                            assertTrue(nodeStakeUpdate.isPresent(), "Node stake update should be present in the block");
+                        },
+                        Duration.ofSeconds(1)));
+    }
+
+    private static Optional<TransactionParts> findFirst(
+            @NonNull final Block b, @NonNull final HederaFunctionality function) {
+        return b.items().stream()
+                .filter(BlockItem::hasEventTransaction)
+                .map(BlockItem::eventTransactionOrThrow)
+                .map(t -> TransactionParts.from(t.applicationTransactionOrThrow()))
+                .filter(parts -> parts.function() == function)
+                .findFirst();
+    }
+
+    static SpecOperation exposeLatestBlockNumber(LongConsumer cb, Duration after) {
+        return exposeLatestBlock(
+                b -> cb.accept(b.items().getFirst().blockHeaderOrThrow().number()), after);
+    }
+
+    static SpecOperation exposeLatestBlock(Consumer<Block> cb, Duration after) {
+        return UtilVerbs.doingContextual((spec) -> {
+            Uninterruptable.tryToSleep(after);
+            try (final var stream = Files.walk(spec.getNetworkNodes().getFirst().getExternalPath(BLOCK_STREAMS_DIR))) {
+                final var lastPath = stream.filter(BlockStreamAccess::isBlockFile)
+                        .max(comparing(BlockStreamAccess::extractBlockNumber))
+                        .orElseThrow();
+                cb.accept(blockFrom(lastPath));
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        });
+    }
+
     static SpecOperation validateRecordFees(final String record, List<Long> expectedFeeAccounts) {
         return UtilVerbs.withOpContext((spec, opLog) -> {
             var fileCreate = getTxnRecord(record);
             allRunFor(spec, fileCreate);
             var response = fileCreate.getResponseRecord();
             assertEquals(
+                    1,
                     response.getTransferList().getAccountAmountsList().stream()
                             .filter(aa -> aa.getAmount() < 0)
-                            .count(),
-                    1);
+                            .count());
             // When the feature is disabled the node fees go to node. Network fee is split between 98, 800 and 801
             assertEquals(
                     expectedFeeAccounts,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip1064Tests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip1064Tests.java
@@ -671,11 +671,10 @@ public class RepeatableHip1064Tests {
                 cryptoTransfer(tinyBarsFromTo(GENESIS, NODE_REWARD, ONE_MILLION_HBARS)),
                 // Move into a new staking period
                 waitUntilStartOfNextStakingPeriod(1),
-                // This round should be the first across the stake period boundary, hence trigger rewards and side
-                // effects
+                // Close a block whose only chance of exporting a NodeStakeUpdate is the node reward payment
                 doingContextual(spec -> spec.repeatableEmbeddedHederaOrThrow().handleRoundWithNoUserTransactions()),
                 sleepForBlockPeriod(),
-                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1)),
+                doingContextual(spec -> spec.repeatableEmbeddedHederaOrThrow().handleRoundWithNoUserTransactions()),
                 sleepForBlockPeriod(),
                 cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1)),
                 exposeLatestBlock(


### PR DESCRIPTION
**Description**:
 - Closes #20083 
 - Now the relevant calls to `blockStreamManager.setLastHandleTime()` are both done through the `StakePeriodChanges.advanceTimeTo()` method, which triggers side effects of crossing stake period boundary if appropriate.
     * There is one special case at genesis, when we do _not_ want to consider any side effects since the involved entities will not exist yet.