### PR TITLE
chore: add support for build- candidate tag deploy to previewnet

### DIFF
--- a/.github/workflows/node-flow-deploy-preview.yaml
+++ b/.github/workflows/node-flow-deploy-preview.yaml
@@ -45,16 +45,30 @@ jobs:
       - name: Extract Tag Version
         id: tag
         run: |
-          RELEASE_VERSION="$(semver get release "${{ github.event.inputs.tag-to-deploy }}")"
-          PRERELEASE_VERSION="$(semver get prerel "${{ github.event.inputs.tag-to-deploy }}")"
-
-          FINAL_VERSION="${RELEASE_VERSION}"
-          PRERELEASE_FLAG="false"
-          [[ -n "${PRERELEASE_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PRERELEASE_VERSION}"
-          [[ -n "${PRERELEASE_VERSION}" ]] && PRERELEASE_FLAG="true"
-
-          echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
-          echo "prerelease=${PRERELEASE_FLAG}" >>"${GITHUB_OUTPUT}"
+          TAG="${{ github.event.inputs.tag-to-deploy }}"
+          
+          if semver get release "${TAG}" >/dev/null 2>&1; then
+            RELEASE_VERSION="$(semver get release "${{ github.event.inputs.tag-to-deploy }}")"
+            PRERELEASE_VERSION="$(semver get prerel "${{ github.event.inputs.tag-to-deploy }}")"
+  
+            FINAL_VERSION="${RELEASE_VERSION}"
+            PRERELEASE_FLAG="false"
+            [[ -n "${PRERELEASE_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PRERELEASE_VERSION}"
+            [[ -n "${PRERELEASE_VERSION}" ]] && PRERELEASE_FLAG="true"
+  
+            echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
+            echo "prerelease=${PRERELEASE_FLAG}" >>"${GITHUB_OUTPUT}"
+          
+          elif [[ "${TAG}" =~ ^build-[0-9]+$ ]]; then
+            echo "Valid build tag: ${TAG}"
+            echo "version=${TAG}" >> "${GITHUB_OUTPUT}"
+            echo "prerelease=true" >> "${GITHUB_OUTPUT}"
+          
+          else
+            echo "Invalid tag format: ${TAG}"
+            echo "Tag must be valid semver or match 'build-XXXXX' (digits only)"
+            exit 1
+          fi
 
   deploy-tag:
     name: Deploy Tag

--- a/.github/workflows/node-zxc-deploy-preview.yaml
+++ b/.github/workflows/node-zxc-deploy-preview.yaml
@@ -96,12 +96,25 @@ jobs:
       - name: Verify Version Update (As Specified)
         if: ${{ inputs.version-policy == 'specified' && !cancelled() && !failure() }}
         run: |
-          VALID_VERSION="$(semver validate "${{ inputs.new-version }}")"
+          if [[ "$(semver validate "$VERSION" 2>/dev/null || echo "invalid")" == "valid" ]]; then
+            VALID_VERSION="true"
+          fi
+          
+          if [[ "$VERSION" =~ ^build-[0-9]+$ ]]; then
+            VALID_VERSION="true"
+          fi
 
-          if [[ "${VALID_VERSION}" != "valid" ]]; then
+          if [[ "$VALID_VERSION" != "true" ]]; then
             echo "::error title=Version Error::The supplied new-version parameter (${{ inputs.new-version }}) is invalid and does not conform to the semantic versioning specifications."
             exit 2
+          else
+            echo "Input version validated"
           fi
+
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.ref }}
 
       - name: Authenticate to Google Cloud
         uses: step-security/google-github-auth@40f6deebd366f16c782d7a0ad0844e3b96a032a6 # v2.1.10


### PR DESCRIPTION
**Description**:

Add support for `build-XXXXX` candidate tag structure when deploying to previewnet.

**Related Issue(s)**:

Fixes #20168
