### PR TITLE
fix: 20515: CryptoBench hashing is unstable

### DIFF
--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValue.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValue.java
@@ -23,10 +23,6 @@ public class BenchmarkValue implements VirtualValue {
         valueSize = size;
     }
 
-    public static int getValueSize() {
-        return valueSize;
-    }
-
     public BenchmarkValue() {
         // default constructor for deserialize
     }
@@ -36,8 +32,12 @@ public class BenchmarkValue implements VirtualValue {
         Utils.toBytes(seed, valueBytes);
     }
 
-    public BenchmarkValue(BenchmarkValue other) {
-        valueBytes = Arrays.copyOf(other.valueBytes, other.valueBytes.length);
+    private BenchmarkValue(byte[] valueBytes) {
+        this.valueBytes = Arrays.copyOf(valueBytes, valueBytes.length);
+    }
+
+    protected BenchmarkValue(BenchmarkValue other) {
+        this(other.valueBytes);
     }
 
     public BenchmarkValue(final ReadableSequentialData in) {
@@ -50,20 +50,18 @@ public class BenchmarkValue implements VirtualValue {
         return Utils.fromBytes(valueBytes);
     }
 
-    public void update(LongUnaryOperator updater) {
-        long value = Utils.fromBytes(valueBytes);
-        value = updater.applyAsLong(value);
-        Utils.toBytes(value, valueBytes);
-    }
-
     @Override
     public VirtualValue copy() {
-        return new BenchmarkValue(this);
+        return new BenchmarkValue(this.valueBytes);
     }
 
     @Override
     public VirtualValue asReadOnly() {
-        return new BenchmarkValue(this);
+        return this;
+    }
+
+    public Builder copyBuilder() {
+        return new Builder(this);
     }
 
     public int getSizeInBytes() {
@@ -135,5 +133,25 @@ public class BenchmarkValue implements VirtualValue {
     @Override
     public int hashCode() {
         return Arrays.hashCode(valueBytes);
+    }
+
+    public static final class Builder {
+
+        private byte[] valueBytes;
+
+        public Builder(final BenchmarkValue value) {
+            this.valueBytes = Arrays.copyOf(value.valueBytes, value.valueBytes.length);
+        }
+
+        public Builder update(LongUnaryOperator updater) {
+            long value = Utils.fromBytes(valueBytes);
+            value = updater.applyAsLong(value);
+            Utils.toBytes(value, valueBytes);
+            return this;
+        }
+
+        public BenchmarkValue build() {
+            return new BenchmarkValue(valueBytes);
+        }
     }
 }

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/CryptoBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/CryptoBench.java
@@ -140,23 +140,25 @@ public abstract class CryptoBench extends VirtualMapBench {
                 if (value1 == null) {
                     value1 = new BenchmarkValue(amount);
                 } else {
-                    value1.update(l -> l + amount);
+                    value1 = value1.copyBuilder().update(l -> l + amount).build();
                 }
                 virtualMap.put(key1, value1, BenchmarkValueCodec.INSTANCE);
 
                 if (value2 == null) {
                     value2 = new BenchmarkValue(-amount);
                 } else {
-                    value2.update(l -> l - amount);
+                    value2 = value2.copyBuilder().update(l -> l - amount).build();
                 }
                 virtualMap.put(key2, value2, BenchmarkValueCodec.INSTANCE);
 
                 // Model fees
                 value1 = virtualMap.get(fixedKey1, BenchmarkValueCodec.INSTANCE);
-                value1.update(l -> l + 1);
+                assert value1 != null;
+                value1 = value1.copyBuilder().update(l -> l + 1).build();
                 virtualMap.put(fixedKey1, value1, BenchmarkValueCodec.INSTANCE);
                 value2 = virtualMap.get(fixedKey2, BenchmarkValueCodec.INSTANCE);
-                value2.update(l -> l + 1);
+                assert value2 != null;
+                value2 = value2.copyBuilder().update(l -> l + 1).build();
                 virtualMap.put(fixedKey2, value2, BenchmarkValueCodec.INSTANCE);
 
                 if (verify) {
@@ -251,23 +253,25 @@ public abstract class CryptoBench extends VirtualMapBench {
                 if (value1 == null) {
                     value1 = new BenchmarkValue(amount);
                 } else {
-                    value1.update(l -> l + amount);
+                    value1 = value1.copyBuilder().update(l -> l + amount).build();
                 }
                 virtualMap.put(key1, value1, BenchmarkValueCodec.INSTANCE);
 
                 if (value2 == null) {
                     value2 = new BenchmarkValue(-amount);
                 } else {
-                    value2.update(l -> l - amount);
+                    value2 = value2.copyBuilder().update(l -> l - amount).build();
                 }
                 virtualMap.put(key2, value2, BenchmarkValueCodec.INSTANCE);
 
                 // Model fees
                 value1 = virtualMap.get(fixedKey1, BenchmarkValueCodec.INSTANCE);
-                value1.update(l -> l + 1);
+                assert value1 != null;
+                value1 = value1.copyBuilder().update(l -> l + 1).build();
                 virtualMap.put(fixedKey1, value1, BenchmarkValueCodec.INSTANCE);
                 value2 = virtualMap.get(fixedKey2, BenchmarkValueCodec.INSTANCE);
-                value2.update(l -> l + 1);
+                assert value2 != null;
+                value2 = value2.copyBuilder().update(l -> l + 1).build();
                 virtualMap.put(fixedKey2, value2, BenchmarkValueCodec.INSTANCE);
 
                 if (verify) {
@@ -374,8 +378,8 @@ public abstract class CryptoBench extends VirtualMapBench {
                 BenchmarkValue value1 = buffer.removeFirst().orElse(new BenchmarkValue(0));
                 BenchmarkValue value2 = buffer.removeFirst().orElse(new BenchmarkValue(0));
                 long amount = Utils.randomLong(MAX_AMOUNT);
-                value1.update(l -> l + amount);
-                value2.update(l -> l - amount);
+                value1 = value1.copyBuilder().update(l -> l + amount).build();
+                value2 = value2.copyBuilder().update(l -> l - amount).build();
                 int keyId1 = keys[j * KEYS_PER_RECORD];
                 int keyId2 = keys[j * KEYS_PER_RECORD + 1];
                 currentMap.put(BenchmarkKey.longToKey(keyId1), value1, BenchmarkValueCodec.INSTANCE);
@@ -383,10 +387,12 @@ public abstract class CryptoBench extends VirtualMapBench {
 
                 // Model fees
                 value1 = virtualMap.get(fixedKey1, BenchmarkValueCodec.INSTANCE);
-                value1.update(l -> l + 1);
+                assert value1 != null;
+                value1 = value1.copyBuilder().update(l -> l + 1).build();
                 virtualMap.put(fixedKey1, value1, BenchmarkValueCodec.INSTANCE);
                 value2 = virtualMap.get(fixedKey2, BenchmarkValueCodec.INSTANCE);
-                value2.update(l -> l + 1);
+                assert value2 != null;
+                value2 = value2.copyBuilder().update(l -> l + 1).build();
                 virtualMap.put(fixedKey2, value2, BenchmarkValueCodec.INSTANCE);
 
                 if (verify) {

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/FCHashMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/FCHashMapBench.java
@@ -38,14 +38,15 @@ public class FCHashMapBench extends BaseBench {
             for (int j = 0; j < numRecords; ++j) {
                 long id = Utils.randomLong(maxKey);
                 BenchmarkKey key = new BenchmarkKey(id);
-                var modifiableValue = fcHashMap.getForModify(key);
+                BenchmarkValue value = fcHashMap.get(key);
                 long val = nextValue();
-                if (modifiableValue != null) {
+                if (value != null) {
                     if ((val & 0xff) == 0) {
                         fcHashMap.remove(key);
                         if (verify) map[(int) id] = 0L;
                     } else {
-                        modifiableValue.value().update((l) -> l + val);
+                        value = value.copyBuilder().update((l) -> l + val).build();
+                        fcHashMap.put(key, value);
                         if (verify) map[(int) id] += val;
                     }
                 } else {

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/VirtualMapBench.java
@@ -56,7 +56,7 @@ public class VirtualMapBench extends VirtualMapBaseBench {
                         virtualMap.remove(key);
                         if (verify) map[(int) id] = 0L;
                     } else {
-                        value.update(l -> l + val);
+                        value = value.copyBuilder().update(l -> l + val).build();
                         virtualMap.put(key, value, BenchmarkValueCodec.INSTANCE);
                         if (verify) map[(int) id] += val;
                     }
@@ -154,7 +154,7 @@ public class VirtualMapBench extends VirtualMapBaseBench {
                 BenchmarkValue value = virtualMap.get(key, BenchmarkValueCodec.INSTANCE);
                 final long val = nextValue();
                 if (value != null) {
-                    value.update(l -> l + val);
+                    value = value.copyBuilder().update(l -> l + val).build();
                     virtualMap.put(key, value, BenchmarkValueCodec.INSTANCE);
                     if (verify) map[(int) id] += val;
                 } else {


### PR DESCRIPTION
Fix summary:

* No changes to any module other than swirlds-benchmarks
* `BenchmarkValue` is now immutable
* To update benchmark value's value, a builder is introduced to `BenchmarkValue`. It creates a new instance of `BenchmarkValue` every time
* `CryptoBench` is updated to use the builder

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/20515
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
