### PR TITLE
fix: 20399: HalfDiskHashMap resize support in the state validator

### DIFF
--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validators/merkledb/ValidateLeafIndexHalfDiskHashMap.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validators/merkledb/ValidateLeafIndexHalfDiskHashMap.java
@@ -21,8 +21,10 @@ import com.hedera.statevalidation.parameterresolver.VirtualMapAndDataSourceRecor
 import com.hedera.statevalidation.reporting.Report;
 import com.hedera.statevalidation.reporting.SlackReportGenerator;
 import com.swirlds.merkledb.MerkleDbDataSource;
+import com.swirlds.merkledb.collections.LongList;
 import com.swirlds.merkledb.files.hashmap.ParsedBucket;
 import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.LongConsumer;
 import org.apache.logging.log4j.LogManager;
@@ -63,11 +65,13 @@ public class ValidateLeafIndexHalfDiskHashMap {
         final var nullLeafsInfo = new CopyOnWriteArrayList<NullLeafInfo>();
         final var unexpectedKeyInfos = new CopyOnWriteArrayList<UnexpectedKeyInfo>();
         final var pathMismatchInfos = new CopyOnWriteArrayList<PathMismatchInfo>();
+        final var hashCodeMismatchInfos = new CopyOnWriteArrayList<HashCodeMismatchInfo>();
         final var incorrectBucketIndexList = new CopyOnWriteArrayList<Integer>();
+        final LongList index = hdhm.getBucketIndexToBucketLocation();
         LongConsumer consumer = i -> {
             long bucketLocation = 0;
             try {
-                bucketLocation = hdhm.getBucketIndexToBucketLocation().get(i);
+                bucketLocation = index.get(i);
                 if (bucketLocation == 0) {
                     return;
                 }
@@ -76,40 +80,48 @@ public class ValidateLeafIndexHalfDiskHashMap {
                     // FUTURE WORK: report
                     return;
                 }
-                ParsedBucket bucket = new ParsedBucket();
+                final ParsedBucket bucket = new ParsedBucket();
                 bucket.readFrom(bucketData);
-                if (bucket.getBucketIndex() != i) {
-                    incorrectBucketIndexList.add(bucket.getBucketIndex());
+                final int bucketIndex = bucket.getBucketIndex();
+                if ((bucketIndex & i) != bucketIndex) {
+                    incorrectBucketIndexList.add((int) i);
                 }
                 var bucketIterator = new BucketIterator(bucket);
-                long path;
                 while (bucketIterator.hasNext()) {
-                    ParsedBucket.BucketEntry entry = bucketIterator.next();
-                    Bytes keyBytes = entry.getKeyBytes();
-                    path = entry.getValue();
+                    final ParsedBucket.BucketEntry entry = bucketIterator.next();
+                    final Bytes keyBytes = entry.getKeyBytes();
+                    final long path = entry.getValue();
                     // get path -> dataLocation
                     var dataLocation = pathToDiskLocationLeafNodes.get(path);
                     if (dataLocation == 0) {
+                        printFileDataLocationError(log, "Stale path", dfc, bucketLocation);
                         collectInfo(new StalePathInfo(path, parseKey(keyBytes)), stalePathsInfos);
                         continue;
                     }
                     final BufferedData leafData = leafStoreDFC.readDataItem(dataLocation);
                     if (leafData == null) {
-                        printFileDataLocationError(log, "Record with null leafs!", dfc, bucketLocation);
+                        printFileDataLocationError(log, "Null leaf", dfc, bucketLocation);
                         collectInfo(new NullLeafInfo(path, parseKey(keyBytes)), nullLeafsInfo);
                         continue;
                     }
-                    final VirtualLeafBytes leafBytes = VirtualLeafBytes.parseFrom(leafData);
+                    final VirtualLeafBytes<?> leafBytes = VirtualLeafBytes.parseFrom(leafData);
                     if (!keyBytes.equals(leafBytes.keyBytes())) {
-                        printFileDataLocationError(log, "Record with unexpected key!", dfc, bucketLocation);
+                        printFileDataLocationError(log, "Leaf key mismatch", dfc, bucketLocation);
                         collectInfo(
                                 new UnexpectedKeyInfo(path, parseKey(keyBytes), parseKey(leafBytes.keyBytes())),
                                 unexpectedKeyInfos);
                     }
                     if (leafBytes.path() != path) {
-                        printFileDataLocationError(log, "Record with unexpected path!", dfc, bucketLocation);
+                        printFileDataLocationError(log, "Leaf path mismatch", dfc, bucketLocation);
                         collectInfo(
                                 new PathMismatchInfo(path, leafBytes.path(), parseKey(keyBytes)), pathMismatchInfos);
+                        continue;
+                    }
+                    final int hashCode = entry.getHashCode();
+                    if ((hashCode & bucketIndex) != bucketIndex) {
+                        printFileDataLocationError(log, "Hash code mismatch", dfc, bucketLocation);
+                        collectInfo(new HashCodeMismatchInfo(hashCode, bucketIndex), hashCodeMismatchInfos);
+                        continue;
                     }
                 }
             } catch (Exception e) {
@@ -149,20 +161,36 @@ public class ValidateLeafIndexHalfDiskHashMap {
                     pathMismatchInfos.size());
         }
 
+        if (!hashCodeMismatchInfos.isEmpty()) {
+            log.error("Hash code mismatch info:\n{}", hashCodeMismatchInfos);
+            log.error(
+                    "There are {} records with mismatch hash codes, please, check the logs for more info",
+                    hashCodeMismatchInfos.size());
+        }
+
         assertTrue(
                 (stalePathsInfos.isEmpty() || skipStaleKeysValidation)
                                 && nullLeafsInfo.isEmpty()
                                 && unexpectedKeyInfos.isEmpty()
                                 && pathMismatchInfos.isEmpty()
                                 && incorrectBucketIndexList.isEmpty()
+                                && hashCodeMismatchInfos.isEmpty()
                         || skipIncorrectBucketIndexValidation,
-                "One of the test condition hasn't been met. " + "Conditions: "
-                        + "(stalePathsInfos.isEmpty() || skipStaleKeysValidation) = %s, nullLeafsInfo.isEmpty() = %s,  unexpectedKeyInfos.isEmpty() = %s, pathMismatchInfos.isEmpty() = %s, incorrectBucketIndexList.isEmpty() = %s || skipIncorrectBucketIndexValidation. IncorrectBucketIndexInfos: %s"
+                "One of the test condition hasn't been met. "
+                        + "Conditions: "
+                        + ("stalePathsInfos.isEmpty() = %s, "
+                                        + "nullLeafsInfo.isEmpty() = %s, "
+                                        + "unexpectedKeyInfos.isEmpty() = %s, "
+                                        + "pathMismatchInfos.isEmpty() = %s, "
+                                        + "hashCodeMismatchInfos.isEmpty() = %s, "
+                                        + "incorrectBucketIndexList.isEmpty() = %s. "
+                                        + "IncorrectBucketIndexInfos: %s")
                                 .formatted(
-                                        (stalePathsInfos.isEmpty() || skipStaleKeysValidation),
+                                        stalePathsInfos.isEmpty(),
                                         nullLeafsInfo.isEmpty(),
                                         unexpectedKeyInfos.isEmpty(),
                                         pathMismatchInfos.isEmpty(),
+                                        hashCodeMismatchInfos.isEmpty(),
                                         incorrectBucketIndexList.isEmpty(),
                                         incorrectBucketIndexList));
     }
@@ -177,22 +205,28 @@ public class ValidateLeafIndexHalfDiskHashMap {
         }
     }
 
+    // Bucket entry path is not found in the leaf index
     record StalePathInfo(long path, VirtualMapKey key) {
         @Override
+        @NonNull
         public String toString() {
             return "StalePathInfo{" + "path=" + path + ", key=" + key + "}\n";
         }
     }
 
+    // Bucket entry path is in the leaf index, but leaf data cannot be loaded
     private record NullLeafInfo(long path, VirtualMapKey key) {
         @Override
+        @NonNull
         public String toString() {
             return "NullLeafInfo{" + "path=" + path + ", key=" + key + "}\n";
         }
     }
 
+    // Bucket entry key doesn't match leaf key, leaf is loaded by entry path
     record UnexpectedKeyInfo(long path, VirtualMapKey expectedKey, VirtualMapKey actualKey) {
         @Override
+        @NonNull
         public String toString() {
             return "UnexpectedKeyInfo{" + "path="
                     + path + ", expectedKey="
@@ -201,13 +235,24 @@ public class ValidateLeafIndexHalfDiskHashMap {
         }
     }
 
+    // Bucket entry path doesn't match leaf path, leaf is loaded by entry path
     private record PathMismatchInfo(long expectedPath, long actualPath, VirtualMapKey key) {
         @Override
+        @NonNull
         public String toString() {
             return "PathMismatchInfo{" + "expectedPath="
                     + expectedPath + ", actualPath="
                     + actualPath + ", key="
                     + key + "}\n";
+        }
+    }
+
+    // Bucket entry hash code doesn't match bucket index (modulo HDHM resize)
+    private record HashCodeMismatchInfo(int entryHashCode, int bucketIndex) {
+        @Override
+        @NonNull
+        public String toString() {
+            return "HashCodeMismatchInfo{" + "entryHashCode=" + entryHashCode + ", bucketIndex=" + bucketIndex + "}\n";
         }
     }
 }

--- a/hedera-state-validator/src/main/java/module-info.java
+++ b/hedera-state-validator/src/main/java/module-info.java
@@ -30,6 +30,7 @@ module com.hedera.state.validator {
     requires org.hiero.base.utility;
     requires org.hiero.consensus.utility;
     requires com.fasterxml.jackson.databind;
+    requires com.github.spotbugs.annotations;
     requires com.google.gson;
     requires info.picocli;
     requires org.apache.logging.log4j;


### PR DESCRIPTION
Fix summary:

* `ValidateLeafIndexHalfDiskHashMap`: changed bucket index check, so only lower bucket index bits are taken into consideration
* `ValidateLeafIndexHalfDiskHashMap`: added a new check that bucket entry hash code should match bucket index

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/20399
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
