### PR TITLE
build: (0.64) add 'hedera-protobuf-java-api' to published artifacts

### DIFF
--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 dependencies {
     published(project(":app"))
+    published(project(":hedera-protobuf-java-api"))
     // examples that also contain tests we would like to run
     implementation(project(":swirlds-platform-base-example"))
     implementation(project(":ConsistencyTestingTool"))


### PR DESCRIPTION
**Description**:
Cherry-Pick the fix to publish `hedera-protobuf-java-api` to Maven Central into the `release/0.64` branch.

**Related issue(s)**:

Fixes #20140 


