### PR TITLE
feat: Create GenerateStateTool for Otter

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/tools/GenerateStateTool.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/tools/GenerateStateTool.java
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.tools;
+
+import com.swirlds.common.io.utility.FileUtils;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.Objects;
+import org.hiero.otter.fixtures.Network;
+import org.hiero.otter.fixtures.TestEnvironment;
+import org.hiero.otter.fixtures.TimeManager;
+import org.hiero.otter.fixtures.turtle.TurtleTestEnvironment;
+
+/**
+ * Utility tool that generates a saved platform state using a minimal "turtle" test environment
+ * and installs it as the {@code previous-version-state} test resource for consensus otter tests.
+ * <p>
+ * This tool performs the following steps:
+ * <ul>
+ *   <li>Creates a 1-node network</li>
+ *   <li>Runs it for some time</li>
+ *   <li>Freezes the network and shuts it down</li>
+ *   <li>Moves the produced saved state</li>
+ * </ul>
+ * Intended to be run manually when refreshing the prior-version state used by tests.
+ */
+public class GenerateStateTool {
+
+    /** Deterministic seed used to initialize the turtle test environment. */
+    private static final long SEED = 5045275509048911830L;
+
+    /** Test environment used to create and control the ephemeral network. */
+    private final TestEnvironment environment;
+
+    /**
+     * Create a new tool bound to the given test environment.
+     *
+     * @param environment the test environment to use; must not be {@code null}
+     */
+    public GenerateStateTool(@NonNull final TestEnvironment environment) {
+        this.environment = Objects.requireNonNull(environment, "environment cannot be null");
+    }
+
+    /**
+     * Generate a saved state by starting a 1-node network, letting it run for some time,
+     * freezing it, and shutting it down.
+     * <p>
+     * Side effects: writes state files under {@code build/turtle/node-0/data/saved}.
+     */
+    public void generateState() {
+        final Network network = environment.network();
+        final TimeManager timeManager = environment.timeManager();
+
+        network.addNodes(1);
+        network.start();
+        timeManager.waitFor(Duration.ofMinutes(5L));
+        network.freeze();
+
+        network.shutdown();
+    }
+
+    /**
+     * Replace the {@code previous-version-state} test resource with the most recently generated state.
+     * <p>
+     * Deletes the target directory if it already exists, then moves the content to the resources directory from the consensus-otter-tests module
+     *
+     * @throws IOException if file operations fail
+     */
+    public void copyFilesInPlace() throws IOException {
+        final Path rootOutputDirectory = Path.of("build", "turtle", "node-0", "data", "saved");
+        final Path savedStateDirectory =
+                Path.of("platform-sdk", "consensus-otter-tests", "src", "test", "resources", "previous-version-state");
+
+        if (Files.exists(savedStateDirectory)) {
+            FileUtils.deleteDirectory(savedStateDirectory);
+        }
+        Files.createDirectories(savedStateDirectory);
+
+        FileUtils.moveDirectory(rootOutputDirectory, savedStateDirectory);
+    }
+
+    /**
+     * Command-line entry point. Generates a state using a deterministic turtle environment
+     * and installs it into test resources.
+     * <p>
+     * Exit code {@code 0} on success, {@code -1} on failure.
+     *
+     * @param args ignored
+     */
+    public static void main(String[] args) {
+        try {
+            final GenerateStateTool generateStateTool = new GenerateStateTool(new TurtleTestEnvironment(SEED));
+            generateStateTool.generateState();
+            generateStateTool.copyFilesInPlace();
+        } catch (final RuntimeException | IOException exp) {
+            System.err.println(exp.getMessage());
+            System.exit(-1);
+        }
+
+        System.exit(0);
+    }
+}

--- a/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/FileUtils.java
+++ b/platform-sdk/swirlds-common/src/main/java/com/swirlds/common/io/utility/FileUtils.java
@@ -17,11 +17,15 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
 import java.nio.file.StandardCopyOption;
+import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -317,5 +321,58 @@ public final class FileUtils {
         for (final Path file : files) {
             Files.delete(file);
         }
+    }
+
+    /**
+     * Moves a source directory, along with its contents, to a target location.
+     * If the target directory does not exist, it will be created.
+     * The method preserves the directory structure during the move operation.
+     * After all files and subdirectories are moved, the source directory is deleted.
+     *
+     * @param source the path of the directory to be moved, must not be null
+     * @param target the path where the directory should be moved, must not be null
+     * @throws IOException if the source does not exist or an I/O error occurs during the operation
+     */
+    public static void moveDirectory(@NonNull final Path source, @NonNull final Path target) throws IOException {
+        Objects.requireNonNull(source, "Source path cannot be null");
+        Objects.requireNonNull(target, "Target path cannot be null");
+
+        if (!Files.exists(source)) {
+            throw new IOException(source + " does not exist");
+        }
+        if (!Files.exists(target)) {
+            Files.createDirectories(target);
+        }
+
+        Files.walkFileTree(source, new SimpleFileVisitor<>() {
+            @NonNull
+            @Override
+            public FileVisitResult preVisitDirectory(@NonNull final Path dir, @NonNull final BasicFileAttributes attrs)
+                    throws IOException {
+                final Path relative = source.relativize(dir);
+                final Path targetDir = target.resolve(relative);
+                Files.createDirectories(targetDir);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @NonNull
+            @Override
+            public FileVisitResult visitFile(@NonNull final Path file, @NonNull final BasicFileAttributes attrs)
+                    throws IOException {
+                final Path relative = source.relativize(file);
+                final Path targetFile = target.resolve(relative);
+                Files.move(file, targetFile, StandardCopyOption.REPLACE_EXISTING);
+                return FileVisitResult.CONTINUE;
+            }
+
+            @NonNull
+            @Override
+            public FileVisitResult postVisitDirectory(@NonNull final Path dir, @Nullable final IOException exc)
+                    throws IOException {
+                // Delete the source directory after moving all files
+                Files.delete(dir);
+                return FileVisitResult.CONTINUE;
+            }
+        });
     }
 }


### PR DESCRIPTION
Fix #20277 

Utility tool that generates a saved platform state using a minimal turtle test environment and installs it as the {@code previous-version-state} test resource for consensus otter tests.

This tool performs the following steps:
* Creates a 1-node network
* Runs it for some time
* Freezes the network and shuts it down
* Moves the produced saved state

Intended to be run manually when refreshing the prior-version state used by tests.