### PR TITLE
fix: Use `requires transitive` for `com.swirlds.common.test.fixtures`

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/module-info.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/module-info.java
@@ -2,6 +2,7 @@
 module org.hiero.otter.fixtures {
     requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;
+    requires transitive com.swirlds.common.test.fixtures;
     requires transitive com.swirlds.common;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.logging;
@@ -23,7 +24,6 @@ module org.hiero.otter.fixtures {
     requires com.hedera.node.config;
     requires com.swirlds.base.test.fixtures;
     requires com.swirlds.base;
-    requires com.swirlds.common.test.fixtures;
     requires com.swirlds.component.framework;
     requires com.swirlds.config.extensions;
     requires com.swirlds.merkledb;


### PR DESCRIPTION
**Description**:
Fixes compiler warning,
```
> Task :consensus-otter-tests:compileTestFixturesJava
Note: GraalVmProcessor: writing GraalVM metadata for 1 Java classes to `META-INF/native-image/com.hedera.hashgraph/consensus-otter-tests/reflect-config.json`.
Note: PluginProcessor: writing plugin descriptor for 1 Log4j Plugins to `META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat`.
/Users/michaeltinker/YetYetAnotherDev/hedera-services/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Network.java:41: warning: [exports] interface WeightGenerator in module com.swirlds.common.test.fixtures is not indirectly exported using 'requires transitive'
    List<Node> addNodes(int count, WeightGenerator weightGenerator);
                                   ^
error: warnings found and -Werror specified
```