### PR TITLE
chore: cherry-pick: Change BlockBufferService backpressure logic

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
@@ -8,6 +8,8 @@ import com.hedera.node.app.metrics.BlockStreamMetrics;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.BlockBufferConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
+import com.hedera.node.config.types.BlockStreamWriterMode;
+import com.hedera.node.config.types.StreamMode;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.math.BigDecimal;
@@ -22,7 +24,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.inject.Inject;
@@ -42,6 +43,7 @@ import org.apache.logging.log4j.Logger;
 @Singleton
 public class BlockBufferService {
     private static final Logger logger = LogManager.getLogger(BlockBufferService.class);
+    private static final int DEFAULT_BUFFER_SIZE = 150;
 
     /**
      * Buffer that stores recent blocks. This buffer is unbounded, however it is technically capped because back
@@ -93,10 +95,10 @@ public class BlockBufferService {
      * Metrics API for block stream-specific metrics.
      */
     private final BlockStreamMetrics blockStreamMetrics;
-    /**
-     * Flag that indicates if streaming to block nodes is enabled. This flag is set once upon startup and cannot change.
-     */
-    private final AtomicBoolean isStreamingEnabled = new AtomicBoolean(false);
+
+    private final boolean grpcStreamingEnabled;
+    private final boolean backpressureEnabled;
+
     /**
      * The timestamp of the most recent attempt at proactive buffer recovery.
      */
@@ -122,22 +124,14 @@ public class BlockBufferService {
             @NonNull final ConfigProvider configProvider, @NonNull final BlockStreamMetrics blockStreamMetrics) {
         this.configProvider = configProvider;
         this.blockStreamMetrics = blockStreamMetrics;
-        isStreamingEnabled.set(streamToBlockNodesEnabled());
+        BlockStreamConfig blockStreamConfig = configProvider.getConfiguration().getConfigData(BlockStreamConfig.class);
+        this.grpcStreamingEnabled = blockStreamConfig.writerMode() != BlockStreamWriterMode.FILE;
+        this.backpressureEnabled = (blockStreamConfig.streamMode() == StreamMode.BLOCKS && grpcStreamingEnabled);
 
-        // Only start the pruning thread if we're streaming to block nodes
-        if (isStreamingEnabled.get()) {
+        // Only start the pruning thread if gRPC streaming is enabled
+        if (grpcStreamingEnabled) {
             scheduleNextPruning();
         }
-    }
-
-    /**
-     * @return true if streaming to block nodes is enabled, else false
-     */
-    private boolean streamToBlockNodesEnabled() {
-        return configProvider
-                .getConfiguration()
-                .getConfigData(BlockStreamConfig.class)
-                .streamToBlockNodes();
     }
 
     /**
@@ -224,22 +218,12 @@ public class BlockBufferService {
      * @throws IllegalArgumentException if the block number is negative
      */
     public void openBlock(final long blockNumber) {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 
         if (blockNumber < 0) {
             throw new IllegalArgumentException("Block number must be non-negative");
-        }
-
-        final long lastAcked = highestAckedBlockNumber.get();
-        if (blockNumber <= lastAcked) {
-            logger.error(
-                    "Attempted to open block {}, but a later block (lastAcked={}) has already been acknowledged",
-                    blockNumber,
-                    lastAcked);
-            throw new IllegalStateException("Attempted to open block " + blockNumber + ", but a later block (lastAcked="
-                    + lastAcked + ") has already been acknowledged");
         }
 
         final BlockState existingBlock = blockBuffer.get(blockNumber);
@@ -268,7 +252,7 @@ public class BlockBufferService {
      * @throws IllegalStateException if no block is currently open
      */
     public void addItem(final long blockNumber, @NonNull final BlockItem blockItem) {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
         requireNonNull(blockItem, "blockItem must not be null");
@@ -285,7 +269,7 @@ public class BlockBufferService {
      * @throws IllegalStateException if no block is currently open
      */
     public void closeBlock(final long blockNumber) {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 
@@ -324,7 +308,7 @@ public class BlockBufferService {
      * @param blockNumber the block number to mark acknowledged up to and including
      */
     public void setLatestAcknowledgedBlock(final long blockNumber) {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 
@@ -373,7 +357,7 @@ public class BlockBufferService {
      * enough capacity - i.e. the buffer is saturated - then this method will block until there is enough capacity.
      */
     public void ensureNewBlocksPermitted() {
-        if (!isStreamingEnabled.get()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 
@@ -414,7 +398,7 @@ public class BlockBufferService {
          */
         final Duration blockPeriod = blockPeriod();
         final long idealMaxBufferSize =
-                blockPeriod.isZero() || blockPeriod.isNegative() ? 150 : ttl.dividedBy(blockPeriod);
+                blockPeriod.isZero() || blockPeriod.isNegative() ? DEFAULT_BUFFER_SIZE : ttl.dividedBy(blockPeriod);
         int numPruned = 0;
         int numChecked = 0;
         int numPendingAck = 0;
@@ -433,7 +417,23 @@ public class BlockBufferService {
                 continue;
             }
 
-            if (block.blockNumber() <= highestBlockAcked) {
+            if (!backpressureEnabled) {
+                // If backpressure is disabled, remove blocks based solely on TTL
+                if (closedTimestamp.isBefore(cutoffInstant)) {
+                    it.remove();
+                    ++numPruned;
+                } else {
+                    // Track unacknowledged blocks
+                    if (block.blockNumber() > highestBlockAcked) {
+                        ++numPendingAck;
+                        oldestUnackedTimestamp.updateAndGet(
+                                current -> current.compareTo(closedTimestamp) < 0 ? current : closedTimestamp);
+                    }
+                    // Keep track of earliest remaining block
+                    newEarliestBlock =
+                            (newEarliestBlock == Long.MIN_VALUE) ? blockNum : Math.min(newEarliestBlock, blockNum);
+                }
+            } else if (block.blockNumber() <= highestBlockAcked) {
                 // this block is eligible for pruning if it is old enough
                 if (closedTimestamp.isBefore(cutoffInstant)) {
                     it.remove();
@@ -508,7 +508,7 @@ public class BlockBufferService {
      * continues to be saturated.
      */
     private void checkBuffer() {
-        if (!streamToBlockNodesEnabled()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 
@@ -640,6 +640,10 @@ public class BlockBufferService {
      * @param latestPruneResult the latest pruning result
      */
     private void disableBackPressureIfRecovered(final PruneResult latestPruneResult) {
+        if (!backpressureEnabled) {
+            // back pressure is not enabled, so nothing to do
+            return;
+        }
         final double recoveryThreshold = recoveryThreshold();
 
         if (latestPruneResult.saturationPercent > recoveryThreshold) {
@@ -670,14 +674,9 @@ public class BlockBufferService {
      * @param latestPruneResult the latest pruning result
      */
     private void enableBackPressure(final PruneResult latestPruneResult) {
-        logger.warn(
-                "Block buffer is saturated; backpressure is being enabled "
-                        + "(idealMaxBufferSize={}, blocksChecked={}, blocksPruned={}, blocksPendingAck={}, saturation={}%)",
-                latestPruneResult.idealMaxBufferSize,
-                latestPruneResult.numBlocksChecked,
-                latestPruneResult.numBlocksPruned,
-                latestPruneResult.numBlocksPendingAck,
-                latestPruneResult.saturationPercent);
+        if (!backpressureEnabled) {
+            return;
+        }
 
         CompletableFuture<Boolean> oldCf;
         CompletableFuture<Boolean> newCf;
@@ -688,6 +687,14 @@ public class BlockBufferService {
             if (oldCf == null || oldCf.isDone()) {
                 // If the existing future is null or is completed, we need to create a new one
                 newCf = new CompletableFuture<>();
+                logger.warn(
+                        "Block buffer is saturated; backpressure is being enabled "
+                                + "(idealMaxBufferSize={}, blocksChecked={}, blocksPruned={}, blocksPendingAck={}, saturation={}%)",
+                        latestPruneResult.idealMaxBufferSize,
+                        latestPruneResult.numBlocksChecked,
+                        latestPruneResult.numBlocksPruned,
+                        latestPruneResult.numBlocksPendingAck,
+                        latestPruneResult.saturationPercent);
             } else {
                 // If the existing future is not null and not completed, re-use it
                 newCf = oldCf;
@@ -696,7 +703,7 @@ public class BlockBufferService {
     }
 
     private void scheduleNextPruning() {
-        if (!streamToBlockNodesEnabled()) {
+        if (!grpcStreamingEnabled) {
             return;
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
@@ -328,7 +328,7 @@ public class BlockState {
         final RequestWrapper rs = new RequestWrapper(index, psr, new AtomicBoolean(false));
         requestsByIndex.put(index, rs);
 
-        logger.debug("[Block {}] Created new request (index={}, numItems={})", blockNumber, index, blockItems.size());
+        logger.trace("[Block {}] Created new request (index={}, numItems={})", blockNumber, index, blockItems.size());
 
         if (!pendingItems.isEmpty()) {
             processPendingItems(batchSize);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/GrpcBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/GrpcBlockItemWriter.java
@@ -6,6 +6,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.node.app.blocks.BlockItemWriter;
 import com.hedera.node.internal.network.PendingProof;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -63,6 +64,11 @@ public class GrpcBlockItemWriter implements BlockItemWriter {
     @Override
     public void writeItem(@NonNull byte[] bytes) {
         throw new UnsupportedOperationException("writeItem is not supported in this implementation");
+    }
+
+    @Override
+    public void writePbjItemAndBytes(@NonNull final BlockItem item, @NonNull Bytes bytes) {
+        writePbjItem(item);
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
@@ -22,10 +22,12 @@ import com.hedera.node.app.blocks.impl.streaming.BlockBufferService.PruneResult;
 import com.hedera.node.app.metrics.BlockStreamMetrics;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfigImpl;
+import com.hedera.node.config.VersionedConfiguration;
 import com.hedera.node.config.data.BlockBufferConfig;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.node.config.types.BlockStreamWriterMode;
+import com.hedera.node.config.types.StreamMode;
 import com.swirlds.config.api.Configuration;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
@@ -39,7 +41,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.AfterEach;
@@ -55,7 +56,6 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
     private static final VarHandle execSvcHandle;
     private static final VarHandle blockBufferHandle;
-    private static final VarHandle isStreamingEnabledHandle;
     private static final VarHandle backPressureFutureRefHandle;
     private static final VarHandle highestAckedBlockNumberHandle;
     private static final VarHandle lastPruningResultHandle;
@@ -68,8 +68,6 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
                     .findVarHandle(BlockBufferService.class, "blockBuffer", ConcurrentMap.class);
             execSvcHandle = MethodHandles.privateLookupIn(BlockBufferService.class, lookup)
                     .findVarHandle(BlockBufferService.class, "execSvc", ScheduledExecutorService.class);
-            isStreamingEnabledHandle = MethodHandles.privateLookupIn(BlockBufferService.class, lookup)
-                    .findVarHandle(BlockBufferService.class, "isStreamingEnabled", AtomicBoolean.class);
             backPressureFutureRefHandle = MethodHandles.privateLookupIn(BlockBufferService.class, lookup)
                     .findVarHandle(BlockBufferService.class, "backpressureCompletableFutureRef", AtomicReference.class);
             highestAckedBlockNumberHandle = MethodHandles.privateLookupIn(BlockBufferService.class, lookup)
@@ -90,6 +88,15 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
     @Mock
     private ConfigProvider configProvider;
+
+    @Mock
+    private VersionedConfiguration versionedConfiguration;
+
+    @Mock
+    private BlockStreamConfig blockStreamConfig;
+
+    @Mock
+    private BlockBufferConfig blockBufferConfig;
 
     @Mock
     private BlockNodeConnectionManager connectionManager;
@@ -327,19 +334,6 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testOpenBlock_blockAfterAcked() {
-        blockBufferService = new BlockBufferService(configProvider, blockStreamMetrics);
-        blockBufferService.setBlockNodeConnectionManager(connectionManager);
-        final AtomicLong highestAckedBlockNumber = highestAckedBlockNumber(blockBufferService);
-        highestAckedBlockNumber.set(10);
-
-        assertThatThrownBy(() -> blockBufferService.openBlock(8))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessage(
-                        "Attempted to open block 8, but a later block (lastAcked=10) has already been acknowledged");
-    }
-
-    @Test
     void testOpenBlock_existingBlock_proofNotSent() {
         blockBufferService = new BlockBufferService(configProvider, blockStreamMetrics);
         blockBufferService.setBlockNodeConnectionManager(connectionManager);
@@ -384,6 +378,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
                 .withConfigDataType(BlockStreamConfig.class)
                 .withConfigDataType(BlockBufferConfig.class)
                 .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("blockStream.blockPeriod", Duration.ofSeconds(1))
                 .withValue("blockStream.blockItemBatchSize", 3)
                 .withValue("blockStream.buffer.blockTtl", blockTtl)
@@ -578,6 +573,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
                 .withValue("blockStream.buffer.blockTtl", blockTtl)
                 .withValue("blockStream.buffer.pruneInterval", pruneInterval)
                 .withValue("blockStream.writerMode", BlockStreamWriterMode.FILE_AND_GRPC)
+                .withValue("blockStream.streamMode", StreamMode.BLOCKS)
                 .getOrCreateConfig();
         when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
 
@@ -691,12 +687,52 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testOpenBlock_streamingDisabled() {
-        blockBufferService = new BlockBufferService(configProvider, blockStreamMetrics);
-        final AtomicBoolean isStreamingEnabled = isStreamingEnabled(blockBufferService);
-        final ConcurrentMap<Long, BlockState> buffer = blockBuffer(blockBufferService);
+    void testBlockBufferNoBackpressureWhenStreamModeNotBlocksAndStreaming() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "FILE_AND_GRPC")
+                .withValue("blockStream.streamMode", "BOTH")
+                .withValue("blockStream.blockPeriod", Duration.ofSeconds(1))
+                .withValue("blockStream.buffer.blockTtl", Duration.ofSeconds(10))
+                .withValue("blockStream.buffer.pruneInterval", Duration.ZERO)
+                .withValue("blockStream.buffer.actionStageThreshold", 50.0)
+                .withValue("blockStream.buffer.actionGracePeriod", Duration.ofSeconds(2))
+                .withValue("blockStream.buffer.recoveryThreshold", 100.0)
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
 
-        isStreamingEnabled.set(false);
+        blockBufferService = new BlockBufferService(configProvider, blockStreamMetrics);
+        blockBufferService.setBlockNodeConnectionManager(connectionManager);
+
+        // The buffer will become fully saturated after 10 blocks
+        for (int i = 1; i <= 10; ++i) {
+            blockBufferService.openBlock(i);
+            blockBufferService.closeBlock(i);
+        }
+
+        checkBufferHandle.invoke(blockBufferService);
+
+        final PruneResult initialPruningResult = lastPruningResult(blockBufferService);
+        assertThat(initialPruningResult.isSaturated).isEqualTo(true);
+        assertThat(initialPruningResult.numBlocksPruned).isZero();
+        assertThat(initialPruningResult.numBlocksPendingAck).isEqualTo(10);
+
+        // back pressure should NOT be enabled
+        final AtomicReference<CompletableFuture<Boolean>> backPressureFutureRef =
+                backpressureCompletableFutureRef(blockBufferService);
+
+        assertThat(backPressureFutureRef).hasNullValue();
+    }
+
+    @Test
+    void testOpenBlock_streamingDisabled() {
+        when(configProvider.getConfiguration()).thenReturn(versionedConfiguration);
+        when(versionedConfiguration.getConfigData(BlockStreamConfig.class)).thenReturn(blockStreamConfig);
+        when(blockStreamConfig.writerMode()).thenReturn(BlockStreamWriterMode.FILE);
+        when(blockStreamConfig.streamMode()).thenReturn(StreamMode.BOTH);
+        blockBufferService = new BlockBufferService(configProvider, blockStreamMetrics);
+        final ConcurrentMap<Long, BlockState> buffer = blockBuffer(blockBufferService);
 
         blockBufferService.openBlock(10L);
 
@@ -708,11 +744,12 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
     @Test
     void testAddItem_streamingDisabled() {
+        when(configProvider.getConfiguration()).thenReturn(versionedConfiguration);
+        when(versionedConfiguration.getConfigData(BlockStreamConfig.class)).thenReturn(blockStreamConfig);
+        when(blockStreamConfig.writerMode()).thenReturn(BlockStreamWriterMode.FILE);
+        when(blockStreamConfig.streamMode()).thenReturn(StreamMode.BOTH);
         blockBufferService = new BlockBufferService(configProvider, blockStreamMetrics);
-        final AtomicBoolean isStreamingEnabled = isStreamingEnabled(blockBufferService);
         final ConcurrentMap<Long, BlockState> buffer = blockBuffer(blockBufferService);
-
-        isStreamingEnabled.set(false);
 
         final BlockItem item = BlockItem.newBuilder()
                 .blockHeader(BlockHeader.newBuilder().number(10L).build())
@@ -728,10 +765,11 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
     @Test
     void testCloseBlock_streamingDisabled() {
+        when(configProvider.getConfiguration()).thenReturn(versionedConfiguration);
+        when(versionedConfiguration.getConfigData(BlockStreamConfig.class)).thenReturn(blockStreamConfig);
+        when(blockStreamConfig.writerMode()).thenReturn(BlockStreamWriterMode.FILE);
+        when(blockStreamConfig.streamMode()).thenReturn(StreamMode.BOTH);
         blockBufferService = new BlockBufferService(configProvider, blockStreamMetrics);
-        final AtomicBoolean isStreamingEnabled = isStreamingEnabled(blockBufferService);
-
-        isStreamingEnabled.set(false);
 
         blockBufferService.closeBlock(10L);
 
@@ -741,10 +779,11 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
     @Test
     void testSetLatestAcknowledgedBlock_streamingDisabled() {
+        when(configProvider.getConfiguration()).thenReturn(versionedConfiguration);
+        when(versionedConfiguration.getConfigData(BlockStreamConfig.class)).thenReturn(blockStreamConfig);
+        when(blockStreamConfig.writerMode()).thenReturn(BlockStreamWriterMode.FILE);
+        when(blockStreamConfig.streamMode()).thenReturn(StreamMode.BOTH);
         blockBufferService = new BlockBufferService(configProvider, blockStreamMetrics);
-        final AtomicBoolean isStreamingEnabled = isStreamingEnabled(blockBufferService);
-
-        isStreamingEnabled.set(false);
 
         blockBufferService.setLatestAcknowledgedBlock(10L);
 
@@ -754,12 +793,14 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
     @Test
     void testEnsureNewBlocksPermitted_streamingDisabled() throws InterruptedException {
+        when(configProvider.getConfiguration()).thenReturn(versionedConfiguration);
+        when(versionedConfiguration.getConfigData(BlockStreamConfig.class)).thenReturn(blockStreamConfig);
+        when(blockStreamConfig.writerMode()).thenReturn(BlockStreamWriterMode.FILE);
+        when(blockStreamConfig.streamMode()).thenReturn(StreamMode.BOTH);
         blockBufferService = new BlockBufferService(configProvider, blockStreamMetrics);
-        final AtomicBoolean isStreamingEnabled = isStreamingEnabled(blockBufferService);
         final AtomicReference<CompletableFuture<Boolean>> backPressureFutureRef =
                 backpressureCompletableFutureRef(blockBufferService);
 
-        isStreamingEnabled.set(false);
         backPressureFutureRef.set(new CompletableFuture<>());
 
         final CountDownLatch doneLatch = new CountDownLatch(1);
@@ -1051,6 +1092,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
                 .withConfigDataType(BlockStreamConfig.class)
                 .withConfigDataType(BlockBufferConfig.class)
                 .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("blockStream.blockPeriod", Duration.ofSeconds(1))
                 .withValue("blockStream.buffer.blockTtl", Duration.ofSeconds(10))
                 .withValue("blockStream.buffer.pruneInterval", Duration.ZERO)
@@ -1114,6 +1156,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
                 .withConfigDataType(BlockStreamConfig.class)
                 .withConfigDataType(BlockBufferConfig.class)
                 .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("blockStream.blockPeriod", Duration.ofSeconds(1))
                 .withValue("blockStream.buffer.blockTtl", Duration.ofSeconds(10))
                 .withValue("blockStream.buffer.pruneInterval", Duration.ZERO)
@@ -1163,10 +1206,6 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
     private AtomicLong highestAckedBlockNumber(final BlockBufferService bufferService) {
         return (AtomicLong) highestAckedBlockNumberHandle.get(bufferService);
-    }
-
-    private AtomicBoolean isStreamingEnabled(final BlockBufferService bufferService) {
-        return (AtomicBoolean) isStreamingEnabledHandle.get(bufferService);
     }
 
     private AtomicReference<CompletableFuture<Boolean>> backpressureCompletableFutureRef(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/HapiBlockNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/HapiBlockNode.java
@@ -48,5 +48,7 @@ public @interface HapiBlockNode {
         long[] blockNodeIds() default {};
 
         long[] blockNodePriorities() default {};
+
+        String[] applicationPropertiesOverrides() default {};
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/NetworkTargetingExtension.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/extensions/NetworkTargetingExtension.java
@@ -128,6 +128,13 @@ public class NetworkTargetingExtension implements BeforeEachCallback, AfterEachC
                     targetBlockNodeNetwork
                             .getBlockNodePrioritiesBySubProcessNodeId()
                             .put(subProcessNodeConfig.nodeId(), subProcessNodeConfig.blockNodePriorities());
+                    if (subProcessNodeConfig.applicationPropertiesOverrides().length > 0) {
+                        targetNetwork
+                                .getApplicationPropertyOverrides()
+                                .put(
+                                        subProcessNodeConfig.nodeId(),
+                                        Arrays.asList(subProcessNodeConfig.applicationPropertiesOverrides()));
+                    }
                 }
 
                 targetBlockNodeNetwork.start();

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/subprocess/SubProcessNetwork.java
@@ -3,6 +3,7 @@ package com.hedera.services.bdd.junit.hedera.subprocess;
 
 import static com.hedera.node.app.info.DiskStartupNetworks.GENESIS_NETWORK_JSON;
 import static com.hedera.node.app.info.DiskStartupNetworks.OVERRIDE_NETWORK_JSON;
+import static com.hedera.services.bdd.junit.hedera.ExternalPath.APPLICATION_PROPERTIES;
 import static com.hedera.services.bdd.junit.hedera.ExternalPath.DATA_CONFIG_DIR;
 import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
 import static com.hedera.services.bdd.junit.hedera.subprocess.ProcessUtils.awaitStatus;
@@ -45,6 +46,8 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -99,6 +102,8 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
     private final long realm;
 
     private List<Consumer<HederaNode>> postInitWorkingDirActions = new ArrayList<>();
+
+    private Map<Long, List<String>> applicationPropertyOverrides = new HashMap<>();
 
     /**
      * Wraps a runnable, allowing us to defer running it until we know we are the privileged runner
@@ -164,6 +169,7 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
                 Collections.max(nodes.stream().map(SubProcessNode::getNodeId).toList());
         this.configTxt = configTxtForLocal(name(), nodes(), nextInternalGossipPort, nextExternalGossipPort);
         this.genesisConfigTxt = configTxt;
+        this.postInitWorkingDirActions.add(this::configureApplicationProperties);
     }
 
     /**
@@ -584,6 +590,61 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
         throw new RuntimeException("Could not find available port after 100 attempts");
     }
 
+    public void configureApplicationProperties(HederaNode node) {
+        // Update bootstrap properties for the node from bootstrapPropertyOverrides if there are any
+        final var nodeId = node.getNodeId();
+        if (applicationPropertyOverrides.containsKey(nodeId)) {
+            final var properties = applicationPropertyOverrides.get(nodeId);
+            log.info("Configuring application properties for node {}: {}", nodeId, properties);
+            Path appPropertiesPath = node.getExternalPath(APPLICATION_PROPERTIES);
+            log.info(
+                    "Attempting to update application.properties at path {} for node {}",
+                    appPropertiesPath,
+                    node.getNodeId());
+
+            try {
+                // First check if file exists and log current content
+                if (Files.exists(appPropertiesPath)) {
+                    String currentContent = Files.readString(appPropertiesPath);
+                    log.info(
+                            "Current application.properties content for node {}: {}", node.getNodeId(), currentContent);
+                } else {
+                    log.info(
+                            "application.properties does not exist yet for node {}, will create new file",
+                            node.getNodeId());
+                }
+
+                // Prepare the block stream config string
+                StringBuilder propertyBuilder = new StringBuilder();
+                for (int i = 0; i < properties.size(); i += 2) {
+                    propertyBuilder.append(properties.get(i)).append("=").append(properties.get(i + 1));
+                    if (i < properties.size() - 1) {
+                        propertyBuilder.append(System.lineSeparator());
+                    }
+                }
+
+                // Write the properties with CREATE and APPEND options
+                Files.writeString(
+                        appPropertiesPath,
+                        propertyBuilder.toString(),
+                        StandardOpenOption.CREATE,
+                        StandardOpenOption.APPEND);
+
+                // Verify the file was updated
+                String updatedContent = Files.readString(appPropertiesPath);
+                log.info(
+                        "application.properties content after update for node {}: {}",
+                        node.getNodeId(),
+                        updatedContent);
+            } catch (IOException e) {
+                log.error("Failed to update application.properties for node {}: {}", node.getNodeId(), e.getMessage());
+                throw new RuntimeException("Failed to update application.properties for node " + node.getNodeId(), e);
+            }
+        } else {
+            log.info("No bootstrap property overrides for node {}", nodeId);
+        }
+    }
+
     public List<Consumer<HederaNode>> getPostInitWorkingDirActions() {
         return postInitWorkingDirActions;
     }
@@ -601,5 +662,9 @@ public class SubProcessNetwork extends AbstractGrpcNetwork implements HederaNetw
     @Override
     public PrometheusClient prometheusClient() {
         return PROMETHEUS_CLIENT;
+    }
+
+    public Map<Long, List<String>> getApplicationPropertyOverrides() {
+        return applicationPropertyOverrides;
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackpressureSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackpressureSuite.java
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.blocknode;
+
+import static com.hedera.services.bdd.junit.TestTags.BLOCK_NODE_SIMULATOR;
+import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.utilops.BlockNodeSimulatorVerbs.blockNodeSimulator;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertHgcaaLogContainsTimeframe;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertHgcaaLogDoesNotContain;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForAny;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilNextBlocks;
+
+import com.hedera.services.bdd.HapiBlockNode;
+import com.hedera.services.bdd.HapiBlockNode.BlockNodeConfig;
+import com.hedera.services.bdd.HapiBlockNode.SubProcessNodeConfig;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
+import com.hedera.services.bdd.junit.hedera.BlockNodeMode;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.LockSupport;
+import java.util.stream.Stream;
+import org.hiero.consensus.model.status.PlatformStatus;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * This suite specifically tests the behavior of the block buffer service blocking the transaction handling thread
+ * in HandleWorkflow depending on the configuration of streamMode and writerMode.
+ */
+@Tag(BLOCK_NODE_SIMULATOR)
+@OrderedInIsolation
+public class BlockNodeBackpressureSuite {
+
+    @HapiTest
+    @HapiBlockNode(
+            networkSize = 1,
+            blockNodeConfigs = {@BlockNodeConfig(nodeId = 0, mode = BlockNodeMode.SIMULATOR)},
+            subProcessNodeConfigs = {
+                @SubProcessNodeConfig(
+                        nodeId = 0,
+                        blockNodeIds = {0},
+                        blockNodePriorities = {0},
+                        applicationPropertiesOverrides = {
+                            "blockStream.buffer.blockTtl", "30s",
+                            "blockStream.streamMode", "BOTH",
+                            "blockStream.writerMode", "FILE_AND_GRPC"
+                        })
+            })
+    final Stream<DynamicTest> noBackPressureAppliedWhenBufferFull() {
+        return hapiTest(
+                waitUntilNextBlocks(5),
+                blockNodeSimulator(0).shutDownImmediately(),
+                waitUntilNextBlocks(30),
+                assertHgcaaLogDoesNotContain(
+                        byNodeId(0),
+                        "Block buffer is saturated; backpressure is being enabled",
+                        Duration.ofSeconds(15)));
+    }
+
+    @HapiTest
+    @HapiBlockNode(
+            networkSize = 1,
+            blockNodeConfigs = {@BlockNodeConfig(nodeId = 0, mode = BlockNodeMode.SIMULATOR)},
+            subProcessNodeConfigs = {
+                @SubProcessNodeConfig(
+                        nodeId = 0,
+                        blockNodeIds = {0},
+                        blockNodePriorities = {0},
+                        applicationPropertiesOverrides = {
+                            "blockStream.buffer.blockTtl", "30s",
+                            "blockStream.streamMode", "BLOCKS",
+                            "blockStream.writerMode", "FILE_AND_GRPC"
+                        })
+            })
+    final Stream<DynamicTest> backPressureAppliedWhenBlocksAndFileAndGrpc() {
+        final AtomicReference<Instant> time = new AtomicReference<>();
+        return hapiTest(
+                waitUntilNextBlocks(5),
+                blockNodeSimulator(0).shutDownImmediately(),
+                doingContextual(spec -> time.set(Instant.now())),
+                sourcingContextual(spec -> assertHgcaaLogContainsTimeframe(
+                        byNodeId(0),
+                        time::get,
+                        Duration.ofMinutes(1),
+                        Duration.ofMinutes(1),
+                        "Block buffer is saturated; backpressure is being enabled",
+                        "!!! Block buffer is saturated; blocking thread until buffer is no longer saturated")),
+                waitForAny(byNodeId(0), Duration.ofSeconds(30), PlatformStatus.CHECKING));
+    }
+
+    @HapiTest
+    @HapiBlockNode(
+            networkSize = 1,
+            blockNodeConfigs = {@BlockNodeConfig(nodeId = 0, mode = BlockNodeMode.SIMULATOR)},
+            subProcessNodeConfigs = {
+                @SubProcessNodeConfig(
+                        nodeId = 0,
+                        blockNodeIds = {0},
+                        blockNodePriorities = {0},
+                        applicationPropertiesOverrides = {
+                            "blockStream.buffer.blockTtl", "30s",
+                            "blockStream.streamMode", "BLOCKS",
+                            "blockStream.writerMode", "GRPC"
+                        })
+            })
+    final Stream<DynamicTest> backPressureAppliedWhenBlocksAndGrpc() {
+        final AtomicReference<Instant> time = new AtomicReference<>();
+        return hapiTest(
+                doingContextual(
+                        spec -> LockSupport.parkNanos(Duration.ofSeconds(10).toNanos())),
+                blockNodeSimulator(0).shutDownImmediately(),
+                doingContextual(spec -> time.set(Instant.now())),
+                sourcingContextual(spec -> assertHgcaaLogContainsTimeframe(
+                        byNodeId(0),
+                        time::get,
+                        Duration.ofMinutes(1),
+                        Duration.ofMinutes(1),
+                        "Block buffer is saturated; backpressure is being enabled",
+                        "!!! Block buffer is saturated; blocking thread until buffer is no longer saturated")),
+                waitForAny(byNodeId(0), Duration.ofSeconds(30), PlatformStatus.CHECKING));
+    }
+}


### PR DESCRIPTION
**Description**:
This PR cherry-picks the commit 54c499c to the release/0.65 branch.

Until Block Streams become the authoritative source of truth, backpressure via the block buffer service should not be enabled unless the StreamMode is BLOCKS and the BLockStreamWriterMode is FILE_AND_GRPC or GRPC specifically.

**Related issue(s)**:

Fixes #20502 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
