### PR TITLE
feat: Added health-check command for pcli

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/HealthCheckCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/HealthCheckCommand.java
@@ -20,6 +20,9 @@ import picocli.CommandLine;
 public class HealthCheckCommand extends AbstractCommand {
 
     private String file;
+    private int clockLimit;
+    private double randomLimit;
+    private double fileLimit;
 
     @CommandLine.Option(
             names = {"-f", "--file"},
@@ -28,30 +31,92 @@ public class HealthCheckCommand extends AbstractCommand {
         this.file = file;
     }
 
+    @CommandLine.Option(
+            names = {"--clock-limit"},
+            description = "Minimum amount of calls per second for clock check to pass")
+    private void setClockLimit(final int clockLimit) {
+        this.clockLimit = clockLimit;
+    }
+
+    @CommandLine.Option(
+            names = {"--random-limit"},
+            description = "Maximum time (in ms) for random entropy generator to count as a pass")
+    private void setRandomLimit(final double randomLimit) {
+        this.randomLimit = randomLimit;
+    }
+
+    @CommandLine.Option(
+            names = {"--file-limit"},
+            description = "Maximum time (in ms) for file read check to count as a pass")
+    private void setFileLimit(final double fileLimit) {
+        this.fileLimit = fileLimit;
+    }
+
     @Override
     public Integer call() throws Exception {
         System.out.println(
                 "Please be warned - all these statistics are printed for non-warmed JVM, so they are not representative of the real world performance");
 
-        printOSClockSpeedReport();
-        printOSEntropyReport();
+        final long clockSpeed = printOSClockSpeedReport();
+        final double randomSpeed = printOSEntropyReport();
 
         if (file != null) {
-            printOSFileSystemReport(Path.of(file));
+            final double fileSpeed = printOSFileSystemReport(Path.of(file));
+            if (fileLimit > 0 && fileSpeed > fileLimit) {
+                System.out.printf("File read time time too big, above limit of %f ms%n", fileLimit);
+                return 3;
+            }
+        }
+
+        if (clockLimit > 0 && clockSpeed < clockLimit) {
+            System.out.printf("Clock speed not good enough, below limit of %d calls/sec%n", clockLimit);
+            return 1;
+        }
+
+        if (randomLimit > 0 && randomSpeed > randomLimit) {
+            System.out.printf("Random entropy time too big, above limit of %f ms%n", randomLimit);
+            return 2;
         }
 
         return 0;
     }
 
-    public static void printOSFileSystemReport(final Path fileToRead) {
+    public static long printOSClockSpeedReport() {
+        final OSClockSourceSpeedCheck.Report clockSpeedReport = OSClockSourceSpeedCheck.execute();
+        System.out.printf("Average clock source speed: %d calls/sec%n", clockSpeedReport.callsPerSec());
+        return clockSpeedReport.callsPerSec();
+    }
+
+    public static double printOSEntropyReport() {
+        try {
+            final OSEntropyCheck.Report randomSpeed = OSEntropyCheck.execute();
+            if (randomSpeed.success()) {
+                final double elapsedMillis = randomSpeed.elapsedNanos() * UnitConstants.NANOSECONDS_TO_MILLISECONDS;
+                System.out.printf(
+                        "First random number generation time: %d nanos (%s millis), generated long=%d%n",
+                        randomSpeed.elapsedNanos(), elapsedMillis, randomSpeed.randomLong());
+                return elapsedMillis;
+            } else {
+                System.out.println("Random number generation check failed due to timeout");
+                return Double.POSITIVE_INFINITY;
+            }
+        } catch (InterruptedException e) {
+            System.out.println("Thread interrupted while measuring the random number generation speed");
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static double printOSFileSystemReport(final Path fileToRead) {
         try {
             final OSFileSystemCheck.Report report = OSFileSystemCheck.execute(fileToRead);
             if (report.code() == OSFileSystemCheck.TestResultCode.SUCCESS) {
                 final double elapsedMillis = report.readNanos() * UnitConstants.NANOSECONDS_TO_MILLISECONDS;
                 System.out.printf(
-                        "File system check passed, took %d nanos (%s millis) "
+                        "File system check, took %d nanos (%s millis) "
                                 + "to open the file and read 1 byte (data=%s)%n",
                         report.readNanos(), elapsedMillis, report.data());
+                return elapsedMillis;
             } else {
                 if (report.exception() == null) {
                     System.out.printf("File system check failed. Reason: %s%n", report.code());
@@ -60,32 +125,10 @@ public class HealthCheckCommand extends AbstractCommand {
                             "File system check failed with exception. Reason: %s%n%s%n",
                             report.code(), report.exception());
                 }
+                return Double.POSITIVE_INFINITY;
             }
         } catch (InterruptedException e) {
             System.out.println("Thread interrupted while checking the file system");
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
-    }
-
-    public static void printOSClockSpeedReport() {
-        final OSClockSourceSpeedCheck.Report clockSpeedReport = OSClockSourceSpeedCheck.execute();
-        System.out.printf("Average clock source speed: %d calls/sec%n", clockSpeedReport.callsPerSec());
-    }
-
-    public static void printOSEntropyReport() {
-        try {
-            final OSEntropyCheck.Report randomSpeed = OSEntropyCheck.execute();
-            if (randomSpeed.success()) {
-                final double elapsedMillis = randomSpeed.elapsedNanos() * UnitConstants.NANOSECONDS_TO_MILLISECONDS;
-                System.out.printf(
-                        "First random number generation time: %d nanos (%s millis), generated long=%d%n",
-                        randomSpeed.elapsedNanos(), elapsedMillis, randomSpeed.randomLong());
-            } else {
-                System.out.println("Random number generation check failed due to timeout");
-            }
-        } catch (InterruptedException e) {
-            System.out.println("Thread interrupted while measuring the random number generation speed");
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/HealthCheckCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/HealthCheckCommand.java
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.platform.cli;
+
+import com.swirlds.base.units.UnitConstants;
+import com.swirlds.cli.PlatformCli;
+import com.swirlds.cli.utility.AbstractCommand;
+import com.swirlds.cli.utility.SubcommandOf;
+import com.swirlds.platform.health.clock.OSClockSourceSpeedCheck;
+import com.swirlds.platform.health.entropy.OSEntropyCheck;
+import com.swirlds.platform.health.filesystem.OSFileSystemCheck;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.file.Path;
+import picocli.CommandLine;
+
+@CommandLine.Command(
+        name = "health-check",
+        mixinStandardHelpOptions = true,
+        description = "Executes basic OS health checks and reports results")
+@SubcommandOf(PlatformCli.class)
+public class HealthCheckCommand extends AbstractCommand {
+
+    private String file;
+
+    @CommandLine.Option(
+            names = {"-f", "--file"},
+            description = "Path to existing non-empty file on which read performance will be checked")
+    private void setFile(@NonNull final String file) {
+        this.file = file;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        System.out.println(
+                "Please be warned - all these statistics are printed for non-warmed JVM, so they are not representative of the real world performance");
+
+        printOSClockSpeedReport();
+        printOSEntropyReport();
+
+        if (file != null) {
+            printOSFileSystemReport(Path.of(file));
+        }
+
+        return 0;
+    }
+
+    public static void printOSFileSystemReport(final Path fileToRead) {
+        try {
+            final OSFileSystemCheck.Report report = OSFileSystemCheck.execute(fileToRead);
+            if (report.code() == OSFileSystemCheck.TestResultCode.SUCCESS) {
+                final double elapsedMillis = report.readNanos() * UnitConstants.NANOSECONDS_TO_MILLISECONDS;
+                System.out.printf(
+                        "File system check passed, took %d nanos (%s millis) "
+                                + "to open the file and read 1 byte (data=%s)%n",
+                        report.readNanos(), elapsedMillis, report.data());
+            } else {
+                if (report.exception() == null) {
+                    System.out.printf("File system check failed. Reason: %s%n", report.code());
+                } else {
+                    System.out.printf(
+                            "File system check failed with exception. Reason: %s%n%s%n",
+                            report.code(), report.exception());
+                }
+            }
+        } catch (InterruptedException e) {
+            System.out.println("Thread interrupted while checking the file system");
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static void printOSClockSpeedReport() {
+        final OSClockSourceSpeedCheck.Report clockSpeedReport = OSClockSourceSpeedCheck.execute();
+        System.out.printf("Average clock source speed: %d calls/sec%n", clockSpeedReport.callsPerSec());
+    }
+
+    public static void printOSEntropyReport() {
+        try {
+            final OSEntropyCheck.Report randomSpeed = OSEntropyCheck.execute();
+            if (randomSpeed.success()) {
+                final double elapsedMillis = randomSpeed.elapsedNanos() * UnitConstants.NANOSECONDS_TO_MILLISECONDS;
+                System.out.printf(
+                        "First random number generation time: %d nanos (%s millis), generated long=%d%n",
+                        randomSpeed.elapsedNanos(), elapsedMillis, randomSpeed.randomLong());
+            } else {
+                System.out.println("Random number generation check failed due to timeout");
+            }
+        } catch (InterruptedException e) {
+            System.out.println("Thread interrupted while measuring the random number generation speed");
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheckMain.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/health/OSHealthCheckMain.java
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.health;
 
-import com.swirlds.base.units.UnitConstants;
-import com.swirlds.platform.health.clock.OSClockSourceSpeedCheck;
-import com.swirlds.platform.health.entropy.OSEntropyCheck;
-import com.swirlds.platform.health.filesystem.OSFileSystemCheck;
+import static com.swirlds.platform.cli.HealthCheckCommand.printOSClockSpeedReport;
+import static com.swirlds.platform.cli.HealthCheckCommand.printOSEntropyReport;
+import static com.swirlds.platform.cli.HealthCheckCommand.printOSFileSystemReport;
+
 import java.nio.file.Path;
 
 /**
@@ -18,58 +18,11 @@ public final class OSHealthCheckMain {
      * Prints the results of the OS health checks using system defaults
      */
     public static void main(final String[] args) {
+        System.out.println("OBSOLETE! Please use pcli.sh health-check instead");
         printOSClockSpeedReport();
         printOSEntropyReport();
         if (args.length > 0) {
             printOSFileSystemReport(Path.of(args[0]));
-        }
-    }
-
-    private static void printOSFileSystemReport(final Path fileToRead) {
-        try {
-            final OSFileSystemCheck.Report report = OSFileSystemCheck.execute(fileToRead);
-            if (report.code() == OSFileSystemCheck.TestResultCode.SUCCESS) {
-                final double elapsedMillis = report.readNanos() * UnitConstants.NANOSECONDS_TO_MILLISECONDS;
-                System.out.printf(
-                        "File system check passed, took %d nanos (%s millis) "
-                                + "to open the file and read 1 byte (data=%s)%n",
-                        report.readNanos(), elapsedMillis, report.data());
-            } else {
-                if (report.exception() == null) {
-                    System.out.printf("File system check failed. Reason: %s%n", report.code());
-                } else {
-                    System.out.printf(
-                            "File system check failed with exception. Reason: %s%n%s%n",
-                            report.code(), report.exception());
-                }
-            }
-        } catch (InterruptedException e) {
-            System.out.println("Thread interrupted while checking the file system");
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
-        }
-    }
-
-    private static void printOSClockSpeedReport() {
-        final OSClockSourceSpeedCheck.Report clockSpeedReport = OSClockSourceSpeedCheck.execute();
-        System.out.printf("Average clock source speed: %d calls/sec%n", clockSpeedReport.callsPerSec());
-    }
-
-    private static void printOSEntropyReport() {
-        try {
-            final OSEntropyCheck.Report randomSpeed = OSEntropyCheck.execute();
-            if (randomSpeed.success()) {
-                final double elapsedMillis = randomSpeed.elapsedNanos() * UnitConstants.NANOSECONDS_TO_MILLISECONDS;
-                System.out.printf(
-                        "First random number generation time: %d nanos (%s millis), generated long=%d%n",
-                        randomSpeed.elapsedNanos(), elapsedMillis, randomSpeed.randomLong());
-            } else {
-                System.out.println("Random number generation check failed due to timeout");
-            }
-        } catch (InterruptedException e) {
-            System.out.println("Thread interrupted while measuring the random number generation speed");
-            Thread.currentThread().interrupt();
-            throw new RuntimeException(e);
         }
     }
 }


### PR DESCRIPTION
**Description**:

Adds `health-check` command to pcli, which allows running:
- clock speed report
- random entropy speed report
- file access speed report

**Related issue(s)**:
Fixes #5363 

**Notes for reviewer**:
Please note it is reporting the output in the format that was previously used by the random utility run with the main method. I'm not sure what a real use case for that command is; if the outputs are supposed to be parsed in an automated way, maybe we can put the numbers in a more obvious place.

I have also added the possibility to specify limits under which the tool will fail (return non-zero). If used as an automated check, it should allow for using it without scraping the output.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
