### PR TITLE
fix: 20454: Virtual hasher should not include any hash for path 2 if virtual tree has only one leaf

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/hash/VirtualHasherTestBase.java
@@ -99,7 +99,7 @@ public class VirtualHasherTestBase extends VirtualTestBase {
 
         final long rightChildPath = Path.getRightChildPath(internalNode.path());
         VirtualHashRecord rightChild = ds.getInternal(rightChildPath);
-        Hash rightHash = Cryptography.NULL_HASH;
+        Hash rightHash = null;
         if (rightChild != null) {
             if (rightChildPath < ds.firstLeafPath) {
                 rightChild = hashSubTree(ds, md, rightChild);
@@ -111,7 +111,9 @@ public class VirtualHasherTestBase extends VirtualTestBase {
         md.reset();
         md.update((byte) 0x02);
         leftHash.getBytes().writeTo(md);
-        rightHash.getBytes().writeTo(md);
+        if (rightHash != null) {
+            rightHash.getBytes().writeTo(md);
+        }
         final Hash hash = new Hash(md.digest(), Cryptography.DEFAULT_DIGEST_TYPE);
         VirtualHashRecord record = new VirtualHashRecord(internalNode.path(), hash);
         ds.setInternal(record);


### PR DESCRIPTION
Fix summary:

* When virtual tree contains only two elements, root and one leaf, root hash doesn't use any hash for path 2. Previously, NULL_HASH was used
* Existing unit tests are updated

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/20454
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
