### PR TITLE
chore: Update block_stream_publish_service.proto to v0.15.0 specification

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/block/block_stream_publish_service.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/block/block_stream_publish_service.proto
@@ -239,19 +239,6 @@ message PublishStreamResponse {
      * system to validate the block.
      */
     bytes block_root_hash = 2;
-
-    /**
-     * A flag indicating that the received block duplicates an
-     * existing block.
-     * <p>
-     * If a Publisher receives acknowledgement with this flag set
-     * true the Publisher MAY end the stream.<br/>
-     * The `block_number` returned SHALL be the last block known and
-     * verified by the Block-Node.<br/>
-     * The Publisher MAY resume publishing immediately after the indicated
-     * block.
-     */
-    bool block_already_exists = 3;
   }
 
   /**
@@ -334,8 +321,6 @@ message PublishStreamResponse {
     /**
      * The number of the last completed, _persisted_, and _verified_ block.
      * <p>
-     * Block-Nodes SHOULD only end a stream after a block state proof to
-     * avoid the need to resend items, except for errors.<br/>
      * If status is a failure code, the Publisher MUST start a new
      * stream at the beginning of the first block _following_ this number
      * (e.g. if this is 91827362983, then the new stream must start with
@@ -367,11 +352,26 @@ message PublishStreamResponse {
       SUCCESS = 1;
 
       /**
+       * The request cannot be fulfilled.<br/>
+       * The client sent a malformed or structurally incorrect request.
+       * <p>
+       * The client MAY retry the request after correcting the form and
+       * structure.
+       */
+      INVALID_REQUEST = 2;
+
+      /**
+       * The Block-Node had an error and cannot continue processing.<br/>
+       * The Publisher may retry again later.
+       */
+      ERROR = 3;
+
+      /**
        * The delay between items was too long.
        * <p>
        * The source MUST start a new stream before the failed block.
        */
-      TIMEOUT = 2;
+      TIMEOUT = 4;
 
       /**
        * An item received is already stored.<br/>
@@ -379,13 +379,13 @@ message PublishStreamResponse {
        * The source MUST start a new stream after the last persisted and
        * verified block.
        */
-      DUPLICATE_BLOCK = 3;
+      DUPLICATE_BLOCK = 5;
 
       /**
        * A block state proof item could not be validated.<br/>
        * The source MUST start a new stream before the failed block.
        */
-      BAD_BLOCK_PROOF = 4;
+      BAD_BLOCK_PROOF = 6;
 
       /**
        * The Block-Node is "behind" the Publisher.<br/>
@@ -398,13 +398,7 @@ message PublishStreamResponse {
        * blocks from another Block-Node or other source of recent historical
        * block stream data.
        */
-      BEHIND = 5;
-
-      /**
-       * The Block-Node had an internal error and cannot continue processing.<br/>
-       * The Publisher may retry again later.
-       */
-      INTERNAL_ERROR = 6;
+      BEHIND = 7;
 
       /**
        * The Block-Node failed to store the block persistently.
@@ -414,7 +408,7 @@ message PublishStreamResponse {
        * The Publisher MUST NOT discard the block until it is successfully
        * persisted and verified (and acknowledged) by at least one Block-Node.
        */
-      PERSISTENCE_FAILED = 7;
+      PERSISTENCE_FAILED = 8;
     }
 
   }

--- a/hedera-node/docs/design/app/blocks/BlockNodeConnection.md
+++ b/hedera-node/docs/design/app/blocks/BlockNodeConnection.md
@@ -76,11 +76,12 @@ sequenceDiagram
 | `SUCCESS`                     | Immediate             | 30 seconds                  | No                  | 10 seconds      |                                                                                                     |
 | `BEHIND` with block in buffer | No                    | 1 second                    | Yes                 | 10 seconds      |                                                                                                     |
 | `BEHIND` w/o block in buffer  | Yes                   | 30 seconds                  | No                  | 10 seconds      | CN sends `EndStream.TOO_FAR_BEHIND` to indicate the BN to look for the block from other Block Nodes |
-| `INTERNAL_ERROR`              | Immediate             | 30 seconds                  | No                  | 10 seconds      |                                                                                                     |
+| `ERROR`                       | Immediate             | 30 seconds                  | No                  | 10 seconds      |                                                                                                     |
 | `PERSISTENCE_FAILED`          | Immediate             | 30 seconds                  | No                  | 10 seconds      |                                                                                                     |
 | `TIMEOUT`                     | No                    | 1 second                    | Yes                 | 10 seconds      |                                                                                                     |
 | `DUPLICATE_BLOCK`             | No                    | 1 second                    | Yes                 | 10 seconds      |                                                                                                     |
 | `BAD_BLOCK_PROOF`             | No                    | 1 second                    | Yes                 | 10 seconds      |                                                                                                     |
+| `INVALID_REQUEST`             | No                    | 1 second                    | Yes                 | 10 seconds      |                                                                                                     |
 | `UNKNOWN`                     | Yes                   | 30 seconds                  | No                  | 10 seconds      |                                                                                                     |
 
 ### EndOfStream Rate Limiting

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeCommunicationTestBase.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeCommunicationTestBase.java
@@ -57,11 +57,9 @@ public abstract class BlockNodeCommunicationTestBase {
     }
 
     @NonNull
-    protected static PublishStreamResponse createBlockAckResponse(final long blockNumber, final boolean alreadyExists) {
-        final BlockAcknowledgement blockAck = BlockAcknowledgement.newBuilder()
-                .blockNumber(blockNumber)
-                .blockAlreadyExists(alreadyExists)
-                .build();
+    protected static PublishStreamResponse createBlockAckResponse(final long blockNumber) {
+        final BlockAcknowledgement blockAck =
+                BlockAcknowledgement.newBuilder().blockNumber(blockNumber).build();
 
         return PublishStreamResponse.newBuilder().acknowledgement(blockAck).build();
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
@@ -132,7 +132,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
 
     @Test
     void testOnNext_acknowledgement_notStreaming() {
-        final PublishStreamResponse response = createBlockAckResponse(10L, false);
+        final PublishStreamResponse response = createBlockAckResponse(10L);
         when(connectionManager.currentStreamingBlockNumber())
                 .thenReturn(-1L); // we aren't streaming anything to the block node
         when(stateManager.getLastBlockNumberProduced()).thenReturn(10L);
@@ -150,7 +150,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
 
     @Test
     void testOnNext_acknowledgement_olderThanCurrentStreamingAndProducing() {
-        final PublishStreamResponse response = createBlockAckResponse(8L, false);
+        final PublishStreamResponse response = createBlockAckResponse(8L);
 
         when(connectionManager.currentStreamingBlockNumber()).thenReturn(10L);
         when(stateManager.getLastBlockNumberProduced()).thenReturn(10L);
@@ -171,7 +171,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
     void testOnNext_acknowledgement_newerThanCurrentProducing() {
         // I don't think this scenario is possible... we should never stream a block that is newer than the block
         // currently being produced.
-        final PublishStreamResponse response = createBlockAckResponse(11L, false);
+        final PublishStreamResponse response = createBlockAckResponse(11L);
 
         when(connectionManager.currentStreamingBlockNumber()).thenReturn(11L);
         when(stateManager.getLastBlockNumberProduced()).thenReturn(10L);
@@ -190,7 +190,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
 
     @Test
     void testOnNext_acknowledgement_newerThanCurrentStreaming() {
-        final PublishStreamResponse response = createBlockAckResponse(11L, false);
+        final PublishStreamResponse response = createBlockAckResponse(11L);
 
         when(connectionManager.currentStreamingBlockNumber()).thenReturn(10L);
         when(stateManager.getLastBlockNumberProduced()).thenReturn(12L);
@@ -239,7 +239,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
     @ParameterizedTest
     @EnumSource(
             value = EndOfStream.Code.class,
-            names = {"INTERNAL_ERROR", "PERSISTENCE_FAILED"})
+            names = {"ERROR", "PERSISTENCE_FAILED"})
     void testOnNext_endOfStream_blockNodeInternalError(final EndOfStream.Code responseCode) {
         openConnectionAndResetMocks();
         final PublishStreamResponse response = createEndOfStreamResponse(responseCode, 10L);
@@ -259,7 +259,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
     @ParameterizedTest
     @EnumSource(
             value = EndOfStream.Code.class,
-            names = {"TIMEOUT", "DUPLICATE_BLOCK", "BAD_BLOCK_PROOF"})
+            names = {"TIMEOUT", "DUPLICATE_BLOCK", "BAD_BLOCK_PROOF", "INVALID_REQUEST"})
     void testOnNext_endOfStream_clientFailures(final EndOfStream.Code responseCode) {
         openConnectionAndResetMocks();
         final PublishStreamResponse response = createEndOfStreamResponse(responseCode, 10L);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/simulator/SimulatedBlockNodeServer.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/simulator/SimulatedBlockNodeServer.java
@@ -280,7 +280,7 @@ public class SimulatedBlockNodeServer {
                                             blockNumber,
                                             responseObserver.hashCode(),
                                             port);
-                                    buildAndSendBlockAcknowledgement(blockNumber, responseObserver, true);
+                                    buildAndSendBlockAcknowledgement(blockNumber, responseObserver);
                                     // Continue to the next BlockItem in the request
                                     continue;
                                 }
@@ -372,7 +372,7 @@ public class SimulatedBlockNodeServer {
                                         port);
                                 for (final StreamObserver<PublishStreamResponse> observer : activeStreams) {
                                     // Send Ack with blockAlreadyExists=false
-                                    buildAndSendBlockAcknowledgement(blockNumber, observer, false);
+                                    buildAndSendBlockAcknowledgement(blockNumber, observer);
                                 }
 
                                 // Reset currentBlockNumber for this stream, as it finished sending this block
@@ -646,26 +646,19 @@ public class SimulatedBlockNodeServer {
      *
      * @param blockNumber The block number being acknowledged.
      * @param responseObserver The observer to send the acknowledgment to.
-     * @param blockAlreadyExists Indicates if the block was already fully processed.
      */
     private void buildAndSendBlockAcknowledgement(
-            final long blockNumber,
-            final StreamObserver<PublishStreamResponse> responseObserver,
-            final boolean blockAlreadyExists) {
+            final long blockNumber, final StreamObserver<PublishStreamResponse> responseObserver) {
         final PublishStreamResponse.BlockAcknowledgement ack = PublishStreamResponse.BlockAcknowledgement.newBuilder()
                 .setBlockNumber(blockNumber)
-                .setBlockNumber(
-                        lastVerifiedBlockNumber.get()) // TODO: why is the block number set twice? which is correct?
-                .setBlockAlreadyExists(blockAlreadyExists) // Set based on the parameter
                 .build();
         final PublishStreamResponse response =
                 PublishStreamResponse.newBuilder().setAcknowledgement(ack).build();
         try {
             responseObserver.onNext(response);
             log.debug(
-                    "Sent BlockAcknowledgement for block {} (exists={}) to stream {} on port {}. Last verified: {}",
+                    "Sent BlockAcknowledgement for block {} to stream {} on port {}. Last verified: {}",
                     blockNumber,
-                    blockAlreadyExists,
                     responseObserver.hashCode(),
                     port,
                     lastVerifiedBlockNumber.get());


### PR DESCRIPTION
**Description**:
This PR updates the `block_stream_publish_service.proto` file to `v0.15.0` of what's in the block node repository.

In the future, the consensus node will utilize the protobuf sources for the block stream publish service published by the block node repository.

Key changes in this PR include removing the `block_already_exists` field, introducing new response codes, updating tests to reflect these changes, and modifying related methods. Below is a breakdown of the most important changes:

### Protocol Updates:
- Removed the `block_already_exists` field from the `PublishStreamResponse` message definition, simplifying the acknowledgment structure.
- Introduced new response codes `INVALID_REQUEST` and `ERROR` while renumbering existing codes to maintain consistency.

### Documentation Updates:
- Updated the table in `BlockNodeConnection.md` to replace `INTERNAL_ERROR` with `ERROR` and include the new `INVALID_REQUEST` response code.

### Codebase Simplification:
- Removed the `blockAlreadyExists` parameter from `handleAcknowledgement` and related methods, simplifying the acknowledgment logic.
- Updated logging statements and method calls to reflect the removal of `blockAlreadyExists`.

### Test Updates:
- Refactored test cases to remove `blockAlreadyExists` from `createBlockAckResponse` calls and added coverage for `INVALID_REQUEST` and `ERROR` response codes.

**Related issue(s)**:

Fixes #20481

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
