### PR TITLE
test: Fix solo bugs, add first unit tests

### DIFF
--- a/gradle/aggregation/build.gradle.kts
+++ b/gradle/aggregation/build.gradle.kts
@@ -21,6 +21,7 @@ dependencies {
     implementation(project(":test-clients"))
     implementation(project(":consensus-otter-docker-app"))
     implementation(project(":consensus-otter-tests"))
+    implementation(project(":yahcli"))
 }
 
 tasks.testCodeCoverageReport {

--- a/hedera-node/test-clients/src/main/java/module-info.java
+++ b/hedera-node/test-clients/src/main/java/module-info.java
@@ -68,8 +68,9 @@ open module com.hedera.node.test.clients {
     exports com.hedera.services.bdd.junit.restart;
     exports com.hedera.services.bdd.junit.hedera.remote;
     exports com.hedera.services.bdd.spec.remote;
+	exports com.hedera.services.bdd.suites.utils.sysfiles;
 
-    provides LauncherSessionListener with
+	provides LauncherSessionListener with
             SharedNetworkLauncherSessionListener;
 
     requires com.hedera.node.app.hapi.fees;

--- a/hedera-node/yahcli/src/main/java/module-info.java
+++ b/hedera-node/yahcli/src/main/java/module-info.java
@@ -1,5 +1,27 @@
 // SPDX-License-Identifier: Apache-2.0
-module com.hedera.node.test.clients.yahcli {
+module com.hedera.node.yahcli {
+    exports com.hedera.services.yahcli;
+
+    opens com.hedera.services.yahcli to
+            info.picocli;
+    opens com.hedera.services.yahcli.commands.keys to
+            info.picocli;
+    opens com.hedera.services.yahcli.commands.accounts to
+            info.picocli;
+    opens com.hedera.services.yahcli.commands.fees to
+            info.picocli;
+    opens com.hedera.services.yahcli.commands.files to
+            info.picocli;
+    opens com.hedera.services.yahcli.commands.system to
+            info.picocli;
+    opens com.hedera.services.yahcli.commands.schedules to
+            info.picocli;
+    opens com.hedera.services.yahcli.commands.nodes to
+            info.picocli;
+
+    exports com.hedera.services.yahcli.config.domain;
+    exports com.hedera.services.yahcli.config;
+
     requires com.hedera.node.app.hapi.utils;
     requires com.hedera.node.app.service.addressbook;
     requires com.hedera.node.app;

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/AddressBookTranslationTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/AddressBookTranslationTest.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.yahcli.test;
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.suites.utils.sysfiles.AddressBookPojo;
+import com.hederahashgraph.api.proto.java.NodeAddressBook;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class AddressBookTranslationTest {
+    @Test
+    void noIpv4AddressParsesAsPojo() {
+        final var builder = NodeAddressBook.newBuilder();
+        builder.addNodeAddressBuilder()
+                .addServiceEndpointBuilder()
+                .setDomainName("www.example.com")
+                .setPort(1234)
+                .setIpAddressV4(ByteString.EMPTY)
+                .build();
+        final var newAddressBook = builder.build();
+        final var result = AddressBookPojo.addressBookFrom(newAddressBook);
+        Assertions.assertThat(result.getEntries()).hasSizeGreaterThan(0);
+    }
+}

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/ExceptionMsgUtils.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/ExceptionMsgUtils.java
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.yahcli.test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class ExceptionMsgUtils {
+
+    private ExceptionMsgUtils() {
+        // Utility class
+    }
+
+    public static void assertMissingRequiredParamMsg(final Exception exception, final String paramName) {
+        assertThat(exception.getMessage())
+                .containsIgnoringCase("Missing required parameter")
+                .contains("'<" + paramName + ">'");
+    }
+
+    public static void assertInvalidOptionMsg(final Exception exception, final String optionName) {
+        assertThat(exception.getMessage())
+                .containsIgnoringCase("Invalid value for option")
+                .contains("'<" + optionName + ">'");
+    }
+
+    public static void assertUnknownOptionMsg(final Exception exception, final String optionName) {
+        assertThat(exception.getMessage())
+                .containsIgnoringCase("Unknown option")
+                .contains("'" + optionName + "'");
+    }
+}

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/YahcliTestBase.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/YahcliTestBase.java
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.yahcli.test;
+
+import com.hedera.services.yahcli.Yahcli;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import picocli.CommandLine;
+
+public class YahcliTestBase {
+    // (FUTURE) Wrap System.out and System.err to capture _and display_ outputs
+    private final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private final ByteArrayOutputStream errContent = new ByteArrayOutputStream();
+    private final PrintStream originalOut = System.out;
+    private final PrintStream originalErr = System.err;
+
+    private Yahcli yahcli;
+    private CommandLine commandLine;
+
+    @BeforeEach
+    void setUp() {
+        // Reset the test output streams
+        outContent.reset();
+        errContent.reset();
+
+        // Modify the output streams to capture System.out and System.err
+        System.setOut(new PrintStream(outContent));
+        System.setErr(new PrintStream(errContent));
+
+        // Instantiate the `Yahcli` and `CommandLine` instances
+        yahcli = new Yahcli();
+        commandLine = new CommandLine(yahcli);
+    }
+
+    @AfterEach
+    void restoreStreams() {
+        System.setOut(originalOut);
+        System.setErr(originalErr);
+    }
+
+    protected CommandLine.ParseResult parseArgs(final String args) {
+        return commandLine.parseArgs(args.split(" "));
+    }
+
+    protected Yahcli testSubjectCli() {
+        return yahcli;
+    }
+}

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/config/ConfigManagerTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/config/ConfigManagerTest.java
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.yahcli.test.config;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import com.hedera.services.yahcli.config.ConfigManager;
+import com.hedera.services.yahcli.config.domain.GlobalConfig;
+import com.hedera.services.yahcli.config.domain.NetConfig;
+import com.hedera.services.yahcli.test.YahcliTestBase;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import picocli.CommandLine;
+
+class ConfigManagerTest extends YahcliTestBase {
+    @ParameterizedTest
+    @ValueSource(strings = {"", " \t \r \n "})
+    void unspecifiedDefaultPayerFailsGracefully(String input) {
+        // Construct a network configuration with an unspecified default payer
+        final var defaultNetConfig = new NetConfig();
+        defaultNetConfig.setDefaultPayer(input);
+        final var globalConfig = new GlobalConfig();
+        globalConfig.setNetworks(Map.of("localhost", defaultNetConfig));
+
+        // Initialize the Yahcli instance with the necessary args
+        parseArgs("-n localhost -a 3 -i 3");
+
+        final var subject = new ConfigManager(testSubjectCli(), globalConfig);
+
+        final var result = Assertions.assertThrows(CommandLine.ParameterException.class, subject::asSpecConfig);
+        assertThat(result.getMessage()).contains("No payer was specified, and no default is available in ");
+    }
+}

--- a/hedera-node/yahcli/src/test/java/module-info.java
+++ b/hedera-node/yahcli/src/test/java/module-info.java
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+module com.hedera.node.yahcli.test {
+    requires com.hedera.node.app;
+    requires com.hedera.node.hapi;
+    requires com.hedera.node.test.clients;
+    requires com.hedera.node.yahcli;
+    requires org.hiero.base.utility;
+    requires com.github.spotbugs.annotations;
+    requires com.google.common;
+    requires com.google.protobuf;
+    requires info.picocli;
+    requires net.i2p.crypto.eddsa;
+    requires org.apache.logging.log4j;
+    requires org.assertj.core;
+    requires org.junit.jupiter.api;
+    requires org.junit.jupiter.params;
+    requires org.yaml.snakeyaml;
+
+    // For test visibility
+    opens com.hedera.services.yahcli.test to
+            org.junit.platform.commons,
+            org.junit.jupiter.api,
+            org.assertj.core;
+    opens com.hedera.services.yahcli.test.config to
+            org.junit.platform.commons;
+}


### PR DESCRIPTION
This PR adds fixes for the two bugs mentioned in #20386 by (respectively) preventively checking for a null/blank default payer, and by using the raw input length to parse the IP address. 

Notably, this PR also includes the remaining steps to get our first ongoing automated tests for yahcli in place. 