### PR TITLE
chore: 19741 numeric validation test add negative amount scenarios (#…

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/CallTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/common/CallTranslator.java
@@ -27,7 +27,8 @@ public interface CallTranslator<T> {
      * @param attempt the selector to match (in the Attempt)
      * @return the SystemContractMethod for the attempt (or it can be empty if unknown)
      */
-    abstract @NonNull Optional<SystemContractMethod> identifyMethod(@NonNull final T attempt);
+    @NonNull
+    Optional<SystemContractMethod> identifyMethod(@NonNull T attempt);
 
     /**
      * Returns a call from the given attempt.

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ownerof/OwnerOfTranslator.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/ownerof/OwnerOfTranslator.java
@@ -53,7 +53,7 @@ public class OwnerOfTranslator extends AbstractCallTranslator<HtsCallAttempt> {
     @Override
     public OwnerOfCall callFrom(@NonNull final HtsCallAttempt attempt) {
         // Since zero is never a valid serial number, if we clamp the passed value, the result
-        // will be a revert with INVALID_NFT_ID as reason
+        // will be a revert with INVALID_TOKEN_NFT_SERIAL_NUMBER as reason
         final var serialNo = asExactLongValueOrZero(
                 OWNER_OF.decodeCall(attempt.input().toArrayUnsafe()).get(0));
         return new OwnerOfCall(

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/AssertMessages.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/AssertMessages.java
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.contract.impl.test;
+
+public class AssertMessages {
+
+    public static final String STATUS = "Status does not match";
+    public static final String OUTPUT = "Output does not match";
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/ExchangeRateSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/ExchangeRateSystemContractTest.java
@@ -16,14 +16,11 @@ import com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils;
 import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
 import com.hedera.node.config.data.ContractsConfig;
 import java.math.BigInteger;
-import java.time.Instant;
-import java.util.Optional;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
-import org.hyperledger.besu.evm.precompile.PrecompiledContract.PrecompileContractResult;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,8 +44,6 @@ class ExchangeRateSystemContractTest {
     @Mock
     private ContractsConfig contractsConfig;
 
-    private PrecompileContractResult invalidResult =
-            PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(ExceptionalHaltReason.INVALID_OPERATION));
     private ExchangeRateSystemContract subject;
 
     private MockedStatic<FrameUtils> frameUtils;
@@ -101,7 +96,7 @@ class ExchangeRateSystemContractTest {
 
         final var result = subject.computeFully(EXCHANGE_RATE_CONTRACT_ID, underflowInput, frame);
         assertThat(result.output()).isEqualTo(Bytes.EMPTY);
-        assertThat(result.result().getHaltReason().get()).isEqualTo(ExceptionalHaltReason.INVALID_OPERATION);
+        assertThat(result.result().getHaltReason()).hasValue(ExceptionalHaltReason.INVALID_OPERATION);
     }
 
     @Test
@@ -109,7 +104,7 @@ class ExchangeRateSystemContractTest {
         final var fragmentSelector = Bytes.of(0xab);
         final var result = subject.computeFully(EXCHANGE_RATE_CONTRACT_ID, fragmentSelector, frame);
         assertThat(result.output()).isEqualTo(Bytes.EMPTY);
-        assertThat(result.result().getHaltReason().get()).isEqualTo(ExceptionalHaltReason.INVALID_OPERATION);
+        assertThat(result.result().getHaltReason()).hasValue(ExceptionalHaltReason.INVALID_OPERATION);
     }
 
     @Test
@@ -118,7 +113,7 @@ class ExchangeRateSystemContractTest {
         final var input = Bytes.concatenate(fragmentSelector, Bytes32.ZERO);
         final var result = subject.computeFully(EXCHANGE_RATE_CONTRACT_ID, input, frame);
         assertThat(result.output()).isEqualTo(Bytes.EMPTY);
-        assertThat(result.result().getHaltReason().get()).isEqualTo(ExceptionalHaltReason.INVALID_OPERATION);
+        assertThat(result.result().getHaltReason()).hasValue(ExceptionalHaltReason.INVALID_OPERATION);
     }
 
     private static Bytes tinycentsInput(final long validAmount) {
@@ -151,10 +146,6 @@ class ExchangeRateSystemContractTest {
         return Bytes32.wrap(word);
     }
 
-    private static Bytes argOf(final long amount) {
-        return Bytes.wrap(Longs.toByteArray(amount));
-    }
-
     private void givenRate(final ExchangeRate rate) {
         frameUtils.when(() -> proxyUpdaterFor(frame)).thenReturn(updater);
         given(updater.currentExchangeRate()).willReturn(rate);
@@ -170,8 +161,6 @@ class ExchangeRateSystemContractTest {
             .centEquiv(someCentEquiv)
             .build();
     private static final long someTinybarAmount = tinycentsToTinybars(someTinycentAmount, someRate);
-    private static final Instant now = Instant.ofEpochSecond(1_234_567, 890);
-    private static final long GAS_REQUIREMENT = 100L;
 
     private static long tinycentsToTinybars(final long amount, final ExchangeRate rate) {
         final var hbarEquiv = rate.hbarEquiv();

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/grantapproval/ERCGrantApprovalCallTest.java
@@ -4,13 +4,16 @@ package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ALLOWANCE_SPENDER_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_NFT_SERIAL_NUMBER;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NEGATIVE_ALLOWANCE_AMOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.FUNGIBLE_TOKEN_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_FUNGIBLE_TOKEN_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.OWNER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.REVOKE_APPROVAL_SPENDER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.UNAUTHORIZED_SPENDER_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.asBytesResult;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.ordinalRevertOutputFor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -23,20 +26,20 @@ import com.hedera.hapi.node.base.ResponseCodeEnum;
 import com.hedera.hapi.node.base.TokenType;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Nft;
-import com.hedera.hapi.node.state.token.Token;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.scope.VerificationStrategy;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.ERCGrantApprovalCall;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.grantapproval.GrantApprovalTranslator;
 import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuilder;
-import com.hedera.node.app.service.contract.impl.state.ProxyWorldUpdater;
+import com.hedera.node.app.service.contract.impl.test.AssertMessages;
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.service.token.ReadableAccountStore;
-import org.apache.tuweni.units.bigints.UInt256;
+import java.util.Set;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.frame.MessageFrame.State;
 import org.junit.jupiter.api.Test;
+import org.mockito.BDDMockito.BDDMyOngoingStubbing;
 import org.mockito.Mock;
 
 class ERCGrantApprovalCallTest extends CallTestBase {
@@ -55,9 +58,6 @@ class ERCGrantApprovalCallTest extends CallTestBase {
     private Nft nft;
 
     @Mock
-    private Token token;
-
-    @Mock
     private Account account;
 
     @Mock
@@ -66,11 +66,7 @@ class ERCGrantApprovalCallTest extends CallTestBase {
     @Mock
     private ReadableAccountStore accountStore;
 
-    @Mock
-    private ProxyWorldUpdater updater;
-
-    @Test
-    void erc20approve() {
+    private void prepareErc20approve(final long amount, final ResponseCodeEnum status) {
         subject = new ERCGrantApprovalCall(
                 mockEnhancement(),
                 systemContractGasCalculator,
@@ -78,7 +74,7 @@ class ERCGrantApprovalCallTest extends CallTestBase {
                 OWNER_ID,
                 FUNGIBLE_TOKEN_ID,
                 UNAUTHORIZED_SPENDER_ID,
-                100L,
+                amount,
                 TokenType.FUNGIBLE_COMMON);
         given(systemContractOperations.dispatch(
                         any(TransactionBody.class),
@@ -86,31 +82,52 @@ class ERCGrantApprovalCallTest extends CallTestBase {
                         eq(OWNER_ID),
                         eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
-        given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
-        given(nativeOperations.readableAccountStore()).willReturn(accountStore);
-        given(accountStore.getAccountById(any(AccountID.class))).willReturn(account);
-        given(account.accountIdOrThrow())
-                .willReturn(AccountID.newBuilder().accountNum(1).build());
-        given(account.alias()).willReturn(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(new byte[] {1, 2, 3}));
-        final var result = subject.execute(frame).fullResult().result();
-
-        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());
-        assertEquals(
-                asBytesResult(
-                        GrantApprovalTranslator.ERC_GRANT_APPROVAL.getOutputs().encode(Tuple.singleton(true))),
-                result.getOutput());
+        given(recordBuilder.status()).willReturn(status);
+        if (status == SUCCESS) {
+            given(nativeOperations.readableAccountStore()).willReturn(accountStore);
+            given(accountStore.getAccountById(any(AccountID.class))).willReturn(account);
+            given(account.accountIdOrThrow())
+                    .willReturn(AccountID.newBuilder().accountNum(1).build());
+            given(account.alias()).willReturn(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(new byte[] {1, 2, 3}));
+        }
     }
 
     @Test
-    void erc721approve() {
+    void erc20approve() {
+        // given
+        prepareErc20approve(100L, SUCCESS);
+        // when
+        final var result = subject.execute(frame).fullResult().result();
+        // then
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState(), AssertMessages.STATUS);
+        assertEquals(
+                asBytesResult(
+                        GrantApprovalTranslator.ERC_GRANT_APPROVAL.getOutputs().encode(Tuple.singleton(true))),
+                result.getOutput(),
+                AssertMessages.OUTPUT);
+    }
+
+    @Test
+    void erc20approveNegativeAmount() {
+        // given
+        prepareErc20approve(-1, NEGATIVE_ALLOWANCE_AMOUNT);
+        // when
+        final var result = subject.execute(frame).fullResult().result();
+        // then
+        assertEquals(MessageFrame.State.REVERT, result.getState(), AssertMessages.STATUS);
+        assertEquals(ordinalRevertOutputFor(NEGATIVE_ALLOWANCE_AMOUNT), result.getOutput(), AssertMessages.OUTPUT);
+    }
+
+    private void prepareErc721approve(
+            final AccountID spenderId, final long serial, final ResponseCodeEnum... statuses) {
         subject = new ERCGrantApprovalCall(
                 mockEnhancement(),
                 systemContractGasCalculator,
                 verificationStrategy,
                 OWNER_ID,
                 NON_FUNGIBLE_TOKEN_ID,
-                UNAUTHORIZED_SPENDER_ID,
-                100L,
+                spenderId,
+                serial,
                 TokenType.NON_FUNGIBLE_UNIQUE);
         given(systemContractOperations.dispatch(
                         any(TransactionBody.class),
@@ -118,140 +135,101 @@ class ERCGrantApprovalCallTest extends CallTestBase {
                         eq(OWNER_ID),
                         eq(ContractCallStreamBuilder.class)))
                 .willReturn(recordBuilder);
-        given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
-        given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID, 100L)).willReturn(nft);
-        given(nativeOperations.getToken(NON_FUNGIBLE_TOKEN_ID)).willReturn(token);
-        given(nativeOperations.readableAccountStore()).willReturn(accountStore);
-        given(accountStore.getAccountById(any(AccountID.class))).willReturn(account);
-        given(account.accountIdOrThrow())
-                .willReturn(AccountID.newBuilder().accountNum(1).build());
-        given(account.alias()).willReturn(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(new byte[] {1, 2, 3}));
-        final var result = subject.execute(frame).fullResult().result();
+        BDDMyOngoingStubbing<ResponseCodeEnum> given = given(recordBuilder.status());
+        for (final ResponseCodeEnum status : statuses) {
+            given = given.willReturn(status);
+        }
+        given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID, serial)).willReturn(nft);
+        if (Set.of(statuses).contains(SUCCESS)) {
+            given(nativeOperations.readableAccountStore()).willReturn(accountStore);
+            given(accountStore.getAccountById(any(AccountID.class))).willReturn(account);
+            given(account.accountIdOrThrow())
+                    .willReturn(AccountID.newBuilder().accountNum(1).build());
+            given(account.alias()).willReturn(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(new byte[] {1, 2, 3}));
+        }
+    }
 
-        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());
+    @Test
+    void prepareErc721approve() {
+        // given
+        prepareErc721approve(UNAUTHORIZED_SPENDER_ID, 100L, SUCCESS);
+        // when
+        final var result = subject.execute(frame).fullResult().result();
+        // then
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState(), AssertMessages.STATUS);
         assertEquals(
                 asBytesResult(GrantApprovalTranslator.ERC_GRANT_APPROVAL_NFT
                         .getOutputs()
                         .encode(Tuple.EMPTY)),
-                result.getOutput());
+                result.getOutput(),
+                AssertMessages.OUTPUT);
+    }
+
+    @Test
+    void prepareErc721approveNegativeSerial() {
+        // given
+        prepareErc721approve(UNAUTHORIZED_SPENDER_ID, -1, INVALID_TOKEN_NFT_SERIAL_NUMBER);
+        // when
+        final var result = subject.execute(frame).fullResult().result();
+        // then
+        assertEquals(State.REVERT, result.getState(), AssertMessages.STATUS);
+        assertEquals(
+                ordinalRevertOutputFor(INVALID_TOKEN_NFT_SERIAL_NUMBER), result.getOutput(), AssertMessages.OUTPUT);
     }
 
     @Test
     void erc721approveFailsWithInvalidSpenderAllowance() {
-        subject = new ERCGrantApprovalCall(
-                mockEnhancement(),
-                systemContractGasCalculator,
-                verificationStrategy,
-                OWNER_ID,
-                NON_FUNGIBLE_TOKEN_ID,
-                UNAUTHORIZED_SPENDER_ID,
-                100L,
-                TokenType.NON_FUNGIBLE_UNIQUE);
-        given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID, 100L)).willReturn(nft);
-        given(nativeOperations.getToken(NON_FUNGIBLE_TOKEN_ID)).willReturn(token);
-        given(systemContractOperations.dispatch(
-                        any(TransactionBody.class),
-                        eq(verificationStrategy),
-                        eq(OWNER_ID),
-                        eq(ContractCallStreamBuilder.class)))
-                .willReturn(recordBuilder);
-        given(recordBuilder.status()).willReturn(INVALID_ALLOWANCE_SPENDER_ID);
+        // given
+        prepareErc721approve(UNAUTHORIZED_SPENDER_ID, 100L, INVALID_ALLOWANCE_SPENDER_ID);
+        // when
         final var result = subject.execute(frame).fullResult().result();
-
-        assertEquals(State.REVERT, result.getState());
-        assertEquals(UInt256.valueOf(INVALID_ALLOWANCE_SPENDER_ID.protoOrdinal()), result.getOutput());
+        // then
+        assertEquals(State.REVERT, result.getState(), AssertMessages.STATUS);
+        assertEquals(ordinalRevertOutputFor(INVALID_ALLOWANCE_SPENDER_ID), result.getOutput(), AssertMessages.OUTPUT);
     }
 
     @Test
     void erc721approveFailsWithSenderDoesNotOwnNFTSerialNumber() {
-        subject = new ERCGrantApprovalCall(
-                mockEnhancement(),
-                systemContractGasCalculator,
-                verificationStrategy,
-                OWNER_ID,
-                NON_FUNGIBLE_TOKEN_ID,
+        // given
+        prepareErc721approve(
                 UNAUTHORIZED_SPENDER_ID,
                 100L,
-                TokenType.NON_FUNGIBLE_UNIQUE);
-        // make sure nft is found
-        given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID, 100L)).willReturn(nft);
-        given(nativeOperations.getToken(NON_FUNGIBLE_TOKEN_ID)).willReturn(token);
-        given(systemContractOperations.dispatch(
-                        any(TransactionBody.class),
-                        eq(verificationStrategy),
-                        eq(OWNER_ID),
-                        eq(ContractCallStreamBuilder.class)))
-                .willReturn(recordBuilder);
-        given(recordBuilder.status())
-                .willReturn(DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL)
-                .willReturn(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
-
+                DELEGATING_SPENDER_DOES_NOT_HAVE_APPROVE_FOR_ALL,
+                SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
+        // when
         final var result = subject.execute(frame).fullResult().result();
-
-        assertEquals(State.REVERT, result.getState());
-        assertEquals(UInt256.valueOf(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO.protoOrdinal()), result.getOutput());
+        // then
+        assertEquals(State.REVERT, result.getState(), AssertMessages.STATUS);
+        assertEquals(
+                ordinalRevertOutputFor(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO), result.getOutput(), AssertMessages.OUTPUT);
         verify(recordBuilder).status(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO);
     }
 
     @Test
     void erc721approveFailsWithInvalidTokenNFTSerialNumber() {
-        subject = new ERCGrantApprovalCall(
-                mockEnhancement(),
-                systemContractGasCalculator,
-                verificationStrategy,
-                OWNER_ID,
-                NON_FUNGIBLE_TOKEN_ID,
-                UNAUTHORIZED_SPENDER_ID,
-                100L,
-                TokenType.NON_FUNGIBLE_UNIQUE);
-        // make sure nft is found
-        given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID, 100L)).willReturn(null);
-        given(systemContractOperations.dispatch(
-                        any(TransactionBody.class),
-                        eq(verificationStrategy),
-                        eq(OWNER_ID),
-                        eq(ContractCallStreamBuilder.class)))
-                .willReturn(recordBuilder);
-        given(recordBuilder.status()).willReturn(INVALID_TOKEN_NFT_SERIAL_NUMBER);
-
+        // given
+        prepareErc721approve(UNAUTHORIZED_SPENDER_ID, 100L, INVALID_TOKEN_NFT_SERIAL_NUMBER);
+        // when
         final var result = subject.execute(frame).fullResult().result();
-
-        assertEquals(State.REVERT, result.getState());
-        assertEquals(UInt256.valueOf(INVALID_TOKEN_NFT_SERIAL_NUMBER.protoOrdinal()), result.getOutput());
+        // then
+        assertEquals(State.REVERT, result.getState(), AssertMessages.STATUS);
+        assertEquals(
+                ordinalRevertOutputFor(INVALID_TOKEN_NFT_SERIAL_NUMBER), result.getOutput(), AssertMessages.OUTPUT);
     }
 
     @Test
     void erc721revoke() {
-        subject = new ERCGrantApprovalCall(
-                mockEnhancement(),
-                systemContractGasCalculator,
-                verificationStrategy,
-                OWNER_ID,
-                NON_FUNGIBLE_TOKEN_ID,
-                REVOKE_APPROVAL_SPENDER_ID,
-                100L,
-                TokenType.NON_FUNGIBLE_UNIQUE);
-        given(systemContractOperations.dispatch(
-                        any(TransactionBody.class),
-                        eq(verificationStrategy),
-                        eq(OWNER_ID),
-                        eq(ContractCallStreamBuilder.class)))
-                .willReturn(recordBuilder);
-        given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
-        given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID, 100L)).willReturn(nft);
-        given(nativeOperations.getToken(NON_FUNGIBLE_TOKEN_ID)).willReturn(token);
-        given(nativeOperations.readableAccountStore()).willReturn(accountStore);
-        given(accountStore.getAccountById(any(AccountID.class))).willReturn(account);
-        given(account.accountIdOrThrow())
-                .willReturn(AccountID.newBuilder().accountNum(1).build());
-        given(account.alias()).willReturn(com.hedera.pbj.runtime.io.buffer.Bytes.wrap(new byte[] {1, 2, 3}));
+        // given
+        prepareErc721approve(REVOKE_APPROVAL_SPENDER_ID, 100L, SUCCESS);
+        // when
         final var result = subject.execute(frame).fullResult().result();
-
-        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState());
+        // then
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.getState(), AssertMessages.STATUS);
         assertEquals(
                 asBytesResult(GrantApprovalTranslator.ERC_GRANT_APPROVAL_NFT
                         .getOutputs()
                         .encode(Tuple.EMPTY)),
-                result.getOutput());
+                result.getOutput(),
+                AssertMessages.OUTPUT);
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/TokenKeyCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/TokenKeyCallTest.java
@@ -24,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TokenKeyCallTest extends CallTestBase {
+
     @Test
     void returnsEd25519KeyStatusForPresentToken() {
         final var key = Key.newBuilder().ed25519(AN_ED25519_KEY.ed25519()).build();

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/address_0x167/TokenKeyTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/address_0x167/TokenKeyTranslatorTest.java
@@ -26,11 +26,23 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 
 class TokenKeyTranslatorTest extends CallAttemptTestBase {
+
     @Mock
     private HtsCallAttempt attempt;
 
     @Mock
     private ContractMetrics contractMetrics;
+
+    private final Token token = Token.newBuilder()
+            .adminKey(keyBuilder("adminKey"))
+            .kycKey(keyBuilder("kycKey"))
+            .freezeKey(keyBuilder("freezeKey"))
+            .wipeKey(keyBuilder("wipeKey"))
+            .supplyKey(keyBuilder("supplyKey"))
+            .feeScheduleKey(keyBuilder("feeScheduleKey"))
+            .pauseKey(keyBuilder("pauseKey"))
+            .metadataKey(keyBuilder("metadataKey"))
+            .build();
 
     private TokenKeyTranslator subject;
 
@@ -66,39 +78,23 @@ class TokenKeyTranslatorTest extends CallAttemptTestBase {
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 4, 8, 16, 32, 64})
     void testTokenKey(final int keyType) {
-        final Token token = Token.newBuilder()
-                .adminKey(keyBuilder("adminKey"))
-                .kycKey(keyBuilder("kycKey"))
-                .freezeKey(keyBuilder("freezeKey"))
-                .wipeKey(keyBuilder("wipeKey"))
-                .supplyKey(keyBuilder("supplyKey"))
-                .feeScheduleKey(keyBuilder("feeScheduleKey"))
-                .pauseKey(keyBuilder("pauseKey"))
-                .metadataKey(keyBuilder("metadataKey"))
-                .build();
-
         final Key result = TokenKeyCommons.getTokenKey(token, keyType, HTS_167_CONTRACT_ID);
         assertThat(result).isNotNull();
     }
 
     @Test
     void testTokenKeyWithMetaKey() {
-        final Token token = Token.newBuilder()
-                .adminKey(keyBuilder("adminKey"))
-                .kycKey(keyBuilder("kycKey"))
-                .freezeKey(keyBuilder("freezeKey"))
-                .wipeKey(keyBuilder("wipeKey"))
-                .supplyKey(keyBuilder("supplyKey"))
-                .feeScheduleKey(keyBuilder("feeScheduleKey"))
-                .pauseKey(keyBuilder("pauseKey"))
-                .metadataKey(keyBuilder("metadataKey"))
-                .build();
-
         final Key result = TokenKeyCommons.getTokenKey(token, 128, HTS_167_CONTRACT_ID);
         assertThat(result).isNull();
     }
 
-    private Key keyBuilder(final String keyName) {
+    @Test
+    void testTokenKeyWithNegativeKey() {
+        final Key result = TokenKeyCommons.getTokenKey(token, -1, HTS_167_CONTRACT_ID);
+        assertThat(result).isNull();
+    }
+
+    private static Key keyBuilder(final String keyName) {
         return Key.newBuilder().ed25519(Bytes.wrap(keyName.getBytes())).build();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/address_0x16c/TokenKeyTranslatorTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenkey/address_0x16c/TokenKeyTranslatorTest.java
@@ -29,11 +29,23 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class TokenKeyTranslatorTest extends CallAttemptTestBase {
+
     @Mock
     private HtsCallAttempt attempt;
 
     @Mock
     private ContractMetrics contractMetrics;
+
+    private final Token token = Token.newBuilder()
+            .adminKey(keyBuilder("adminKey"))
+            .kycKey(keyBuilder("kycKey"))
+            .freezeKey(keyBuilder("freezeKey"))
+            .wipeKey(keyBuilder("wipeKey"))
+            .supplyKey(keyBuilder("supplyKey"))
+            .feeScheduleKey(keyBuilder("feeScheduleKey"))
+            .pauseKey(keyBuilder("pauseKey"))
+            .metadataKey(keyBuilder("metadataKey"))
+            .build();
 
     private TokenKeyTranslator subject;
 
@@ -69,22 +81,17 @@ class TokenKeyTranslatorTest extends CallAttemptTestBase {
     @ParameterizedTest
     @ValueSource(ints = {1, 2, 4, 8, 16, 32, 64, 128})
     void testTokenKey(final int keyType) {
-        final Token token = Token.newBuilder()
-                .adminKey(keyBuilder("adminKey"))
-                .kycKey(keyBuilder("kycKey"))
-                .freezeKey(keyBuilder("freezeKey"))
-                .wipeKey(keyBuilder("wipeKey"))
-                .supplyKey(keyBuilder("supplyKey"))
-                .feeScheduleKey(keyBuilder("feeScheduleKey"))
-                .pauseKey(keyBuilder("pauseKey"))
-                .metadataKey(keyBuilder("metadataKey"))
-                .build();
-
         final Key result = TokenKeyCommons.getTokenKey(token, keyType, HTS_16C_CONTRACT_ID);
         assertThat(result).isNotNull();
     }
 
-    private Key keyBuilder(final String keyName) {
+    @Test
+    void testTokenKeyWithNegativeKey() {
+        final Key result = TokenKeyCommons.getTokenKey(token, -1, HTS_16C_CONTRACT_ID);
+        assertThat(result).isNull();
+    }
+
+    private static Key keyBuilder(final String keyName) {
         return Key.newBuilder().ed25519(Bytes.wrap(keyName.getBytes())).build();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenuri/TokenUriCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/tokenuri/TokenUriCallTest.java
@@ -15,6 +15,8 @@ import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.commo
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class TokenUriCallTest extends CallTestBase {
     private TokenUriCall subject;
@@ -37,12 +39,12 @@ class TokenUriCallTest extends CallTestBase {
                 result.getOutput());
     }
 
-    @Test
-    void returnNonExistingTokenErrorMetadata() {
+    @ParameterizedTest
+    @ValueSource(longs = {-1L, NFT_SERIAL_NO})
+    public void returnErrorMetadata(final long serialNo) {
         // given
-        subject = new TokenUriCall(gasCalculator, mockEnhancement(), NON_FUNGIBLE_TOKEN, NFT_SERIAL_NO);
-        given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN.tokenId(), NFT_SERIAL_NO))
-                .willReturn(null);
+        subject = new TokenUriCall(gasCalculator, mockEnhancement(), NON_FUNGIBLE_TOKEN, serialNo);
+        given(nativeOperations.getNft(NON_FUNGIBLE_TOKEN_ID, serialNo)).willReturn(null);
         // when
         final var result = subject.execute(frame).fullResult().result();
         // then

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/NumericValidationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/NumericValidationTest.java
@@ -155,7 +155,7 @@ public class NumericValidationTest {
         }
 
         @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
-        @DisplayName("FT 0x167 approve(address,address,uint256)")
+        @DisplayName("FT 0x167 approve(address,address,uint)")
         public Stream<DynamicTest> failToApproveFungibleToken() {
             return Stream.of(
                             // java.lang.ArithmeticException: BigInteger out of long range
@@ -163,9 +163,9 @@ public class NumericValidationTest {
                             // See CryptoApproveAllowanceHandler.pureChecks
                             new UintTestCase(BigInteger.ZERO, SUCCESS))
                     .flatMap(testCase -> hapiTest(numericContract
-                            .call("approve", fungibleToken, numericContractComplex, testCase.amount)
+                            .call("approve", fungibleToken, numericContractComplex, testCase.amount())
                             .gas(1_000_000L)
-                            .andAssert(txn -> txn.hasKnownStatus(testCase.status))));
+                            .andAssert(txn -> txn.hasKnownStatus(testCase.status()))));
         }
 
         @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
@@ -178,9 +178,9 @@ public class NumericValidationTest {
                             new UintTestCase(BigInteger.ZERO, CONTRACT_REVERT_EXECUTED),
                             new UintTestCase(NFT_SERIAL_FOR_APPROVE, SUCCESS))
                     .flatMap(testCase -> hapiTest(numericContract
-                            .call("approveNFT", nftToken, numericContractComplex, testCase.amount)
+                            .call("approveNFT", nftToken, numericContractComplex, testCase.amount())
                             .gas(1_000_000L)
-                            .andAssert(txn -> txn.hasKnownStatus(testCase.status))));
+                            .andAssert(txn -> txn.hasKnownStatus(testCase.status()))));
         }
     }
 
@@ -373,12 +373,12 @@ public class NumericValidationTest {
                             new UintTestCase(BigInteger.ZERO, CONTRACT_REVERT_EXECUTED),
                             new UintTestCase(BigInteger.ONE, SUCCESS))
                     .flatMap(testCase -> hapiTest(numericContract
-                            .call("tokenURI", nftToken, testCase.amount)
-                            .andAssert(txn -> txn.hasKnownStatus(testCase.status))));
+                            .call("tokenURI", nftToken, testCase.amount())
+                            .andAssert(txn -> txn.hasKnownStatus(testCase.status()))));
         }
 
         @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
-        @DisplayName("NFT 0x167 getTokenKey(address,uint256)")
+        @DisplayName("NFT 0x167 getTokenKey(address,uint)")
         public Stream<DynamicTest> failToGetTokenKeyNft() {
             return Stream.of(
                             // KEY_NOT_PROVIDED
@@ -387,8 +387,8 @@ public class NumericValidationTest {
                             new UintTestCase(BigInteger.ZERO, CONTRACT_REVERT_EXECUTED),
                             new UintTestCase(BigInteger.ONE, SUCCESS))
                     .flatMap(testCase -> hapiTest(numericContract
-                            .call("getTokenKey", nftToken, testCase.amount)
-                            .andAssert(txn -> txn.hasKnownStatus(testCase.status))));
+                            .call("getTokenKey", nftToken, testCase.amount())
+                            .andAssert(txn -> txn.hasKnownStatus(testCase.status()))));
         }
 
         @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
@@ -401,8 +401,8 @@ public class NumericValidationTest {
                             new UintTestCase(BigInteger.ZERO, CONTRACT_REVERT_EXECUTED),
                             new UintTestCase(BigInteger.ONE, SUCCESS))
                     .flatMap(testCase -> hapiTest(numericContract
-                            .call("getTokenKey", fungibleToken, testCase.amount)
-                            .andAssert(txn -> txn.hasKnownStatus(testCase.status))));
+                            .call("getTokenKey", fungibleToken, testCase.amount())
+                            .andAssert(txn -> txn.hasKnownStatus(testCase.status()))));
         }
 
         @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
@@ -429,8 +429,8 @@ public class NumericValidationTest {
                             new UintTestCase(BigInteger.ZERO, CONTRACT_REVERT_EXECUTED),
                             new UintTestCase(BigInteger.ONE, SUCCESS))
                     .flatMap(testCase -> hapiTest(numericContract
-                            .call("getApproved", nftToken, testCase.amount)
-                            .andAssert(txn -> txn.hasKnownStatus(testCase.status))));
+                            .call("getApproved", nftToken, testCase.amount())
+                            .andAssert(txn -> txn.hasKnownStatus(testCase.status()))));
         }
 
         @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
@@ -443,8 +443,8 @@ public class NumericValidationTest {
                             new UintTestCase(BigInteger.ZERO, CONTRACT_REVERT_EXECUTED),
                             new UintTestCase(BigInteger.ONE, SUCCESS))
                     .flatMap(testCase -> hapiTest(numericContract
-                            .call("getApprovedERC", nftToken, testCase.amount)
-                            .andAssert(txn -> txn.hasKnownStatus(testCase.status))));
+                            .call("getApprovedERC", nftToken, testCase.amount())
+                            .andAssert(txn -> txn.hasKnownStatus(testCase.status()))));
         }
 
         @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
@@ -457,8 +457,8 @@ public class NumericValidationTest {
                             new UintTestCase(BigInteger.ZERO, CONTRACT_REVERT_EXECUTED),
                             new UintTestCase(BigInteger.ONE, SUCCESS))
                     .flatMap(testCase -> hapiTest(numericContract
-                            .call("ownerOf", nftToken, testCase.amount)
-                            .andAssert(txn -> txn.hasKnownStatus(testCase.status))));
+                            .call("ownerOf", nftToken, testCase.amount())
+                            .andAssert(txn -> txn.hasKnownStatus(testCase.status()))));
         }
     }
 


### PR DESCRIPTION
**Description**:
❗ This PR is created and managed by @gkozyryatskyy. It was previously approved by the smart-contracts-codeowners team.

Add `Unit tests` with negative values send to HSCS and check the fail results.

**Related issue(s)**:

Fixes [#19741](https://github.com/hiero-ledger/hiero-consensus-node/issues/19741)

**Notes for reviewer**:
- change `getTokenKey(address,uint)` -> `getTokenKey(address,uint256)` is equivalent but keep the same signature styles

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
