### PR TITLE
fix: Fix erroneous failure report in deploy prod release tag push

### DIFF
--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -186,6 +186,7 @@ jobs:
   deploy-xts-ci-trigger:
     name: Trigger XTS CI Flow
     runs-on: hiero-network-node-linux-medium
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-enabled == false }}
     needs:
       - release-branch
     steps:
@@ -228,7 +229,7 @@ jobs:
   deploy-integration-ci-trigger:
     name: Trigger Deploy Integration Flow
     runs-on: hiero-network-node-linux-medium
-    if: ${{ inputs.dry-run-enabled == false }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-enabled == false }}
     needs:
       - release-branch
     steps:
@@ -270,7 +271,10 @@ jobs:
     needs:
       - release-branch
       - deploy-xts-ci-trigger
-    if: ${{ inputs.dry-run-enabled == false && (needs.release-branch.result != 'success' || needs.deploy-xts-ci-trigger.result != 'success') && !cancelled() }}
+    if:
+      ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-enabled == false &&
+      (needs.release-branch.result != 'success' || needs.deploy-xts-ci-trigger.result != 'success') &&
+      !cancelled() }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -186,7 +186,7 @@ jobs:
   deploy-xts-ci-trigger:
     name: Trigger XTS CI Flow
     runs-on: hiero-network-node-linux-medium
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry-run-enabled == false }}
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     needs:
       - release-branch
     steps:


### PR DESCRIPTION
## Description

This pull request updates the conditions for triggering certain jobs in the `node-flow-deploy-release-artifact.yaml` workflow file. The changes ensure that the jobs only run when the workflow is triggered by a `workflow_dispatch` event and the `dry-run-enabled` input is set to `false`.

### Updates to job conditions in `.github/workflows/node-flow-deploy-release-artifact.yaml`:

* **Trigger XTS CI Flow (`deploy-xts-ci-trigger`)**: Added a condition to check that the workflow is triggered by a `workflow_dispatch` event in addition to verifying that `dry-run-enabled` is `false`.
* **Trigger Deploy Integration Flow (`deploy-integration-ci-trigger`)**: Updated the condition to include a check for the `workflow_dispatch` event.
* **Deploy Integration CI Job**: Refined the conditional logic to include the `workflow_dispatch` event check while maintaining the existing conditions for `dry-run-enabled`, job results, and cancellation status.

### Related Issue(s)

- Fixes #20354