### PR TITLE
chore: Add methods to suppress multiple node results in Otter

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeConsensusResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeConsensusResultsImpl.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -84,8 +85,9 @@ public class MultipleNodeConsensusResultsImpl implements MultipleNodeConsensusRe
      * {@inheritDoc}
      */
     @Override
-    public @NotNull MultipleNodeConsensusResults suppressingNodes(@NotNull final List<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+    public @NotNull MultipleNodeConsensusResults suppressingNodes(@NotNull final Collection<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress =
+                nodes.stream().distinct().map(Node::selfId).toList();
         final List<SingleNodeConsensusResult> filtered = results.stream()
                 .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
                 .toList();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeConsensusResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeConsensusResultsImpl.java
@@ -9,11 +9,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.ConsensusRoundSubscriber;
 import org.hiero.otter.fixtures.result.MultipleNodeConsensusResults;
 import org.hiero.otter.fixtures.result.OtterResult;
 import org.hiero.otter.fixtures.result.SingleNodeConsensusResult;
 import org.hiero.otter.fixtures.result.SubscriberAction;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Default implementation of {@link MultipleNodeConsensusResults}
@@ -76,6 +78,18 @@ public class MultipleNodeConsensusResultsImpl implements MultipleNodeConsensusRe
                 .filter(result -> !Objects.equals(nodeId, result.nodeId()))
                 .toList();
         return new MultipleNodeConsensusResultsImpl(newResults);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull MultipleNodeConsensusResults suppressingNodes(@NotNull final List<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+        final List<SingleNodeConsensusResult> filtered = results.stream()
+                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
+                .toList();
+        return new MultipleNodeConsensusResultsImpl(filtered);
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeConsensusResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeConsensusResultsImpl.java
@@ -9,7 +9,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.ConsensusRoundSubscriber;
 import org.hiero.otter.fixtures.result.MultipleNodeConsensusResults;
@@ -86,10 +88,9 @@ public class MultipleNodeConsensusResultsImpl implements MultipleNodeConsensusRe
      */
     @Override
     public @NotNull MultipleNodeConsensusResults suppressingNodes(@NotNull final Collection<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress =
-                nodes.stream().distinct().map(Node::selfId).toList();
+        final Set<NodeId> nodeIdsToSuppress = nodes.stream().map(Node::selfId).collect(Collectors.toSet());
         final List<SingleNodeConsensusResult> filtered = results.stream()
-                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
+                .filter(result -> !nodeIdsToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodeConsensusResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeLogResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeLogResultsImpl.java
@@ -10,7 +10,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.LogSubscriber;
 import org.hiero.otter.fixtures.result.MultipleNodeLogResults;
@@ -88,10 +90,9 @@ public class MultipleNodeLogResultsImpl implements MultipleNodeLogResults {
      */
     @Override
     public @NotNull MultipleNodeLogResults suppressingNodes(@NotNull final Collection<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress =
-                nodes.stream().distinct().map(Node::selfId).toList();
+        final Set<NodeId> nodeIdsToSuppress = nodes.stream().map(Node::selfId).collect(Collectors.toSet());
         final List<SingleNodeLogResult> filtered = results.stream()
-                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
+                .filter(result -> !nodeIdsToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodeLogResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeLogResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeLogResultsImpl.java
@@ -10,11 +10,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.LogSubscriber;
 import org.hiero.otter.fixtures.result.MultipleNodeLogResults;
 import org.hiero.otter.fixtures.result.OtterResult;
 import org.hiero.otter.fixtures.result.SingleNodeLogResult;
 import org.hiero.otter.fixtures.result.SubscriberAction;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Default implementation of {@link MultipleNodeLogResults}
@@ -78,6 +80,18 @@ public class MultipleNodeLogResultsImpl implements MultipleNodeLogResults {
                 .toList();
 
         return new MultipleNodeLogResultsImpl(filteredResults);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull MultipleNodeLogResults suppressingNodes(@NotNull final List<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+        final List<SingleNodeLogResult> filtered = results.stream()
+                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
+                .toList();
+        return new MultipleNodeLogResultsImpl(filtered);
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeLogResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeLogResultsImpl.java
@@ -7,6 +7,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.platform.state.NodeId;
 import com.swirlds.logging.legacy.LogMarker;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -86,8 +87,9 @@ public class MultipleNodeLogResultsImpl implements MultipleNodeLogResults {
      * {@inheritDoc}
      */
     @Override
-    public @NotNull MultipleNodeLogResults suppressingNodes(@NotNull final List<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+    public @NotNull MultipleNodeLogResults suppressingNodes(@NotNull final Collection<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress =
+                nodes.stream().distinct().map(Node::selfId).toList();
         final List<SingleNodeLogResult> filtered = results.stream()
                 .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
                 .toList();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeMarkerFileResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeMarkerFileResultsImpl.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -83,8 +84,9 @@ public class MultipleNodeMarkerFileResultsImpl implements MultipleNodeMarkerFile
      * {@inheritDoc}
      */
     @Override
-    public @NotNull MultipleNodeMarkerFileResults suppressingNodes(@NotNull final List<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+    public @NotNull MultipleNodeMarkerFileResults suppressingNodes(@NotNull final Collection<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress =
+                nodes.stream().distinct().map(Node::selfId).toList();
         final List<SingleNodeMarkerFileResult> filtered = results.stream()
                 .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
                 .toList();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeMarkerFileResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeMarkerFileResultsImpl.java
@@ -9,7 +9,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.MarkerFileSubscriber;
 import org.hiero.otter.fixtures.result.MultipleNodeMarkerFileResults;
@@ -85,10 +87,9 @@ public class MultipleNodeMarkerFileResultsImpl implements MultipleNodeMarkerFile
      */
     @Override
     public @NotNull MultipleNodeMarkerFileResults suppressingNodes(@NotNull final Collection<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress =
-                nodes.stream().distinct().map(Node::selfId).toList();
+        final Set<NodeId> nodeIdsToSuppress = nodes.stream().map(Node::selfId).collect(Collectors.toSet());
         final List<SingleNodeMarkerFileResult> filtered = results.stream()
-                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
+                .filter(result -> !nodeIdsToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodeMarkerFileResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeMarkerFileResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeMarkerFileResultsImpl.java
@@ -9,10 +9,12 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.MarkerFileSubscriber;
 import org.hiero.otter.fixtures.result.MultipleNodeMarkerFileResults;
 import org.hiero.otter.fixtures.result.SingleNodeMarkerFileResult;
 import org.hiero.otter.fixtures.result.SubscriberAction;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Default implementation of {@link MultipleNodeMarkerFileResults}
@@ -73,6 +75,18 @@ public class MultipleNodeMarkerFileResultsImpl implements MultipleNodeMarkerFile
     public MultipleNodeMarkerFileResults suppressingNode(@NonNull final NodeId nodeId) {
         final List<SingleNodeMarkerFileResult> filtered = results.stream()
                 .filter(result -> !Objects.equals(nodeId, result.nodeId()))
+                .toList();
+        return new MultipleNodeMarkerFileResultsImpl(filtered);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull MultipleNodeMarkerFileResults suppressingNodes(@NotNull final List<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+        final List<SingleNodeMarkerFileResult> filtered = results.stream()
+                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodeMarkerFileResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePcesResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePcesResultsImpl.java
@@ -3,10 +3,13 @@ package org.hiero.otter.fixtures.internal.result;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.MultipleNodePcesResults;
 import org.hiero.otter.fixtures.result.SingleNodePcesResult;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Default implementation of {@link MultipleNodePcesResults}
@@ -24,6 +27,19 @@ public record MultipleNodePcesResultsImpl(@NonNull List<SingleNodePcesResult> pc
     public MultipleNodePcesResults suppressingNode(@NonNull final NodeId nodeId) {
         final List<SingleNodePcesResult> filtered = pcesResults.stream()
                 .filter(it -> Objects.equals(it.nodeId(), nodeId))
+                .toList();
+        return new MultipleNodePcesResultsImpl(filtered);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull MultipleNodePcesResults suppressingNodes(@NotNull final Collection<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress =
+                nodes.stream().distinct().map(Node::selfId).toList();
+        final List<SingleNodePcesResult> filtered = pcesResults.stream()
+                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodePcesResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePcesResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePcesResultsImpl.java
@@ -6,6 +6,8 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.MultipleNodePcesResults;
 import org.hiero.otter.fixtures.result.SingleNodePcesResult;
@@ -36,10 +38,9 @@ public record MultipleNodePcesResultsImpl(@NonNull List<SingleNodePcesResult> pc
      */
     @Override
     public @NotNull MultipleNodePcesResults suppressingNodes(@NotNull final Collection<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress =
-                nodes.stream().distinct().map(Node::selfId).toList();
+        final Set<NodeId> nodeIdsToSuppress = nodes.stream().map(Node::selfId).collect(Collectors.toSet());
         final List<SingleNodePcesResult> filtered = pcesResults.stream()
-                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
+                .filter(result -> !nodeIdsToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodePcesResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePlatformStatusResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePlatformStatusResultsImpl.java
@@ -9,7 +9,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.MultipleNodePlatformStatusResults;
 import org.hiero.otter.fixtures.result.OtterResult;
@@ -86,10 +88,9 @@ public class MultipleNodePlatformStatusResultsImpl implements MultipleNodePlatfo
      */
     @Override
     public @NotNull MultipleNodePlatformStatusResults suppressingNodes(@NotNull final Collection<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress =
-                nodes.stream().distinct().map(Node::selfId).toList();
+        final Set<NodeId> nodeIdsToSuppress = nodes.stream().map(Node::selfId).collect(Collectors.toSet());
         final List<SingleNodePlatformStatusResult> filtered = results.stream()
-                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
+                .filter(result -> !nodeIdsToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodePlatformStatusResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePlatformStatusResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePlatformStatusResultsImpl.java
@@ -9,11 +9,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.MultipleNodePlatformStatusResults;
 import org.hiero.otter.fixtures.result.OtterResult;
 import org.hiero.otter.fixtures.result.PlatformStatusSubscriber;
 import org.hiero.otter.fixtures.result.SingleNodePlatformStatusResult;
 import org.hiero.otter.fixtures.result.SubscriberAction;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Default implementation of {@link MultipleNodePlatformStatusResults}
@@ -74,6 +76,18 @@ public class MultipleNodePlatformStatusResultsImpl implements MultipleNodePlatfo
     public MultipleNodePlatformStatusResults suppressingNode(@NonNull final NodeId nodeId) {
         final List<SingleNodePlatformStatusResult> filtered = results.stream()
                 .filter(result -> !Objects.equals(nodeId, result.nodeId()))
+                .toList();
+        return new MultipleNodePlatformStatusResultsImpl(filtered);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public @NotNull MultipleNodePlatformStatusResults suppressingNodes(@NotNull final List<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+        final List<SingleNodePlatformStatusResult> filtered = results.stream()
+                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodePlatformStatusResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePlatformStatusResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodePlatformStatusResultsImpl.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -84,8 +85,9 @@ public class MultipleNodePlatformStatusResultsImpl implements MultipleNodePlatfo
      * {@inheritDoc}
      */
     @Override
-    public @NotNull MultipleNodePlatformStatusResults suppressingNodes(@NotNull final List<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+    public @NotNull MultipleNodePlatformStatusResults suppressingNodes(@NotNull final Collection<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress =
+                nodes.stream().distinct().map(Node::selfId).toList();
         final List<SingleNodePlatformStatusResult> filtered = results.stream()
                 .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
                 .toList();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeReconnectResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeReconnectResultsImpl.java
@@ -9,7 +9,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.MultipleNodeReconnectResults;
 import org.hiero.otter.fixtures.result.ReconnectNotificationSubscriber;
@@ -64,10 +66,9 @@ public class MultipleNodeReconnectResultsImpl implements MultipleNodeReconnectRe
      */
     @Override
     public @NotNull MultipleNodeReconnectResults suppressingNodes(@NotNull final Collection<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress =
-                nodes.stream().distinct().map(Node::selfId).toList();
+        final Set<NodeId> nodeIdsToSuppress = nodes.stream().map(Node::selfId).collect(Collectors.toSet());
         final List<SingleNodeReconnectResult> filtered = results.stream()
-                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
+                .filter(result -> !nodeIdsToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodeReconnectResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeReconnectResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeReconnectResultsImpl.java
@@ -9,6 +9,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.result.MultipleNodeReconnectResults;
 import org.hiero.otter.fixtures.result.ReconnectNotificationSubscriber;
 import org.hiero.otter.fixtures.result.SingleNodeReconnectResult;
@@ -52,6 +53,19 @@ public class MultipleNodeReconnectResultsImpl implements MultipleNodeReconnectRe
     public MultipleNodeReconnectResults suppressingNode(@NonNull final NodeId nodeId) {
         final List<SingleNodeReconnectResult> filtered = results.stream()
                 .filter(it -> Objects.equals(it.nodeId(), nodeId))
+                .toList();
+        return new MultipleNodeReconnectResultsImpl(filtered);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     */
+    @Override
+    public @NotNull MultipleNodeReconnectResults suppressingNodes(@NotNull final List<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+        final List<SingleNodeReconnectResult> filtered = results.stream()
+                .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
                 .toList();
         return new MultipleNodeReconnectResultsImpl(filtered);
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeReconnectResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeReconnectResultsImpl.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -62,8 +63,9 @@ public class MultipleNodeReconnectResultsImpl implements MultipleNodeReconnectRe
      *
      */
     @Override
-    public @NotNull MultipleNodeReconnectResults suppressingNodes(@NotNull final List<Node> nodes) {
-        final List<NodeId> nodeIdToSuppress = nodes.stream().map(Node::selfId).toList();
+    public @NotNull MultipleNodeReconnectResults suppressingNodes(@NotNull final Collection<Node> nodes) {
+        final List<NodeId> nodeIdToSuppress =
+                nodes.stream().distinct().map(Node::selfId).toList();
         final List<SingleNodeReconnectResult> filtered = results.stream()
                 .filter(result -> !nodeIdToSuppress.contains(result.nodeId()))
                 .toList();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeConsensusResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeConsensusResults.java
@@ -3,6 +3,7 @@ package org.hiero.otter.fixtures.result;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
 import java.util.List;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.otter.fixtures.Node;
@@ -48,5 +49,25 @@ public interface MultipleNodeConsensusResults extends OtterResult {
     @NonNull
     default MultipleNodeConsensusResults suppressingNode(@NonNull final Node node) {
         return suppressingNode(node.selfId());
+    }
+
+    /**
+     * Excludes the consensus results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose consensus results are to be excluded
+     * @return a new instance of {@link MultipleNodeConsensusResults} with the specified nodes' consensus results excluded
+     */
+    @NonNull
+    MultipleNodeConsensusResults suppressingNodes(@NonNull final List<Node> nodes);
+
+    /**
+     * Excludes the consensus results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose consensus results are to be excluded
+     * @return a new instance of {@link MultipleNodeConsensusResults} with the specified nodes' consensus results excluded
+     */
+    @NonNull
+    default MultipleNodeConsensusResults suppressingNodes(@NonNull final Node... nodes) {
+        return suppressingNodes(Arrays.asList(nodes));
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeConsensusResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeConsensusResults.java
@@ -4,6 +4,7 @@ package org.hiero.otter.fixtures.result;
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.otter.fixtures.Node;
@@ -58,7 +59,7 @@ public interface MultipleNodeConsensusResults extends OtterResult {
      * @return a new instance of {@link MultipleNodeConsensusResults} with the specified nodes' consensus results excluded
      */
     @NonNull
-    MultipleNodeConsensusResults suppressingNodes(@NonNull final List<Node> nodes);
+    MultipleNodeConsensusResults suppressingNodes(@NonNull final Collection<Node> nodes);
 
     /**
      * Excludes the consensus results of one or more nodes from the current results.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeLogResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeLogResults.java
@@ -4,6 +4,7 @@ package org.hiero.otter.fixtures.result;
 import com.hedera.hapi.platform.state.NodeId;
 import com.swirlds.logging.legacy.LogMarker;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
 import java.util.List;
 import org.hiero.otter.fixtures.Node;
 
@@ -52,6 +53,25 @@ public interface MultipleNodeLogResults extends OtterResult {
         return suppressingNode(node.selfId());
     }
 
+    /**
+     * Excludes the log results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose log results are to be excluded
+     * @return a new instance of {@link MultipleNodeLogResults} with the specified nodes' log results excluded
+     */
+    @NonNull
+    MultipleNodeLogResults suppressingNodes(@NonNull final List<Node> nodes);
+
+    /**
+     * Excludes the log results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose log results are to be excluded
+     * @return a new instance of {@link MultipleNodeLogResults} with the specified nodes' log results excluded
+     */
+    @NonNull
+    default MultipleNodeLogResults suppressingNodes(@NonNull final Node... nodes) {
+        return suppressingNodes(Arrays.asList(nodes));
+    }
     /**
      * Excludes the log results associated with the specified log marker from the current results.
      *

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeLogResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeLogResults.java
@@ -5,6 +5,7 @@ import com.hedera.hapi.platform.state.NodeId;
 import com.swirlds.logging.legacy.LogMarker;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.hiero.otter.fixtures.Node;
 
@@ -60,7 +61,7 @@ public interface MultipleNodeLogResults extends OtterResult {
      * @return a new instance of {@link MultipleNodeLogResults} with the specified nodes' log results excluded
      */
     @NonNull
-    MultipleNodeLogResults suppressingNodes(@NonNull final List<Node> nodes);
+    MultipleNodeLogResults suppressingNodes(@NonNull final Collection<Node> nodes);
 
     /**
      * Excludes the log results of one or more nodes from the current results.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeMarkerFileResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeMarkerFileResults.java
@@ -3,6 +3,7 @@ package org.hiero.otter.fixtures.result;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
 import java.util.List;
 import org.hiero.otter.fixtures.Node;
 
@@ -40,6 +41,25 @@ public interface MultipleNodeMarkerFileResults {
         return suppressingNode(node.selfId());
     }
 
+    /**
+     * Excludes the marker file results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose marker file results are to be excluded
+     * @return a new instance of {@link MultipleNodeMarkerFileResults} with the specified nodes' marker file results excluded
+     */
+    @NonNull
+    MultipleNodeMarkerFileResults suppressingNodes(@NonNull final List<Node> nodes);
+
+    /**
+     * Excludes the marker file results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose marker file results are to be excluded
+     * @return a new instance of {@link MultipleNodeMarkerFileResults} with the specified nodes' marker file results excluded
+     */
+    @NonNull
+    default MultipleNodeMarkerFileResults suppressingNodes(@NonNull final Node... nodes) {
+        return suppressingNodes(Arrays.asList(nodes));
+    }
     /**
      * Subscribes to marker file changes the nodes go through.
      *

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeMarkerFileResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeMarkerFileResults.java
@@ -4,6 +4,7 @@ package org.hiero.otter.fixtures.result;
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.hiero.otter.fixtures.Node;
 
@@ -48,7 +49,7 @@ public interface MultipleNodeMarkerFileResults {
      * @return a new instance of {@link MultipleNodeMarkerFileResults} with the specified nodes' marker file results excluded
      */
     @NonNull
-    MultipleNodeMarkerFileResults suppressingNodes(@NonNull final List<Node> nodes);
+    MultipleNodeMarkerFileResults suppressingNodes(@NonNull final Collection<Node> nodes);
 
     /**
      * Excludes the marker file results of one or more nodes from the current results.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodePcesResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodePcesResults.java
@@ -3,6 +3,8 @@ package org.hiero.otter.fixtures.result;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.hiero.otter.fixtures.Node;
 
@@ -40,5 +42,25 @@ public interface MultipleNodePcesResults {
     @NonNull
     default MultipleNodePcesResults suppressingNode(@NonNull final Node node) {
         return suppressingNode(node.selfId());
+    }
+
+    /**
+     * Excludes the PCES results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose PCES results are to be excluded
+     * @return a new instance of {@link MultipleNodePcesResults} with the specified nodes' PCES results excluded
+     */
+    @NonNull
+    MultipleNodePcesResults suppressingNodes(@NonNull final Collection<Node> nodes);
+
+    /**
+     * Excludes the PCES results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose PCES results are to be excluded
+     * @return a new instance of {@link MultipleNodePcesResults} with the specified nodes' PCES results excluded
+     */
+    @NonNull
+    default MultipleNodePcesResults suppressingNodes(@NonNull final Node... nodes) {
+        return suppressingNodes(Arrays.asList(nodes));
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodePlatformStatusResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodePlatformStatusResults.java
@@ -3,6 +3,7 @@ package org.hiero.otter.fixtures.result;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
 import java.util.List;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.otter.fixtures.Node;
@@ -27,7 +28,8 @@ public interface MultipleNodePlatformStatusResults extends OtterResult {
      * Excludes the status progression of a specific node from the current results.
      *
      * @param nodeId the {@link NodeId} of the node whose status progression is to be excluded
-     * @return a new instance of {@link MultipleNodePlatformStatusResults} with the specified node's status progression excluded
+     * @return a new instance of {@link MultipleNodePlatformStatusResults} with the specified node's status progression
+     * excluded
      */
     @NonNull
     MultipleNodePlatformStatusResults suppressingNode(@NonNull NodeId nodeId);
@@ -41,6 +43,26 @@ public interface MultipleNodePlatformStatusResults extends OtterResult {
     @NonNull
     default MultipleNodePlatformStatusResults suppressingNode(@NonNull final Node node) {
         return suppressingNode(node.selfId());
+    }
+
+    /**
+     * Excludes the status progression of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose status progressions are to be excluded
+     * @return a new instance of {@link MultipleNodePlatformStatusResults} with the specified nodes' status progressions excluded
+     */
+    @NonNull
+    MultipleNodePlatformStatusResults suppressingNodes(@NonNull final List<Node> nodes);
+
+    /**
+     * Excludes the status progression of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose status progressions are to be excluded
+     * @return a new instance of {@link MultipleNodePlatformStatusResults} with the specified nodes' status progressions excluded
+     */
+    @NonNull
+    default MultipleNodePlatformStatusResults suppressingNodes(@NonNull final Node... nodes) {
+        return suppressingNodes(Arrays.asList(nodes));
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodePlatformStatusResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodePlatformStatusResults.java
@@ -4,6 +4,7 @@ package org.hiero.otter.fixtures.result;
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.otter.fixtures.Node;
@@ -52,7 +53,7 @@ public interface MultipleNodePlatformStatusResults extends OtterResult {
      * @return a new instance of {@link MultipleNodePlatformStatusResults} with the specified nodes' status progressions excluded
      */
     @NonNull
-    MultipleNodePlatformStatusResults suppressingNodes(@NonNull final List<Node> nodes);
+    MultipleNodePlatformStatusResults suppressingNodes(@NonNull final Collection<Node> nodes);
 
     /**
      * Excludes the status progression of one or more nodes from the current results.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeReconnectResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeReconnectResults.java
@@ -3,6 +3,7 @@ package org.hiero.otter.fixtures.result;
 
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
 import java.util.List;
 import org.hiero.otter.fixtures.Node;
 
@@ -40,6 +41,26 @@ public interface MultipleNodeReconnectResults {
     @NonNull
     default MultipleNodeReconnectResults suppressingNode(@NonNull final Node node) {
         return suppressingNode(node.selfId());
+    }
+
+    /**
+     * Excludes the reconnect results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose reconnect results are to be excluded
+     * @return a new instance of {@link MultipleNodeReconnectResults} with the specified nodes' reconnect results excluded
+     */
+    @NonNull
+    MultipleNodeReconnectResults suppressingNodes(@NonNull final List<Node> nodes);
+
+    /**
+     * Excludes the reconnect results of one or more nodes from the current results.
+     *
+     * @param nodes the nodes whose reconnect results are to be excluded
+     * @return a new instance of {@link MultipleNodeReconnectResults} with the specified nodes' reconnect results excluded
+     */
+    @NonNull
+    default MultipleNodeReconnectResults suppressingNodes(@NonNull final Node... nodes) {
+        return suppressingNodes(Arrays.asList(nodes));
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeReconnectResults.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/result/MultipleNodeReconnectResults.java
@@ -4,6 +4,7 @@ package org.hiero.otter.fixtures.result;
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import org.hiero.otter.fixtures.Node;
 
@@ -50,7 +51,7 @@ public interface MultipleNodeReconnectResults {
      * @return a new instance of {@link MultipleNodeReconnectResults} with the specified nodes' reconnect results excluded
      */
     @NonNull
-    MultipleNodeReconnectResults suppressingNodes(@NonNull final List<Node> nodes);
+    MultipleNodeReconnectResults suppressingNodes(@NonNull final Collection<Node> nodes);
 
     /**
      * Excludes the reconnect results of one or more nodes from the current results.


### PR DESCRIPTION
Fixes #20313