### PR TITLE
chore(20379): Enable FileChannel api and DontSync sync option

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesConfig.java
@@ -99,6 +99,6 @@ public record PcesConfig(
         @ConfigProperty(defaultValue = "1ms") Duration replayHealthThreshold,
         @ConfigProperty(defaultValue = "true") boolean limitReplayFrequency,
         @ConfigProperty(defaultValue = "5000") int maxEventReplayFrequency,
-        @ConfigProperty(defaultValue = "EVERY_SELF_EVENT") FileSyncOption inlinePcesSyncOption,
-        @ConfigProperty(defaultValue = "OUTPUT_STREAM") PcesFileWriterType pcesFileWriterType,
+        @ConfigProperty(defaultValue = "DONT_SYNC") FileSyncOption inlinePcesSyncOption,
+        @ConfigProperty(defaultValue = "FILE_CHANNEL") PcesFileWriterType pcesFileWriterType,
         @ConfigProperty(defaultValue = "OUTPUT_STREAM") PcesFileWriterType macPcesFileWriterType) {}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileChannelWriter.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/event/preconsensus/PcesFileChannelWriter.java
@@ -65,10 +65,10 @@ public class PcesFileChannelWriter implements PcesFileWriter {
     @Override
     public long writeEvent(@NonNull final GossipEvent event) throws IOException {
         final int size = GossipEvent.PROTOBUF.measureRecord(event);
-        final boolean expandBuffer = size > buffer.capacity();
+        final boolean expandBuffer = (size + Integer.BYTES) > buffer.capacity();
         if (expandBuffer) {
             MemoryUtils.closeDirectByteBuffer(buffer);
-            buffer = ByteBuffer.allocateDirect(size);
+            buffer = ByteBuffer.allocateDirect(size + Integer.BYTES);
             writableSequentialData = BufferedData.wrap(buffer);
         }
         buffer.putInt(size);


### PR DESCRIPTION
**Description**:
After running a few programs https://github.com/hiero-ledger/hiero-consensus-node/issues/18458
and[experiments](https://github.com/hiero-ledger/hiero-consensus-node/pull/20048/files)
where we test different scenarios simulating deterministic failures:

sig kill
Runtime.getRuntime().halt(42),
or by Unsafe.getUnsafe().putAddress(0L, 42L),
That would cause the JVM to exit before calling the API that would produce the fsync system call in the OS., We confirmed that all the data was successfully stored in the file in all the scenarios that did not buffer.

The experiment is run as a JUnit test, and is [passing](https://scans.gradle.com/s/4mbylh2a32xyu/tests/task/:swirlds-platform-core:test/details/com.swirlds.platform.FileWritingCrashExperimentTest?top-execution=1) on GitHub runners too (also a Linux, if I understand correctly)

given that information, we want to enable the fileChannel writer for PCES and use the FileSyncOption.DONT_SYNC option measures iops and compare performance results.

**Related issue(s)**:

Fixes #20379