### PR TITLE
chore: Isolate and partition nodes in Turtle

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
@@ -52,8 +52,7 @@ public class BirthRoundFreezeTest {
         // the freeze round. Events created after this time should have a birth round greater
         // than the freeze round.
         final Instant postFreezeShutdownTime = timeManager.now();
-        final long freezeRound =
-                network.getNodes().getFirst().newConsensusResult().lastRoundNum();
+        final long freezeRound = network.nodes().getFirst().newConsensusResult().lastRoundNum();
 
         assertThat(network.newPcesResults()).haveMaxBirthRoundLessThanOrEqualTo(freezeRound);
 

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
@@ -52,7 +52,8 @@ public class BirthRoundFreezeTest {
         // the freeze round. Events created after this time should have a birth round greater
         // than the freeze round.
         final Instant postFreezeShutdownTime = timeManager.now();
-        final long freezeRound = network.getNodes().getFirst().newConsensusResult().lastRoundNum();
+        final long freezeRound =
+                network.getNodes().getFirst().newConsensusResult().lastRoundNum();
 
         assertThat(network.newPcesResults()).haveMaxBirthRoundLessThanOrEqualTo(freezeRound);
 

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/BirthRoundFreezeTest.java
@@ -52,7 +52,7 @@ public class BirthRoundFreezeTest {
         // the freeze round. Events created after this time should have a birth round greater
         // than the freeze round.
         final Instant postFreezeShutdownTime = timeManager.now();
-        final long freezeRound = network.nodes().getFirst().newConsensusResult().lastRoundNum();
+        final long freezeRound = network.getNodes().getFirst().newConsensusResult().lastRoundNum();
 
         assertThat(network.newPcesResults()).haveMaxBirthRoundLessThanOrEqualTo(freezeRound);
 

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/CheckingRecoveryTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/CheckingRecoveryTest.java
@@ -48,7 +48,7 @@ public class CheckingRecoveryTest {
         // Run the nodes for some time
         timeManager.waitFor(Duration.ofSeconds(30L));
 
-        final Node nodeToThrottle = network.nodes().getLast();
+        final Node nodeToThrottle = network.getNodes().getLast();
         assertThat(nodeToThrottle.newPlatformStatusResult())
                 .hasSteps(target(ACTIVE).requiringInterim(REPLAYING_EVENTS, OBSERVING, CHECKING));
 

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/CheckingRecoveryTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/CheckingRecoveryTest.java
@@ -39,7 +39,8 @@ public class CheckingRecoveryTest {
         // Setup simulation
 
         // Add more than 3 nodes with balanced weights so that one node can be lost without halting consensus
-        network.addNodes(4, WeightGenerators.BALANCED);
+        network.setWeightGenerator(WeightGenerators.BALANCED);
+        network.addNodes(4);
 
         assertContinuouslyThat(network.newConsensusResults()).haveEqualRounds();
         network.start();
@@ -47,7 +48,7 @@ public class CheckingRecoveryTest {
         // Run the nodes for some time
         timeManager.waitFor(Duration.ofSeconds(30L));
 
-        final Node nodeToThrottle = network.getNodes().getLast();
+        final Node nodeToThrottle = network.nodes().getLast();
         assertThat(nodeToThrottle.newPlatformStatusResult())
                 .hasSteps(target(ACTIVE).requiringInterim(REPLAYING_EVENTS, OBSERVING, CHECKING));
 

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/ReconnectTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/ReconnectTest.java
@@ -42,17 +42,18 @@ public class ReconnectTest {
         // Setup simulation
 
         // Add more than 3 nodes with balanced weights so that one node can be taken down without halting consensus
-        network.addNodes(4, WeightGenerators.BALANCED);
+        network.setWeightGenerator(WeightGenerators.BALANCED);
+        network.addNodes(4);
 
         // Set the rounds non-ancient and expired to smaller values to allow nodes to fall behind quickly
-        network.getNodes().forEach(node -> {
+        network.nodes().forEach(node -> {
             node.configuration()
                     .set(ConsensusConfig_.ROUNDS_NON_ANCIENT, ROUNDS_NON_ANCIENT)
                     .set(ConsensusConfig_.ROUNDS_EXPIRED, ROUNDS_EXPIRED);
         });
 
         // Set the node we will force to reconnect
-        final Node nodeToReconnect = network.getNodes().getLast();
+        final Node nodeToReconnect = network.nodes().getLast();
 
         // Setup continuous assertions
         assertContinuouslyThat(network.newConsensusResults()).haveEqualRounds();

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/ReconnectTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/ReconnectTest.java
@@ -46,14 +46,14 @@ public class ReconnectTest {
         network.addNodes(4);
 
         // Set the rounds non-ancient and expired to smaller values to allow nodes to fall behind quickly
-        network.nodes().forEach(node -> {
+        network.getNodes().forEach(node -> {
             node.configuration()
                     .set(ConsensusConfig_.ROUNDS_NON_ANCIENT, ROUNDS_NON_ANCIENT)
                     .set(ConsensusConfig_.ROUNDS_EXPIRED, ROUNDS_EXPIRED);
         });
 
         // Set the node we will force to reconnect
-        final Node nodeToReconnect = network.nodes().getLast();
+        final Node nodeToReconnect = network.getNodes().getLast();
 
         // Setup continuous assertions
         assertContinuouslyThat(network.newConsensusResults()).haveEqualRounds();

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
@@ -126,7 +126,7 @@ public class SandboxTest {
 
         // Validations
         final MultipleNodeLogResults logResults = network.newLogResults()
-                .suppressingNode(network.getNodes().getFirst())
+                .suppressingNode(network.nodes().getFirst())
                 .suppressingLogMarker(STARTUP);
         assertThat(logResults).haveNoMessagesWithLevelHigherThan(Level.WARN);
 

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/SandboxTest.java
@@ -126,7 +126,7 @@ public class SandboxTest {
 
         // Validations
         final MultipleNodeLogResults logResults = network.newLogResults()
-                .suppressingNode(network.nodes().getFirst())
+                .suppressingNode(network.getNodes().getFirst())
                 .suppressingLogMarker(STARTUP);
         assertThat(logResults).haveNoMessagesWithLevelHigherThan(Level.WARN);
 

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkIsolationTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkIsolationTest.java
@@ -1,0 +1,398 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.test.turtle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hiero.consensus.model.status.PlatformStatus.ACTIVE;
+import static org.hiero.otter.fixtures.OtterAssertions.assertContinuouslyThat;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.hiero.otter.fixtures.Network;
+import org.hiero.otter.fixtures.Node;
+import org.hiero.otter.fixtures.TestEnvironment;
+import org.hiero.otter.fixtures.TimeManager;
+import org.hiero.otter.fixtures.network.Partition;
+import org.hiero.otter.fixtures.turtle.TurtleTestEnvironment;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for the node isolation functionality in the Network interface.
+ */
+public class NetworkIsolationTest {
+
+    /**
+     * Provides a stream of test environments for the parameterized tests.
+     *
+     * @return a stream of {@link TestEnvironment} instances
+     */
+    public static Stream<TestEnvironment> environments() {
+        return Stream.of(new TurtleTestEnvironment(0L));
+    }
+
+    /**
+     * Test that a single node can be isolated from the network.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testIsolateSingleNode(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        // Setup network with 4 nodes
+        final List<Node> nodes = network.addNodes(4);
+        final Node nodeToIsolate = nodes.getFirst();
+
+        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+
+        network.start();
+
+        // Wait for nodes to become active
+        timeManager.waitFor(Duration.ofSeconds(30));
+
+        // Isolate the first node
+        final Partition partition = network.isolate(nodeToIsolate);
+
+        // Verify the node is isolated
+        assertThat(network.isIsolated(nodeToIsolate)).isTrue();
+        assertThat(partition).isNotNull();
+        assertThat(partition.nodes()).containsExactly(nodeToIsolate);
+        assertThat(partition.size()).isEqualTo(1);
+
+        // Verify the node is in a partition
+        assertThat(network.getPartitionContaining(nodeToIsolate)).isEqualTo(partition);
+        assertThat(network.partitions()).contains(partition);
+
+        // Let the network run with the isolated node
+        timeManager.waitFor(Duration.ofSeconds(10));
+
+        // Other nodes should continue to make progress
+        assertThat(nodes.get(1).platformStatus()).isEqualTo(ACTIVE);
+        assertThat(nodes.get(2).platformStatus()).isEqualTo(ACTIVE);
+        assertThat(nodes.get(3).platformStatus()).isEqualTo(ACTIVE);
+
+        network.shutdown();
+    }
+
+    /**
+     * Test that an isolated node can be rejoined with the network.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testRejoinIsolatedNode(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        // Setup network with 4 nodes
+        final List<Node> nodes = network.addNodes(4);
+        final Node nodeToIsolate = nodes.getFirst();
+
+        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+
+        network.start();
+
+        // Wait for nodes to become active
+        timeManager.waitFor(Duration.ofSeconds(5));
+
+        // Isolate and then rejoin the node
+        final Partition partition = network.isolate(nodeToIsolate);
+        assertThat(network.isIsolated(nodeToIsolate)).isTrue();
+
+        timeManager.waitFor(Duration.ofSeconds(5));
+
+        // Rejoin the node
+        network.rejoin(nodeToIsolate);
+
+        // Verify the node is no longer isolated
+        assertThat(network.isIsolated(nodeToIsolate)).isFalse();
+        assertThat(network.getPartitionContaining(nodeToIsolate)).isNull();
+        assertThat(network.partitions()).doesNotContain(partition);
+
+        // Let the network run after rejoining
+        timeManager.waitFor(Duration.ofSeconds(10));
+
+        // All nodes should be active
+        for (final Node node : nodes) {
+            assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+        }
+
+        network.shutdown();
+    }
+
+    /**
+     * Test the isIsolated method for various scenarios.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testIsIsolatedCheck(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+
+        // Setup network with 4 nodes
+        final List<Node> nodes = network.addNodes(4);
+        final Node node1 = nodes.getFirst();
+        final Node node2 = nodes.get(1);
+        final Node node3 = nodes.get(2);
+
+        network.start();
+
+        // Initially no nodes are isolated
+        assertThat(network.isIsolated(node1)).isFalse();
+        assertThat(network.isIsolated(node2)).isFalse();
+        assertThat(network.isIsolated(node3)).isFalse();
+
+        // Isolate node1
+        network.isolate(node1);
+        assertThat(network.isIsolated(node1)).isTrue();
+        assertThat(network.isIsolated(node2)).isFalse();
+
+        // Create a partition with multiple nodes (not isolated)
+        final Partition multiNodePartition = network.createPartition(Set.of(node2, node3));
+        assertThat(network.isIsolated(node2)).isFalse(); // Part of multi-node partition
+        assertThat(network.isIsolated(node3)).isFalse(); // Part of multi-node partition
+
+        network.shutdown();
+    }
+
+    /**
+     * Test isolating multiple nodes independently.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testIsolateMultipleNodes(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        // Setup network with 5 nodes
+        final List<Node> nodes = network.addNodes(5);
+        final Node node1 = nodes.getFirst();
+        final Node node2 = nodes.get(1);
+
+        network.start();
+
+        // Wait for nodes to become active
+        timeManager.waitFor(Duration.ofSeconds(5));
+
+        // Isolate two nodes independently
+        final Partition partition1 = network.isolate(node1);
+        final Partition partition2 = network.isolate(node2);
+
+        // Verify both nodes are isolated
+        assertThat(network.isIsolated(node1)).isTrue();
+        assertThat(network.isIsolated(node2)).isTrue();
+
+        // Verify they are in separate partitions
+        assertThat(partition1).isNotEqualTo(partition2);
+        assertThat(partition1.nodes()).containsExactly(node1);
+        assertThat(partition2.nodes()).containsExactly(node2);
+
+        // Verify the network has both partitions
+        assertThat(network.partitions()).containsExactlyInAnyOrder(partition1, partition2);
+
+        // Rejoin one node
+        network.rejoin(node1);
+        assertThat(network.isIsolated(node1)).isFalse();
+        assertThat(network.isIsolated(node2)).isTrue();
+        assertThat(network.partitions()).containsExactly(partition2);
+
+        network.shutdown();
+    }
+
+    /**
+     * Test that isolating a node that is already in a partition throws an exception.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testIsolateAlreadyPartitionedNode(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+
+        // Setup network with 4 nodes
+        final List<Node> nodes = network.addNodes(4);
+        final Node node1 = nodes.getFirst();
+
+        network.start();
+
+        // First isolate the node
+        network.isolate(node1);
+
+        // Try to isolate the same node again - should throw exception
+        assertThatThrownBy(() -> network.isolate(node1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("already in a partition");
+
+        network.shutdown();
+    }
+
+    /**
+     * Test that rejoining a node that is not isolated throws an exception.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testRejoinNonIsolatedNode(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+
+        // Setup network with 4 nodes
+        final List<Node> nodes = network.addNodes(4);
+        final Node node1 = nodes.getFirst();
+
+        network.start();
+
+        // Try to rejoin a node that is not isolated - should throw exception
+        assertThatThrownBy(() -> network.rejoin(node1))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not isolated");
+
+        network.shutdown();
+    }
+
+    /**
+     * Test the partition lifecycle with isolation.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testPartitionLifecycleWithIsolation(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        // Setup network with 4 nodes
+        final List<Node> nodes = network.addNodes(4);
+        final Node node1 = nodes.getFirst();
+        final Node node2 = nodes.get(1);
+
+        network.start();
+
+        // Create a regular partition first
+        final Partition regularPartition = network.createPartition(Set.of(node1, node2));
+        assertThat(network.getPartitionContaining(node1)).isEqualTo(regularPartition);
+        assertThat(network.getPartitionContaining(node2)).isEqualTo(regularPartition);
+        assertThat(network.isIsolated(node1)).isFalse();
+        assertThat(network.isIsolated(node2)).isFalse();
+
+        // Remove the partition
+        network.removePartition(regularPartition);
+        assertThat(network.getPartitionContaining(node1)).isNull();
+        assertThat(network.getPartitionContaining(node2)).isNull();
+
+        // Now isolate node1
+        final Partition isolationPartition = network.isolate(node1);
+        assertThat(network.isIsolated(node1)).isTrue();
+        assertThat(network.getPartitionContaining(node1)).isEqualTo(isolationPartition);
+
+        // Remove the isolation partition using removePartition
+        network.removePartition(isolationPartition);
+        assertThat(network.isIsolated(node1)).isFalse();
+        assertThat(network.getPartitionContaining(node1)).isNull();
+
+        network.shutdown();
+    }
+
+    /**
+     * Test restoreConnectivity with isolated nodes.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testRestoreConnectivityWithIsolatedNodes(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        // Setup network with 5 nodes
+        final List<Node> nodes = network.addNodes(5);
+        final Node node1 = nodes.getFirst();
+        final Node node2 = nodes.get(1);
+        final Node node3 = nodes.get(2);
+        final Node node4 = nodes.get(3);
+
+        network.start();
+
+        // Wait for nodes to become active
+        timeManager.waitFor(Duration.ofSeconds(5));
+
+        // Create various partitions and isolations
+        network.isolate(node1);
+        network.isolate(node2);
+        final Partition multiNodePartition = network.createPartition(Set.of(node3, node4));
+
+        // Verify the state
+        assertThat(network.isIsolated(node1)).isTrue();
+        assertThat(network.isIsolated(node2)).isTrue();
+        assertThat(network.getPartitionContaining(node3)).isEqualTo(multiNodePartition);
+        assertThat(network.getPartitionContaining(node4)).isEqualTo(multiNodePartition);
+        assertThat(network.partitions()).hasSize(3);
+
+        // Restore all connectivity
+        network.restoreConnectivity();
+
+        // Verify all nodes are no longer isolated or partitioned
+        assertThat(network.isIsolated(node1)).isFalse();
+        assertThat(network.isIsolated(node2)).isFalse();
+        assertThat(network.getPartitionContaining(node1)).isNull();
+        assertThat(network.getPartitionContaining(node2)).isNull();
+        assertThat(network.getPartitionContaining(node3)).isNull();
+        assertThat(network.getPartitionContaining(node4)).isNull();
+        assertThat(network.partitions()).isEmpty();
+
+        // Let the network run after restoration
+        timeManager.waitFor(Duration.ofSeconds(10));
+
+        // All nodes should be active
+        for (final Node node : nodes) {
+            assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+        }
+
+        network.shutdown();
+    }
+
+    /**
+     * Test isolation behavior during network freeze.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testIsolationDuringFreeze(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        // Setup network with 4 nodes
+        final List<Node> nodes = network.addNodes(4);
+        final Node nodeToIsolate = nodes.getFirst();
+
+        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+
+        network.start();
+
+        // Wait for nodes to become active
+        timeManager.waitFor(Duration.ofSeconds(5));
+
+        // Isolate a node
+        network.isolate(nodeToIsolate);
+        assertThat(network.isIsolated(nodeToIsolate)).isTrue();
+
+        // Freeze the network
+        network.freeze();
+
+        // The isolated node should remain isolated during freeze
+        assertThat(network.isIsolated(nodeToIsolate)).isTrue();
+
+        network.shutdown();
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkIsolationTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkIsolationTest.java
@@ -95,7 +95,7 @@ class NetworkIsolationTest {
     @MethodSource("environments")
     void testRejoinIsolatedNode(@NonNull final TestEnvironment env) {
         // Rejoining a network requires the RECONNECT capability.
-        if (! env.capabilities().contains(Capability.RECONNECT)) {
+        if (!env.capabilities().contains(Capability.RECONNECT)) {
             return;
         }
         try {

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkIsolationTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkIsolationTest.java
@@ -11,19 +11,23 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.hiero.otter.fixtures.Capability;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
 import org.hiero.otter.fixtures.network.Partition;
 import org.hiero.otter.fixtures.turtle.TurtleTestEnvironment;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 /**
  * Tests for the node isolation functionality in the Network interface.
  */
-public class NetworkIsolationTest {
+class NetworkIsolationTest {
+
+    private static final long RANDOM_SEED = 0L;
 
     /**
      * Provides a stream of test environments for the parameterized tests.
@@ -31,7 +35,7 @@ public class NetworkIsolationTest {
      * @return a stream of {@link TestEnvironment} instances
      */
     public static Stream<TestEnvironment> environments() {
-        return Stream.of(new TurtleTestEnvironment(0L));
+        return Stream.of(new TurtleTestEnvironment(RANDOM_SEED));
     }
 
     /**
@@ -42,42 +46,44 @@ public class NetworkIsolationTest {
     @ParameterizedTest
     @MethodSource("environments")
     void testIsolateSingleNode(@NonNull final TestEnvironment env) {
-        final Network network = env.network();
-        final TimeManager timeManager = env.timeManager();
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
 
-        // Setup network with 4 nodes
-        final List<Node> nodes = network.addNodes(4);
-        final Node nodeToIsolate = nodes.getFirst();
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node nodeToIsolate = nodes.getFirst();
 
-        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+            assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
 
-        network.start();
+            network.start();
 
-        // Wait for nodes to become active
-        timeManager.waitFor(Duration.ofSeconds(30));
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(30));
 
-        // Isolate the first node
-        final Partition partition = network.isolate(nodeToIsolate);
+            // Isolate the first node
+            final Partition partition = network.isolate(nodeToIsolate);
 
-        // Verify the node is isolated
-        assertThat(network.isIsolated(nodeToIsolate)).isTrue();
-        assertThat(partition).isNotNull();
-        assertThat(partition.nodes()).containsExactly(nodeToIsolate);
-        assertThat(partition.size()).isEqualTo(1);
+            // Verify the node is isolated
+            assertThat(network.isIsolated(nodeToIsolate)).isTrue();
+            assertThat(partition).isNotNull();
+            assertThat(partition.nodes()).containsExactly(nodeToIsolate);
+            assertThat(partition.size()).isEqualTo(1);
 
-        // Verify the node is in a partition
-        assertThat(network.getPartitionContaining(nodeToIsolate)).isEqualTo(partition);
-        assertThat(network.partitions()).contains(partition);
+            // Verify the node is in a partition
+            assertThat(network.getPartitionContaining(nodeToIsolate)).isEqualTo(partition);
+            assertThat(network.partitions()).contains(partition);
 
-        // Let the network run with the isolated node
-        timeManager.waitFor(Duration.ofSeconds(10));
+            // Let the network run with the isolated node
+            timeManager.waitFor(Duration.ofSeconds(10));
 
-        // Other nodes should continue to make progress
-        assertThat(nodes.get(1).platformStatus()).isEqualTo(ACTIVE);
-        assertThat(nodes.get(2).platformStatus()).isEqualTo(ACTIVE);
-        assertThat(nodes.get(3).platformStatus()).isEqualTo(ACTIVE);
-
-        network.shutdown();
+            // Other nodes should continue to make progress
+            assertThat(nodes.get(1).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(2).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(3).platformStatus()).isEqualTo(ACTIVE);
+        } finally {
+            env.destroy();
+        }
     }
 
     /**
@@ -88,43 +94,49 @@ public class NetworkIsolationTest {
     @ParameterizedTest
     @MethodSource("environments")
     void testRejoinIsolatedNode(@NonNull final TestEnvironment env) {
-        final Network network = env.network();
-        final TimeManager timeManager = env.timeManager();
-
-        // Setup network with 4 nodes
-        final List<Node> nodes = network.addNodes(4);
-        final Node nodeToIsolate = nodes.getFirst();
-
-        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
-
-        network.start();
-
-        // Wait for nodes to become active
-        timeManager.waitFor(Duration.ofSeconds(5));
-
-        // Isolate and then rejoin the node
-        final Partition partition = network.isolate(nodeToIsolate);
-        assertThat(network.isIsolated(nodeToIsolate)).isTrue();
-
-        timeManager.waitFor(Duration.ofSeconds(5));
-
-        // Rejoin the node
-        network.rejoin(nodeToIsolate);
-
-        // Verify the node is no longer isolated
-        assertThat(network.isIsolated(nodeToIsolate)).isFalse();
-        assertThat(network.getPartitionContaining(nodeToIsolate)).isNull();
-        assertThat(network.partitions()).doesNotContain(partition);
-
-        // Let the network run after rejoining
-        timeManager.waitFor(Duration.ofSeconds(10));
-
-        // All nodes should be active
-        for (final Node node : nodes) {
-            assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+        // Rejoining a network requires the RECONNECT capability.
+        if (! env.capabilities().contains(Capability.RECONNECT)) {
+            return;
         }
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
 
-        network.shutdown();
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node nodeToIsolate = nodes.getFirst();
+
+            assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Isolate and then rejoin the node
+            final Partition partition = network.isolate(nodeToIsolate);
+            assertThat(network.isIsolated(nodeToIsolate)).isTrue();
+
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Rejoin the node
+            network.rejoin(nodeToIsolate);
+
+            // Verify the node is no longer isolated
+            assertThat(network.isIsolated(nodeToIsolate)).isFalse();
+            assertThat(network.getPartitionContaining(nodeToIsolate)).isNull();
+            assertThat(network.partitions()).doesNotContain(partition);
+
+            // Let the network run after rejoining
+            timeManager.waitFor(Duration.ofSeconds(10));
+
+            // All nodes should be active
+            for (final Node node : nodes) {
+                assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+            }
+        } finally {
+            env.destroy();
+        }
     }
 
     /**
@@ -135,32 +147,34 @@ public class NetworkIsolationTest {
     @ParameterizedTest
     @MethodSource("environments")
     void testIsIsolatedCheck(@NonNull final TestEnvironment env) {
-        final Network network = env.network();
+        try {
+            final Network network = env.network();
 
-        // Setup network with 4 nodes
-        final List<Node> nodes = network.addNodes(4);
-        final Node node1 = nodes.getFirst();
-        final Node node2 = nodes.get(1);
-        final Node node3 = nodes.get(2);
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node node1 = nodes.getFirst();
+            final Node node2 = nodes.get(1);
+            final Node node3 = nodes.get(2);
 
-        network.start();
+            network.start();
 
-        // Initially no nodes are isolated
-        assertThat(network.isIsolated(node1)).isFalse();
-        assertThat(network.isIsolated(node2)).isFalse();
-        assertThat(network.isIsolated(node3)).isFalse();
+            // Initially no nodes are isolated
+            assertThat(network.isIsolated(node1)).isFalse();
+            assertThat(network.isIsolated(node2)).isFalse();
+            assertThat(network.isIsolated(node3)).isFalse();
 
-        // Isolate node1
-        network.isolate(node1);
-        assertThat(network.isIsolated(node1)).isTrue();
-        assertThat(network.isIsolated(node2)).isFalse();
+            // Isolate node1
+            network.isolate(node1);
+            assertThat(network.isIsolated(node1)).isTrue();
+            assertThat(network.isIsolated(node2)).isFalse();
 
-        // Create a partition with multiple nodes (not isolated)
-        final Partition multiNodePartition = network.createPartition(Set.of(node2, node3));
-        assertThat(network.isIsolated(node2)).isFalse(); // Part of multi-node partition
-        assertThat(network.isIsolated(node3)).isFalse(); // Part of multi-node partition
-
-        network.shutdown();
+            // Create a partition with multiple nodes (not isolated)
+            final Partition multiNodePartition = network.createPartition(Set.of(node2, node3));
+            assertThat(network.isIsolated(node2)).isFalse(); // Part of multi-node partition
+            assertThat(network.isIsolated(node3)).isFalse(); // Part of multi-node partition
+        } finally {
+            env.destroy();
+        }
     }
 
     /**
@@ -171,42 +185,44 @@ public class NetworkIsolationTest {
     @ParameterizedTest
     @MethodSource("environments")
     void testIsolateMultipleNodes(@NonNull final TestEnvironment env) {
-        final Network network = env.network();
-        final TimeManager timeManager = env.timeManager();
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
 
-        // Setup network with 5 nodes
-        final List<Node> nodes = network.addNodes(5);
-        final Node node1 = nodes.getFirst();
-        final Node node2 = nodes.get(1);
+            // Setup network with 5 nodes
+            final List<Node> nodes = network.addNodes(5);
+            final Node node1 = nodes.getFirst();
+            final Node node2 = nodes.get(1);
 
-        network.start();
+            network.start();
 
-        // Wait for nodes to become active
-        timeManager.waitFor(Duration.ofSeconds(5));
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
 
-        // Isolate two nodes independently
-        final Partition partition1 = network.isolate(node1);
-        final Partition partition2 = network.isolate(node2);
+            // Isolate two nodes independently
+            final Partition partition1 = network.isolate(node1);
+            final Partition partition2 = network.isolate(node2);
 
-        // Verify both nodes are isolated
-        assertThat(network.isIsolated(node1)).isTrue();
-        assertThat(network.isIsolated(node2)).isTrue();
+            // Verify both nodes are isolated
+            assertThat(network.isIsolated(node1)).isTrue();
+            assertThat(network.isIsolated(node2)).isTrue();
 
-        // Verify they are in separate partitions
-        assertThat(partition1).isNotEqualTo(partition2);
-        assertThat(partition1.nodes()).containsExactly(node1);
-        assertThat(partition2.nodes()).containsExactly(node2);
+            // Verify they are in separate partitions
+            assertThat(partition1).isNotEqualTo(partition2);
+            assertThat(partition1.nodes()).containsExactly(node1);
+            assertThat(partition2.nodes()).containsExactly(node2);
 
-        // Verify the network has both partitions
-        assertThat(network.partitions()).containsExactlyInAnyOrder(partition1, partition2);
+            // Verify the network has both partitions
+            assertThat(network.partitions()).containsExactlyInAnyOrder(partition1, partition2);
 
-        // Rejoin one node
-        network.rejoin(node1);
-        assertThat(network.isIsolated(node1)).isFalse();
-        assertThat(network.isIsolated(node2)).isTrue();
-        assertThat(network.partitions()).containsExactly(partition2);
-
-        network.shutdown();
+            // Rejoin one node
+            network.rejoin(node1);
+            assertThat(network.isIsolated(node1)).isFalse();
+            assertThat(network.isIsolated(node2)).isTrue();
+            assertThat(network.partitions()).containsExactly(partition2);
+        } finally {
+            env.destroy();
+        }
     }
 
     /**
@@ -217,23 +233,25 @@ public class NetworkIsolationTest {
     @ParameterizedTest
     @MethodSource("environments")
     void testIsolateAlreadyPartitionedNode(@NonNull final TestEnvironment env) {
-        final Network network = env.network();
+        try {
+            final Network network = env.network();
 
-        // Setup network with 4 nodes
-        final List<Node> nodes = network.addNodes(4);
-        final Node node1 = nodes.getFirst();
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node node1 = nodes.getFirst();
 
-        network.start();
+            network.start();
 
-        // First isolate the node
-        network.isolate(node1);
+            // First isolate the node
+            network.isolate(node1);
 
-        // Try to isolate the same node again - should throw exception
-        assertThatThrownBy(() -> network.isolate(node1))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("already in a partition");
-
-        network.shutdown();
+            // Try to isolate the same node again - should throw exception
+            assertThatThrownBy(() -> network.isolate(node1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("already in a partition");
+        } finally {
+            env.destroy();
+        }
     }
 
     /**
@@ -244,20 +262,22 @@ public class NetworkIsolationTest {
     @ParameterizedTest
     @MethodSource("environments")
     void testRejoinNonIsolatedNode(@NonNull final TestEnvironment env) {
-        final Network network = env.network();
+        try {
+            final Network network = env.network();
 
-        // Setup network with 4 nodes
-        final List<Node> nodes = network.addNodes(4);
-        final Node node1 = nodes.getFirst();
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node node1 = nodes.getFirst();
 
-        network.start();
+            network.start();
 
-        // Try to rejoin a node that is not isolated - should throw exception
-        assertThatThrownBy(() -> network.rejoin(node1))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("not isolated");
-
-        network.shutdown();
+            // Try to rejoin a node that is not isolated - should throw exception
+            assertThatThrownBy(() -> network.rejoin(node1))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("not isolated");
+        } finally {
+            env.destroy();
+        }
     }
 
     /**
@@ -268,39 +288,41 @@ public class NetworkIsolationTest {
     @ParameterizedTest
     @MethodSource("environments")
     void testPartitionLifecycleWithIsolation(@NonNull final TestEnvironment env) {
-        final Network network = env.network();
-        final TimeManager timeManager = env.timeManager();
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
 
-        // Setup network with 4 nodes
-        final List<Node> nodes = network.addNodes(4);
-        final Node node1 = nodes.getFirst();
-        final Node node2 = nodes.get(1);
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node node1 = nodes.getFirst();
+            final Node node2 = nodes.get(1);
 
-        network.start();
+            network.start();
 
-        // Create a regular partition first
-        final Partition regularPartition = network.createPartition(Set.of(node1, node2));
-        assertThat(network.getPartitionContaining(node1)).isEqualTo(regularPartition);
-        assertThat(network.getPartitionContaining(node2)).isEqualTo(regularPartition);
-        assertThat(network.isIsolated(node1)).isFalse();
-        assertThat(network.isIsolated(node2)).isFalse();
+            // Create a regular partition first
+            final Partition regularPartition = network.createPartition(Set.of(node1, node2));
+            assertThat(network.getPartitionContaining(node1)).isEqualTo(regularPartition);
+            assertThat(network.getPartitionContaining(node2)).isEqualTo(regularPartition);
+            assertThat(network.isIsolated(node1)).isFalse();
+            assertThat(network.isIsolated(node2)).isFalse();
 
-        // Remove the partition
-        network.removePartition(regularPartition);
-        assertThat(network.getPartitionContaining(node1)).isNull();
-        assertThat(network.getPartitionContaining(node2)).isNull();
+            // Remove the partition
+            network.removePartition(regularPartition);
+            assertThat(network.getPartitionContaining(node1)).isNull();
+            assertThat(network.getPartitionContaining(node2)).isNull();
 
-        // Now isolate node1
-        final Partition isolationPartition = network.isolate(node1);
-        assertThat(network.isIsolated(node1)).isTrue();
-        assertThat(network.getPartitionContaining(node1)).isEqualTo(isolationPartition);
+            // Now isolate node1
+            final Partition isolationPartition = network.isolate(node1);
+            assertThat(network.isIsolated(node1)).isTrue();
+            assertThat(network.getPartitionContaining(node1)).isEqualTo(isolationPartition);
 
-        // Remove the isolation partition using removePartition
-        network.removePartition(isolationPartition);
-        assertThat(network.isIsolated(node1)).isFalse();
-        assertThat(network.getPartitionContaining(node1)).isNull();
-
-        network.shutdown();
+            // Remove the isolation partition using removePartition
+            network.removePartition(isolationPartition);
+            assertThat(network.isIsolated(node1)).isFalse();
+            assertThat(network.getPartitionContaining(node1)).isNull();
+        } finally {
+            env.destroy();
+        }
     }
 
     /**
@@ -311,54 +333,56 @@ public class NetworkIsolationTest {
     @ParameterizedTest
     @MethodSource("environments")
     void testRestoreConnectivityWithIsolatedNodes(@NonNull final TestEnvironment env) {
-        final Network network = env.network();
-        final TimeManager timeManager = env.timeManager();
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
 
-        // Setup network with 5 nodes
-        final List<Node> nodes = network.addNodes(5);
-        final Node node1 = nodes.getFirst();
-        final Node node2 = nodes.get(1);
-        final Node node3 = nodes.get(2);
-        final Node node4 = nodes.get(3);
+            // Setup network with 5 nodes
+            final List<Node> nodes = network.addNodes(5);
+            final Node node1 = nodes.getFirst();
+            final Node node2 = nodes.get(1);
+            final Node node3 = nodes.get(2);
+            final Node node4 = nodes.get(3);
 
-        network.start();
+            network.start();
 
-        // Wait for nodes to become active
-        timeManager.waitFor(Duration.ofSeconds(5));
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
 
-        // Create various partitions and isolations
-        network.isolate(node1);
-        network.isolate(node2);
-        final Partition multiNodePartition = network.createPartition(Set.of(node3, node4));
+            // Create various partitions and isolations
+            network.isolate(node1);
+            network.isolate(node2);
+            final Partition multiNodePartition = network.createPartition(Set.of(node3, node4));
 
-        // Verify the state
-        assertThat(network.isIsolated(node1)).isTrue();
-        assertThat(network.isIsolated(node2)).isTrue();
-        assertThat(network.getPartitionContaining(node3)).isEqualTo(multiNodePartition);
-        assertThat(network.getPartitionContaining(node4)).isEqualTo(multiNodePartition);
-        assertThat(network.partitions()).hasSize(3);
+            // Verify the state
+            assertThat(network.isIsolated(node1)).isTrue();
+            assertThat(network.isIsolated(node2)).isTrue();
+            assertThat(network.getPartitionContaining(node3)).isEqualTo(multiNodePartition);
+            assertThat(network.getPartitionContaining(node4)).isEqualTo(multiNodePartition);
+            assertThat(network.partitions()).hasSize(3);
 
-        // Restore all connectivity
-        network.restoreConnectivity();
+            // Restore all connectivity
+            network.restoreConnectivity();
 
-        // Verify all nodes are no longer isolated or partitioned
-        assertThat(network.isIsolated(node1)).isFalse();
-        assertThat(network.isIsolated(node2)).isFalse();
-        assertThat(network.getPartitionContaining(node1)).isNull();
-        assertThat(network.getPartitionContaining(node2)).isNull();
-        assertThat(network.getPartitionContaining(node3)).isNull();
-        assertThat(network.getPartitionContaining(node4)).isNull();
-        assertThat(network.partitions()).isEmpty();
+            // Verify all nodes are no longer isolated or partitioned
+            assertThat(network.isIsolated(node1)).isFalse();
+            assertThat(network.isIsolated(node2)).isFalse();
+            assertThat(network.getPartitionContaining(node1)).isNull();
+            assertThat(network.getPartitionContaining(node2)).isNull();
+            assertThat(network.getPartitionContaining(node3)).isNull();
+            assertThat(network.getPartitionContaining(node4)).isNull();
+            assertThat(network.partitions()).isEmpty();
 
-        // Let the network run after restoration
-        timeManager.waitFor(Duration.ofSeconds(10));
+            // Let the network run after restoration
+            timeManager.waitFor(Duration.ofSeconds(10));
 
-        // All nodes should be active
-        for (final Node node : nodes) {
-            assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+            // All nodes should be active
+            for (final Node node : nodes) {
+                assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+            }
+        } finally {
+            env.destroy();
         }
-
-        network.shutdown();
     }
 
     /**
@@ -366,33 +390,36 @@ public class NetworkIsolationTest {
      *
      * @param env the test environment for this test
      */
+    @Disabled("Investigate how this scenario is handled in production and adjust accordingly")
     @ParameterizedTest
     @MethodSource("environments")
     void testIsolationDuringFreeze(@NonNull final TestEnvironment env) {
-        final Network network = env.network();
-        final TimeManager timeManager = env.timeManager();
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
 
-        // Setup network with 4 nodes
-        final List<Node> nodes = network.addNodes(4);
-        final Node nodeToIsolate = nodes.getFirst();
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node nodeToIsolate = nodes.getFirst();
 
-        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+            assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
 
-        network.start();
+            network.start();
 
-        // Wait for nodes to become active
-        timeManager.waitFor(Duration.ofSeconds(5));
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
 
-        // Isolate a node
-        network.isolate(nodeToIsolate);
-        assertThat(network.isIsolated(nodeToIsolate)).isTrue();
+            // Isolate a node
+            network.isolate(nodeToIsolate);
+            assertThat(network.isIsolated(nodeToIsolate)).isTrue();
 
-        // Freeze the network
-        network.freeze();
+            // Freeze the network
+            network.freeze();
 
-        // The isolated node should remain isolated during freeze
-        assertThat(network.isIsolated(nodeToIsolate)).isTrue();
-
-        network.shutdown();
+            // The isolated node should remain isolated during freeze
+            assertThat(network.isIsolated(nodeToIsolate)).isTrue();
+        } finally {
+            env.destroy();
+        }
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkPartitionTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkPartitionTest.java
@@ -1,0 +1,563 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.test.turtle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hiero.consensus.model.status.PlatformStatus.ACTIVE;
+import static org.hiero.consensus.model.status.PlatformStatus.CHECKING;
+import static org.hiero.otter.fixtures.OtterAssertions.assertContinuouslyThat;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Stream;
+import org.hiero.otter.fixtures.Network;
+import org.hiero.otter.fixtures.Node;
+import org.hiero.otter.fixtures.TestEnvironment;
+import org.hiero.otter.fixtures.TimeManager;
+import org.hiero.otter.fixtures.network.Partition;
+import org.hiero.otter.fixtures.turtle.TurtleTestEnvironment;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests for the network partition functionality in the Network interface.
+ */
+class NetworkPartitionTest {
+
+    private static final long RANDOM_SEED = 0L;
+
+    /**
+     * Provides a stream of test environments for the parameterized tests.
+     *
+     * @return a stream of {@link TestEnvironment} instances
+     */
+    public static Stream<TestEnvironment> environments() {
+        return Stream.of(new TurtleTestEnvironment(RANDOM_SEED));
+    }
+
+    /**
+     * Test that a partition can be created with multiple nodes.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testCreateBasicPartition(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
+
+            // Setup network with 5 nodes
+            final List<Node> nodes = network.addNodes(6);
+            final Node node0 = nodes.get(0);
+            final Node node1 = nodes.get(1);
+            final Node node2 = nodes.get(2);
+
+            assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(30));
+
+            // Create a partition with two nodes
+            final Partition partition = network.createPartition(Set.of(node0, node1));
+
+            // Verify the partition was created correctly
+            assertThat(partition).isNotNull();
+            assertThat(partition.nodes()).containsExactlyInAnyOrder(node0, node1);
+            assertThat(partition.size()).isEqualTo(2);
+
+            // Verify nodes are in the partition
+            assertThat(network.getPartitionContaining(node0)).isEqualTo(partition);
+            assertThat(network.getPartitionContaining(node1)).isEqualTo(partition);
+            assertThat(network.getPartitionContaining(node2)).isNull();
+
+            // Verify partition is tracked by the network
+            assertThat(network.partitions()).contains(partition);
+
+            // Verify nodes in partition are not isolated (partition has multiple nodes)
+            assertThat(network.isIsolated(node0)).isFalse();
+            assertThat(network.isIsolated(node1)).isFalse();
+            assertThat(network.isIsolated(node2)).isFalse();
+
+            // Let the network run with the partition
+            timeManager.waitFor(Duration.ofSeconds(30));
+
+            // Nodes outside partition should continue to make progress
+            assertThat(nodes.get(0).platformStatus()).isEqualTo(CHECKING);
+            assertThat(nodes.get(1).platformStatus()).isEqualTo(CHECKING);
+            assertThat(nodes.get(2).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(3).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(4).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(5).platformStatus()).isEqualTo(ACTIVE);
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test that multiple partitions can be created simultaneously.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testCreateMultiplePartitions(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
+
+            // Setup network with 6 nodes
+            final List<Node> nodes = network.addNodes(6);
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Create two separate partitions
+            final Partition partition1 = network.createPartition(Set.of(nodes.get(0), nodes.get(1)));
+            final Partition partition2 = network.createPartition(Set.of(nodes.get(2), nodes.get(3)));
+
+            // Verify both partitions exist
+            assertThat(network.partitions()).containsExactlyInAnyOrder(partition1, partition2);
+            assertThat(partition1).isNotEqualTo(partition2);
+
+            // Verify nodes are in correct partitions
+            assertThat(network.getPartitionContaining(nodes.get(0))).isEqualTo(partition1);
+            assertThat(network.getPartitionContaining(nodes.get(1))).isEqualTo(partition1);
+            assertThat(network.getPartitionContaining(nodes.get(2))).isEqualTo(partition2);
+            assertThat(network.getPartitionContaining(nodes.get(3))).isEqualTo(partition2);
+
+            // Verify remaining nodes are not in any partition
+            assertThat(network.getPartitionContaining(nodes.get(4))).isNull();
+            assertThat(network.getPartitionContaining(nodes.get(5))).isNull();
+
+            // Let the network run with multiple partitions
+            timeManager.waitFor(Duration.ofSeconds(10));
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test that a partition with a single node behaves like isolation.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testSingleNodePartition(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
+
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node nodeToPartition = nodes.getFirst();
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Create a partition with a single node
+            final Partition partition = network.createPartition(Set.of(nodeToPartition));
+
+            // Verify the partition was created
+            assertThat(partition.nodes()).containsExactly(nodeToPartition);
+            assertThat(partition.size()).isEqualTo(1);
+            assertThat(network.getPartitionContaining(nodeToPartition)).isEqualTo(partition);
+
+            // Single node partition should be considered isolated
+            assertThat(network.isIsolated(nodeToPartition)).isTrue();
+
+            // Other nodes should not be isolated
+            for (int i = 1; i < nodes.size(); i++) {
+                assertThat(network.isIsolated(nodes.get(i))).isFalse();
+            }
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test that partitions can be removed and connectivity restored.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testRemovePartition(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
+
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node node1 = nodes.get(0);
+            final Node node2 = nodes.get(1);
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Create a partition
+            final Partition partition = network.createPartition(Set.of(node1, node2));
+            assertThat(network.partitions()).contains(partition);
+            assertThat(network.getPartitionContaining(node1)).isEqualTo(partition);
+            assertThat(network.getPartitionContaining(node2)).isEqualTo(partition);
+
+            // Remove the partition
+            network.removePartition(partition);
+
+            // Verify partition is removed
+            assertThat(network.partitions()).doesNotContain(partition);
+            assertThat(network.getPartitionContaining(node1)).isNull();
+            assertThat(network.getPartitionContaining(node2)).isNull();
+
+            // Let the network run after partition removal
+            timeManager.waitFor(Duration.ofSeconds(10));
+
+            // All nodes should be active again
+            for (final Node node : nodes) {
+                assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+            }
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test that creating a partition with empty nodes throws an exception.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testCreatePartitionWithEmptyNodes(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+
+            // Setup network with 4 nodes
+            network.addNodes(4);
+            network.start();
+
+            // Try to create a partition with no nodes - should throw exception
+            assertThatThrownBy(() -> network.createPartition(Set.of()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Cannot create a partition with no nodes.");
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test that creating a partition with nodes already in a partition throws an exception.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testCreatePartitionWithAlreadyPartitionedNodes(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+
+            // Setup network with 4 nodes
+            final List<Node> nodes = network.addNodes(4);
+            final Node node1 = nodes.get(0);
+            final Node node2 = nodes.get(1);
+            final Node node3 = nodes.get(2);
+
+            network.start();
+
+            // Create first partition
+            network.createPartition(Set.of(node1, node2));
+
+            // Try to create another partition with node1 - should throw exception
+            assertThatThrownBy(() -> network.createPartition(Set.of(node1, node3)))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("Cannot create a partition with nodes that are already in a partition.");
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test that large partitions can be created and managed.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testLargePartition(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
+
+            // Setup network with 10 nodes
+            final List<Node> nodes = network.addNodes(10);
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Create a large partition with 7 nodes
+            final Set<Node> partitionNodes = Set.of(
+                    nodes.get(0), nodes.get(1), nodes.get(2), nodes.get(3),
+                    nodes.get(4), nodes.get(5), nodes.get(6)
+            );
+            final Partition partition = network.createPartition(partitionNodes);
+
+            // Verify the large partition
+            assertThat(partition.nodes()).hasSize(7);
+            assertThat(partition.nodes()).containsExactlyInAnyOrderElementsOf(partitionNodes);
+
+            // Verify all nodes in partition are tracked correctly
+            for (final Node node : partitionNodes) {
+                assertThat(network.getPartitionContaining(node)).isEqualTo(partition);
+                assertThat(network.isIsolated(node)).isFalse(); // Multi-node partition
+            }
+
+            // Verify remaining nodes are not in partition
+            for (int i = 7; i < 10; i++) {
+                assertThat(network.getPartitionContaining(nodes.get(i))).isNull();
+            }
+
+            // Let the network run with the large partition
+            timeManager.waitFor(Duration.ofSeconds(30));
+
+            // Non-partitioned nodes should continue to make progress
+            assertThat(nodes.get(0).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(1).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(2).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(3).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(4).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(5).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(6).platformStatus()).isEqualTo(ACTIVE);
+            assertThat(nodes.get(7).platformStatus()).isEqualTo(CHECKING);
+            assertThat(nodes.get(8).platformStatus()).isEqualTo(CHECKING);
+            assertThat(nodes.get(9).platformStatus()).isEqualTo(CHECKING);
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test that partitions work correctly with network freeze operations.
+     *
+     * @param env the test environment for this test
+     */
+    @Disabled("Investigate how partitions interact with freeze in production")
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testPartitionDuringFreeze(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
+
+            // Setup network with 5 nodes
+            final List<Node> nodes = network.addNodes(5);
+            final Node node0 = nodes.get(0);
+            final Node node1 = nodes.get(1);
+
+            assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Create a partition
+            final Partition partition = network.createPartition(Set.of(node0, node1));
+            assertThat(network.getPartitionContaining(node0)).isEqualTo(partition);
+
+            // Freeze the network
+            network.freeze();
+
+            // The partition should remain intact during freeze
+            assertThat(network.getPartitionContaining(node0)).isEqualTo(partition);
+            assertThat(network.partitions()).contains(partition);
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test that restoreConnectivity removes all partitions.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testRestoreConnectivityWithPartitions(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
+
+            // Setup network with 8 nodes
+            final List<Node> nodes = network.addNodes(8);
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Create multiple partitions
+            final Partition partition1 = network.createPartition(Set.of(nodes.get(0), nodes.get(1)));
+            final Partition partition2 = network.createPartition(Set.of(nodes.get(2), nodes.get(3), nodes.get(4)));
+            final Partition partition3 = network.createPartition(Set.of(nodes.get(5))); // Single node partition
+
+            // Verify partitions exist
+            assertThat(network.partitions()).containsExactlyInAnyOrder(partition1, partition2, partition3);
+            assertThat(network.isIsolated(nodes.get(5))).isTrue();
+
+            // Restore connectivity
+            network.restoreConnectivity();
+
+            // Verify all partitions are removed
+            assertThat(network.partitions()).isEmpty();
+            for (final Node node : nodes) {
+                assertThat(network.getPartitionContaining(node)).isNull();
+                assertThat(network.isIsolated(node)).isFalse();
+            }
+
+            // Let the network run after connectivity restoration
+            timeManager.waitFor(Duration.ofSeconds(10));
+
+            // All nodes should be active
+            for (final Node node : nodes) {
+                assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+            }
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test that partition lifecycle works correctly with complex scenarios.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testComplexPartitionLifecycle(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
+
+            // Setup network with 6 nodes
+            final List<Node> nodes = network.addNodes(6);
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Create initial partition
+            final Partition partition1 = network.createPartition(Set.of(nodes.get(0), nodes.get(1), nodes.get(2)));
+            assertThat(network.partitions()).hasSize(1);
+
+            // Remove the partition
+            network.removePartition(partition1);
+            assertThat(network.partitions()).isEmpty();
+
+            // Create new partitions with different configurations
+            final Partition partition2 = network.createPartition(Set.of(nodes.get(0), nodes.get(3)));
+            final Partition partition3 = network.createPartition(Set.of(nodes.get(1))); // Isolated node
+
+            // Verify the new state
+            assertThat(network.partitions()).containsExactlyInAnyOrder(partition2, partition3);
+            assertThat(network.isIsolated(nodes.get(1))).isTrue();
+            assertThat(network.isIsolated(nodes.get(0))).isFalse(); // Part of multi-node partition
+
+            // Remove one partition and verify the other remains
+            network.removePartition(partition3);
+            assertThat(network.partitions()).containsExactly(partition2);
+            assertThat(network.isIsolated(nodes.get(1))).isFalse();
+            assertThat(network.getPartitionContaining(nodes.get(0))).isEqualTo(partition2);
+
+            // Final cleanup
+            network.removePartition(partition2);
+            assertThat(network.partitions()).isEmpty();
+
+            // Let the network run after all partitions are removed
+            timeManager.waitFor(Duration.ofSeconds(10));
+
+            // All nodes should be active
+            for (final Node node : nodes) {
+                assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+                assertThat(network.getPartitionContaining(node)).isNull();
+                assertThat(network.isIsolated(node)).isFalse();
+            }
+        } finally {
+            env.destroy();
+        }
+    }
+
+    /**
+     * Test interaction between partitions and node isolation.
+     *
+     * @param env the test environment for this test
+     */
+    @ParameterizedTest
+    @MethodSource("environments")
+    void testPartitionAndIsolationInteraction(@NonNull final TestEnvironment env) {
+        try {
+            final Network network = env.network();
+            final TimeManager timeManager = env.timeManager();
+
+            // Setup network with 6 nodes
+            final List<Node> nodes = network.addNodes(6);
+
+            network.start();
+
+            // Wait for nodes to become active
+            timeManager.waitFor(Duration.ofSeconds(5));
+
+            // Create a multi-node partition
+            final Partition multiNodePartition = network.createPartition(Set.of(nodes.get(0), nodes.get(1)));
+
+            // Isolate another node (creates single-node partition)
+            final Partition isolationPartition = network.isolate(nodes.get(2));
+
+            // Verify both partitions exist
+            assertThat(network.partitions()).containsExactlyInAnyOrder(multiNodePartition, isolationPartition);
+
+            // Verify isolation behavior
+            assertThat(network.isIsolated(nodes.get(0))).isFalse(); // Part of multi-node partition
+            assertThat(network.isIsolated(nodes.get(1))).isFalse(); // Part of multi-node partition
+            assertThat(network.isIsolated(nodes.get(2))).isTrue();  // Isolated node
+
+            // Try to isolate a node that's already in a partition - should throw exception
+            assertThatThrownBy(() -> network.isolate(nodes.getFirst()))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("already in a partition");
+
+            // Rejoin the isolated node
+            network.rejoin(nodes.get(2));
+            assertThat(network.isIsolated(nodes.get(2))).isFalse();
+            assertThat(network.partitions()).containsExactly(multiNodePartition);
+
+            // Remove the remaining partition
+            network.removePartition(multiNodePartition);
+            assertThat(network.partitions()).isEmpty();
+
+            // Let the network run with full connectivity
+            timeManager.waitFor(Duration.ofSeconds(10));
+
+            // All nodes should be active
+            for (final Node node : nodes) {
+                assertThat(node.platformStatus()).isEqualTo(ACTIVE);
+            }
+        } finally {
+            env.destroy();
+        }
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkPartitionTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/test/turtle/NetworkPartitionTest.java
@@ -310,9 +310,7 @@ class NetworkPartitionTest {
 
             // Create a large partition with 7 nodes
             final Set<Node> partitionNodes = Set.of(
-                    nodes.get(0), nodes.get(1), nodes.get(2), nodes.get(3),
-                    nodes.get(4), nodes.get(5), nodes.get(6)
-            );
+                    nodes.get(0), nodes.get(1), nodes.get(2), nodes.get(3), nodes.get(4), nodes.get(5), nodes.get(6));
             final Partition partition = network.createPartition(partitionNodes);
 
             // Verify the large partition
@@ -533,7 +531,7 @@ class NetworkPartitionTest {
             // Verify isolation behavior
             assertThat(network.isIsolated(nodes.get(0))).isFalse(); // Part of multi-node partition
             assertThat(network.isIsolated(nodes.get(1))).isFalse(); // Part of multi-node partition
-            assertThat(network.isIsolated(nodes.get(2))).isTrue();  // Isolated node
+            assertThat(network.isIsolated(nodes.get(2))).isTrue(); // Isolated node
 
             // Try to isolate a node that's already in a partition - should throw exception
             assertThatThrownBy(() -> network.isolate(nodes.getFirst()))

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/module-info.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/module-info.java
@@ -45,6 +45,7 @@ module org.hiero.otter.fixtures {
     exports org.hiero.otter.fixtures.assertions;
     exports org.hiero.otter.fixtures.junit;
     exports org.hiero.otter.fixtures.logging;
+    exports org.hiero.otter.fixtures.network;
     exports org.hiero.otter.fixtures.result;
     exports org.hiero.otter.fixtures.container.proto;
     exports org.hiero.otter.fixtures.app;

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Network.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Network.java
@@ -37,7 +37,7 @@ public interface Network {
      * @return a list of nodes in the network
      */
     @NonNull
-    default List<Node> nodes() {
+    default List<Node> getNodes() {
         return topology().nodes();
     }
 
@@ -103,8 +103,8 @@ public interface Network {
      *
      * @return the network weight
      */
-    default long totalWeight() {
-        return nodes().stream().mapToLong(Node::weight).sum();
+    default long getTotalWeight() {
+        return getNodes().stream().mapToLong(Node::weight).sum();
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/TestEnvironment.java
@@ -2,6 +2,7 @@
 package org.hiero.otter.fixtures;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Set;
 
 /**
  * Interface representing the test environment of an Otter test.
@@ -10,6 +11,14 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * the network, time manager, transaction generator, and validator.
  */
 public interface TestEnvironment {
+
+    /**
+     * Get the capabilities supported by this test environment.
+     *
+     * @return the set of capabilities
+     */
+    @NonNull
+    Set<Capability> capabilities();
 
     /**
      * Get the network associated with this test environment.
@@ -39,9 +48,6 @@ public interface TestEnvironment {
      * Destroys the test environment. Once this method is called, the test environment and all its
      * components are no longer usable. This method is idempotent, meaning that it is safe to call
      * multiple times.
-     *
-     * @throws InterruptedException if the thread is interrupted while waiting for the destruction
-     * process to complete causing the test to fail.
      */
-    void destroy() throws InterruptedException;
+    void destroy();
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNode.java
@@ -62,7 +62,6 @@ import org.hiero.otter.fixtures.result.SingleNodeMarkerFileResult;
 import org.hiero.otter.fixtures.result.SingleNodePcesResult;
 import org.hiero.otter.fixtures.result.SingleNodePlatformStatusResult;
 import org.hiero.otter.fixtures.result.SingleNodeReconnectResult;
-import org.jetbrains.annotations.NotNull;
 import org.testcontainers.containers.Network;
 import org.testcontainers.images.builder.ImageFromDockerfile;
 
@@ -260,7 +259,7 @@ public class ContainerNode extends AbstractNode implements Node, TimeTickReceive
      */
     @Override
     @NonNull
-    public @NotNull SingleNodeReconnectResult newReconnectResult() {
+    public SingleNodeReconnectResult newReconnectResult() {
         return new SingleNodeReconnectResultImpl(selfId, newPlatformStatusResult(), newLogResult());
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerTestEnvironment.java
@@ -67,6 +67,15 @@ public class ContainerTestEnvironment implements TestEnvironment {
      */
     @Override
     @NonNull
+    public Set<Capability> capabilities() {
+        return CAPABILITIES;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
     public Network network() {
         return network;
     }
@@ -93,7 +102,7 @@ public class ContainerTestEnvironment implements TestEnvironment {
      * {@inheritDoc}
      */
     @Override
-    public void destroy() throws InterruptedException {
+    public void destroy() {
         network.destroy();
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/AbstractNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/AbstractNetwork.java
@@ -147,6 +147,7 @@ public abstract class AbstractNetwork implements Network {
      */
     @Override
     public void start() {
+        updateConnections();
         defaultStartAction.start();
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/AbstractNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/AbstractNetwork.java
@@ -260,7 +260,7 @@ public abstract class AbstractNetwork implements Network {
      */
     @Override
     public void setVersion(@NonNull final SemanticVersion version) {
-        for (final Node node : nodes()) {
+        for (final Node node : getNodes()) {
             node.setVersion(version);
         }
     }
@@ -270,7 +270,7 @@ public abstract class AbstractNetwork implements Network {
      */
     @Override
     public void bumpConfigVersion() {
-        for (final Node node : nodes()) {
+        for (final Node node : getNodes()) {
             node.bumpConfigVersion();
         }
     }
@@ -282,7 +282,7 @@ public abstract class AbstractNetwork implements Network {
     @NonNull
     public MultipleNodeConsensusResults newConsensusResults() {
         final List<SingleNodeConsensusResult> results =
-                nodes().stream().map(Node::newConsensusResult).toList();
+                getNodes().stream().map(Node::newConsensusResult).toList();
         return new MultipleNodeConsensusResultsImpl(results);
     }
 
@@ -293,7 +293,7 @@ public abstract class AbstractNetwork implements Network {
     @Override
     public MultipleNodeLogResults newLogResults() {
         final List<SingleNodeLogResult> results =
-                nodes().stream().map(Node::newLogResult).toList();
+                getNodes().stream().map(Node::newLogResult).toList();
 
         return new MultipleNodeLogResultsImpl(results);
     }
@@ -305,7 +305,7 @@ public abstract class AbstractNetwork implements Network {
     @NonNull
     public MultipleNodePlatformStatusResults newPlatformStatusResults() {
         final List<SingleNodePlatformStatusResult> statusProgressions =
-                nodes().stream().map(Node::newPlatformStatusResult).toList();
+                getNodes().stream().map(Node::newPlatformStatusResult).toList();
         return new MultipleNodePlatformStatusResultsImpl(statusProgressions);
     }
 
@@ -316,7 +316,7 @@ public abstract class AbstractNetwork implements Network {
     @NonNull
     public MultipleNodeReconnectResults newReconnectResults() {
         final List<SingleNodeReconnectResult> reconnectResults =
-                nodes().stream().map(Node::newReconnectResult).toList();
+                getNodes().stream().map(Node::newReconnectResult).toList();
         return new MultipleNodeReconnectResultsImpl(reconnectResults);
     }
 
@@ -327,7 +327,7 @@ public abstract class AbstractNetwork implements Network {
     @NonNull
     public MultipleNodePcesResults newPcesResults() {
         final List<SingleNodePcesResult> results =
-                nodes().stream().map(Node::newPcesResult).toList();
+                getNodes().stream().map(Node::newPcesResult).toList();
         return new MultipleNodePcesResultsImpl(results);
     }
 
@@ -338,7 +338,7 @@ public abstract class AbstractNetwork implements Network {
     @NonNull
     public MultipleNodeMarkerFileResults newMarkerFileResults() {
         final List<SingleNodeMarkerFileResult> results =
-                nodes().stream().map(Node::newMarkerFileResult).toList();
+                getNodes().stream().map(Node::newMarkerFileResult).toList();
         return new MultipleNodeMarkerFileResultsImpl(results);
     }
 
@@ -347,7 +347,7 @@ public abstract class AbstractNetwork implements Network {
      */
     @Override
     public boolean nodeIsBehindByNodeWeight(@NonNull final Node maybeBehindNode) {
-        final Set<Node> otherNodes = nodes().stream()
+        final Set<Node> otherNodes = getNodes().stream()
                 .filter(n -> !n.selfId().equals(maybeBehindNode.selfId()))
                 .collect(Collectors.toSet());
 
@@ -365,7 +365,7 @@ public abstract class AbstractNetwork implements Network {
                 weightOfAheadNodes += maybeAheadNode.weight();
             }
         }
-        return Threshold.STRONG_MINORITY.isSatisfiedBy(weightOfAheadNodes, totalWeight());
+        return Threshold.STRONG_MINORITY.isSatisfiedBy(weightOfAheadNodes, getTotalWeight());
     }
 
     /**
@@ -373,7 +373,7 @@ public abstract class AbstractNetwork implements Network {
      */
     @Override
     public boolean nodeIsBehindByNodeCount(@NonNull final Node maybeBehindNode, final double fraction) {
-        final Set<Node> otherNodes = nodes().stream()
+        final Set<Node> otherNodes = getNodes().stream()
                 .filter(n -> !n.selfId().equals(maybeBehindNode.selfId()))
                 .collect(Collectors.toSet());
 
@@ -402,7 +402,7 @@ public abstract class AbstractNetwork implements Network {
      * @return the {@link BooleanSupplier}
      */
     protected BooleanSupplier allNodesInStatus(@NonNull final PlatformStatus status) {
-        return () -> nodes().stream().allMatch(node -> node.platformStatus() == status);
+        return () -> getNodes().stream().allMatch(node -> node.platformStatus() == status);
     }
 
     /**
@@ -420,8 +420,8 @@ public abstract class AbstractNetwork implements Network {
 
     private void updateConnections() {
         final Map<ConnectionKey, ConnectionData> connections = new HashMap<>();
-        for (final Node sender : nodes()) {
-            for (final Node receiver : nodes()) {
+        for (final Node sender : getNodes()) {
+            for (final Node receiver : getNodes()) {
                 if (sender.selfId().equals(receiver.selfId())) {
                     continue; // Skip self-connections
                 }
@@ -464,7 +464,7 @@ public abstract class AbstractNetwork implements Network {
 
             log.info("Starting network...");
             state = State.RUNNING;
-            for (final Node node : nodes()) {
+            for (final Node node : getNodes()) {
                 node.start();
             }
 
@@ -487,7 +487,7 @@ public abstract class AbstractNetwork implements Network {
             log.info("Sending freeze transaction...");
             final byte[] freezeTransaction =
                     createFreezeTransaction(timeManager().now().plus(FREEZE_DELAY));
-            nodes().stream()
+            getNodes().stream()
                     .filter(Node::isActive)
                     .findFirst()
                     .orElseThrow(() -> new AssertionError("No active node found to send freeze transaction to."))
@@ -510,7 +510,7 @@ public abstract class AbstractNetwork implements Network {
             throwIfInState(State.SHUTDOWN, "Network has already been shut down.");
 
             log.info("Killing nodes immediately...");
-            for (final Node node : nodes()) {
+            for (final Node node : getNodes()) {
                 node.killImmediately();
             }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/network/ConnectionKey.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/network/ConnectionKey.java
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.internal.network;
+
+import com.hedera.hapi.platform.state.NodeId;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Represents a key for a connection between two nodes in the topology.
+ *
+ * @param sender the starting node of the connection
+ * @param receiver the ending node of the connection
+ */
+public record ConnectionKey(@NonNull NodeId sender, @NonNull NodeId receiver) {}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/network/MeshTopologyImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/network/MeshTopologyImpl.java
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.internal.network;
+
+import static java.util.Objects.requireNonNull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import org.assertj.core.data.Percentage;
+import org.hiero.otter.fixtures.InstrumentedNode;
+import org.hiero.otter.fixtures.Node;
+import org.hiero.otter.fixtures.network.BandwidthLimit;
+import org.hiero.otter.fixtures.network.MeshTopology;
+
+/**
+ * An implementation of {@link MeshTopology}.
+ *
+ * @param <T> the type of nodes in the topology
+ */
+public class MeshTopologyImpl<T extends Node> implements TopologyImplementation<T>, MeshTopology {
+
+    private static final Duration AVERAGE_NETWORK_DELAY = Duration.ofMillis(200);
+    private static final ConnectionData DEFAULT =
+            new ConnectionData(true, AVERAGE_NETWORK_DELAY, Percentage.withPercentage(5), BandwidthLimit.UNLIMITED);
+
+    private final Function<Integer, List<T>> nodeFactory;
+    private final List<T> nodes = new ArrayList<>();
+
+    /**
+     * Constructor for the {@link MeshTopologyImpl} class.
+     *
+     * @param nodeFactory a function that creates a list of nodes given the count
+     */
+    public MeshTopologyImpl(final Function<Integer, List<T>> nodeFactory) {
+        this.nodeFactory = requireNonNull(nodeFactory);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public List<Node> addNodes(final int count) {
+        final List<T> newNodes = nodeFactory.apply(count);
+        nodes.addAll(newNodes);
+        return Collections.unmodifiableList(newNodes);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public InstrumentedNode addInstrumentedNode() {
+        throw new UnsupportedOperationException("Instrumented nodes are not supported yet");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public List<Node> nodes() {
+        return Collections.unmodifiableList(nodes);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
+    public ConnectionData getConnectionData(@NonNull final Node sender, @NonNull final Node receiver) {
+        return DEFAULT;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public List<T> nodesImpl() {
+        return Collections.unmodifiableList(nodes);
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/network/TopologyImplementation.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/network/TopologyImplementation.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.internal.network;
+
+import java.util.List;
+import org.hiero.otter.fixtures.Node;
+import org.hiero.otter.fixtures.network.Topology;
+
+/**
+ * Interface representing the topology of a Turtle network.
+ * It extends the {@link Topology} interface and provides a method to retrieve Turtle nodes.
+ *
+ * @param <T> the type of nodes in the topology, which must extend {@link Node}
+ */
+public interface TopologyImplementation<T extends Node> extends Topology {
+
+    /**
+     * Returns the nodes in the topology cast to the specific {@link Node} type.
+     *
+     * @return a list of nodes in the topology
+     */
+    List<T> nodesImpl();
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeReconnectResultsImpl.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/result/MultipleNodeReconnectResultsImpl.java
@@ -13,7 +13,6 @@ import org.hiero.otter.fixtures.result.MultipleNodeReconnectResults;
 import org.hiero.otter.fixtures.result.ReconnectNotificationSubscriber;
 import org.hiero.otter.fixtures.result.SingleNodeReconnectResult;
 import org.hiero.otter.fixtures.result.SubscriberAction;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Default implementation of {@link MultipleNodeReconnectResults}
@@ -60,7 +59,7 @@ public class MultipleNodeReconnectResultsImpl implements MultipleNodeReconnectRe
      * {@inheritDoc}
      */
     @Override
-    public void subscribe(@NotNull final ReconnectNotificationSubscriber subscriber) {
+    public void subscribe(@NonNull final ReconnectNotificationSubscriber subscriber) {
         reconnectSubscribers.add(subscriber);
     }
 
@@ -68,7 +67,7 @@ public class MultipleNodeReconnectResultsImpl implements MultipleNodeReconnectRe
      * {@inheritDoc}
      */
     @Override
-    @NotNull
+    @NonNull
     public List<SingleNodeReconnectResult> reconnectResults() {
         return results;
     }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/junit/OtterTestExtension.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/junit/OtterTestExtension.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.io.IOException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Parameter;
 import java.util.List;
@@ -128,8 +127,7 @@ public class OtterTestExtension
      * @param extensionContext the current extension context; never {@code null}
      */
     @Override
-    public void preDestroyTestInstance(@NonNull final ExtensionContext extensionContext)
-            throws IOException, InterruptedException {
+    public void preDestroyTestInstance(@NonNull final ExtensionContext extensionContext) {
         final TestEnvironment testEnvironment =
                 (TestEnvironment) extensionContext.getStore(EXTENSION_NAMESPACE).remove(ENVIRONMENT_KEY);
         if (testEnvironment != null) {

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/network/BandwidthLimit.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/network/BandwidthLimit.java
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.network;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Represents network bandwidth with various unit conversions. Provides type safety and clarity for bandwidth
+ * specifications.
+ */
+@SuppressWarnings("unused")
+public class BandwidthLimit {
+
+    private static final long UNLIMITED_BYTES_PER_SECOND = Long.MAX_VALUE;
+
+    /**
+     * Represents an unlimited bandwidth limit.
+     */
+    public static final BandwidthLimit UNLIMITED = new BandwidthLimit(UNLIMITED_BYTES_PER_SECOND);
+
+    private final long bytesPerSecond;
+
+    private BandwidthLimit(final long bytesPerSecond) {
+        if (bytesPerSecond < 0) {
+            throw new IllegalArgumentException("Bandwidth cannot be negative");
+        }
+        this.bytesPerSecond = bytesPerSecond;
+    }
+
+    /**
+     * Creates a bandwidth specification in bytes per second.
+     *
+     * @param bytesPerSecond the bandwidth in bytes per second
+     * @return a new BandwidthLimit object
+     */
+    @NonNull
+    public static BandwidthLimit ofBytesPerSecond(final long bytesPerSecond) {
+        return new BandwidthLimit(bytesPerSecond);
+    }
+
+    /**
+     * Creates a bandwidth specification in kilobytes per second.
+     *
+     * @param kilobytesPerSecond the bandwidth in kilobytes per second
+     * @return a new BandwidthLimit object
+     */
+    @NonNull
+    public static BandwidthLimit ofKilobytesPerSecond(final long kilobytesPerSecond) {
+        return new BandwidthLimit(kilobytesPerSecond * 1024L);
+    }
+
+    /**
+     * Creates a bandwidth specification in megabytes per second.
+     *
+     * @param megabytesPerSecond the bandwidth in megabytes per second
+     * @return a new BandwidthLimit object
+     */
+    @NonNull
+    public static BandwidthLimit ofMegabytesPerSecond(final long megabytesPerSecond) {
+        return new BandwidthLimit(megabytesPerSecond * 1024L * 1024L);
+    }
+
+    /**
+     * Converts this bandwidth to bytes per second.
+     *
+     * @return the bandwidth in bytes per second
+     */
+    public long toBytesPerSecond() {
+        return bytesPerSecond;
+    }
+
+    /**
+     * Checks if this bandwidth limit is unlimited.
+     *
+     * @return {@code true} if the bandwidth is unlimited, {@code false} otherwise
+     */
+    public boolean isUnlimited() {
+        return bytesPerSecond == UNLIMITED_BYTES_PER_SECOND;
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/network/MeshTopology.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/network/MeshTopology.java
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.network;
+
+/**
+ * Represents a mesh network topology.
+ */
+public interface MeshTopology extends Topology {}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/network/Partition.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/network/Partition.java
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.network;
+
+import static java.util.Objects.requireNonNull;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Collection;
+import java.util.Set;
+import org.hiero.otter.fixtures.Node;
+
+/**
+ * Represents a network partition containing a group of nodes.
+ * Nodes within the partition are connected to each other but isolated from external nodes.
+ */
+public class Partition {
+
+    /**
+     * Creates a partition from a collection of nodes.
+     *
+     * @param nodes the nodes to include in the partition
+     * @return a new Partition object
+     * @throws NullPointerException if {@code nodes} is {@code null}
+     * @throws IllegalArgumentException if {@code nodes} is empty
+     */
+    public static Partition of(@NonNull final Collection<? extends Node> nodes) {
+        return new Partition(nodes);
+    }
+
+    private final Set<Node> nodes;
+
+    private Partition(@NonNull final Collection<? extends Node> nodes) {
+        if (nodes.isEmpty()) {
+            throw new IllegalArgumentException("Partition cannot be empty");
+        }
+        this.nodes = Set.copyOf(nodes);
+    }
+
+    /**
+     * Gets the nodes in this partition.
+     *
+     * @return an unmodifiable set of nodes in this partition
+     */
+    @NonNull
+    public Set<Node> nodes() {
+        return nodes;
+    }
+
+    /**
+     * Checks if the partition contains the specified node.
+     *
+     * @param node the node to check
+     * @return true if the node is in this partition
+     */
+    public boolean contains(@NonNull final Node node) {
+        return nodes.contains(requireNonNull(node));
+    }
+
+    /**
+     * Gets the number of nodes in this partition.
+     *
+     * @return the size of the partition
+     */
+    public int size() {
+        return nodes.size();
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/network/Topology.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/network/Topology.java
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.network;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import java.util.List;
+import org.assertj.core.data.Percentage;
+import org.hiero.otter.fixtures.InstrumentedNode;
+import org.hiero.otter.fixtures.Node;
+
+/**
+ * Interface representing a network topology.
+ *
+ * <p>This interface defines methods for adding nodes to a topology. The specific way nodes are connected and their
+ * properties such as latency, jitter, and bandwidth depend on the implementation of the topology.
+ */
+@SuppressWarnings("unused")
+public interface Topology {
+
+    /**
+     * Adds a single node to the topology.
+     *
+     * <p>How the node is connected to existing nodes and its latency, jitter, and bandwidth depend on the specific topology implementation.
+     *
+     * @return the created node
+     */
+    @NonNull
+    default Node addNode() {
+        return addNodes(1).getFirst();
+    }
+
+    /**
+     * Adds multiple nodes to the topology.
+     *
+     * <p>How the node is connected to existing nodes and its latency, jitter, and bandwidth depend on the specific topology implementation.
+     *
+     * @param count the number of nodes to add
+     * @return list of created nodes
+     */
+    @NonNull
+    List<Node> addNodes(int count);
+
+    /**
+     * Add an instrumented node to the topology.
+     *
+     * <p>This method is used to add a node that has additional instrumentation for testing purposes.
+     * For example, it can exhibit malicious or erroneous behavior.
+     *
+     * @return the added instrumented node
+     */
+    @NonNull
+    InstrumentedNode addInstrumentedNode();
+
+    /**
+     * Get the list of nodes in the topology.
+     *
+     * <p>The {@link List} cannot be modified directly. However, if a node is added or removed from the topology, the
+     * list is automatically updated. That means, if it is necessary to have a constant list, it is recommended to
+     * create a copy.
+     *
+     * @return a list of nodes in the topology
+     */
+    @NonNull
+    List<Node> nodes();
+
+    /**
+     * Get the default connection data for a connection between two nodes in the topology.
+     *
+     * @param sender the source node
+     * @param receiver the destination node
+     * @return the {@link ConnectionData}
+     */
+    @NonNull
+    ConnectionData getConnectionData(@NonNull Node sender, @NonNull Node receiver);
+
+    /**
+     * Represents the data associated with a connection between two nodes in the topology.
+     *
+     * @param connected indicates whether the nodes are connected
+     */
+    record ConnectionData(
+            boolean connected,
+            @NonNull Duration latency,
+            @NonNull Percentage jitter,
+            @NonNull BandwidthLimit bandwidthLimit) {
+
+        /**
+         * Creates a new instance of {@link ConnectionData} with the specified {@code connected} parameters.
+         *
+         * @param connected indicates whether the nodes are connected
+         * @return a new instance of {@link ConnectionData} with the specified connected state
+         */
+        public ConnectionData withConnected(final boolean connected) {
+            return new ConnectionData(connected, latency, jitter, bandwidthLimit);
+        }
+
+        /**
+         * Creates a new instance of {@link ConnectionData} with the specified {@code latency} and {@code jitter}.
+         *
+         * @param latency the latency of the connection
+         * @param jitter the jitter of the connection
+         * @return a new instance of {@link ConnectionData} with the specified latency and jitter
+         */
+        public ConnectionData withLatencyAndJitter(@NonNull final Duration latency, @NonNull final Percentage jitter) {
+            return new ConnectionData(connected, latency, jitter, bandwidthLimit);
+        }
+
+        /**
+         * Creates a new instance of {@link ConnectionData} with the specified {@code bandwidthLimit}.
+         *
+         * @param bandwidthLimit the bandwidth limit of the connection
+         * @return a new instance of {@link ConnectionData} with the specified bandwidth limit
+         */
+        public ConnectionData withBandwidthLimit(@NonNull final BandwidthLimit bandwidthLimit) {
+            return new ConnectionData(connected, latency, jitter, bandwidthLimit);
+        }
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -177,10 +177,8 @@ public class TurtleNetwork extends AbstractNetwork implements TimeTickReceiver {
     /**
      * Shuts down the network and cleans up resources. Once this method is called, the network cannot be started again.
      * This method is idempotent and can be called multiple times without any side effects.
-     *
-     * @throws InterruptedException if the thread is interrupted while the network is being destroyed
      */
-    void destroy() throws InterruptedException {
+    void destroy() {
         log.info("Destroying network...");
         transactionGenerator.stop();
         for (final TurtleNode node : topology.nodesImpl()) {

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -116,7 +116,7 @@ public class TurtleNetwork extends AbstractNetwork implements TimeTickReceiver {
     private List<TurtleNode> createTurtleNodes(final int count) {
         throwIfInState(State.RUNNING, "Cannot add nodes after the network has been started.");
         throwIfInState(State.SHUTDOWN, "Cannot add nodes after the network has been started.");
-        if (!nodes().isEmpty()) {
+        if (!getNodes().isEmpty()) {
             throw new UnsupportedOperationException("Adding nodes incrementally is not supported yet.");
         }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -2,41 +2,41 @@
 package org.hiero.otter.fixtures.turtle;
 
 import static java.util.Objects.requireNonNull;
-import static org.hiero.otter.fixtures.turtle.TurtleTestEnvironment.AVERAGE_NETWORK_DELAY;
-import static org.hiero.otter.fixtures.turtle.TurtleTestEnvironment.STANDARD_DEVIATION_NETWORK_DELAY;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.NodeId;
 import com.swirlds.common.test.fixtures.Randotron;
-import com.swirlds.common.test.fixtures.WeightGenerator;
 import com.swirlds.platform.test.fixtures.addressbook.RandomRosterBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.node.KeysAndCerts;
-import org.hiero.otter.fixtures.InstrumentedNode;
 import org.hiero.otter.fixtures.Network;
-import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.TimeManager;
 import org.hiero.otter.fixtures.TransactionFactory;
 import org.hiero.otter.fixtures.TransactionGenerator;
 import org.hiero.otter.fixtures.internal.AbstractNetwork;
+import org.hiero.otter.fixtures.internal.AbstractTimeManager.TimeTickReceiver;
+import org.hiero.otter.fixtures.internal.network.ConnectionKey;
+import org.hiero.otter.fixtures.internal.network.MeshTopologyImpl;
+import org.hiero.otter.fixtures.internal.network.TopologyImplementation;
+import org.hiero.otter.fixtures.network.Topology;
+import org.hiero.otter.fixtures.network.Topology.ConnectionData;
 import org.hiero.otter.fixtures.turtle.gossip.SimulatedNetwork;
 
 /**
  * An implementation of {@link Network} that is based on the Turtle framework.
  */
-public class TurtleNetwork extends AbstractNetwork implements TurtleTimeManager.TimeTickReceiver {
+public class TurtleNetwork extends AbstractNetwork implements TimeTickReceiver {
 
     private static final Logger log = LogManager.getLogger();
 
@@ -48,9 +48,8 @@ public class TurtleNetwork extends AbstractNetwork implements TurtleTimeManager.
     private final TurtleTimeManager timeManager;
     private final TurtleLogging logging;
     private final Path rootOutputDirectory;
-    private final List<TurtleNode> nodes = new ArrayList<>();
     private final TurtleTransactionGenerator transactionGenerator;
-    private final List<Node> publicNodes = Collections.unmodifiableList(nodes);
+    private final TopologyImplementation<TurtleNode> topology = new MeshTopologyImpl<>(this::createTurtleNodes);
 
     private ExecutorService executorService;
     private SimulatedNetwork simulatedNetwork;
@@ -109,11 +108,15 @@ public class TurtleNetwork extends AbstractNetwork implements TurtleTimeManager.
      * {@inheritDoc}
      */
     @Override
+    protected void onConnectionsChanged(final Map<ConnectionKey, ConnectionData> connections) {
+        simulatedNetwork.setConnections(connections);
+    }
+
     @NonNull
-    public List<Node> addNodes(final int count, @NonNull final WeightGenerator weightGenerator) {
+    private List<TurtleNode> createTurtleNodes(final int count) {
         throwIfInState(State.RUNNING, "Cannot add nodes after the network has been started.");
         throwIfInState(State.SHUTDOWN, "Cannot add nodes after the network has been started.");
-        if (!nodes.isEmpty()) {
+        if (!nodes().isEmpty()) {
             throw new UnsupportedOperationException("Adding nodes incrementally is not supported yet.");
         }
 
@@ -126,17 +129,13 @@ public class TurtleNetwork extends AbstractNetwork implements TurtleTimeManager.
                 .withRealKeysEnabled(true);
         final Roster roster = rosterBuilder.build();
 
-        simulatedNetwork =
-                new SimulatedNetwork(randotron, roster, AVERAGE_NETWORK_DELAY, STANDARD_DEVIATION_NETWORK_DELAY);
+        simulatedNetwork = new SimulatedNetwork(randotron, roster);
 
-        final List<TurtleNode> nodeList = roster.rosterEntries().stream()
+        return roster.rosterEntries().stream()
                 .map(entry -> NodeId.newBuilder().id(entry.nodeId()).build())
                 .sorted(Comparator.comparing(NodeId::id))
                 .map(nodeId -> createTurtleNode(nodeId, roster, rosterBuilder.getPrivateKeys(nodeId)))
                 .toList();
-        nodes.addAll(nodeList);
-
-        return publicNodes;
     }
 
     private TurtleNode createTurtleNode(
@@ -151,17 +150,8 @@ public class TurtleNetwork extends AbstractNetwork implements TurtleTimeManager.
      */
     @Override
     @NonNull
-    public InstrumentedNode addInstrumentedNode() {
-        throw new UnsupportedOperationException("Adding instrumented nodes is not implemented yet.");
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    @NonNull
-    public List<Node> getNodes() {
-        return publicNodes;
+    public Topology topology() {
+        return topology;
     }
 
     /**
@@ -174,11 +164,11 @@ public class TurtleNetwork extends AbstractNetwork implements TurtleTimeManager.
         }
 
         simulatedNetwork.tick(now);
-        transactionGenerator.tick(now, nodes);
+        transactionGenerator.tick(now, topology.nodesImpl());
 
         // Iteration order over nodes does not need to be deterministic -- nodes are not permitted to communicate with
         // each other during the tick phase, and they run on separate threads to boot.
-        CompletableFuture.allOf(nodes.stream()
+        CompletableFuture.allOf(topology.nodesImpl().stream()
                         .map(node -> CompletableFuture.runAsync(() -> node.tick(now), executorService))
                         .toArray(CompletableFuture[]::new))
                 .join();
@@ -193,7 +183,7 @@ public class TurtleNetwork extends AbstractNetwork implements TurtleTimeManager.
     void destroy() throws InterruptedException {
         log.info("Destroying network...");
         transactionGenerator.stop();
-        for (final TurtleNode node : nodes) {
+        for (final TurtleNode node : topology.nodesImpl()) {
             node.destroy();
         }
         if (executorService != null) {

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -313,10 +313,8 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
     /**
      * Shuts down the node and cleans up resources. Once this method is called, the node cannot be started again. This
      * method is idempotent and can be called multiple times without any side effects.
-     *
-     * @throws InterruptedException if the thread is interrupted while the node is being destroyed
      */
-    void destroy() throws InterruptedException {
+    void destroy() {
         try {
             ThreadContext.put(THREAD_CONTEXT_NODE_ID, toJSON(selfId));
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -72,7 +72,6 @@ import org.hiero.otter.fixtures.result.SingleNodePlatformStatusResult;
 import org.hiero.otter.fixtures.result.SingleNodeReconnectResult;
 import org.hiero.otter.fixtures.turtle.gossip.SimulatedGossip;
 import org.hiero.otter.fixtures.turtle.gossip.SimulatedNetwork;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * A node in the turtle network.
@@ -167,7 +166,7 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
      * <p>This method is not supported in TurtleNode and will throw an {@link UnsupportedOperationException}.
      */
     @Override
-    public void startSyntheticBottleneck(@NotNull final Duration delayPerRound) {
+    public void startSyntheticBottleneck(@NonNull final Duration delayPerRound) {
         throw new UnsupportedOperationException("Synthetic bottleneck is not supported in TurtleNode.");
     }
 
@@ -279,7 +278,8 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
      * <p>This method is not supported in TurtleNode and will throw an {@link UnsupportedOperationException}.
      */
     @Override
-    public @NotNull SingleNodeReconnectResult newReconnectResult() {
+    @NonNull
+    public SingleNodeReconnectResult newReconnectResult() {
         throw new UnsupportedOperationException("Reconnect is not supported in TurtleNode.");
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -38,8 +38,6 @@ public class TurtleTestEnvironment implements TestEnvironment {
     static final String SWIRLD_NAME = "123";
 
     static final Duration GRANULARITY = Duration.ofMillis(10);
-    static final Duration AVERAGE_NETWORK_DELAY = Duration.ofMillis(200);
-    static final Duration STANDARD_DEVIATION_NETWORK_DELAY = Duration.ofMillis(10);
 
     private final TurtleNetwork network;
     private final TurtleTransactionGenerator transactionGenerator;

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -13,6 +13,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.constructable.ConstructableRegistry;
@@ -100,6 +101,15 @@ public class TurtleTestEnvironment implements TestEnvironment {
      */
     @Override
     @NonNull
+    public Set<Capability> capabilities() {
+        return Set.of();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @NonNull
     public Network network() {
         return network;
     }
@@ -126,7 +136,7 @@ public class TurtleTestEnvironment implements TestEnvironment {
      * {@inheritDoc}
      */
     @Override
-    public void destroy() throws InterruptedException {
+    public void destroy() {
         InMemorySubscriptionManager.INSTANCE.reset();
         network.destroy();
         ConstructableRegistry.getInstance().reset();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/gossip/SimulatedNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/gossip/SimulatedNetwork.java
@@ -2,22 +2,26 @@
 package org.hiero.otter.fixtures.turtle.gossip;
 
 import static java.util.Objects.requireNonNull;
+import static java.util.stream.Collectors.toMap;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.time.Duration;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.PriorityQueue;
 import java.util.Random;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.roster.AddressBook;
 import org.hiero.consensus.roster.RosterUtils;
+import org.hiero.otter.fixtures.internal.network.ConnectionKey;
+import org.hiero.otter.fixtures.network.Topology.ConnectionData;
 
 /**
  * Connects {@link SimulatedGossip} peers in a simulated network.
@@ -25,6 +29,7 @@ import org.hiero.consensus.roster.RosterUtils;
  * This gossip simulation is intentionally simplistic. It does not attempt to mimic any real gossip algorithm in any
  * meaningful way and makes no attempt to reduce the rate of duplicate events.
  */
+@SuppressWarnings("removal")
 public class SimulatedNetwork {
 
     /**
@@ -53,37 +58,24 @@ public class SimulatedNetwork {
      */
     private final Map<NodeId, SimulatedGossip> gossipInstances = new HashMap<>();
 
-    /**
-     * The average delay for events to travel between nodes, in nanoseconds.
-     */
-    private final long averageDelayNanos;
+    @Nullable
+    private Map<GossipConnectionKey, ConnectionData> connections;
 
-    /**
-     * The standard deviation of the delay for events to travel between nodes, in nanoseconds.
-     */
-    private final long standardDeviationDelayNanos;
+    private Map<GossipConnectionKey, Instant> lastDeliveryTimestamps = new HashMap<>();
 
     /**
      * Constructor.
      *
      * @param random                 the random number generator to use for simulating network delays
      * @param roster                 the roster of the network
-     * @param averageDelay           the average delay for events to travel between nodes
-     * @param standardDeviationDelay the standard deviation of the delay for events to travel between nodes
      */
-    public SimulatedNetwork(
-            @NonNull final Random random,
-            @NonNull final Roster roster,
-            @NonNull final Duration averageDelay,
-            @NonNull final Duration standardDeviationDelay) {
+    public SimulatedNetwork(@NonNull final Random random, @NonNull final Roster roster) {
         this(
                 random,
                 roster.rosterEntries().stream()
                         .map(RosterUtils::getNodeId)
                         .sorted()
-                        .toList(),
-                averageDelay,
-                standardDeviationDelay);
+                        .toList());
     }
 
     /**
@@ -91,22 +83,12 @@ public class SimulatedNetwork {
      *
      * @param random                 the random number generator to use for simulating network delays
      * @param addressBook            the address book of the network
-     * @param averageDelay           the average delay for events to travel between nodes
-     * @param standardDeviationDelay the standard deviation of the delay for events to travel between nodes
      */
-    public SimulatedNetwork(
-            @NonNull final Random random,
-            @NonNull final AddressBook addressBook,
-            @NonNull final Duration averageDelay,
-            @NonNull final Duration standardDeviationDelay) {
-        this(random, addressBook.getNodeIdSet().stream().sorted().toList(), averageDelay, standardDeviationDelay);
+    public SimulatedNetwork(@NonNull final Random random, @NonNull final AddressBook addressBook) {
+        this(random, addressBook.getNodeIdSet().stream().sorted().toList());
     }
 
-    private SimulatedNetwork(
-            @NonNull final Random random,
-            @NonNull final List<NodeId> nodeIds,
-            @NonNull final Duration averageDelay,
-            @NonNull final Duration standardDeviationDelay) {
+    private SimulatedNetwork(@NonNull final Random random, @NonNull final List<NodeId> nodeIds) {
 
         this.random = requireNonNull(random);
 
@@ -116,9 +98,16 @@ public class SimulatedNetwork {
             eventsInTransit.put(nodeId, new PriorityQueue<>());
             gossipInstances.put(nodeId, new SimulatedGossip(this, nodeId));
         }
+    }
 
-        this.averageDelayNanos = averageDelay.toNanos();
-        this.standardDeviationDelayNanos = standardDeviationDelay.toNanos();
+    /**
+     * Set the connection data for this simulated network.
+     *
+     * @param newConnections the connection data
+     */
+    public void setConnections(@NonNull final Map<ConnectionKey, ConnectionData> newConnections) {
+        this.connections = newConnections.entrySet().stream()
+                .collect(toMap(entry -> GossipConnectionKey.of(entry.getKey()), Entry::getValue));
     }
 
     /**
@@ -182,6 +171,10 @@ public class SimulatedNetwork {
      * @param now the current time
      */
     private void transmitEvents(@NonNull final Instant now) {
+        if (connections == null) {
+            return; // No connections have been set, so we cannot transmit events.
+        }
+
         // Transmission order of the loops in this method must be deterministic, else nodes may receive events
         // in nondeterministic orders with nondeterministic timing.
 
@@ -194,20 +187,47 @@ public class SimulatedNetwork {
                         continue;
                     }
 
-                    final PriorityQueue<EventInTransit> receiverEvents = eventsInTransit.get(receiver);
+                    final GossipConnectionKey connectionKey = new GossipConnectionKey(sender, receiver);
+                    final ConnectionData connectionData = connections.get(connectionKey);
 
-                    final Instant deliveryTime = now.plusNanos(
-                            (long) (averageDelayNanos + random.nextGaussian() * standardDeviationDelayNanos));
+                    if (connectionData == null || !connectionData.connected()) {
+                        // No connection between sender and receiver, so skip this event
+                        continue;
+                    }
+
+                    // Simulate network latency and jitter using truncated Gaussian distribution
+                    final double sigma = connectionData.latency().toNanos() * connectionData.jitter().value / 100.0;
+                    final double jitter = Math.clamp(random.nextGaussian() * sigma, -3 * sigma, 3 * sigma);
+                    Instant deliveryTime =
+                            now.plus(connectionData.latency()).plusNanos((long) jitter);
+
+                    // Ensure delivery time is always incremental
+                    final Instant lastDeliveryTime =
+                            lastDeliveryTimestamps.getOrDefault(connectionKey, Instant.MIN);
+                    if (deliveryTime.isBefore(lastDeliveryTime)) {
+                        deliveryTime = lastDeliveryTime.plusNanos(1L);
+                    }
+                    lastDeliveryTimestamps.put(connectionKey, deliveryTime);
 
                     // create a copy so that nodes don't modify each other's events
                     final PlatformEvent eventToDeliver = event.copyGossipedData();
                     eventToDeliver.setSenderId(sender);
                     eventToDeliver.setTimeReceived(deliveryTime);
                     final EventInTransit eventInTransit = new EventInTransit(eventToDeliver, sender, deliveryTime);
-                    receiverEvents.add(eventInTransit);
+                    eventsInTransit.get(receiver).add(eventInTransit);
                 }
             }
             events.clear();
+        }
+    }
+
+    // Can be removed if we are able to clean up NodeId usage
+    // https://github.com/hiero-ledger/hiero-consensus-node/issues/20537
+    private record GossipConnectionKey(@NonNull NodeId sender, @NonNull NodeId receiver) {
+
+        static GossipConnectionKey of(@NonNull final ConnectionKey key) {
+            return new GossipConnectionKey(
+                    NodeId.of(key.sender().id()), NodeId.of(key.receiver().id()));
         }
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/gossip/SimulatedNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/gossip/SimulatedNetwork.java
@@ -198,12 +198,10 @@ public class SimulatedNetwork {
                     // Simulate network latency and jitter using truncated Gaussian distribution
                     final double sigma = connectionData.latency().toNanos() * connectionData.jitter().value / 100.0;
                     final double jitter = Math.clamp(random.nextGaussian() * sigma, -3 * sigma, 3 * sigma);
-                    Instant deliveryTime =
-                            now.plus(connectionData.latency()).plusNanos((long) jitter);
+                    Instant deliveryTime = now.plus(connectionData.latency()).plusNanos((long) jitter);
 
                     // Ensure delivery time is always incremental
-                    final Instant lastDeliveryTime =
-                            lastDeliveryTimestamps.getOrDefault(connectionKey, Instant.MIN);
+                    final Instant lastDeliveryTime = lastDeliveryTimestamps.getOrDefault(connectionKey, Instant.MIN);
                     if (deliveryTime.isBefore(lastDeliveryTime)) {
                         deliveryTime = lastDeliveryTime.plusNanos(1L);
                     }


### PR DESCRIPTION
**Description**:

This PR adds core functionality for simulating more realistic network behavior and network failures. It provides functionality for creating partitions and isolating single nodes (which is treated like a single-node partition).

This PR also introduces an idea of how we can perform more complex tests of the Otter framework.

**Related issue(s)**:

Fixes #20257 