### PR TITLE
chore: Improve test task

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/CheckingRecoveryTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/CheckingRecoveryTest.java
@@ -12,12 +12,12 @@ import static org.hiero.otter.fixtures.assertions.StatusProgressionStep.target;
 
 import com.swirlds.common.test.fixtures.WeightGenerators;
 import java.time.Duration;
+import org.hiero.otter.fixtures.Capability;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.OtterTest;
 import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
-import org.junit.jupiter.api.Disabled;
 
 /**
  * Tests to verify that a node can recover from {@link org.hiero.consensus.model.status.PlatformStatus#CHECKING} status
@@ -32,9 +32,7 @@ public class CheckingRecoveryTest {
      * @param env the test environment for this test
      * @throws InterruptedException if an operation times out
      */
-    @Disabled(
-            "This test works, but is disabled until we can indicate which environments support the required capabilities.")
-    @OtterTest
+    @OtterTest(requires = Capability.BACK_PRESSURE)
     void testCheckingRecovery(final TestEnvironment env) throws InterruptedException {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/ReconnectTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/ReconnectTest.java
@@ -16,6 +16,7 @@ import static org.hiero.otter.fixtures.assertions.StatusProgressionStep.target;
 import com.swirlds.common.test.fixtures.WeightGenerators;
 import com.swirlds.platform.consensus.ConsensusConfig_;
 import java.time.Duration;
+import org.hiero.otter.fixtures.Capability;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.OtterTest;
@@ -33,7 +34,7 @@ public class ReconnectTest {
     private static final long ROUNDS_EXPIRED = 10L;
 
     @Disabled("Disabled until the container networks are fully supported")
-    @OtterTest
+    @OtterTest(requires = Capability.RECONNECT)
     void testSimpleNodeDeathReconnect(final TestEnvironment env) throws InterruptedException {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Capability.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Capability.java
@@ -9,5 +9,10 @@ public enum Capability {
     /**
      * The test requires the ability to reconnect a node to the network.
      */
-    RECONNECT
+    RECONNECT,
+
+    /**
+     * The test requires the ability to build up back pressure in the wiring model.
+     */
+    BACK_PRESSURE,
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerTestEnvironment.java
@@ -15,7 +15,7 @@ import org.hiero.otter.fixtures.internal.RegularTimeManager;
  */
 public class ContainerTestEnvironment implements TestEnvironment {
 
-    public static final Set<Capability> CAPABILITIES = Set.of(Capability.RECONNECT);
+    public static final Set<Capability> CAPABILITIES = Set.of(Capability.RECONNECT, Capability.BACK_PRESSURE);
 
     private final ContainerNetwork network;
     private final RegularTimeManager timeManager = new RegularTimeManager();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -196,6 +196,8 @@ public class TurtleNetwork extends AbstractNetwork implements TurtleTimeManager.
         for (final TurtleNode node : nodes) {
             node.destroy();
         }
-        executorService.shutdownNow();
+        if (executorService != null) {
+            executorService.shutdownNow();
+        }
     }
 }


### PR DESCRIPTION
**Description**:

This PR changes the behavior of the Gradle test task for the Otter test. Instead of always using Turtle, we pick it only if it supports all required capabilities. Otherwise, we choose the container environment.

**Related issue(s)**:

Fixes #20227 