### PR TITLE
chore: Genesis BN Comm Test Case and fix log statement

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
@@ -670,15 +670,6 @@ public class BlockBufferService {
      * @param latestPruneResult the latest pruning result
      */
     private void enableBackPressure(final PruneResult latestPruneResult) {
-        logger.warn(
-                "Block buffer is saturated; backpressure is being enabled "
-                        + "(idealMaxBufferSize={}, blocksChecked={}, blocksPruned={}, blocksPendingAck={}, saturation={}%)",
-                latestPruneResult.idealMaxBufferSize,
-                latestPruneResult.numBlocksChecked,
-                latestPruneResult.numBlocksPruned,
-                latestPruneResult.numBlocksPendingAck,
-                latestPruneResult.saturationPercent);
-
         CompletableFuture<Boolean> oldCf;
         CompletableFuture<Boolean> newCf;
 
@@ -688,6 +679,14 @@ public class BlockBufferService {
             if (oldCf == null || oldCf.isDone()) {
                 // If the existing future is null or is completed, we need to create a new one
                 newCf = new CompletableFuture<>();
+                logger.warn(
+                        "Block buffer is saturated; backpressure is being enabled "
+                                + "(idealMaxBufferSize={}, blocksChecked={}, blocksPruned={}, blocksPendingAck={}, saturation={}%)",
+                        latestPruneResult.idealMaxBufferSize,
+                        latestPruneResult.numBlocksChecked,
+                        latestPruneResult.numBlocksPruned,
+                        latestPruneResult.numBlocksPendingAck,
+                        latestPruneResult.saturationPercent);
             } else {
                 // If the existing future is not null and not completed, re-use it
                 newCf = oldCf;


### PR DESCRIPTION
**Description**:
This PR moves a log statement to prevent log spam when the buffer is saturated. In addition another test case at genesis in which all nodes go into checking then go back to active once the connections to block nodes are reestablished and resume streaming.

### Fix Log Spam with WARN messages:
* Moved the warning log message for enabling backpressure from the `disableBackPressureIfRecovered` method to the `enableBackPressure` method.

### New Test for Block Buffer Saturation:
* Added the `genesisBlockBufferSaturation` test in `BlockNodeSimulatorSuite`, which causes block buffer saturation across multiple nodes, verifies log messages during saturation, and ensures proper recovery. This test includes configurations for a 4-node network and specific node priorities.

**Related issue(s)**:

Fixes #18482

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
