### PR TITLE
chore: Update default for diskNetworkExport

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/NetworkAdminConfig.java
@@ -36,7 +36,7 @@ public record NetworkAdminConfig(
                                 "HintsKeyPublication,HintsPreprocessingVote,HintsPartialSignature,HistoryAssemblySignature,HistoryProofKeyPublication,HistoryProofVote,CrsPublication")
                 @NetworkProperty
                 HederaFunctionalitySet nodeTransactionsAllowList,
-        @ConfigProperty(defaultValue = "network.json") @NodeProperty String diskNetworkExportFile,
+        @ConfigProperty(defaultValue = "output/network.json") @NodeProperty String diskNetworkExportFile,
         @ConfigProperty(defaultValue = "NEVER") DiskNetworkExport diskNetworkExport,
         @ConfigProperty(defaultValue = "true") @NodeProperty boolean exportCandidateRoster,
         @ConfigProperty(defaultValue = "candidate-roster.json") @NodeProperty String candidateRosterExportFile,


### PR DESCRIPTION
**Description**:
This pull request includes a small change to the `NetworkAdminConfig` class in the `hedera-node/hedera-config` module. The change updates the default value of the `diskNetworkExportFile` property to (`output/network.json`).

**Related issue(s)**:

Fixes #20358 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
