### PR TITLE
build: add 'hedera-protobuf-java-api' to published artifacts

### DIFF
--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 dependencies {
     published(project(":app"))
+    published(project(":hedera-protobuf-java-api"))
     // examples that also contain tests we would like to run
     implementation(project(":swirlds-platform-base-example"))
     implementation(project(":ConsistencyTestingTool"))


### PR DESCRIPTION
**Description**:

Restores the publishing of `hedera-protobuf-java-api` which has been accidentally removed when moving to the new Maven Central mechanism. Hence, follow up to #19567.

**Related issue(s)**:

#19567

**Note**

I testes that this fixes the problem by:
- Locally removing the `SNAPSHOT` from the version in `version.txt`
- Running `./gradlew nmcpZipAggregation` and inspecting `gradle/aggregation/build/nmcp/zip/aggregation.zip` which contains everything that would get published.

