### PR TITLE
feat: `STALE` Status Code in Transaction Receipts

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1844,8 +1844,12 @@ enum ResponseCodeEnum {
     TOO_MANY_LAMBDA_STORAGE_UPDATES = 513;
 
     /**
-     * A transaction was contained in a stale self event and will never reach consensus. Clients could resubmit
-     * this transaction if it's transactionValidStart is greater than the current consensus time of the network.
+     * The transaction was included in an event that has become stale and will never reach consensus.
+     * The transaction will not be executed and should be resubmitted if desired.
+     *
+     * This status indicates the transaction was valid and properly formed, but network conditions
+     * prevented the containing event from progressing through consensus. This is distinct from
+     * other failure modes as the transaction itself was not rejected for validation reasons.
      */
-    TRANSACTION_IN_STALE_SELF_EVENT = 514;
+    STALE = 514;
 }

--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1847,5 +1847,5 @@ enum ResponseCodeEnum {
      * A transaction was contained in a stale self event and will never reach consensus. Clients could resubmit
      * this transaction if it's transactionValidStart is greater than the current consensus time of the network.
      */
-    TRANSACTION_IN_STALE_EVENT = 514;
+    TRANSACTION_IN_STALE_SELF_EVENT = 514;
 }

--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1842,4 +1842,10 @@ enum ResponseCodeEnum {
      * The LambdaSStore tried to update too many storage slots in a single transaction.
      */
     TOO_MANY_LAMBDA_STORAGE_UPDATES = 513;
+
+    /**
+     * A transaction was contained in a stale self event and will never reach consensus. Clients could resubmit
+     * this transaction if it's transactionValidStart is greater than the current consensus time of the network.
+     */
+    TRANSACTION_IN_STALE_EVENT = 514;
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -114,6 +114,7 @@ import com.hedera.node.config.data.TssConfig;
 import com.hedera.node.config.data.VersionConfig;
 import com.hedera.node.config.types.StreamMode;
 import com.hedera.node.internal.network.Network;
+import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.notification.NotificationEngine;
 import com.swirlds.config.api.Configuration;
@@ -1448,8 +1449,8 @@ public final class Hedera implements SwirldMain<MerkleNodeState>, PlatformStatus
                     final TransactionID transactionID = transactionBody.transactionIDOrThrow();
                     // Mark the TransactionID as stale for resubmission allowance and query reporting.
                     component.deduplicationCache().markStale(transactionID);
-                } catch (Exception e) {
-                    // Ignore parsing errors for transactions
+                } catch (ParseException e) {
+                    // Ignore parsing errors for stale events
                 }
             }
         };

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -1453,7 +1453,7 @@ public final class Hedera implements SwirldMain<MerkleNodeState>, PlatformStatus
             } catch (ParseException e) {
                 // Ignore parsing errors for stale events
             } catch (Exception e) {
-                logger.warn("Exception during staleEventCallback while for transaction {}: {}", tx, e.getMessage(), e);
+                logger.warn("Exception during staleEventCallback for transaction {}: {}", tx, e.getMessage(), e);
             }
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
@@ -37,6 +37,7 @@ import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.spi.AppContext;
 import com.hedera.node.app.spi.records.RecordCache;
 import com.hedera.node.app.spi.throttle.Throttle;
+import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.state.HederaStateInjectionModule;
 import com.hedera.node.app.state.WorkingStateAccessor;
 import com.hedera.node.app.throttle.ThrottleServiceManager;
@@ -150,6 +151,8 @@ public interface HederaInjectionComponent {
     AsyncFatalIssListener fatalIssListener();
 
     CurrentPlatformStatus currentPlatformStatus();
+
+    DeduplicationCache deduplicationCache();
 
     @Component.Builder
     interface Builder {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -362,6 +362,9 @@ public class ServicesMain implements SwirldMain<MerkleNodeState> {
                 .withConfiguration(platformConfig)
                 .withKeysAndCerts(keysAndCerts)
                 .withSystemTransactionEncoderCallback(hedera::encodeSystemTransaction);
+        if (hedera.staleEventCallback() != null) {
+            platformBuilder.withStaleEventCallback(hedera.staleEventCallback());
+        }
         final var platform = platformBuilder.build();
         hedera.init(platform, selfId);
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -362,7 +362,7 @@ public class ServicesMain implements SwirldMain<MerkleNodeState> {
                 .withConfiguration(platformConfig)
                 .withKeysAndCerts(keysAndCerts)
                 .withSystemTransactionEncoderCallback(hedera::encodeSystemTransaction)
-                .withStaleEventCallback(event -> hedera.staleEventCallback(event));
+                .withStaleEventCallback(hedera::staleEventCallback);
 
         final var platform = platformBuilder.build();
         hedera.init(platform, selfId);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -361,10 +361,9 @@ public class ServicesMain implements SwirldMain<MerkleNodeState> {
                 .withPlatformContext(platformContext)
                 .withConfiguration(platformConfig)
                 .withKeysAndCerts(keysAndCerts)
-                .withSystemTransactionEncoderCallback(hedera::encodeSystemTransaction);
-        if (hedera.staleEventCallback() != null) {
-            platformBuilder.withStaleEventCallback(hedera.staleEventCallback());
-        }
+                .withSystemTransactionEncoderCallback(hedera::encodeSystemTransaction)
+                .withStaleEventCallback(event -> hedera.staleEventCallback(event));
+
         final var platform = platformBuilder.build();
         hedera.init(platform, selfId);
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
@@ -32,6 +32,27 @@ public interface DeduplicationCache {
      */
     boolean contains(@NonNull TransactionID transactionID);
 
+    /**
+     * Marks the given TransactionID as having been observed in a stale event. This information is kept
+     * in-memory only and ages out with the same policy as {@link #add(TransactionID)}.
+     * @param transactionID the transaction ID to mark as stale
+     */
+    void markStale(@NonNull TransactionID transactionID);
+
+    /**
+     * Returns true if the given {@link TransactionID} has been observed in a stale event and has not yet aged out.
+     * @param transactionID the transaction ID to check
+     * @return true if the transaction ID has been marked as stale
+     */
+    boolean isStale(@NonNull TransactionID transactionID);
+
+    /**
+     * Clears the stale state for the given {@link TransactionID}.
+     * @param transactionID the transaction ID to clear from the stale state
+     * @return true if the stale state was cleared
+     */
+    boolean clearStale(@NonNull TransactionID transactionID);
+
     /** Clear everything from the cache. Used during reconnect */
     void clear();
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
@@ -2,7 +2,9 @@
 package com.hedera.node.app.state;
 
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.node.app.state.recordcache.DeduplicationCacheImpl.TxStatus;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A cache for de-duplicating transactions. This cache is <strong>NOT</strong> stored in state. It contains only the
@@ -40,18 +42,20 @@ public interface DeduplicationCache {
     void markStale(@NonNull TransactionID transactionID);
 
     /**
-     * Returns true if the given {@link TransactionID} has been observed in a stale event and has not yet aged out.
-     * @param transactionID the transaction ID to check
-     * @return true if the transaction ID has been marked as stale
-     */
-    boolean isStale(@NonNull TransactionID transactionID);
-
-    /**
      * Clears the stale state for the given {@link TransactionID}.
      * @param transactionID the transaction ID to clear from the stale state
      * @return true if the stale state was cleared
      */
     boolean clearStale(@NonNull TransactionID transactionID);
+
+    /**
+     * Get the status of a transaction in the cache. If the transaction is not in the cache, or if it has
+     * aged out, then this will return null.
+     * @param transactionID the transaction ID to get the status for
+     * @return the status of the transaction, or null if it is not in the cache or has aged out
+     */
+    @Nullable
+    TxStatus getTxStatus(@NonNull TransactionID transactionID);
 
     /** Clear everything from the cache. Used during reconnect */
     void clear();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
@@ -42,13 +42,6 @@ public interface DeduplicationCache {
     void markStale(@NonNull TransactionID transactionID);
 
     /**
-     * Clears the stale state for the given {@link TransactionID}.
-     * @param transactionID the transaction ID to clear from the stale state
-     * @return true if the stale state was cleared
-     */
-    boolean clearStale(@NonNull TransactionID transactionID);
-
-    /**
      * Get the status of a transaction in the cache. If the transaction is not in the cache, or if it has
      * aged out, then this will return null.
      * @param transactionID the transaction ID to get the status for

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
@@ -103,15 +103,13 @@ public final class DeduplicationCacheImpl implements DeduplicationCache {
 
     /** {@inheritDoc} */
     @Override
-    public boolean isStale(@NonNull TransactionID transactionID) {
-        final var status = submittedTxns.get(transactionID);
-        return status == TxStatus.STALE;
-    }
-
-    /** {@inheritDoc} */
-    @Override
     public boolean clearStale(@NonNull TransactionID transactionID) {
         return submittedTxns.replace(transactionID, TxStatus.STALE, TxStatus.SUBMITTED);
+    }
+
+    @Override
+    public TxStatus getTxStatus(@NonNull TransactionID transactionID) {
+        return submittedTxns.get(transactionID);
     }
 
     /** {@inheritDoc} */

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
@@ -103,6 +103,10 @@ public final class DeduplicationCacheImpl implements DeduplicationCache {
 
     @Override
     public TxStatus getTxStatus(@NonNull TransactionID transactionID) {
+        // We will prune the set here as well. By pruning before looking up, we are sure that we only return true
+        // if the transactionID is still valid
+        final var epochSeconds = approxEarliestValidStartSecond();
+        removeTransactionsOlderThan(epochSeconds);
         return submittedTxns.get(transactionID);
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
@@ -101,12 +101,6 @@ public final class DeduplicationCacheImpl implements DeduplicationCache {
         submittedTxns.computeIfPresent(transactionID, (key, value) -> TxStatus.STALE);
     }
 
-    /** {@inheritDoc} */
-    @Override
-    public boolean clearStale(@NonNull TransactionID transactionID) {
-        return submittedTxns.replace(transactionID, TxStatus.STALE, TxStatus.SUBMITTED);
-    }
-
     @Override
     public TxStatus getTxStatus(@NonNull TransactionID transactionID) {
         return submittedTxns.get(transactionID);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
@@ -16,7 +16,6 @@ import com.hedera.node.config.data.HederaConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.InstantSource;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
@@ -106,7 +105,6 @@ public final class DeduplicationCacheImpl implements DeduplicationCache {
     public boolean clearStale(@NonNull TransactionID transactionID) {
         return staleTxns.remove(transactionID);
     }
-
 
     /** {@inheritDoc} */
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
@@ -2,7 +2,7 @@
 package com.hedera.node.app.state.recordcache;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
-import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_IN_STALE_EVENT;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_IN_STALE_SELF_EVENT;
 import static com.hedera.hapi.util.HapiUtils.TIMESTAMP_COMPARATOR;
 import static com.hedera.hapi.util.HapiUtils.isBefore;
 import static com.hedera.node.app.spi.records.RecordCache.matchesExceptNonce;
@@ -480,7 +480,7 @@ public class RecordCacheImpl implements HederaRecordCache {
         boolean isKnownToDeduplicationCache = deduplicationCache.contains(txnId);
         if (isKnownToDeduplicationCache && deduplicationCache.isStale(txnId)) {
             final var receipt = TransactionReceipt.newBuilder()
-                    .status(TRANSACTION_IN_STALE_EVENT)
+                    .status(TRANSACTION_IN_STALE_SELF_EVENT)
                     .build();
             final var record = TransactionRecord.newBuilder()
                     .transactionID(txnId)
@@ -493,7 +493,7 @@ public class RecordCacheImpl implements HederaRecordCache {
         } else if (isKnownToDeduplicationCache) {
             return EMPTY_HISTORY_SOURCE;
         } else {
-            return  null;
+            return null;
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -275,8 +275,8 @@ public final class IngestChecker {
         // will convert that to INVALID_TRANSACTION_BODY.
         assert functionality != HederaFunctionality.NONE;
 
-        // 3. Deduplicate
-        if (deduplicationCache.contains(txInfo.transactionID())) {
+        // 3. Deduplicate the transaction and check for staleness
+        if (deduplicationCache.contains(txInfo.transactionID()) && !deduplicationCache.isStale(txInfo.transactionID())) {
             throw new PreCheckException(DUPLICATE_TRANSACTION);
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -276,7 +276,8 @@ public final class IngestChecker {
         assert functionality != HederaFunctionality.NONE;
 
         // 3. Deduplicate the transaction and check for staleness
-        if (deduplicationCache.contains(txInfo.transactionID()) && !deduplicationCache.isStale(txInfo.transactionID())) {
+        if (deduplicationCache.contains(txInfo.transactionID())
+                && !deduplicationCache.isStale(txInfo.transactionID())) {
             throw new PreCheckException(DUPLICATE_TRANSACTION);
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -26,6 +26,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.WAITING_FOR_LEDGER_ID;
 import static com.hedera.hapi.util.HapiUtils.isHollow;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
+import static com.hedera.node.app.state.recordcache.DeduplicationCacheImpl.TxStatus.SUBMITTED;
 import static com.hedera.node.app.workflows.InnerTransaction.NO;
 import static com.hedera.node.app.workflows.InnerTransaction.YES;
 import static com.hedera.node.app.workflows.handle.dispatch.DispatchValidator.WorkflowCheck.INGEST;
@@ -276,8 +277,7 @@ public final class IngestChecker {
         assert functionality != HederaFunctionality.NONE;
 
         // 3. Deduplicate the transaction and check for staleness
-        if (deduplicationCache.contains(txInfo.transactionID())
-                && !deduplicationCache.isStale(txInfo.transactionID())) {
+        if (deduplicationCache.getTxStatus(txInfo.transactionID()) == SUBMITTED) {
             throw new PreCheckException(DUPLICATE_TRANSACTION);
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
@@ -143,7 +143,14 @@ public class SubmissionManager {
             // and BEFORE we record the transaction as a duplicate.
             final var txId = txBody.transactionIDOrThrow();
             if (submittedTxns.contains(txId)) {
-                throw new PreCheckException(DUPLICATE_TRANSACTION);
+                if (submittedTxns.isStale(txId)) {
+                    boolean wasStale = submittedTxns.clearStale(txId);
+                    if (!wasStale) {
+                        throw new PreCheckException(DUPLICATE_TRANSACTION);
+                    }
+                } else {
+                    throw new PreCheckException(DUPLICATE_TRANSACTION);
+                }
             }
 
             // This call to submit to the platform should almost always work. Maybe under extreme load it will fail,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
@@ -147,13 +147,6 @@ public class SubmissionManager {
             if (txStatus == TxStatus.SUBMITTED) {
                 // If the transaction is already submitted, we do not want to submit it again.
                 throw new PreCheckException(DUPLICATE_TRANSACTION);
-            } else if (txStatus == TxStatus.STALE) {
-                // If the transaction is stale, we want to clear it and then submit it again.
-                boolean wasStale = submittedTxns.clearStale(txId);
-                if (!wasStale) {
-                    // If the transaction was not stale, then it was a duplicate.
-                    throw new PreCheckException(DUPLICATE_TRANSACTION);
-                }
             }
 
             // This call to submit to the platform should almost always work. Maybe under extreme load it will fail,

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/DeduplicationCacheTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/DeduplicationCacheTest.java
@@ -220,18 +220,17 @@ final class DeduplicationCacheTest {
     }
 
     @Test
-    @DisplayName("clearStale causes isStale to return false")
-    void clearStaleUpdatesStatus() {
+    @DisplayName("add clears STALE status")
+    void addClearsStaleUpdatesStatus() {
         // Given a transaction marked as stale
         final var txId = createTransactionID();
         cache.add(txId);
         cache.markStale(txId);
 
         // When clearing the stale status
-        final var result = cache.clearStale(txId);
+        cache.add(txId);
 
         // Then the map no longer contains the transaction ID so isStale returns false
-        assertThat(result).isTrue();
         assertThat(cache.getTxStatus(txId) == TxStatus.SUBMITTED).isTrue();
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/DeduplicationCacheTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/DeduplicationCacheTest.java
@@ -210,13 +210,13 @@ final class DeduplicationCacheTest {
         // Given a transaction in the cache
         final var txId = createTransactionID();
         cache.add(txId);
-        assertThat(!cache.isStale(txId)).isTrue();
+        assertThat(cache.getTxStatus(txId) == TxStatus.SUBMITTED).isTrue();
 
         // When marking it as stale
         cache.markStale(txId);
 
         // Then the status is updated to STALE
-        assertThat(cache.isStale(txId)).isTrue();
+        assertThat(cache.getTxStatus(txId) == TxStatus.STALE).isTrue();
     }
 
     @Test
@@ -232,7 +232,7 @@ final class DeduplicationCacheTest {
 
         // Then the map no longer contains the transaction ID so isStale returns false
         assertThat(result).isTrue();
-        assertThat(cache.isStale(txId)).isFalse();
+        assertThat(cache.getTxStatus(txId) == TxStatus.SUBMITTED).isTrue();
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
@@ -5,6 +5,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_IS_IMMUTABLE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.STALE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNKNOWN;
 import static com.hedera.node.app.state.HederaRecordCache.DuplicateCheckResult.NO_DUPLICATE;
@@ -735,5 +736,62 @@ final class RecordCacheImplTest extends AppTestBase {
             // Then we can check for a duplicate by transaction ID
             assertThat(cache.hasDuplicate(txId, currentNodeId)).isEqualTo(SAME_NODE);
         }
+    }
+
+    @Test
+    @DisplayName("getReceipts returns STALE_RECEIPT_SOURCE for stale transactions")
+    void getReceiptsForStaleTransaction() {
+        final var cache = new RecordCacheImpl(dedupeCache, wsa, props, networkInfo);
+        // Given a transaction marked as stale
+        final var now = Instant.now();
+        final var txnId = TransactionID.newBuilder()
+                .transactionValidStart(
+                        Timestamp.newBuilder().seconds(now.getEpochSecond()).build())
+                .build();
+        dedupeCache.add(txnId);
+        dedupeCache.markStale(txnId);
+
+        // When getting receipts
+        final var result = cache.getReceipts(txnId);
+
+        // Then it returns the STALE_RECEIPT_SOURCE
+        assertThat(result.priorityReceipt(txnId).status() == STALE).isTrue();
+    }
+
+    @Test
+    @DisplayName("getReceipts returns EMPTY_HISTORY_SOURCE for submitted transactions")
+    void getReceiptsForSubmittedTransaction() {
+        final var cache = new RecordCacheImpl(dedupeCache, wsa, props, networkInfo);
+        // Given a transaction marked as stale
+        final var now = Instant.now();
+        final var txnId = TransactionID.newBuilder()
+                .transactionValidStart(
+                        Timestamp.newBuilder().seconds(now.getEpochSecond()).build())
+                .build();
+        dedupeCache.add(txnId);
+
+        // When getting receipts
+        final var result = cache.getReceipts(txnId);
+
+        // Then it returns the EMPTY_HISTORY_SOURCE
+        assertThat(result.priorityReceipt(txnId).status() == UNKNOWN).isTrue();
+    }
+
+    @Test
+    @DisplayName("getReceipts returns null for unknown transactions")
+    void getReceiptsForUnknownTransaction() {
+        final var cache = new RecordCacheImpl(dedupeCache, wsa, props, networkInfo);
+        // Given a transaction marked as stale
+        final var now = Instant.now();
+        final var txnId = TransactionID.newBuilder()
+                .transactionValidStart(
+                        Timestamp.newBuilder().seconds(now.getEpochSecond()).build())
+                .build();
+
+        // When getting receipts
+        final var result = cache.getReceipts(txnId);
+
+        // Then it returns null
+        assertThat(result).isNull();
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
@@ -148,9 +148,9 @@ final class SubmissionManagerTest extends AppTestBase {
         void testSubmittingDuplicateTransactionsCloseTogether() throws PreCheckException {
             // Given a platform that will succeed in taking bytes
             when(platform.createTransaction(any())).thenReturn(true);
-            when(deduplicationCache.contains(txBody.transactionIDOrThrow()))
-                    .thenReturn(false)
-                    .thenReturn(true);
+            when(deduplicationCache.getTxStatus(txBody.transactionIDOrThrow()))
+                    .thenReturn(null)
+                    .thenReturn(SUBMITTED);
 
             // When we submit a duplicate transaction twice in close succession, then the second one fails
             // with a DUPLICATE_TRANSACTION error
@@ -168,12 +168,10 @@ final class SubmissionManagerTest extends AppTestBase {
         void testSubmittingDuplicateTransactionsCloseTogetherStaleness() throws PreCheckException {
             // Given a platform that will succeed in taking bytes
             when(platform.createTransaction(any())).thenReturn(true);
-            when(deduplicationCache.contains(txBody.transactionIDOrThrow())).thenReturn(false);
-            when(deduplicationCache.getTxStatus(txBody.transactionIDOrThrow())).thenReturn(SUBMITTED);
+            when(deduplicationCache.getTxStatus(txBody.transactionIDOrThrow())).thenReturn(null);
 
             submissionManager.submit(txBody, bytes);
 
-            when(deduplicationCache.contains(txBody.transactionIDOrThrow())).thenReturn(true);
             when(deduplicationCache.getTxStatus(txBody.transactionIDOrThrow())).thenReturn(STALE);
             when(deduplicationCache.clearStale(txBody.transactionIDOrThrow())).thenReturn(true);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
@@ -8,6 +8,7 @@ import static com.hedera.node.app.state.recordcache.DeduplicationCacheImpl.TxSta
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -178,7 +179,7 @@ final class SubmissionManagerTest extends AppTestBase {
             // as the first one has become stale
             submissionManager.submit(txBody, bytes);
             // Verify we clear the stale transaction status from the deduplication cache by adding
-            verify(deduplicationCache).add(txBody.transactionIDOrThrow());
+            verify(deduplicationCache, times(2)).add(txBody.transactionIDOrThrow());
         }
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
@@ -173,13 +173,12 @@ final class SubmissionManagerTest extends AppTestBase {
             submissionManager.submit(txBody, bytes);
 
             when(deduplicationCache.getTxStatus(txBody.transactionIDOrThrow())).thenReturn(STALE);
-            when(deduplicationCache.clearStale(txBody.transactionIDOrThrow())).thenReturn(true);
 
             // When we submit a duplicate transaction twice in close succession, the second one is allowed
             // as the first one has become stale
             submissionManager.submit(txBody, bytes);
-            // Verify we safely clear the stale transaction status from the deduplication cache
-            verify(deduplicationCache).clearStale(txBody.transactionIDOrThrow());
+            // Verify we clear the stale transaction status from the deduplication cache by adding
+            verify(deduplicationCache).add(txBody.transactionIDOrThrow());
         }
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/SubmissionManagerTest.java
@@ -3,6 +3,8 @@ package com.hedera.node.app.workflows.ingest;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PLATFORM_TRANSACTION_NOT_CREATED;
+import static com.hedera.node.app.state.recordcache.DeduplicationCacheImpl.TxStatus.STALE;
+import static com.hedera.node.app.state.recordcache.DeduplicationCacheImpl.TxStatus.SUBMITTED;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -167,12 +169,12 @@ final class SubmissionManagerTest extends AppTestBase {
             // Given a platform that will succeed in taking bytes
             when(platform.createTransaction(any())).thenReturn(true);
             when(deduplicationCache.contains(txBody.transactionIDOrThrow())).thenReturn(false);
-            when(deduplicationCache.isStale(txBody.transactionIDOrThrow())).thenReturn(false);
+            when(deduplicationCache.getTxStatus(txBody.transactionIDOrThrow())).thenReturn(SUBMITTED);
 
             submissionManager.submit(txBody, bytes);
 
             when(deduplicationCache.contains(txBody.transactionIDOrThrow())).thenReturn(true);
-            when(deduplicationCache.isStale(txBody.transactionIDOrThrow())).thenReturn(true);
+            when(deduplicationCache.getTxStatus(txBody.transactionIDOrThrow())).thenReturn(STALE);
             when(deduplicationCache.clearStale(txBody.transactionIDOrThrow())).thenReturn(true);
 
             // When we submit a duplicate transaction twice in close succession, the second one is allowed

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/EmbeddedReason.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/EmbeddedReason.java
@@ -19,8 +19,7 @@ public enum EmbeddedReason {
      */
     MANIPULATES_EVENT_VERSION,
     /**
-     * The test manipulates the workflow of the simulated consensus event for a transaction.
-     * For example, the test may only want to preHandle a transaction and invoke a stale consensus event callback.
+     * The test manipulates the workflow of submitted transactions.
      */
     MANIPULATES_WORKFLOW,
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/EmbeddedReason.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/EmbeddedReason.java
@@ -18,4 +18,9 @@ public enum EmbeddedReason {
      * The test manipulates the software version of the simulated consensus event for a transaction.
      */
     MANIPULATES_EVENT_VERSION,
+    /**
+     * The test manipulates the workflow of the simulated consensus event for a transaction.
+     * For example, the test may only want to preHandle a transaction and invoke a stale consensus event callback.
+     */
+    MANIPULATES_WORKFLOW,
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -71,7 +71,6 @@ import org.hiero.base.crypto.Hash;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.roster.AddressBook;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * Implementation support for {@link EmbeddedHedera}.
@@ -378,17 +377,16 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     }
 
     @Override
-    public void triggerStaleEventCallbackForTransaction(@NotNull Transaction transaction) {
+    public void triggerStaleEventCallbackForTransaction(@NonNull Transaction transaction) {
         requireNonNull(transaction);
         final var serializedSignedTx = HapiTxnOp.serializedSignedTxFrom(transaction);
         final FakeEvent fakeStaleEvent =
                 new FakeEvent(defaultNodeId, now(), createAppPayloadWrapper(serializedSignedTx));
-        hedera.staleEventCallback()
-                .accept(new PlatformEvent(new GossipEvent(
-                        fakeStaleEvent.getEventCore(),
-                        fakeStaleEvent.getSignature(),
-                        List.of(Bytes.wrap(serializedSignedTx)),
-                        List.of())));
+        hedera.staleEventCallback(new PlatformEvent(new GossipEvent(
+                fakeStaleEvent.getEventCore(),
+                fakeStaleEvent.getSignature(),
+                List.of(Bytes.wrap(serializedSignedTx)),
+                List.of())));
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -378,7 +378,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     }
 
     @Override
-    public void injectStaleEventForTransaction(@NotNull Transaction transaction) {
+    public void triggerStaleEventCallbackForTransaction(@NotNull Transaction transaction) {
         requireNonNull(transaction);
         final var serializedSignedTx = HapiTxnOp.serializedSignedTxFrom(transaction);
         final FakeEvent fakeStaleEvent =

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -6,6 +6,7 @@ import static com.hedera.services.bdd.junit.hedera.ExternalPath.ADDRESS_BOOK;
 import static com.hedera.services.bdd.junit.hedera.embedded.fakes.FakePlatformContext.PLATFORM_CONFIG;
 import static com.swirlds.platform.system.InitTrigger.GENESIS;
 import static com.swirlds.platform.system.InitTrigger.RESTART;
+import static com.swirlds.platform.system.transaction.TransactionWrapperUtils.createAppPayloadWrapper;
 import static java.util.Objects.requireNonNull;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.Collectors.toMap;
@@ -16,6 +17,7 @@ import static org.hiero.consensus.roster.RosterUtils.rosterFrom;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.platform.event.GossipEvent;
 import com.hedera.node.app.Hedera;
 import com.hedera.node.app.ServicesMain;
 import com.hedera.node.app.fixtures.state.FakeServiceMigrator;
@@ -28,9 +30,11 @@ import com.hedera.node.internal.network.Network;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.AbstractFakePlatform;
+import com.hedera.services.bdd.junit.hedera.embedded.fakes.FakeEvent;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.FakeHintsService;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.FakeHistoryService;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.LapsingBlockHashSigner;
+import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
@@ -53,8 +57,11 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -62,8 +69,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.constructable.ConstructableRegistry;
 import org.hiero.base.crypto.Hash;
+import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.roster.AddressBook;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * Implementation support for {@link EmbeddedHedera}.
@@ -107,6 +116,8 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     protected Hedera hedera;
     protected SemanticVersion version;
     protected boolean blockStreamEnabled;
+
+    protected Set<Bytes> staleTransactions = new HashSet<>();
 
     /**
      * Non-final because the compiler can't tell that the {@link com.hedera.node.app.Hedera.HintsServiceFactory} lambda we give the
@@ -365,5 +376,19 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
         return new AddressBook(stream(spliteratorUnknownSize(addressBook.iterator(), 0), false)
                 .map(address -> address.copySetSigCert(sigCert))
                 .toList());
+    }
+
+    @Override
+    public void injectStaleEventForTransaction(@NotNull Transaction transaction) {
+        requireNonNull(transaction);
+        final var serializedSignedTx = HapiTxnOp.serializedSignedTxFrom(transaction);
+        final FakeEvent fakeStaleEvent = new FakeEvent(defaultNodeId, now(), createAppPayloadWrapper(serializedSignedTx));
+        hedera.staleEventCallback().accept(new PlatformEvent(new GossipEvent(fakeStaleEvent.getEventCore(),
+                fakeStaleEvent.getSignature(), List.of(Bytes.wrap(serializedSignedTx)), List.of())));
+    }
+
+    @Override
+    public void markTransactionStale(@NonNull Transaction transaction) {
+        staleTransactions.add(Bytes.wrap(transaction.getSignedTransactionBytes().toByteArray()));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
@@ -7,10 +7,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 
 import com.hedera.hapi.node.base.SemanticVersion;
-import com.hedera.hapi.node.transaction.SignedTransaction;
-import com.hedera.hapi.platform.event.GossipEvent;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
-import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.AbstractFakePlatform;
@@ -36,10 +33,8 @@ import java.util.stream.IntStream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.event.ConsensusEvent;
-import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.Round;
 import org.hiero.consensus.model.transaction.ScopedSystemTransaction;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An embedded Hedera node that can be used in concurrent tests.
@@ -209,15 +204,9 @@ class ConcurrentEmbeddedHedera extends AbstractEmbeddedHedera implements Embedde
                 // Now drain all events that will go in the next round and pre-handle them
                 final List<FakeEvent> newEvents = new ArrayList<>();
                 queue.drainTo(newEvents);
-                // If any newEvents contain Transactions which have been marked as stale, do not preHandle them
-                newEvents.removeIf(event -> {
-                    final Bytes transactionBytes = event.transaction.getApplicationTransaction();
-                    boolean isStaleAndShouldBeSkipped = staleTransactions.contains(transactionBytes);
-                    if (isStaleAndShouldBeSkipped){
-                        staleTransactions.remove(transactionBytes);
-                    }
-                    return isStaleAndShouldBeSkipped;
-                });
+                if (allEventsStale.get()) {
+                    newEvents.clear();
+                }
                 newEvents.forEach(event -> hedera.onPreHandle(event, state, NOOP_STATE_SIG_CALLBACK));
                 prehandledEvents.addAll(newEvents);
             } catch (Throwable t) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
@@ -133,10 +133,8 @@ public interface EmbeddedHedera {
     void injectStaleEventForTransaction(@NonNull Transaction transaction);
 
     /**
-     *
-     * @param transaction
+     * Sets whether all events should be considered stale.
+     * @param considerAllEventsStale true if all events should be considered stale, false otherwise
      */
-    void markTransactionStale(@NonNull Transaction transaction);
-
-
+    void considerAllEventsStale(boolean considerAllEventsStale);
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
@@ -129,4 +129,14 @@ public interface EmbeddedHedera {
      * @return the response to the transaction
      */
     TransactionResponse submit(Transaction transaction, AccountID nodeAccountId, long eventBirthRound);
+
+    void injectStaleEventForTransaction(@NonNull Transaction transaction);
+
+    /**
+     *
+     * @param transaction
+     */
+    void markTransactionStale(@NonNull Transaction transaction);
+
+
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
@@ -130,7 +130,11 @@ public interface EmbeddedHedera {
      */
     TransactionResponse submit(Transaction transaction, AccountID nodeAccountId, long eventBirthRound);
 
-    void injectStaleEventForTransaction(@NonNull Transaction transaction);
+    /**
+     * Triggers the stale event callback for a given transaction.
+     * @param transaction the transaction for which to trigger the stale event callback
+     */
+    void triggerStaleEventCallbackForTransaction(@NonNull Transaction transaction);
 
     /**
      * Sets whether all events should be considered stale.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
@@ -7,6 +7,7 @@ import static com.swirlds.platform.system.transaction.TransactionWrapperUtils.cr
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.platform.event.GossipEvent;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -31,9 +32,11 @@ import java.util.Queue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import org.hiero.consensus.model.event.ConsensusEvent;
+import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.Round;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.transaction.ScopedSystemTransaction;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * An embedded Hedera node that handles transactions synchronously on ingest and thus

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
@@ -7,7 +7,6 @@ import static com.swirlds.platform.system.transaction.TransactionWrapperUtils.cr
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;
-import com.hedera.hapi.platform.event.GossipEvent;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -32,11 +31,9 @@ import java.util.Queue;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import org.hiero.consensus.model.event.ConsensusEvent;
-import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.Round;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.transaction.ScopedSystemTransaction;
-import org.jetbrains.annotations.NotNull;
 
 /**
  * An embedded Hedera node that handles transactions synchronously on ingest and thus

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -118,8 +118,6 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
 
     protected List<Condition> conditions = new ArrayList<>();
 
-    protected boolean submitWithPreviousTransaction = false;
-
     /**
      * Serializes a signed transaction from the given {@link Transaction}.
      * @param tx the transaction to serialize
@@ -216,12 +214,7 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
         configureTlsFor(spec);
         int retryCount = 1;
         while (true) {
-            Transaction txn = null;
-            if (submitWithPreviousTransaction) {
-                txn = txnSubmitted;
-            } else {
-                txn = finalizedTxn(spec, opBodyDef(spec));
-            }
+            Transaction txn = finalizedTxn(spec, opBodyDef(spec));
 
             if (!loggingOff) {
                 String message = String.format("%s submitting %s via %s", spec.logPrefix(), this, txnToString(txn));
@@ -895,15 +888,6 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
 
     public T hasSuccessReceipt(@NonNull final Consumer<TransactionReceipt> receiptValidator) {
         this.receiptValidator = requireNonNull(receiptValidator);
-        return self();
-    }
-
-    /**
-     * Sets the flag to submit this transaction with the previous transaction.
-     * @return the current instance of the transaction operation
-     */
-    public T submitWithPreviousTransaction() {
-        this.submitWithPreviousTransaction = true;
         return self();
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
@@ -58,7 +58,7 @@ public class StaleEventTest {
                                 .getStatus());
 
                 // Now inject a stale event containing the same txn; expect receipt query to return
-                // TRANSACTION_IN_STALE_EVENT, client can resubmit the transaction
+                // STALE, client can resubmit the transaction
                 embeddedNetwork
                         .embeddedHederaOrThrow()
                         .triggerStaleEventCallbackForTransaction(transfer.getSubmittedTransaction());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
@@ -1,0 +1,78 @@
+package com.hedera.services.bdd.suites.records;
+
+import static com.hedera.services.bdd.junit.EmbeddedReason.MANIPULATES_WORKFLOW;
+import static com.hedera.services.bdd.junit.EmbeddedReason.NEEDS_STATE_ACCESS;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeUpdate;
+import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.viewNode;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.GRPC_PROXY_ENDPOINT_FQDN;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hederahashgraph.api.proto.java.Response;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.services.bdd.junit.EmbeddedHapiTest;
+import com.hedera.services.bdd.junit.hedera.embedded.EmbeddedNetwork;
+import com.hedera.services.bdd.spec.queries.QueryVerbs;
+import com.hedera.services.bdd.spec.queries.meta.HapiGetReceipt;
+import com.hedera.services.bdd.spec.transactions.TxnVerbs;
+import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.Transaction;
+import com.hederahashgraph.api.proto.java.TransactionID;
+import java.security.cert.CertificateEncodingException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+
+public class StaleEventTest {
+
+    @EmbeddedHapiTest(MANIPULATES_WORKFLOW)
+    final Stream<DynamicTest> transactionFromStaleEventCanBeResubmitted() {
+        return hapiTest(
+                newKeyNamed("alice"),
+                cryptoCreate("alice"),
+                doingContextual(spec -> {
+                    final var transfer = new HapiCryptoTransfer(HapiCryptoTransfer.tinyBarsFromTo(DEFAULT_PAYER, "alice", ONE_HUNDRED_HBARS))
+                            .payingWith(DEFAULT_PAYER);
+                    try {
+                        final Transaction txn = transfer.signedTxnFor(spec);
+                        final var embeddedNetwork = (EmbeddedNetwork) spec.targetNetworkOrThrow();
+                        // Run through ingest only to populate the DeduplicationCache, we will expect a receipt query with OK status and UNKNOWN
+                        final TransactionBody txnBody = TransactionBody.PROTOBUF.parse(
+                                SignedTransaction.PROTOBUF.parse(
+                                        Bytes.wrap(txn.getSignedTransactionBytes().toByteArray())).bodyBytes());
+                        TransactionID txnID = TransactionID.parseFrom(com.hedera.hapi.node.base.TransactionID.PROTOBUF.toBytes(txnBody.transactionID())
+                                .toByteArray());
+
+                        embeddedNetwork.embeddedHederaOrThrow().markTransactionStale(txn);
+                        System.out.println("SignedTransaction: " + txn.getSignedTransactionBytes());
+                        // Execute the HapiCryptoTransfer, it should be silently ignored in a stale FakeEvent however,
+                        // it will be added to the DeduplicationCache
+                        transfer.execFor(spec);
+
+                        HapiGetReceipt hapiGetReceipt = getReceipt(txnID).hasAnswerOnlyPrecheck(ResponseCodeEnum.OK).hasPriorityStatus(ResponseCodeEnum.UNKNOWN);
+                        hapiGetReceipt.execFor(spec);
+                        System.out.println("Response : " + hapiGetReceipt.getResponse());
+
+                        // Now inject a stale event containing the same txn; expect receipt query to return TRANSACTION_IN_STALE_EVENT, client can resubmit the transaction
+                        embeddedNetwork.embeddedHederaOrThrow().injectStaleEventForTransaction(txn);
+                        HapiGetReceipt nextReceipt = getReceipt(txnID).hasAnswerOnlyPrecheck(ResponseCodeEnum.OK).hasPriorityStatus(ResponseCodeEnum.TRANSACTION_IN_STALE_EVENT);
+                        nextReceipt.execFor(spec);
+                        System.out.println("Response : " + nextReceipt.getResponse());
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+    }
+
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
@@ -1,36 +1,27 @@
+// SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.suites.records;
 
 import static com.hedera.services.bdd.junit.EmbeddedReason.MANIPULATES_WORKFLOW;
-import static com.hedera.services.bdd.junit.EmbeddedReason.NEEDS_STATE_ACCESS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.asTimestamp;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeCreate;
-import static com.hedera.services.bdd.spec.transactions.TxnVerbs.nodeUpdate;
-import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.viewNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
-import static com.hedera.services.bdd.suites.hip869.NodeCreateTest.GRPC_PROXY_ENDPOINT_FQDN;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_IN_STALE_SELF_EVENT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.hedera.hapi.node.transaction.SignedTransaction;
-import com.hedera.hapi.node.transaction.TransactionBody;
-import com.hederahashgraph.api.proto.java.Response;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.hedera.embedded.EmbeddedNetwork;
-import com.hedera.services.bdd.spec.queries.QueryVerbs;
 import com.hedera.services.bdd.spec.queries.meta.HapiGetReceipt;
-import com.hedera.services.bdd.spec.transactions.TxnVerbs;
 import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.Transaction;
-import com.hederahashgraph.api.proto.java.TransactionID;
-import java.security.cert.CertificateEncodingException;
-import java.util.concurrent.atomic.AtomicReference;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 
@@ -38,41 +29,67 @@ public class StaleEventTest {
 
     @EmbeddedHapiTest(MANIPULATES_WORKFLOW)
     final Stream<DynamicTest> transactionFromStaleEventCanBeResubmitted() {
-        return hapiTest(
-                newKeyNamed("alice"),
-                cryptoCreate("alice"),
-                doingContextual(spec -> {
-                    final var transfer = new HapiCryptoTransfer(HapiCryptoTransfer.tinyBarsFromTo(DEFAULT_PAYER, "alice", ONE_HUNDRED_HBARS))
-                            .payingWith(DEFAULT_PAYER);
-                    try {
-                        final Transaction txn = transfer.signedTxnFor(spec);
-                        final var embeddedNetwork = (EmbeddedNetwork) spec.targetNetworkOrThrow();
-                        // Run through ingest only to populate the DeduplicationCache, we will expect a receipt query with OK status and UNKNOWN
-                        final TransactionBody txnBody = TransactionBody.PROTOBUF.parse(
-                                SignedTransaction.PROTOBUF.parse(
-                                        Bytes.wrap(txn.getSignedTransactionBytes().toByteArray())).bodyBytes());
-                        TransactionID txnID = TransactionID.parseFrom(com.hedera.hapi.node.base.TransactionID.PROTOBUF.toBytes(txnBody.transactionID())
-                                .toByteArray());
+        return hapiTest(newKeyNamed("alice"), cryptoCreate("alice"), doingContextual(spec -> {
+            spec.registry().saveTimestamp("txn", asTimestamp(Instant.now()));
+            final var transfer = new HapiCryptoTransfer(
+                            HapiCryptoTransfer.tinyBarsFromTo(DEFAULT_PAYER, "alice", ONE_HUNDRED_HBARS))
+                    .payingWith(DEFAULT_PAYER)
+                    .via("txn")
+                    .fireAndForget();
+            try {
+                final Transaction txn = transfer.signedTxnFor(spec);
+                final var embeddedNetwork = (EmbeddedNetwork) spec.targetNetworkOrThrow();
+                embeddedNetwork.embeddedHederaOrThrow().considerAllEventsStale(true);
+                // Execute the HapiCryptoTransfer, it should be silently ignored in a stale FakeEvent however,
+                // it will be added to the DeduplicationCache
+                transfer.execFor(spec);
 
-                        embeddedNetwork.embeddedHederaOrThrow().markTransactionStale(txn);
-                        System.out.println("SignedTransaction: " + txn.getSignedTransactionBytes());
-                        // Execute the HapiCryptoTransfer, it should be silently ignored in a stale FakeEvent however,
-                        // it will be added to the DeduplicationCache
-                        transfer.execFor(spec);
+                Thread.sleep(Duration.ofSeconds(1));
 
-                        HapiGetReceipt hapiGetReceipt = getReceipt(txnID).hasAnswerOnlyPrecheck(ResponseCodeEnum.OK).hasPriorityStatus(ResponseCodeEnum.UNKNOWN);
-                        hapiGetReceipt.execFor(spec);
-                        System.out.println("Response : " + hapiGetReceipt.getResponse());
+                embeddedNetwork.embeddedHederaOrThrow().considerAllEventsStale(false);
 
-                        // Now inject a stale event containing the same txn; expect receipt query to return TRANSACTION_IN_STALE_EVENT, client can resubmit the transaction
-                        embeddedNetwork.embeddedHederaOrThrow().injectStaleEventForTransaction(txn);
-                        HapiGetReceipt nextReceipt = getReceipt(txnID).hasAnswerOnlyPrecheck(ResponseCodeEnum.OK).hasPriorityStatus(ResponseCodeEnum.TRANSACTION_IN_STALE_EVENT);
-                        nextReceipt.execFor(spec);
-                        System.out.println("Response : " + nextReceipt.getResponse());
-                    } catch (Throwable e) {
-                        throw new RuntimeException(e);
-                    }
-                }));
+                HapiGetReceipt hapiGetReceipt = getReceipt("txn");
+                hapiGetReceipt.execFor(spec);
+                assertEquals(
+                        ResponseCodeEnum.UNKNOWN,
+                        hapiGetReceipt
+                                .getResponse()
+                                .getTransactionGetReceipt()
+                                .getReceipt()
+                                .getStatus());
+
+                // Now inject a stale event containing the same txn; expect receipt query to return
+                // TRANSACTION_IN_STALE_EVENT, client can resubmit the transaction
+                embeddedNetwork
+                        .embeddedHederaOrThrow()
+                        .injectStaleEventForTransaction(transfer.getSubmittedTransaction());
+                HapiGetReceipt nextReceipt = getReceipt("txn");
+                nextReceipt.execFor(spec);
+
+                assertEquals(
+                        TRANSACTION_IN_STALE_SELF_EVENT,
+                        nextReceipt
+                                .getResponse()
+                                .getTransactionGetReceipt()
+                                .getReceipt()
+                                .getStatus());
+
+                // Now resubmit the transaction, it should succeed
+                transfer.submitWithPreviousTransaction().execFor(spec);
+
+                Thread.sleep(Duration.ofSeconds(1));
+                HapiGetReceipt finalReceipt = getReceipt("txn");
+                finalReceipt.execFor(spec);
+                assertEquals(
+                        SUCCESS,
+                        finalReceipt
+                                .getResponse()
+                                .getTransactionGetReceipt()
+                                .getReceipt()
+                                .getStatus());
+            } catch (Throwable e) {
+                throw new RuntimeException(e);
+            }
+        }));
     }
-
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
@@ -4,7 +4,6 @@ package com.hedera.services.bdd.suites.records;
 import static com.hedera.services.bdd.junit.EmbeddedReason.MANIPULATES_WORKFLOW;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
-import static com.hedera.services.bdd.spec.transactions.TxnUtils.asTimestamp;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
@@ -19,9 +18,7 @@ import com.hedera.services.bdd.junit.hedera.embedded.EmbeddedNetwork;
 import com.hedera.services.bdd.spec.queries.meta.HapiGetReceipt;
 import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import com.hederahashgraph.api.proto.java.Transaction;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 
@@ -34,14 +31,12 @@ public class StaleEventTest {
     @EmbeddedHapiTest(MANIPULATES_WORKFLOW)
     final Stream<DynamicTest> transactionFromStaleEventCanBeResubmitted() {
         return hapiTest(newKeyNamed("alice"), cryptoCreate("alice"), doingContextual(spec -> {
-            spec.registry().saveTimestamp("txn", asTimestamp(Instant.now()));
             final var transfer = new HapiCryptoTransfer(
                             HapiCryptoTransfer.tinyBarsFromTo(DEFAULT_PAYER, "alice", ONE_HUNDRED_HBARS))
                     .payingWith(DEFAULT_PAYER)
                     .via("txn")
                     .fireAndForget();
             try {
-                final Transaction txn = transfer.signedTxnFor(spec);
                 final var embeddedNetwork = (EmbeddedNetwork) spec.targetNetworkOrThrow();
                 embeddedNetwork.embeddedHederaOrThrow().considerAllEventsStale(true);
                 // Execute the HapiCryptoTransfer, it should be silently ignored in a stale FakeEvent however,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
@@ -7,8 +7,10 @@ import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
-import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
+import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.STALE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,6 +20,7 @@ import com.hedera.services.bdd.junit.hedera.embedded.EmbeddedNetwork;
 import com.hedera.services.bdd.spec.queries.meta.HapiGetReceipt;
 import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TransactionID;
 import java.time.Duration;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
@@ -30,65 +33,70 @@ public class StaleEventTest {
 
     @EmbeddedHapiTest(MANIPULATES_WORKFLOW)
     final Stream<DynamicTest> transactionFromStaleEventCanBeResubmitted() {
-        return hapiTest(newKeyNamed("alice"), cryptoCreate("alice"), doingContextual(spec -> {
-            final var transfer = new HapiCryptoTransfer(
-                            HapiCryptoTransfer.tinyBarsFromTo(DEFAULT_PAYER, "alice", ONE_HUNDRED_HBARS))
-                    .payingWith(DEFAULT_PAYER)
-                    .via("txn")
-                    .fireAndForget();
-            try {
-                final var embeddedNetwork = (EmbeddedNetwork) spec.targetNetworkOrThrow();
-                embeddedNetwork.embeddedHederaOrThrow().considerAllEventsStale(true);
-                // Execute the HapiCryptoTransfer, it should be silently ignored in a stale FakeEvent however,
-                // it will be added to the DeduplicationCache
-                transfer.execFor(spec);
+        return hapiTest(
+                newKeyNamed("alice"),
+                cryptoCreate("alice").balance(ONE_MILLION_HBARS),
+                usableTxnIdNamed("txnId").payerId("alice"),
+                doingContextual(spec -> {
+                    final var transfer = new HapiCryptoTransfer(
+                                    HapiCryptoTransfer.tinyBarsFromTo("alice", FUNDING, ONE_HUNDRED_HBARS))
+                            .signedBy("alice")
+                            .txnId("txnId")
+                            .fireAndForget();
+                    try {
+                        final var embeddedNetwork = (EmbeddedNetwork) spec.targetNetworkOrThrow();
+                        embeddedNetwork.embeddedHederaOrThrow().considerAllEventsStale(true);
+                        TransactionID txId = spec.registry().getTxnId("txnId");
+                        // Execute the HapiCryptoTransfer, it should be silently ignored in a stale FakeEvent however,
+                        // it will be added to the DeduplicationCache
+                        transfer.execFor(spec);
 
-                Thread.sleep(Duration.ofSeconds(1));
+                        Thread.sleep(Duration.ofSeconds(1));
 
-                embeddedNetwork.embeddedHederaOrThrow().considerAllEventsStale(false);
+                        embeddedNetwork.embeddedHederaOrThrow().considerAllEventsStale(false);
 
-                HapiGetReceipt hapiGetReceipt = getReceipt("txn");
-                hapiGetReceipt.execFor(spec);
-                assertEquals(
-                        ResponseCodeEnum.UNKNOWN,
-                        hapiGetReceipt
-                                .getResponse()
-                                .getTransactionGetReceipt()
-                                .getReceipt()
-                                .getStatus());
+                        HapiGetReceipt hapiGetReceipt = getReceipt(txId);
+                        hapiGetReceipt.execFor(spec);
+                        assertEquals(
+                                ResponseCodeEnum.UNKNOWN,
+                                hapiGetReceipt
+                                        .getResponse()
+                                        .getTransactionGetReceipt()
+                                        .getReceipt()
+                                        .getStatus());
 
-                // Now inject a stale event containing the same txn; expect receipt query to return
-                // STALE, client can resubmit the transaction
-                embeddedNetwork
-                        .embeddedHederaOrThrow()
-                        .triggerStaleEventCallbackForTransaction(transfer.getSubmittedTransaction());
-                HapiGetReceipt nextReceipt = getReceipt("txn");
-                nextReceipt.execFor(spec);
+                        // Now inject a stale event containing the same txn; expect receipt query to return
+                        // STALE, client can resubmit the transaction
+                        embeddedNetwork
+                                .embeddedHederaOrThrow()
+                                .triggerStaleEventCallbackForTransaction(transfer.getSubmittedTransaction());
+                        HapiGetReceipt nextReceipt = getReceipt("txnId");
+                        nextReceipt.execFor(spec);
 
-                assertEquals(
-                        STALE,
-                        nextReceipt
-                                .getResponse()
-                                .getTransactionGetReceipt()
-                                .getReceipt()
-                                .getStatus());
+                        assertEquals(
+                                STALE,
+                                nextReceipt
+                                        .getResponse()
+                                        .getTransactionGetReceipt()
+                                        .getReceipt()
+                                        .getStatus());
 
-                // Now resubmit the transaction, it should succeed
-                transfer.submitWithPreviousTransaction().execFor(spec);
+                        // Now resubmit the transaction, it should succeed
+                        transfer.execFor(spec);
 
-                Thread.sleep(Duration.ofSeconds(1));
-                HapiGetReceipt finalReceipt = getReceipt("txn");
-                finalReceipt.execFor(spec);
-                assertEquals(
-                        SUCCESS,
-                        finalReceipt
-                                .getResponse()
-                                .getTransactionGetReceipt()
-                                .getReceipt()
-                                .getStatus());
-            } catch (Throwable e) {
-                throw new RuntimeException(e);
-            }
-        }));
+                        Thread.sleep(Duration.ofSeconds(1));
+                        HapiGetReceipt finalReceipt = getReceipt("txnId");
+                        finalReceipt.execFor(spec);
+                        assertEquals(
+                                SUCCESS,
+                                finalReceipt
+                                        .getResponse()
+                                        .getTransactionGetReceipt()
+                                        .getReceipt()
+                                        .getStatus());
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -317,6 +317,7 @@ public class Browser {
                 builder.withConsensusSnapshotOverrideCallback(guiEventStorage::handleSnapshotOverride);
             }
             builder.withSystemTransactionEncoderCallback(appMain::encodeSystemTransaction);
+            builder.withStaleEventCallback(appMain::staleEventCallback);
 
             // Build platform using the Inversion of Control pattern by injecting all needed
             // dependencies into the PlatformBuilder.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
@@ -10,7 +10,9 @@ import com.swirlds.state.State;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.function.Function;
+import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 
 /**
@@ -114,4 +116,16 @@ public interface SwirldMain<T extends MerkleNodeState> extends Runnable {
      */
     @NonNull
     Bytes encodeSystemTransaction(@NonNull final StateSignatureTransaction transaction);
+
+    /**
+     * Optional callback invoked by the platform when a self event is detected to be stale (i.e. will never reach consensus).
+     * Applications may use this to update any in-flight bookkeeping for transaction in the stale event (for example, to update
+     * receipt status or enable re-submission of the transaction).
+     *
+     * <p> Default implementation returns {@code null}, which means the application is not interested in these notifications.
+     * @return a consumer that accepts a {@link PlatformEvent} representing the stale event, or {@code null} if not interested
+     */
+    default Consumer<PlatformEvent> staleEventCallback() {
+        return null;
+    }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
@@ -118,8 +118,8 @@ public interface SwirldMain<T extends MerkleNodeState> extends Runnable {
     Bytes encodeSystemTransaction(@NonNull final StateSignatureTransaction transaction);
 
     /**
-     * Optional callback invoked by the platform when a self event is detected to be stale (i.e. will never reach consensus).
-     * Applications may use this to update any in-flight bookkeeping for transaction in the stale event (for example, to update
+     * Optional callback invoked by the platform when an event is detected to be stale (i.e. will never reach consensus).
+     * Applications may use this to update any in-flight bookkeeping for the transactions in the stale event (for example, to update
      * receipt status or enable re-submission of the transaction).
      *
      * <p> Default implementation returns {@code null}, which means the application is not interested in these notifications.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
@@ -10,7 +10,6 @@ import com.swirlds.state.State;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.function.Consumer;
 import java.util.function.Function;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
@@ -118,14 +117,10 @@ public interface SwirldMain<T extends MerkleNodeState> extends Runnable {
     Bytes encodeSystemTransaction(@NonNull final StateSignatureTransaction transaction);
 
     /**
-     * Optional callback invoked by the platform when an event is detected to be stale (i.e. will never reach consensus).
+     * Callback invoked by the platform when an event is detected to be stale.
      * Applications may use this to update any in-flight bookkeeping for the transactions in the stale event (for example, to update
      * receipt status or enable re-submission of the transaction).
-     *
-     * <p> Default implementation returns {@code null}, which means the application is not interested in these notifications.
-     * @return a consumer that accepts a {@link PlatformEvent} representing the stale event, or {@code null} if not interested
+     * @param platformEvent the stale event that was detected
      */
-    default Consumer<PlatformEvent> staleEventCallback() {
-        return null;
-    }
+    default void staleEventCallback(@NonNull PlatformEvent platformEvent) {}
 }


### PR DESCRIPTION
**Description**:
This pull request introduces support for a callback in execution layer for events which are stale. The main changes add a new `STALE` status code, update the deduplication cache to track and manage stale transactions, and ensure the system can report and allow resubmission of such transactions. Additional changes update related logic and tests to accommodate this new status.

**Stale Transaction Handling:**

* Added a new `STALE` response code to `ResponseCodeEnum`
* Implemented a `staleEventCallback` in `Hedera.java` to mark all transactions in a stale event as stale in the deduplication cache, enabling correct downstream handling and resubmission.
* Updated `ServicesMain.java` to register the new `staleEventCallback` with the platform.

**Deduplication Cache Enhancements:**

* Extended the `DeduplicationCache` interface and its implementation to support marking, checking, and clearing the stale state of transactions. Transactions now have a status (`SUBMITTED` or `STALE`) instead of just being present/absent.
* Updated logic in `RecordCacheImpl` to return a special receipt with status `STALE` for transactions marked as stale.
* Modified deduplication checks in `IngestChecker` and `SubmissionManager` to treat stale transactions differently from duplicates, allowing resubmission after a transaction becomes stale.

**Test Updates:**

* Refactored tests in `DeduplicationCacheTest` to work with the new status-tracking map instead of a set, ensuring correct behavior for stale and submitted transactions.

**Dependency and Interface Changes:**

* Updated interfaces and dependency injection to provide access to the `DeduplicationCache` throughout the application. 

These changes ensure that transactions in stale events are handled gracefully, allowing users to resubmit them and query their status accurately.

**Related issue(s)**:

Fixes #19710 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
