### PR TITLE
fix: NodeRewardManager missingJudgeCounts map initialization

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/NodeRewardManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/NodeRewardManager.java
@@ -116,9 +116,15 @@ public class NodeRewardManager {
      * @param state the state
      */
     public void updateJudgesOnEndRound(State state) {
-        // Track missing judges in this round
-        missingJudgesInLastRoundOf(state).forEach(nodeId -> missedJudgeCounts.merge(nodeId, 1L, Long::sum));
         roundsThisStakingPeriod++;
+        // Track missing judges in this round
+        missingJudgesInLastRoundOf(state).forEach(nodeId -> {
+            if (missedJudgeCounts.containsKey(nodeId)) {
+                missedJudgeCounts.put(nodeId, missedJudgeCounts.get(nodeId) + 1);
+            } else {
+                missedJudgeCounts.put(nodeId, roundsThisStakingPeriod);
+            }
+        });
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/NodeRewardManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/NodeRewardManager.java
@@ -118,13 +118,9 @@ public class NodeRewardManager {
     public void updateJudgesOnEndRound(State state) {
         roundsThisStakingPeriod++;
         // Track missing judges in this round
-        missingJudgesInLastRoundOf(state).forEach(nodeId -> {
-            if (missedJudgeCounts.containsKey(nodeId)) {
-                missedJudgeCounts.put(nodeId, missedJudgeCounts.get(nodeId) + 1);
-            } else {
-                missedJudgeCounts.put(nodeId, roundsThisStakingPeriod);
-            }
-        });
+        missingJudgesInLastRoundOf(state)
+                .forEach(nodeId ->
+                        missedJudgeCounts.compute(nodeId, (k, v) -> (v == null) ? roundsThisStakingPeriod : v + 1));
     }
 
     /**


### PR DESCRIPTION
**Description**:
This pull request modifies the `NodeRewardManager` class to fix a condition regarding the tracking of missed judges during staking periods. It also adds a new test to verify the updated behavior. Currently if the candidate roster is adopted somewhere in the staking period, the new node gets "credit" for being considered active as if it had produced judges for all the previous rounds in a staking period.

### Updates to `NodeRewardManager` logic:

* Updated the `updateJudgesOnEndRound` method to ensure missed judge counts are updated correctly. If a node is already tracked, its count is incremented; otherwise, its missed judge count is initialized to the current total rounds in the staking period.  I.e. (`hedera-node/hedera-app/src/main/java/com/hedera/node/app/services/NodeRewardManager.java`)

### New test case:

* Added `testUpdateJudgesOnEndRoundSetsNewNodeInActiveRosterMissedJudgesToCurrentTotalRoundsInStakingPeriod` to verify that when a new node is added to the active roster, its missed judge count is set to the current total rounds in the staking period. This ensures correctness in scenarios involving dynamic roster changes. (`hedera-node/hedera-app/src/test/java/com/hedera/node/app/services/NodeRewardManagerTest.java`)

**Related issue(s)**:

Fixes #20357

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
