### PR TITLE
fix: 20198: Introduce virtual hash chunks

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualHashChunk.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualHashChunk.java
@@ -1,0 +1,335 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.virtualmap.datasource;
+
+import com.hedera.pbj.runtime.FieldDefinition;
+import com.hedera.pbj.runtime.FieldType;
+import com.hedera.pbj.runtime.ProtoConstants;
+import com.hedera.pbj.runtime.ProtoParserTools;
+import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.swirlds.virtualmap.internal.Path;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.util.Objects;
+import org.hiero.base.crypto.Cryptography;
+import org.hiero.base.crypto.Hash;
+
+/**
+ * A hash chunk is a set of hashs in a virtual sub-tree. Every chunk has 2 hashes at the top level,
+ * 4 hashes at the second level, and so on.
+ *
+ * <p>The number of ranks in a chunk is called chunk height. Minimal chunk height is 1, such chunks
+ * contain just two hashes.
+ *
+ * <p>A chunk is identified by the chunk path, which is a parent of its two top-most hashes. For
+ * example, the root chunk is identified with path 0 (0 is a parent of 1 and 2). If chunk height is 2,
+ * the root chunk at path 0 contains hashes 1, 2, 3, 4, 5, and 6. Such chunk has 4 child chunks
+ * identified by paths 3, 4, 5, and 6. For example, chunk 4 has hashes 9, 10, 19, 20, 21, and 22.
+ *
+ * <p>To store chunks, it doesn’t make sense to index them using chunk paths as it would result in
+ * index size equal to virtual map size with lots of gaps. Instead, every chunk has an ID, the root
+ * chunk has ID=0, the first root child chunk has ID=1, and so on. Chunk paths, IDs, and heights are
+ * dependent. For example, when height is 2, chunk with ID=1 has path=3. When height is 3, chunk with
+ * ID=1 has path=7.
+ *
+ * <p>The number of hashes in a chunk is 2^(height+1)-2. Chunks of height 2 contain 6 hashes, chunks
+ * of height 3 contain 14 hashes, and so on. Let’s call it full chunk size. Since chunk index is based
+ * on chunk IDs, index size is “chunk size” smaller than the size of the virtual map. Chunks closer to
+ * the leaf rank may be incomplete, i.e. contain fewer hashes than the full size. The number of hashes
+ * in {@link #hashData} is always the full chunk size.
+ *
+ * @param path Chunk path
+ * @param height Chunk height
+ * @param hashData Chunk hashes
+ */
+public record VirtualHashChunk(long path, int height, @NonNull byte[] hashData) {
+
+    public static final FieldDefinition FIELD_HASHCHUNK_PATH =
+            new FieldDefinition("path", FieldType.FIXED64, false, true, false, 1);
+    public static final FieldDefinition FIELD_HASHCHUNK_HEIGHT =
+            new FieldDefinition("height", FieldType.FIXED32, false, true, false, 2);
+    public static final FieldDefinition FIELD_HASHCHUNK_HASHDATA =
+            new FieldDefinition("hashData", FieldType.BYTES, false, false, false, 4);
+
+    public VirtualHashChunk {
+        if (height <= 0) {
+            throw new IllegalArgumentException("Wrong chunk height: " + height);
+        }
+        final int rank = Path.getRank(path);
+        if (rank % height != 0) {
+            throw new IllegalArgumentException("Wrong chunk path/height: " + path + "/" + height);
+        }
+        if (hashData == null) {
+            throw new IllegalArgumentException("Null hash data");
+        }
+        final int dataLength = hashData.length;
+        final int expectedHashCount = getChunkSize(height);
+        if (dataLength != Cryptography.DEFAULT_DIGEST_TYPE.digestLength() * expectedHashCount) {
+            throw new IllegalArgumentException("Wrong hash data length: " + dataLength);
+        }
+    }
+
+    public static VirtualHashChunk parseFrom(final ReadableSequentialData in) throws IOException {
+        if (in == null) {
+            return null;
+        }
+
+        long path = 0;
+        int height = 0;
+        byte[] hashData = null;
+
+        while (in.hasRemaining()) {
+            final int field = in.readVarInt(false);
+            final int tag = field >> ProtoParserTools.TAG_FIELD_OFFSET;
+            if (tag == FIELD_HASHCHUNK_PATH.number()) {
+                if ((field & ProtoConstants.TAG_WIRE_TYPE_MASK) != ProtoConstants.WIRE_TYPE_FIXED_64_BIT.ordinal()) {
+                    throw new IllegalArgumentException("Wrong field type: " + field);
+                }
+                path = in.readLong();
+            } else if (tag == FIELD_HASHCHUNK_HEIGHT.number()) {
+                if ((field & ProtoConstants.TAG_WIRE_TYPE_MASK) != ProtoConstants.WIRE_TYPE_FIXED_32_BIT.ordinal()) {
+                    throw new IllegalArgumentException("Wrong field type: " + field);
+                }
+                height = in.readInt();
+            } else if (tag == FIELD_HASHCHUNK_HASHDATA.number()) {
+                if ((field & ProtoConstants.TAG_WIRE_TYPE_MASK) != ProtoConstants.WIRE_TYPE_DELIMITED.ordinal()) {
+                    throw new IllegalArgumentException("Wrong field type: " + field);
+                }
+                final int len = in.readVarInt(false);
+                hashData = new byte[len];
+                if (in.readBytes(hashData) != len) {
+                    throw new IOException("Failed to read " + len + " bytes");
+                }
+            } else {
+                throw new IllegalArgumentException("Unknown field: " + field);
+            }
+        }
+
+        Objects.requireNonNull(hashData, "Missing hash data in the input");
+
+        return new VirtualHashChunk(path, height, hashData);
+    }
+
+    public int getSizeInBytes() {
+        int size = 0;
+        if (path != 0) {
+            size += ProtoWriterTools.sizeOfTag(FIELD_HASHCHUNK_PATH);
+            // Path is FIXED64
+            size += Long.BYTES;
+        }
+        // height is always > 0
+        size += ProtoWriterTools.sizeOfTag(FIELD_HASHCHUNK_HEIGHT);
+        // Height is FIXED32
+        size += Integer.BYTES;
+        // Hash data is never null
+        size += ProtoWriterTools.sizeOfDelimited(FIELD_HASHCHUNK_HASHDATA, hashData.length);
+        return size;
+    }
+
+    public void writeTo(final WritableSequentialData out) throws IOException {
+        final long pos = out.position();
+        if (path != 0) {
+            ProtoWriterTools.writeTag(out, FIELD_HASHCHUNK_PATH);
+            out.writeLong(path);
+        }
+        // height is always > 0
+        ProtoWriterTools.writeTag(out, FIELD_HASHCHUNK_HEIGHT);
+        out.writeInt(height);
+        // Hash data is never null
+        ProtoWriterTools.writeDelimited(out, FIELD_HASHCHUNK_HASHDATA, hashData.length, o -> o.writeBytes(hashData));
+        assert out.position() == pos + getSizeInBytes();
+    }
+
+    /**
+     * Returns chunk ID. The root chunk has ID == 0, the first root child chunk has ID == 1,
+     * and so on.
+     *
+     * @return
+     *      The chunk ID
+     */
+    public long pathToChunkId() {
+        return pathToChunkId(path, height);
+    }
+
+    /**
+     * Returns an ID, starting from 0, of a chunk of the given height, containing
+     * the given virtual path.
+     *
+     * @param path
+     *      Path to check
+     * @param chunkHeight
+     *      Chunk height
+     * @return
+     *      The chunk ID, starting from 0
+     */
+    public static long pathToChunkId(final long path, final int chunkHeight) {
+        assert path > 0;
+        assert chunkHeight > 0;
+        long pp = path + 1;
+        int z = Long.numberOfLeadingZeros(pp);
+        int r = (Long.SIZE - z - 2) % chunkHeight + 1;
+        long m = Long.MIN_VALUE >>> (z + r);
+        return ((pp >>> r) ^ m) + (m - 1) / ((1L << chunkHeight) - 1);
+    }
+
+    /**
+     * Returns a path of chunk with the given ID and height.
+     *
+     * @param chunkId
+     *      Chunk ID, starting from 0
+     * @param chunkHeight
+     *      Chunk height
+     * @return
+     *      The chunk path
+     */
+    public static long chunkIdToChunkPath(final long chunkId, final int chunkHeight) {
+        assert chunkHeight > 0;
+        if (chunkId == 0) {
+            return 0;
+        }
+        final int childCount = 1 << chunkHeight;
+        int chunkRank = 0;
+        int chunksAtRank = 1;
+        int id = 0;
+        while (id < chunkId) {
+            chunksAtRank *= childCount;
+            id += chunksAtRank;
+            chunkRank += chunkHeight;
+        }
+        return Path.getLeftGrandChildPath(0, chunkRank) + chunkId - id + chunksAtRank - 1;
+    }
+
+    /**
+     * Returns a number of hashes stored in the chunk.
+     *
+     * @return
+     *      The number of hashes in the chunk
+     */
+    public int getChunkSize() {
+        return getChunkSize(height);
+    }
+
+    /**
+     * Returns a number of hashes stored in a chunk of the given depth.
+     *
+     * @param chunkHeight
+     *      Chunk height
+     * @return
+     *      The number of hashes in a chunk
+     */
+    public static int getChunkSize(final int chunkHeight) {
+        assert chunkHeight > 0;
+        return (1 << (chunkHeight + 1)) - 2;
+    }
+
+    /**
+     * Returns an index, starting from 0, of the given path in this chunk. Paths are global,
+     * not relative to the chunk. Max index is {@link #getChunkSize()} - 1. If the path is not
+     * in the chunk, an {@link IllegalArgumentException} is thrown.
+     *
+     * @param path
+     *      Path to check
+     * @return
+     *      Path index in the chunk, starting from 0
+     */
+    public int getPathIndexInChunk(final long path) {
+        return getPathIndexInChunk(path, this.path, height);
+    }
+
+    /**
+     * Returns an index, starting from 0, of the given path in a chunk that starts from the specified
+     * first path. Paths are global, not relative to the chunk. Max index is {@link #getChunkSize()} - 1.
+     * If the path is not in the chunk, an {@link IllegalArgumentException} is thrown.
+     *
+     * @param path
+     *      Path to check
+     * @param chunkPath
+     *      Chunk path
+     * @param chunkHeight
+     *      Chunk height
+     * @return
+     *      Path index in the chunk, starting from 0
+     */
+    public static int getPathIndexInChunk(final long path, final long chunkPath, final int chunkHeight) {
+        final long firstChunkPath = Path.getLeftChildPath(chunkPath);
+        if (path < firstChunkPath) {
+            throw new IllegalArgumentException("Path is not in chunk: " + path);
+        }
+        final int chunkSize = getChunkSize(chunkHeight);
+        int index = 0;
+        long firstInLevel = firstChunkPath;
+        int pathsInLevel = 2; // first level in chunks of any depth is always 2
+        while (firstInLevel + pathsInLevel <= path) { // traverse to the right level
+            index += pathsInLevel;
+            if (index >= chunkSize) {
+                throw new IllegalArgumentException("Path is not in chunk: " + path);
+            }
+            firstInLevel = Path.getLeftChildPath(firstInLevel);
+            pathsInLevel = pathsInLevel * 2;
+            if (path < firstInLevel) {
+                throw new IllegalArgumentException("Path is not in chunk: " + path);
+            }
+        }
+        index += Math.toIntExact(path - firstInLevel); // now get the index in the level
+        return index;
+    }
+
+    public long getPath(final int pathIndex) {
+        return getPathInChunk(path, pathIndex, height);
+    }
+
+    public static long getPathInChunk(final long chunkPath, int pathIndex, final int chunkHeight) {
+        if ((pathIndex < 0) || (pathIndex >= getChunkSize(chunkHeight))) {
+            throw new IllegalArgumentException("Wrong path index");
+        }
+        long firstPathInLevel = Path.getLeftChildPath(chunkPath);
+        int pathsInLevel = 2; // first level always has 2 paths
+        while (pathsInLevel <= pathIndex) {
+            pathIndex -= pathsInLevel;
+            firstPathInLevel = firstPathInLevel * 2 + 1;
+            pathsInLevel *= 2;
+        }
+        return firstPathInLevel + pathIndex;
+    }
+
+    private void setHashImpl(final int index, final Hash hash) {
+        final int pos = index * Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+        final int len = Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+        // Is synchronization needed here?
+        hash.getBytes().getBytes(0, hashData, pos, len);
+    }
+
+    private Hash getHashImpl(final int index) {
+        final int pos = index * Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+        final int len = Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+        final byte[] hashBytes = new byte[len];
+        // Is synchronization needed here?
+        System.arraycopy(hashData, pos, hashBytes, 0, len);
+        return new Hash(hashBytes, Cryptography.DEFAULT_DIGEST_TYPE);
+    }
+
+    public void setHashAtPath(final long path, final Hash hash) {
+        final int index = getPathIndexInChunk(path, this.path, height);
+        setHashImpl(index, hash);
+    }
+
+    public Hash getHashAtPath(final long path) {
+        final int index = getPathIndexInChunk(path, this.path, height);
+        return getHashImpl(index);
+    }
+
+    public void setHashAtIndex(final int index, final Hash hash) {
+        if ((index < 0) || (index >= getChunkSize(height))) {
+            throw new IllegalArgumentException("Wrong hash index: " + index);
+        }
+        setHashImpl(index, hash);
+    }
+
+    public Hash getHashAtIndex(final int index) {
+        if ((index < 0) || (index >= getChunkSize(height))) {
+            throw new IllegalArgumentException("Wrong hash index: " + index);
+        }
+        return getHashImpl(index);
+    }
+}

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualHashChunkTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualHashChunkTest.java
@@ -1,0 +1,300 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.virtualmap.datasource;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.swirlds.virtualmap.internal.Path;
+import java.util.Random;
+import org.hiero.base.crypto.Cryptography;
+import org.hiero.base.crypto.Hash;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class VirtualHashChunkTest {
+
+    private static final int HASH_LENGTH = Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+
+    @Test
+    void createTest() {
+        assertThrows(IllegalArgumentException.class, () -> new VirtualHashChunk(0, 0, new byte[HASH_LENGTH]));
+        assertDoesNotThrow(() -> new VirtualHashChunk(0, 1, new byte[HASH_LENGTH * 2]));
+        assertDoesNotThrow(() -> new VirtualHashChunk(1, 1, new byte[HASH_LENGTH * 2]));
+        assertDoesNotThrow(() -> new VirtualHashChunk(5, 1, new byte[HASH_LENGTH * 2]));
+        for (int h = 2; h < 6; h++) {
+            final int height = h;
+            final int chunkSize = VirtualHashChunk.getChunkSize(height);
+            final byte[] hashData = new byte[HASH_LENGTH * chunkSize];
+            assertDoesNotThrow(() -> new VirtualHashChunk(0, height, hashData));
+            assertThrows(IllegalArgumentException.class, () -> new VirtualHashChunk(1, height, hashData));
+            assertDoesNotThrow(() -> new VirtualHashChunk(Path.getLeftGrandChildPath(0, height), height, hashData));
+            assertThrows(
+                    IllegalArgumentException.class,
+                    () -> new VirtualHashChunk(Path.getLeftGrandChildPath(0, height + 1), height, hashData));
+        }
+    }
+
+    @Test
+    void pathToChunkIdTest() {
+        // Chunk height 1
+        assertEquals(0, VirtualHashChunk.pathToChunkId(1, 1));
+        assertEquals(0, VirtualHashChunk.pathToChunkId(2, 1));
+        assertEquals(1, VirtualHashChunk.pathToChunkId(3, 1));
+        assertEquals(1, VirtualHashChunk.pathToChunkId(4, 1));
+        assertEquals(2, VirtualHashChunk.pathToChunkId(5, 1));
+        assertEquals(2, VirtualHashChunk.pathToChunkId(6, 1));
+        // Chunk height 2
+        assertEquals(0, VirtualHashChunk.pathToChunkId(1, 2));
+        assertEquals(0, VirtualHashChunk.pathToChunkId(2, 2));
+        assertEquals(0, VirtualHashChunk.pathToChunkId(3, 2));
+        assertEquals(0, VirtualHashChunk.pathToChunkId(6, 2));
+        assertEquals(1, VirtualHashChunk.pathToChunkId(7, 2));
+        assertEquals(1, VirtualHashChunk.pathToChunkId(8, 2));
+        assertEquals(1, VirtualHashChunk.pathToChunkId(15, 2));
+        assertEquals(1, VirtualHashChunk.pathToChunkId(16, 2));
+        assertEquals(3, VirtualHashChunk.pathToChunkId(11, 2));
+        assertEquals(3, VirtualHashChunk.pathToChunkId(12, 2));
+        assertEquals(3, VirtualHashChunk.pathToChunkId(23, 2));
+        assertEquals(3, VirtualHashChunk.pathToChunkId(26, 2));
+    }
+
+    @Test
+    void chunkIdToChunkPathTest() {
+        // Chunk height 1
+        assertEquals(0, VirtualHashChunk.chunkIdToChunkPath(0, 1));
+        assertEquals(1, VirtualHashChunk.chunkIdToChunkPath(1, 1));
+        assertEquals(2, VirtualHashChunk.chunkIdToChunkPath(2, 1));
+        assertEquals(5, VirtualHashChunk.chunkIdToChunkPath(5, 1));
+        // Chunk height 2
+        assertEquals(0, VirtualHashChunk.chunkIdToChunkPath(0, 2));
+        assertEquals(3, VirtualHashChunk.chunkIdToChunkPath(1, 2));
+        assertEquals(4, VirtualHashChunk.chunkIdToChunkPath(2, 2));
+        assertEquals(5, VirtualHashChunk.chunkIdToChunkPath(3, 2));
+        assertEquals(6, VirtualHashChunk.chunkIdToChunkPath(4, 2));
+        assertEquals(15, VirtualHashChunk.chunkIdToChunkPath(5, 2));
+        assertEquals(19, VirtualHashChunk.chunkIdToChunkPath(9, 2));
+        // Chunk height 3
+        assertEquals(0, VirtualHashChunk.chunkIdToChunkPath(0, 3));
+        assertEquals(7, VirtualHashChunk.chunkIdToChunkPath(1, 3));
+        assertEquals(63, VirtualHashChunk.chunkIdToChunkPath(9, 3));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4, 5})
+    void chunkIdToChunkPathTest2(final int chunkHeight) {
+        for (int path = 1; path < 10000; path++) {
+            final long chunkId = VirtualHashChunk.pathToChunkId(path, chunkHeight);
+            final long chunkPath = VirtualHashChunk.chunkIdToChunkPath(chunkId, chunkHeight);
+            final int pathIndex = VirtualHashChunk.getPathIndexInChunk(path, chunkPath, chunkHeight);
+            assertEquals(path, VirtualHashChunk.getPathInChunk(chunkPath, pathIndex, chunkHeight));
+        }
+    }
+
+    @Test
+    void createDataLengthTest() {
+        final int hashLen = Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+        assertThrows(IllegalArgumentException.class, () -> new VirtualHashChunk(0, 1, null));
+        for (int h = 2; h < 6; h++) {
+            final int height = h;
+            assertThrows(IllegalArgumentException.class, () -> new VirtualHashChunk(0, height, null));
+            final int chunkSize = VirtualHashChunk.getChunkSize(height);
+            final byte[] hashData = new byte[hashLen * chunkSize];
+            final byte[] hashDataMinusOne = new byte[hashLen * chunkSize - 1];
+            final byte[] hashDataPlusOne = new byte[hashLen * chunkSize + 1];
+            assertDoesNotThrow(() -> new VirtualHashChunk(0, height, hashData));
+            assertThrows(IllegalArgumentException.class, () -> new VirtualHashChunk(0, height, hashDataMinusOne));
+            assertThrows(IllegalArgumentException.class, () -> new VirtualHashChunk(0, height, hashDataPlusOne));
+        }
+    }
+
+    @Test
+    void getChunkSizeTest() {
+        assertEquals(2, VirtualHashChunk.getChunkSize(1));
+        assertEquals(6, VirtualHashChunk.getChunkSize(2));
+        assertEquals(14, VirtualHashChunk.getChunkSize(3));
+        assertEquals(30, VirtualHashChunk.getChunkSize(4));
+    }
+
+    @Test
+    void getPathIndexInChunkTest1() {
+        // Chunk at path 0
+        assertEquals(0, VirtualHashChunk.getPathIndexInChunk(1, 0, 1));
+        assertEquals(1, VirtualHashChunk.getPathIndexInChunk(2, 0, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(3, 0, 1));
+        // Chunk at path 1
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(0, 1, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(1, 1, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(2, 1, 1));
+        assertEquals(0, VirtualHashChunk.getPathIndexInChunk(3, 1, 1));
+        assertEquals(1, VirtualHashChunk.getPathIndexInChunk(4, 1, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(5, 1, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(7, 1, 1));
+        // Chunk at path 6
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(0, 6, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(2, 6, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(3, 6, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(12, 6, 1));
+        assertEquals(0, VirtualHashChunk.getPathIndexInChunk(13, 6, 1));
+        assertEquals(1, VirtualHashChunk.getPathIndexInChunk(14, 6, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(15, 6, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(27, 6, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(30, 6, 1));
+    }
+
+    @Test
+    void getPathIndexInChunkTest2() {
+        // Chunk at path 0
+        assertEquals(0, VirtualHashChunk.getPathIndexInChunk(1, 0, 2));
+        assertEquals(1, VirtualHashChunk.getPathIndexInChunk(2, 0, 2));
+        assertEquals(2, VirtualHashChunk.getPathIndexInChunk(3, 0, 2));
+        assertEquals(5, VirtualHashChunk.getPathIndexInChunk(6, 0, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(7, 0, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(28, 0, 2));
+        // Chunk at path 3
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(0, 3, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(3, 3, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(4, 3, 2));
+        assertEquals(0, VirtualHashChunk.getPathIndexInChunk(7, 3, 2));
+        assertEquals(1, VirtualHashChunk.getPathIndexInChunk(8, 3, 2));
+        assertEquals(2, VirtualHashChunk.getPathIndexInChunk(15, 3, 2));
+        assertEquals(5, VirtualHashChunk.getPathIndexInChunk(18, 3, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(9, 3, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(31, 3, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(36, 3, 2));
+        // Chunk at path 14
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(0, 14, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(6, 14, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(13, 14, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(14, 14, 2));
+        assertEquals(0, VirtualHashChunk.getPathIndexInChunk(29, 14, 2));
+        assertEquals(1, VirtualHashChunk.getPathIndexInChunk(30, 14, 2));
+        assertEquals(3, VirtualHashChunk.getPathIndexInChunk(60, 14, 2));
+        assertEquals(4, VirtualHashChunk.getPathIndexInChunk(61, 14, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(58, 14, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(63, 14, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(125, 14, 2));
+    }
+
+    @Test
+    void getPathIndexInChunkTest3() {
+        // Chunk at path 1
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(0, 1, 3));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(1, 1, 3));
+        assertEquals(0, VirtualHashChunk.getPathIndexInChunk(3, 1, 3));
+        assertEquals(1, VirtualHashChunk.getPathIndexInChunk(4, 1, 3));
+        assertEquals(2, VirtualHashChunk.getPathIndexInChunk(7, 1, 3));
+        assertEquals(5, VirtualHashChunk.getPathIndexInChunk(10, 1, 3));
+        assertEquals(6, VirtualHashChunk.getPathIndexInChunk(15, 1, 3));
+        assertEquals(13, VirtualHashChunk.getPathIndexInChunk(22, 1, 3));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(2, 1, 3));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(5, 1, 3));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(11, 1, 3));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathIndexInChunk(31, 1, 3));
+    }
+
+    @Test
+    void getPathTest1() {
+        // Chunk at path 0
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(0, -1, 1));
+        assertEquals(1, VirtualHashChunk.getPathInChunk(0, 0, 1));
+        assertEquals(2, VirtualHashChunk.getPathInChunk(0, 1, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(0, 2, 1));
+        // Chunk at path 3
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(3, -1, 1));
+        assertEquals(7, VirtualHashChunk.getPathInChunk(3, 0, 1));
+        assertEquals(8, VirtualHashChunk.getPathInChunk(3, 1, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(3, 2, 1));
+        // Chunk at path 14
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(14, -1, 1));
+        assertEquals(29, VirtualHashChunk.getPathInChunk(14, 0, 1));
+        assertEquals(30, VirtualHashChunk.getPathInChunk(14, 1, 1));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(14, 2, 1));
+    }
+
+    @Test
+    void getPathTest2() {
+        // Chunk at path 0
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(0, -1, 2));
+        assertEquals(1, VirtualHashChunk.getPathInChunk(0, 0, 2));
+        assertEquals(2, VirtualHashChunk.getPathInChunk(0, 1, 2));
+        assertEquals(3, VirtualHashChunk.getPathInChunk(0, 2, 2));
+        assertEquals(6, VirtualHashChunk.getPathInChunk(0, 5, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(0, 6, 2));
+        // Chunk at path 4
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(4, -1, 2));
+        assertEquals(9, VirtualHashChunk.getPathInChunk(4, 0, 2));
+        assertEquals(10, VirtualHashChunk.getPathInChunk(4, 1, 2));
+        assertEquals(19, VirtualHashChunk.getPathInChunk(4, 2, 2));
+        assertEquals(22, VirtualHashChunk.getPathInChunk(4, 5, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(4, 7, 2));
+        // Chunk at path 16
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(16, -1, 2));
+        assertEquals(33, VirtualHashChunk.getPathInChunk(16, 0, 2));
+        assertEquals(34, VirtualHashChunk.getPathInChunk(16, 1, 2));
+        assertEquals(68, VirtualHashChunk.getPathInChunk(16, 3, 2));
+        assertEquals(69, VirtualHashChunk.getPathInChunk(16, 4, 2));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(16, 8, 2));
+    }
+
+    @Test
+    void getPathTest3() {
+        // Chunk at path 2
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(2, -1, 3));
+        assertEquals(5, VirtualHashChunk.getPathInChunk(2, 0, 3));
+        assertEquals(6, VirtualHashChunk.getPathInChunk(2, 1, 3));
+        assertEquals(11, VirtualHashChunk.getPathInChunk(2, 2, 3));
+        assertEquals(13, VirtualHashChunk.getPathInChunk(2, 4, 3));
+        assertEquals(28, VirtualHashChunk.getPathInChunk(2, 11, 3));
+        assertEquals(29, VirtualHashChunk.getPathInChunk(2, 12, 3));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(2, 14, 3));
+        assertThrows(IllegalArgumentException.class, () -> VirtualHashChunk.getPathInChunk(2, 15, 3));
+    }
+
+    private static Hash genRandomHash() {
+        final Random random = new Random();
+        final byte[] hashData = new byte[HASH_LENGTH];
+        random.nextBytes(hashData);
+        return new Hash(hashData);
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4})
+    void setHashByPathTest(final int height) {
+        final Random random = new Random();
+        final int chunkSize = VirtualHashChunk.getChunkSize(height);
+        final long chunkPath = Path.getLeftGrandChildPath(0, random.nextInt(8) * height);
+        final VirtualHashChunk chunk = new VirtualHashChunk(chunkPath, height, new byte[chunkSize * HASH_LENGTH]);
+        for (int i = 0; i < chunkSize; i++) {
+            final Hash hash = genRandomHash();
+            assertNotEquals(hash, chunk.getHashAtIndex(i));
+            final long path = chunk.getPath(i);
+            assertNotEquals(hash, chunk.getHashAtPath(path));
+            chunk.setHashAtPath(path, hash);
+            assertEquals(hash, chunk.getHashAtIndex(i));
+            assertEquals(hash, chunk.getHashAtPath(path));
+        }
+        assertThrows(IllegalArgumentException.class, () -> chunk.setHashAtPath(chunk.getPath(chunkSize), new Hash()));
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = {1, 2, 3, 4})
+    void setHashByIndexTest(final int height) {
+        final Random random = new Random();
+        final int chunkSize = VirtualHashChunk.getChunkSize(height);
+        final long chunkPath = Path.getLeftGrandChildPath(0, random.nextInt(8) * height);
+        final VirtualHashChunk chunk = new VirtualHashChunk(chunkPath, height, new byte[chunkSize * HASH_LENGTH]);
+        for (int i = 0; i < chunkSize; i++) {
+            final Hash hash = genRandomHash();
+            assertNotEquals(hash, chunk.getHashAtIndex(i));
+            final long path = chunk.getPath(i);
+            assertNotEquals(hash, chunk.getHashAtPath(path));
+            chunk.setHashAtIndex(i, hash);
+            assertEquals(hash, chunk.getHashAtIndex(i));
+            assertEquals(hash, chunk.getHashAtPath(path));
+        }
+        assertThrows(IllegalArgumentException.class, () -> chunk.setHashAtIndex(chunkSize, new Hash()));
+    }
+}


### PR DESCRIPTION
Fix summary: a new class for hash chunks + unit test. I'm sure the class will be changed in the future, this is just a starting point.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/20198
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
