### PR TITLE
test: suppress expected exceptions in unit tests

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/test/resources/log4j2-test.xml
+++ b/platform-sdk/swirlds-merkledb/src/test/resources/log4j2-test.xml
@@ -24,6 +24,8 @@
 		</Console>
 	</Appenders>
 	<Loggers>
+		<!-- to suppress `RuntimeException("testCompactionFailed")` -->
+		<Logger name="com.swirlds.merkledb.MerkleDbCompactionCoordinator" level="OFF"/>
 		<Root level="trace">
 			<AppenderRef ref="Console"/>
 		</Root>

--- a/platform-sdk/swirlds-virtualmap/src/test/resources/log4j2-test.xml
+++ b/platform-sdk/swirlds-virtualmap/src/test/resources/log4j2-test.xml
@@ -32,14 +32,18 @@
 			</Policies>
 			<DefaultRolloverStrategy max="1"/>
 		</RollingRandomAccessFile>
-		<Console name="Console" target="SYSTEM_OUT">
+		<Console name="Console2" target="SYSTEM_OUT">
 			<PatternLayout pattern="%d{HH:mm:ss.SSS} %6r %t %msg%n"/>
 		</Console>
 	</Appenders>
 	<Loggers>
+		<Logger name="com.swirlds.virtualmap.internal.merkle.VirtualRootNode" level="OFF"/>
+		<Logger name="com.swirlds.virtualmap.internal.pipeline.VirtualPipeline" level="OFF"/>
+		<Logger name="com.swirlds.common.merkle.synchronization.task.LearnerPushTask" level="OFF"/>
 		<Root level="trace">
 			<AppenderRef ref="SwirldsPrimaryLog"/>
-			<AppenderRef ref="Console"/>
+<!--			<AppenderRef ref="Console"/>-->
+			<AppenderRef ref="Console2"/>
 		</Root>
 	</Loggers>
 </Configuration>

--- a/platform-sdk/swirlds-virtualmap/src/test/resources/log4j2-test.xml
+++ b/platform-sdk/swirlds-virtualmap/src/test/resources/log4j2-test.xml
@@ -18,10 +18,6 @@
 
 <Configuration status="WARN">
 	<Appenders>
-		<Console name="Console" target="SYSTEM_OUT">
-			<PatternLayout pattern="%style{%t}{bright} %highlight{%-1level} %style{%logger{0}}{cyan} %msg%n"
-						   disableAnsi="false"/>
-		</Console>
 		<RollingRandomAccessFile name="SwirldsPrimaryLog" fileName="swirlds.log" filePattern="swirlds.%i.log"
 								 immediateFlush="true" append="false">
 			<PatternLayout>
@@ -32,18 +28,19 @@
 			</Policies>
 			<DefaultRolloverStrategy max="1"/>
 		</RollingRandomAccessFile>
-		<Console name="Console2" target="SYSTEM_OUT">
+		<Console name="Console" target="SYSTEM_OUT">
 			<PatternLayout pattern="%d{HH:mm:ss.SSS} %6r %t %msg%n"/>
 		</Console>
 	</Appenders>
 	<Loggers>
+		<!-- To suppress a lot of expected exceptions in the output -->
 		<Logger name="com.swirlds.virtualmap.internal.merkle.VirtualRootNode" level="OFF"/>
 		<Logger name="com.swirlds.virtualmap.internal.pipeline.VirtualPipeline" level="OFF"/>
+		<Logger name="com.swirlds.virtualmap.internal.hash.VirtualHasher" level="OFF"/>
 		<Logger name="com.swirlds.common.merkle.synchronization.task.LearnerPushTask" level="OFF"/>
 		<Root level="trace">
 			<AppenderRef ref="SwirldsPrimaryLog"/>
-<!--			<AppenderRef ref="Console"/>-->
-			<AppenderRef ref="Console2"/>
+			<AppenderRef ref="Console"/>
 		</Root>
 	</Loggers>
 </Configuration>


### PR DESCRIPTION
**Description**:
This PR suppresses expected exceptions in unit tests, so they don't overload the test output.

**Related issue(s)**:
Fixes #19942

**Notes for reviewer**:
- Besides Virtual Map Reconnects, some expected exceptions in compaction tests were suppressed;
- Need to keep in mind that exceptions are suppressed in case of debugging something;

