### PR TITLE
test: AtomicRecordsSuite.blck003ReturnsTimestampOfTheBlock flaky test

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/batch/AtomicRecordsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/batch/AtomicRecordsSuite.java
@@ -162,29 +162,29 @@ public class AtomicRecordsSuite {
                 contractCreate(contract),
                 // Ensure we submit these two transactions in the same block
                 waitUntilNextBlock().withBackgroundTraffic(true),
-                atomicBatch(ethereumCall(contract, LOG_NOW)
-                                .type(EthTxData.EthTransactionType.EIP1559)
-                                .signingWith(SECP_256K1_SOURCE_KEY)
-                                .payingWith(RELAYER)
-                                .nonce(0)
-                                .maxFeePerGas(50L)
-                                .gasLimit(1_000_000L)
-                                .via(firstCall)
-                                .deferStatusResolution()
-                                .hasKnownStatus(ResponseCodeEnum.SUCCESS)
-                                .batchKey(BATCH_OPERATOR))
-                        .payingWith(BATCH_OPERATOR),
-                atomicBatch(ethereumCall(contract, LOG_NOW)
-                                .type(EthTxData.EthTransactionType.EIP1559)
-                                .signingWith(SECP_256K1_SOURCE_KEY)
-                                .payingWith(RELAYER)
-                                .nonce(1)
-                                .maxFeePerGas(50L)
-                                .gasLimit(1_000_000L)
-                                .via(secondCall)
-                                .deferStatusResolution()
-                                .hasKnownStatus(ResponseCodeEnum.SUCCESS)
-                                .batchKey(BATCH_OPERATOR))
+                atomicBatch(
+                                ethereumCall(contract, LOG_NOW)
+                                        .type(EthTxData.EthTransactionType.EIP1559)
+                                        .signingWith(SECP_256K1_SOURCE_KEY)
+                                        .payingWith(RELAYER)
+                                        .nonce(0)
+                                        .maxFeePerGas(50L)
+                                        .gasLimit(1_000_000L)
+                                        .via(firstCall)
+                                        .deferStatusResolution()
+                                        .hasKnownStatus(ResponseCodeEnum.SUCCESS)
+                                        .batchKey(BATCH_OPERATOR),
+                                ethereumCall(contract, LOG_NOW)
+                                        .type(EthTxData.EthTransactionType.EIP1559)
+                                        .signingWith(SECP_256K1_SOURCE_KEY)
+                                        .payingWith(RELAYER)
+                                        .nonce(1)
+                                        .maxFeePerGas(50L)
+                                        .gasLimit(1_000_000L)
+                                        .via(secondCall)
+                                        .deferStatusResolution()
+                                        .hasKnownStatus(ResponseCodeEnum.SUCCESS)
+                                        .batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR),
                 withOpContext((spec, opLog) -> {
                     final var firstBlockOp = getTxnRecord(firstCall).hasRetryAnswerOnlyPrecheck(RECORD_NOT_FOUND);


### PR DESCRIPTION
**Description**:
* Wrapping the ethCalls into a single atomicBatch so the timestamp is the same

**Related issue(s)**:

Fixes #20255