### PR TITLE
chore: Stabilize `TokenDeleteSpecs`

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenDeleteSpecs.java
@@ -4,6 +4,7 @@ package com.hedera.services.bdd.suites.token;
 import static com.hedera.services.bdd.junit.TestTags.TOKEN;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.keys.SigMapGenerator.Nature.FULL_PREFIXES;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTokenInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.burnToken;
@@ -32,6 +33,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_IS_IMMUT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_WAS_DELETED;
 
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.spec.keys.TrieSigMapGenerator;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -110,7 +112,11 @@ public class TokenDeleteSpecs {
                                 .treasury(TOKEN_TREASURY)
                                 .payingWith(PAYER))
                 .when()
-                .then(tokenDelete("tbd").payingWith(PAYER).signedBy(PAYER).hasKnownStatus(INVALID_SIGNATURE));
+                .then(tokenDelete("tbd")
+                        .payingWith(PAYER)
+                        .signedBy(PAYER)
+                        .sigMapPrefixes(TrieSigMapGenerator.withNature(FULL_PREFIXES))
+                        .hasKnownStatus(INVALID_SIGNATURE));
     }
 
     @HapiTest


### PR DESCRIPTION
**Description**:
 - Fixes [this](https://scans.gradle.com/s/36emgaf7oyo4w) flake.

```
deletionValidatesWrongAdminKey()
[1]:test-clients:testSubprocesscom.hedera.services.bdd.suites.token.TokenDeleteSpecs

com.hedera.services.bdd.spec.exceptions.HapiTxnCheckStateException: Wrong status!
Expected INVALID_SIGNATURE, was INSUFFICIENT_TX_FEE
```