### PR TITLE
chore: Change BlockBufferService backpressure logic based on BlockStreamConfig StreamMode

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
@@ -8,6 +8,8 @@ import com.hedera.node.app.metrics.BlockStreamMetrics;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockBufferConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
+import com.hedera.node.config.types.BlockStreamWriterMode;
+import com.hedera.node.config.types.StreamMode;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.math.BigDecimal;
@@ -22,7 +24,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
@@ -42,6 +43,7 @@ import org.apache.logging.log4j.Logger;
 @Singleton
 public class BlockBufferService {
     private static final Logger logger = LogManager.getLogger(BlockBufferService.class);
+    public static final int DEFAULT_BUFFER_SIZE = 150;
 
     /**
      * Buffer that stores recent blocks. This buffer is unbounded, however it is technically capped because back
@@ -93,10 +95,11 @@ public class BlockBufferService {
      * Metrics API for block stream-specific metrics.
      */
     private final BlockStreamMetrics blockStreamMetrics;
-    /**
-     * Flag that indicates if streaming to block nodes is enabled. This flag is set once upon startup and cannot change.
-     */
-    private final AtomicBoolean isStreamingEnabled = new AtomicBoolean(false);
+
+    private final boolean grpcStreamingEnabled;
+    private final boolean backpressureEnabled;
+    private final long idealMaxBufferSize;
+
     /**
      * The timestamp of the most recent attempt at proactive buffer recovery.
      */
@@ -122,22 +125,18 @@ public class BlockBufferService {
             @NonNull final ConfigProvider configProvider, @NonNull final BlockStreamMetrics blockStreamMetrics) {
         this.configProvider = configProvider;
         this.blockStreamMetrics = blockStreamMetrics;
-        isStreamingEnabled.set(streamToBlockNodesEnabled());
+        BlockStreamConfig blockStreamConfig = configProvider.getConfiguration().getConfigData(BlockStreamConfig.class);
+        this.grpcStreamingEnabled = blockStreamConfig.writerMode() != BlockStreamWriterMode.FILE;
+        this.backpressureEnabled = (blockStreamConfig.streamMode() == StreamMode.BLOCKS && grpcStreamingEnabled);
+        Duration ttl = blockBufferTtl();
+        Duration blockPeriod = blockPeriod();
+        this.idealMaxBufferSize =
+                blockPeriod.isZero() || blockPeriod.isNegative() ? DEFAULT_BUFFER_SIZE : ttl.dividedBy(blockPeriod);
 
-        // Only start the pruning thread if we're streaming to block nodes
-        if (isStreamingEnabled.get()) {
+        // Only start the pruning thread if backpressure is enabled and gRPC streaming is enabled
+        if (backpressureEnabled) {
             scheduleNextPruning();
         }
-    }
-
-    /**
-     * @return true if streaming to block nodes is enabled, else false
-     */
-    private boolean streamToBlockNodesEnabled() {
-        return configProvider
-                .getConfiguration()
-                .getConfigData(BlockStreamConfig.class)
-                .streamToBlockNodes();
     }
 
     /**
@@ -224,7 +223,7 @@ public class BlockBufferService {
      * @throws IllegalArgumentException if the block number is negative
      */
     public void openBlock(final long blockNumber) {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 
@@ -232,14 +231,20 @@ public class BlockBufferService {
             throw new IllegalArgumentException("Block number must be non-negative");
         }
 
-        final long lastAcked = highestAckedBlockNumber.get();
-        if (blockNumber <= lastAcked) {
-            logger.error(
-                    "Attempted to open block {}, but a later block (lastAcked={}) has already been acknowledged",
-                    blockNumber,
-                    lastAcked);
-            throw new IllegalStateException("Attempted to open block " + blockNumber + ", but a later block (lastAcked="
-                    + lastAcked + ") has already been acknowledged");
+        if (!backpressureEnabled) {
+            // Evict the lowest block number if the buffer is full
+            if (blockBuffer.size() >= idealMaxBufferSize) {
+                final Long lowestBlockNumber =
+                        blockBuffer.keySet().stream().min(Long::compareTo).orElse(null);
+                if (lowestBlockNumber != null) {
+                    blockBuffer.remove(lowestBlockNumber);
+                    earliestBlockNumber.getAndUpdate(current -> current + 1);
+                    logger.debug(
+                            "Block buffer is full and backpressure is disabled; evicting lowest block number {} to make space for block {}",
+                            lowestBlockNumber,
+                            blockNumber);
+                }
+            }
         }
 
         final BlockState existingBlock = blockBuffer.get(blockNumber);
@@ -268,7 +273,7 @@ public class BlockBufferService {
      * @throws IllegalStateException if no block is currently open
      */
     public void addItem(final long blockNumber, @NonNull final BlockItem blockItem) {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
         requireNonNull(blockItem, "blockItem must not be null");
@@ -285,7 +290,7 @@ public class BlockBufferService {
      * @throws IllegalStateException if no block is currently open
      */
     public void closeBlock(final long blockNumber) {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 
@@ -324,7 +329,7 @@ public class BlockBufferService {
      * @param blockNumber the block number to mark acknowledged up to and including
      */
     public void setLatestAcknowledgedBlock(final long blockNumber) {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 
@@ -373,7 +378,7 @@ public class BlockBufferService {
      * enough capacity - i.e. the buffer is saturated - then this method will block until there is enough capacity.
      */
     public void ensureNewBlocksPermitted() {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 
@@ -414,7 +419,7 @@ public class BlockBufferService {
          */
         final Duration blockPeriod = blockPeriod();
         final long idealMaxBufferSize =
-                blockPeriod.isZero() || blockPeriod.isNegative() ? 150 : ttl.dividedBy(blockPeriod);
+                blockPeriod.isZero() || blockPeriod.isNegative() ? DEFAULT_BUFFER_SIZE : ttl.dividedBy(blockPeriod);
         int numPruned = 0;
         int numChecked = 0;
         int numPendingAck = 0;
@@ -508,7 +513,7 @@ public class BlockBufferService {
      * continues to be saturated.
      */
     private void checkBuffer() {
-        if (!streamToBlockNodesEnabled()) {
+        if (!backpressureEnabled) {
             return;
         }
 
@@ -696,7 +701,7 @@ public class BlockBufferService {
     }
 
     private void scheduleNextPruning() {
-        if (!streamToBlockNodesEnabled()) {
+        if (!backpressureEnabled) {
             return;
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
@@ -328,7 +328,7 @@ public class BlockState {
         final RequestWrapper rs = new RequestWrapper(index, psr, new AtomicBoolean(false));
         requestsByIndex.put(index, rs);
 
-        logger.debug("[Block {}] Created new request (index={}, numItems={})", blockNumber, index, blockItems.size());
+        logger.trace("[Block {}] Created new request (index={}, numItems={})", blockNumber, index, blockItems.size());
 
         if (!pendingItems.isEmpty()) {
             processPendingItems(batchSize);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/GrpcBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/GrpcBlockItemWriter.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.node.app.blocks.BlockItemWriter;
 import com.hedera.node.internal.network.PendingProof;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,6 +64,11 @@ public class GrpcBlockItemWriter implements BlockItemWriter {
     @Override
     public void writeItem(@NonNull byte[] bytes) {
         throw new UnsupportedOperationException("writeItem is not supported in this implementation");
+    }
+
+    @Override
+    public void writePbjItemAndBytes(@NonNull final BlockItem item, @NonNull Bytes bytes) {
+        writePbjItem(item);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/HapiBlockNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/HapiBlockNode.java
@@ -48,5 +48,7 @@ public @interface HapiBlockNode {
         long[] blockNodeIds() default {};
 
         long[] blockNodePriorities() default {};
+
+        String[] applicationPropertiesOverrides() default {};
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/NetworkTargetingExtension.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/NetworkTargetingExtension.java
@@ -128,6 +128,13 @@ public class NetworkTargetingExtension implements BeforeEachCallback, AfterEachC
                     targetBlockNodeNetwork
                             .getBlockNodePrioritiesBySubProcessNodeId()
                             .put(subProcessNodeConfig.nodeId(), subProcessNodeConfig.blockNodePriorities());
+                    if (subProcessNodeConfig.applicationPropertiesOverrides().length > 0) {
+                        targetNetwork
+                                .getApplicationPropertyOverrides()
+                                .put(
+                                        subProcessNodeConfig.nodeId(),
+                                        Arrays.asList(subProcessNodeConfig.applicationPropertiesOverrides()));
+                    }
                 }
 
                 targetBlockNodeNetwork.start();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/BlockNodeNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/BlockNodeNetwork.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.junit.hedera;
 
-import static com.hedera.services.bdd.junit.hedera.ExternalPath.APPLICATION_PROPERTIES;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.DATA_CONFIG_DIR;
 import static com.hedera.services.bdd.junit.hedera.subprocess.SubProcessNetwork.findAvailablePort;
 
@@ -13,7 +12,6 @@ import com.hedera.services.bdd.junit.hedera.simulator.SimulatedBlockNodeServer;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -160,49 +158,11 @@ public class BlockNodeNetwork {
                 // Write the config to this consensus node's block-nodes.json
                 Path configPath = node.getExternalPath(DATA_CONFIG_DIR).resolve("block-nodes.json");
                 Files.writeString(configPath, BlockNodeConnectionInfo.JSON.toJSON(connectionInfo));
-
-                // Update application.properties with block stream settings
-                updateApplicationPropertiesWithGrpcStreaming(node);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }
         logger.info("Configured block node connection information for node {}: {}", node.getNodeId(), blockNodes);
-    }
-
-    private static void updateApplicationPropertiesWithGrpcStreaming(HederaNode node) throws IOException {
-        Path appPropertiesPath = node.getExternalPath(APPLICATION_PROPERTIES);
-        logger.info(
-                "Attempting to update application.properties at path {} for node {}",
-                appPropertiesPath,
-                node.getNodeId());
-
-        // First check if file exists and log current content
-        if (Files.exists(appPropertiesPath)) {
-            String currentContent = Files.readString(appPropertiesPath);
-            logger.info("Current application.properties content for node {}: {}", node.getNodeId(), currentContent);
-        } else {
-            logger.info(
-                    "application.properties does not exist yet for node {}, will create new file", node.getNodeId());
-        }
-
-        String blockStreamConfig =
-                """
-                # Block stream configuration
-                blockStream.writerMode=FILE_AND_GRPC
-                blockStream.shutdownNodeOnNoBlockNodes=true
-                blockNode.streamResetPeriod=60s
-                """;
-
-        // Write the properties with CREATE and APPEND options
-        Files.writeString(appPropertiesPath, blockStreamConfig, StandardOpenOption.CREATE, StandardOpenOption.APPEND);
-
-        // Verify the file was updated
-        String updatedContent = Files.readString(appPropertiesPath);
-        logger.info(
-                "Verified application.properties content after update for node {}: {}",
-                node.getNodeId(),
-                updatedContent);
     }
 
     public Map<Long, BlockNodeMode> getBlockNodeModeById() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.junit.hedera.subprocess;
 
 import static com.hedera.node.app.info.DiskStartupNetworks.GENESIS_NETWORK_JSON;
 import static com.hedera.node.app.info.DiskStartupNetworks.OVERRIDE_NETWORK_JSON;
+import static com.hedera.services.bdd.junit.hedera.ExternalPath.APPLICATION_PROPERTIES;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.DATA_CONFIG_DIR;
 import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
 import static com.hedera.services.bdd.junit.hedera.subprocess.ProcessUtils.awaitStatus;
@@ -45,6 +46,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -99,6 +102,8 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
     private final long realm;
 
     private List<Consumer<HederaNode>> postInitWorkingDirActions = new ArrayList<>();
+
+    private Map<Long, List<String>> applicationPropertyOverrides = new HashMap<>();
 
     /**
      * Wraps a runnable, allowing us to defer running it until we know we are the privileged runner
@@ -164,6 +169,7 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
                 Collections.max(nodes.stream().map(SubProcessNode::getNodeId).toList());
         this.configTxt = configTxtForLocal(name(), nodes(), nextInternalGossipPort, nextExternalGossipPort);
         this.genesisConfigTxt = configTxt;
+        this.postInitWorkingDirActions.add(this::configureApplicationProperties);
     }
 
     /**
@@ -584,6 +590,61 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
         throw new RuntimeException("Could not find available port after 100 attempts");
     }
 
+    public void configureApplicationProperties(HederaNode node) {
+        // Update bootstrap properties for the node from bootstrapPropertyOverrides if there are any
+        final var nodeId = node.getNodeId();
+        if (applicationPropertyOverrides.containsKey(nodeId)) {
+            final var properties = applicationPropertyOverrides.get(nodeId);
+            log.info("Configuring application properties for node {}: {}", nodeId, properties);
+            Path appPropertiesPath = node.getExternalPath(APPLICATION_PROPERTIES);
+            log.info(
+                    "Attempting to update application.properties at path {} for node {}",
+                    appPropertiesPath,
+                    node.getNodeId());
+
+            try {
+                // First check if file exists and log current content
+                if (Files.exists(appPropertiesPath)) {
+                    String currentContent = Files.readString(appPropertiesPath);
+                    log.info(
+                            "Current application.properties content for node {}: {}", node.getNodeId(), currentContent);
+                } else {
+                    log.info(
+                            "application.properties does not exist yet for node {}, will create new file",
+                            node.getNodeId());
+                }
+
+                // Prepare the block stream config string
+                StringBuilder propertyBuilder = new StringBuilder();
+                for (int i = 0; i < properties.size(); i += 2) {
+                    propertyBuilder.append(properties.get(i)).append("=").append(properties.get(i + 1));
+                    if (i < properties.size() - 1) {
+                        propertyBuilder.append(System.lineSeparator());
+                    }
+                }
+
+                // Write the properties with CREATE and APPEND options
+                Files.writeString(
+                        appPropertiesPath,
+                        propertyBuilder.toString(),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND);
+
+                // Verify the file was updated
+                String updatedContent = Files.readString(appPropertiesPath);
+                log.info(
+                        "application.properties content after update for node {}: {}",
+                        node.getNodeId(),
+                        updatedContent);
+            } catch (IOException e) {
+                log.error("Failed to update application.properties for node {}: {}", node.getNodeId(), e.getMessage());
+                throw new RuntimeException("Failed to update application.properties for node " + node.getNodeId(), e);
+            }
+        } else {
+            log.info("No bootstrap property overrides for node {}", nodeId);
+        }
+    }
+
     public List<Consumer<HederaNode>> getPostInitWorkingDirActions() {
         return postInitWorkingDirActions;
     }
@@ -601,5 +662,9 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
     @Override
     public PrometheusClient prometheusClient() {
         return PROMETHEUS_CLIENT;
+    }
+
+    public Map<Long, List<String>> getApplicationPropertyOverrides() {
+        return applicationPropertyOverrides;
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackpressureSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackpressureSuite.java
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.blocknode;
+
+import static com.hedera.services.bdd.junit.TestTags.BLOCK_NODE_SIMULATOR;
+import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.utilops.BlockNodeSimulatorVerbs.blockNodeSimulator;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertHgcaaLogContainsTimeframe;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForAny;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilNextBlocks;
+import static java.time.temporal.ChronoUnit.SECONDS;
+
+import com.hedera.services.bdd.HapiBlockNode;
+import com.hedera.services.bdd.HapiBlockNode.BlockNodeConfig;
+import com.hedera.services.bdd.HapiBlockNode.SubProcessNodeConfig;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
+import com.hedera.services.bdd.junit.hedera.BlockNodeMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Stream;
+import org.hiero.consensus.model.status.PlatformStatus;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * This suite specifically tests the behavior of the block buffer service blocking the transaction handling thread
+ * in HandleWorkflow depending on the configuration of streamMode and writerMode.
+ */
+@Tag(BLOCK_NODE_SIMULATOR)
+@OrderedInIsolation
+public class BlockNodeBackpressureSuite {
+
+    @HapiTest
+    @HapiBlockNode(
+            networkSize = 1,
+            blockNodeConfigs = {@BlockNodeConfig(nodeId = 0, mode = BlockNodeMode.SIMULATOR)},
+            subProcessNodeConfigs = {
+                @SubProcessNodeConfig(
+                        nodeId = 0,
+                        blockNodeIds = {0},
+                        blockNodePriorities = {0},
+                        applicationPropertiesOverrides = {
+                            "blockStream.buffer.blockTtl", "30s",
+                            "blockStream.streamMode", "BOTH",
+                            "blockStream.writerMode", "FILE_AND_GRPC"
+                        })
+            })
+    final Stream<DynamicTest> noBackPressureAppliedWhenBufferFull() {
+        final AtomicReference<Instant> time = new AtomicReference<>();
+        return hapiTest(
+                waitUntilNextBlocks(5),
+                blockNodeSimulator(0).shutDownImmediately(),
+                doingContextual(spec -> time.set(Instant.now())),
+                // The node should not stop handling transactions even if the buffer is full
+                // We should see log messages about blocks being evicted
+                sourcingContextual(spec -> assertHgcaaLogContainsTimeframe(
+                        byNodeId(0),
+                        time::get,
+                        Duration.of(20, SECONDS),
+                        Duration.of(45, SECONDS),
+                        "Block buffer is full and backpressure is disabled; evicting lowest block number")));
+    }
+
+    @HapiTest
+    @HapiBlockNode(
+            networkSize = 1,
+            blockNodeConfigs = {@BlockNodeConfig(nodeId = 0, mode = BlockNodeMode.SIMULATOR)},
+            subProcessNodeConfigs = {
+                @SubProcessNodeConfig(
+                        nodeId = 0,
+                        blockNodeIds = {0},
+                        blockNodePriorities = {0},
+                        applicationPropertiesOverrides = {
+                            "blockStream.buffer.blockTtl", "30s",
+                            "blockStream.streamMode", "BLOCKS",
+                            "blockStream.writerMode", "FILE_AND_GRPC"
+                        })
+            })
+    final Stream<DynamicTest> backPressureAppliedWhenBlocksAndFileAndGrpc() {
+        final AtomicReference<Instant> time = new AtomicReference<>();
+        return hapiTest(
+                waitUntilNextBlocks(5),
+                blockNodeSimulator(0).shutDownImmediately(),
+                doingContextual(spec -> time.set(Instant.now())),
+                // The node should not stop handling transactions even if the buffer is full
+                // We should see log messages about blocks being evicted
+                sourcingContextual(spec -> assertHgcaaLogContainsTimeframe(
+                        byNodeId(0),
+                        time::get,
+                        Duration.ofMinutes(1),
+                        Duration.ofMinutes(1),
+                        "Block buffer is saturated; backpressure is being enabled",
+                        "!!! Block buffer is saturated; blocking thread until buffer is no longer saturated")),
+                waitForAny(byNodeId(0), Duration.ofSeconds(30), PlatformStatus.CHECKING));
+    }
+
+    @HapiTest
+    @HapiBlockNode(
+            networkSize = 1,
+            blockNodeConfigs = {@BlockNodeConfig(nodeId = 0, mode = BlockNodeMode.SIMULATOR)},
+            subProcessNodeConfigs = {
+                @SubProcessNodeConfig(
+                        nodeId = 0,
+                        blockNodeIds = {0},
+                        blockNodePriorities = {0},
+                        applicationPropertiesOverrides = {
+                            "blockStream.buffer.blockTtl", "30s",
+                            "blockStream.streamMode", "BLOCKS",
+                            "blockStream.writerMode", "GRPC"
+                        })
+            })
+    final Stream<DynamicTest> backPressureAppliedWhenBlocksAndGrpc() {
+        final AtomicReference<Instant> time = new AtomicReference<>();
+        return hapiTest(
+                doingContextual(
+                        spec -> LockSupport.parkNanos(Duration.ofSeconds(10).toNanos())),
+                blockNodeSimulator(0).shutDownImmediately(),
+                doingContextual(spec -> time.set(Instant.now())),
+                // The node should not stop handling transactions even if the buffer is full
+                // We should see log messages about blocks being evicted
+                sourcingContextual(spec -> assertHgcaaLogContainsTimeframe(
+                        byNodeId(0),
+                        time::get,
+                        Duration.ofMinutes(1),
+                        Duration.ofMinutes(1),
+                        "Block buffer is saturated; backpressure is being enabled",
+                        "!!! Block buffer is saturated; blocking thread until buffer is no longer saturated")),
+                waitForAny(byNodeId(0), Duration.ofSeconds(30), PlatformStatus.CHECKING));
+    }
+}


### PR DESCRIPTION
**Description**:
This pull request updates the buffer management and backpressure logic in the `BlockBufferService` to address that the block buffer should not block the transaction handling thread if it is saturated and if the StreamMode is not `BLOCKS`. It replaces the previous `isStreamingEnabled` flag with two new configuration-driven flags: `grpcStreamingEnabled` and `backpressureEnabled`. Buffer eviction and pruning now depend on these flags, and the buffer size calculation is centralized with a new constant. The associated tests are updated to mock new configuration types and remove outdated logic.

Added tests and updated the test-client to support `application.properties` overrides in `HapiBlockNode` annotation for facilitating block node communication test cases. Note the new `BlockNodeBackpressureSuite` does not run in CI at the moment, these will be added to XTS in the future.

**Buffer and Backpressure Refactoring:**

* Replaced the `isStreamingEnabled` flag with `grpcStreamingEnabled` and `backpressureEnabled`, both set from configuration at construction. All buffer operations now check these new flags instead of the old atomic boolean.
* Updated buffer eviction logic in `openBlock`: when backpressure is disabled and buffer is full, the lowest block number is evicted to make room for new blocks. Removed logic that threw an exception if opening a block after the latest acknowledged block.
* Centralized buffer size calculation with the new constant `DEFAULT_BUFFER_SIZE`, and updated usage throughout the class.

**Code and Logging Cleanup:**

* Changed several logging statements from `debug` to `trace` for less noisy logs in `BlockState`.
* Removed unused imports and the atomic boolean from both implementation and tests.

**Configuration and Testing Updates:**

* Updated tests to mock new configuration types (`VersionedConfiguration`, `BlockStreamConfig`, `BlockBufferConfig`) and removed obsolete test logic related to the old streaming flag.
* Added missing configuration values for `streamMode` in buffer and backpressure tests to ensure new logic is exercised.

**Interface Changes:**

* Added a new method `writePbjItemAndBytes` to `GrpcBlockItemWriter` to support writing both `BlockItem` and its serialized bytes, though the implementation currently delegates to the existing method.

**Related issue(s)**:

Fixes #20502 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
