### PR TITLE
chore: Remove haveMaxDifferenceInLastRoundNum(), some minor cleanups

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
@@ -2,7 +2,6 @@
 package org.hiero.otter.test;
 
 import static org.apache.logging.log4j.Level.WARN;
-import static org.assertj.core.data.Percentage.withPercentage;
 import static org.hiero.otter.fixtures.OtterAssertions.assertThat;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -72,7 +71,6 @@ public class BirthRoundFreezeTest {
         assertThat(network.newConsensusResults())
                 .haveAdvancedSinceRound(freezeRound)
                 .haveEqualCommonRounds()
-                .haveMaxDifferenceInLastRoundNum(withPercentage(5))
                 .haveBirthRoundSplit(postFreezeShutdownTime, freezeRound);
 
         assertThat(network.newPcesResults()).haveBirthRoundSplit(postFreezeShutdownTime, freezeRound);

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/HappyPathTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/HappyPathTest.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.test;
 
-import static org.assertj.core.data.Percentage.withPercentage;
 import static org.hiero.consensus.model.status.PlatformStatus.ACTIVE;
 import static org.hiero.consensus.model.status.PlatformStatus.BEHIND;
 import static org.hiero.consensus.model.status.PlatformStatus.CHECKING;
@@ -52,9 +51,7 @@ public class HappyPathTest {
         // Validations
         assertThat(network.newLogResults()).haveNoErrorLevelMessages();
 
-        assertThat(network.newConsensusResults())
-                .haveEqualCommonRounds()
-                .haveMaxDifferenceInLastRoundNum(withPercentage(10));
+        assertThat(network.newConsensusResults()).haveEqualCommonRounds();
 
         assertThat(network.newPlatformStatusResults())
                 .haveSteps(target(ACTIVE).requiringInterim(REPLAYING_EVENTS, OBSERVING, CHECKING));

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/ReconnectTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/ReconnectTest.java
@@ -2,7 +2,6 @@
 package org.hiero.otter.test;
 
 import static org.assertj.core.api.Fail.fail;
-import static org.assertj.core.data.Percentage.withPercentage;
 import static org.hiero.consensus.model.status.PlatformStatus.ACTIVE;
 import static org.hiero.consensus.model.status.PlatformStatus.BEHIND;
 import static org.hiero.consensus.model.status.PlatformStatus.CHECKING;
@@ -83,9 +82,7 @@ public class ReconnectTest {
 
         assertThat(nodeToReconnect.newReconnectResult()).hasNoFailedReconnects().hasExactSuccessfulReconnects(1);
 
-        assertThat(network.newConsensusResults())
-                .haveEqualCommonRounds()
-                .haveMaxDifferenceInLastRoundNum(withPercentage(5));
+        assertThat(network.newConsensusResults()).haveEqualCommonRounds();
 
         // All non-reconnected nodes should go through the normal status progression
         assertThat(network.newPlatformStatusResults().suppressingNode(nodeToReconnect))

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
@@ -16,7 +16,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import java.util.List;
 import org.apache.logging.log4j.Level;
-import org.assertj.core.data.Percentage;
 import org.hiero.otter.fixtures.InstrumentedNode;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.Node;
@@ -139,8 +138,6 @@ public class SandboxTest {
 
         assertThat(network.newPcesResults()).haveAllBirthRoundsEqualTo(1);
 
-        assertThat(network.newConsensusResults())
-                .haveEqualCommonRounds()
-                .haveMaxDifferenceInLastRoundNum(Percentage.withPercentage(1));
+        assertThat(network.newConsensusResults()).haveEqualCommonRounds();
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodeConsensusResultsAssert.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodeConsensusResultsAssert.java
@@ -11,7 +11,6 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.data.Percentage;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.otter.fixtures.OtterAssertions;
 import org.hiero.otter.fixtures.result.MultipleNodeConsensusResults;
@@ -113,49 +112,6 @@ public class MultipleNodeConsensusResultsAssert
             final List<ConsensusRound> expectedRounds =
                     longestNodeRoundsResult.rounds().subList(0, roundsToAssert.size());
             ConsensusRoundValidator.validate(roundsToAssert, expectedRounds);
-        }
-
-        return this;
-    }
-
-    /**
-     * Verifies that the difference in the number of rounds produced by the fastest and the slowest node is less than or
-     * equal to the given percentage.
-     *
-     * @param expectedDifference the percentage of difference in number of consensus rounds that is allowed between the
-     *                           fastest and the slowest node
-     * @return this assertion object for method chaining
-     */
-    @NonNull
-    public MultipleNodeConsensusResultsAssert haveMaxDifferenceInLastRoundNum(
-            @NonNull final Percentage expectedDifference) {
-        isNotNull();
-
-        // create list of current rounds
-        final List<NodeRoundsResult> currentRoundResults = actual.results().stream()
-                .map(nodeResult -> new NodeRoundsResult(nodeResult.nodeId(), nodeResult.consensusRounds()))
-                .toList();
-
-        // find longest and shortest list
-        final Optional<NodeRoundsResult> optionalLongestResult =
-                currentRoundResults.stream().max(comparingInt(NodeRoundsResult::size));
-        if (optionalLongestResult.isEmpty()) {
-            // no consensus rounds collected
-            return this;
-        }
-        final NodeRoundsResult longestResult = optionalLongestResult.get();
-        final int longestSize = longestResult.size();
-        final int shortestSize = currentRoundResults.stream()
-                .min(comparingInt(NodeRoundsResult::size))
-                .orElseThrow()
-                .size();
-
-        // Check if difference is within bounds
-        final double actualDifference = 100.0 * (longestSize - shortestSize) / longestSize;
-        if (actualDifference > expectedDifference.value) {
-            failWithMessage(
-                    "Expected the difference between the fastest and the slowest node not to be greater than %s, but was %.2f %%",
-                    expectedDifference, actualDifference);
         }
 
         return this;

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodePlatformStatusResultsContinuousAssert.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodePlatformStatusResultsContinuousAssert.java
@@ -81,12 +81,14 @@ public class MultipleNodePlatformStatusResultsContinuousAssert
     }
 
     private MultipleNodePlatformStatusResultsContinuousAssert checkContinuously(
-            final BiConsumer<NodeId, PlatformStatus> check) {
+            @NonNull final BiConsumer<NodeId, PlatformStatus> check) {
         isNotNull();
 
         final PlatformStatusSubscriber subscriber = (nodeId, status) -> switch (state) {
             case ACTIVE -> {
-                check.accept(nodeId, status);
+                if (!suppressedNodeIds.contains(nodeId)) {
+                    check.accept(nodeId, status);
+                }
                 yield CONTINUE;
             }
             case PAUSED -> CONTINUE;


### PR DESCRIPTION
**Description**:

This PR removes `MultipleNodeConsensusResultsAssert.haveMaxDifferenceInLastRoundNum()` and it includes some minor cleanups in multi node continuous assert classes.

**Related issue(s)**:

Fixes #20342 