### PR TITLE
bug: Apply stake boundary side effects in freeze period

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -698,11 +698,7 @@ public class HandleWorkflow {
                     new ReadablePlatformStateStore(state.getReadableStates(PlatformStateService.NAME));
             if (this.initTrigger != EVENT_STREAM_RECOVERY
                     && eventBirthRound <= platformStateStore.getLatestFreezeRound()) {
-                if (streamMode != BLOCKS) {
-                    // This updates consTimeOfLastHandledTxn as a side effect
-                    blockRecordManager.advanceConsensusClock(parentTxn.consensusNow(), parentTxn.state());
-                }
-                blockStreamManager.setLastHandleTime(parentTxn.consensusNow());
+                stakePeriodChanges.advanceTimeTo(parentTxn, true);
                 initializeBuilderInfo(parentTxn.baseBuilder(), parentTxn.txnInfo(), exchangeRateManager.exchangeRates())
                         .status(BUSY);
                 // Flushes the BUSY builder to the stream, no other side effects


### PR DESCRIPTION
This PR fixes the one missing spot where stake boundary effects were disregarded by the block stream management code. The code now delegates block management to the `StakePeriodChanges` object, which appropriately considers staking boundary conditions.

Closes #20271

