### PR TITLE
fix: Fix typo in xts-info output definition

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -34,7 +34,7 @@ jobs:
       xts-commit-branch: ${{ steps.check-tags-exist.outputs.xts-commit-branch }}
       xts-tag-commit-author: ${{ steps.check-tags-exist.outputs.xts-tag-commit-author }}
       xts-tag-commit-email: ${{ steps.check-tags-exist.outputs.xts-tag-commit-email }}
-      xts-info: ${{ steps.check-tags-exist.output.xts-info }}
+      xts-info: ${{ steps.check-tags-exist.outputs.xts-info }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -122,6 +122,8 @@ jobs:
             echo "xts-tag-commit=${XTS_COMMIT}" >> "${GITHUB_STEP_SUMMARY}"
             echo "### Commit List" >> "${GITHUB_STEP_SUMMARY}"
             echo "${COMMIT_LIST}" >> "${GITHUB_STEP_SUMMARY}"
+            echo "### XTS Information" >> "${GITHUB_STEP_SUMMARY}"
+            echo "xts-info=${XTS_COMMIT_BRANCH} - ${XTS_SHORT_COMMIT}" >> "${GITHUB_STEP_SUMMARY}"
 
             git push --delete origin "${XTS_CANDIDATE_TAG}"
             git tag -d "${XTS_CANDIDATE_TAG}"


### PR DESCRIPTION
## Description

This pull request includes updates to the `.github/workflows/zxcron-extended-test-suite.yaml` file to fix a typo in the workflow outputs and enhance the GitHub step summary with additional information.

### Workflow fixes:
* Corrected a typo in the `xts-info` output reference, changing `steps.check-tags-exist.output.xts-info` to `steps.check-tags-exist.outputs.xts-info` to align with the correct syntax for accessing outputs.

### Enhancements to GitHub step summary:
* Added a new section to the GitHub step summary to include "XTS Information," which displays the `xts-info` value in the format `${XTS_COMMIT_BRANCH} - ${XTS_SHORT_COMMIT}` for better visibility of extended test suite details.

### Related issue(s)

Fixes #20284
