### PR TITLE
feat: cherry-pick: `STALE` Status Code in Transaction Receipts

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1842,4 +1842,14 @@ enum ResponseCodeEnum {
      * The LambdaSStore tried to update too many storage slots in a single transaction.
      */
     TOO_MANY_LAMBDA_STORAGE_UPDATES = 513;
+
+    /**
+     * The transaction was included in an event that has become stale and will never reach consensus.
+     * The transaction will not be executed and should be resubmitted if desired.
+     *
+     * This status indicates the transaction was valid and properly formed, but network conditions
+     * prevented the containing event from progressing through consensus. This is distinct from
+     * other failure modes as the transaction itself was not rejected for validation reasons.
+     */
+    STALE = 514;
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/HederaInjectionComponent.java
@@ -37,6 +37,7 @@ import com.hedera.node.app.services.ServicesRegistry;
 import com.hedera.node.app.spi.AppContext;
 import com.hedera.node.app.spi.records.RecordCache;
 import com.hedera.node.app.spi.throttle.Throttle;
+import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.state.HederaStateInjectionModule;
 import com.hedera.node.app.state.WorkingStateAccessor;
 import com.hedera.node.app.throttle.ThrottleServiceManager;
@@ -150,6 +151,8 @@ public interface HederaInjectionComponent {
     AsyncFatalIssListener fatalIssListener();
 
     CurrentPlatformStatus currentPlatformStatus();
+
+    DeduplicationCache deduplicationCache();
 
     @Component.Builder
     interface Builder {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/ServicesMain.java
@@ -361,7 +361,9 @@ public class ServicesMain implements SwirldMain<MerkleNodeState> {
                 .withPlatformContext(platformContext)
                 .withConfiguration(platformConfig)
                 .withKeysAndCerts(keysAndCerts)
-                .withSystemTransactionEncoderCallback(hedera::encodeSystemTransaction);
+                .withSystemTransactionEncoderCallback(hedera::encodeSystemTransaction)
+                .withStaleEventCallback(hedera::staleEventCallback);
+
         final var platform = platformBuilder.build();
         hedera.init(platform, selfId);
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/DeduplicationCache.java
@@ -2,7 +2,9 @@
 package com.hedera.node.app.state;
 
 import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.node.app.state.recordcache.DeduplicationCacheImpl.TxStatus;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 
 /**
  * A cache for de-duplicating transactions. This cache is <strong>NOT</strong> stored in state. It contains only the
@@ -31,6 +33,22 @@ public interface DeduplicationCache {
      * @return {@code true} if the transaction ID is in the cache
      */
     boolean contains(@NonNull TransactionID transactionID);
+
+    /**
+     * Marks the given TransactionID as having been observed in a stale event. This information is kept
+     * in-memory only and ages out with the same policy as {@link #add(TransactionID)}.
+     * @param transactionID the transaction ID to mark as stale
+     */
+    void markStale(@NonNull TransactionID transactionID);
+
+    /**
+     * Get the status of a transaction in the cache. If the transaction is not in the cache, or if it has
+     * aged out, then this will return null.
+     * @param transactionID the transaction ID to get the status for
+     * @return the status of the transaction, or null if it is not in the cache or has aged out
+     */
+    @Nullable
+    TxStatus getTxStatus(@NonNull TransactionID transactionID);
 
     /** Clear everything from the cache. Used during reconnect */
     void clear();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/DeduplicationCacheImpl.java
@@ -16,24 +16,39 @@ import com.hedera.node.config.data.HederaConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.InstantSource;
 import java.util.Comparator;
-import java.util.Set;
-import java.util.concurrent.ConcurrentSkipListSet;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
 /** An implementation of {@link DeduplicationCache}. */
 @Singleton
 public final class DeduplicationCacheImpl implements DeduplicationCache {
+
     /**
-     * The {@link TransactionID}s that this node has already submitted to the platform, sorted by transaction start
+     * The status of a transaction in the deduplication cache.
+     */
+    public enum TxStatus {
+        /**
+         * The transaction has been submitted to the platform.
+         */
+        SUBMITTED,
+        /**
+         * The transaction has been marked as stale.
+         */
+        STALE
+    };
+
+    /**
+     * The {@link TransactionID}s and their corresponding {@link TxStatus} that this node has already submitted to the platform, sorted by transaction start
      * time, such that earlier start times come first.
      * <p>
      * Note that an ID with scheduled set is different from the same ID without scheduled set.
      * In fact, an ID with scheduled set will always match the ID of the ScheduleCreate transaction that created
      * the schedule, except scheduled is set.
      */
-    private final Set<TransactionID> submittedTxns =
-            new ConcurrentSkipListSet<>(Comparator.<TransactionID, Timestamp>comparing(
+    private final ConcurrentNavigableMap<TransactionID, TxStatus> submittedTxns =
+            new ConcurrentSkipListMap<>(Comparator.<TransactionID, Timestamp>comparing(
                             txnId -> txnId.transactionValidStartOrElse(Timestamp.DEFAULT), TIMESTAMP_COMPARATOR)
                     .thenComparing(txnId -> txnId.accountIDOrElse(AccountID.DEFAULT), ACCOUNT_ID_COMPARATOR)
                     .thenComparing(TransactionID::scheduled)
@@ -66,7 +81,7 @@ public final class DeduplicationCacheImpl implements DeduplicationCache {
 
         // If the transaction is within the max transaction duration window, then add it to the set.
         if (transactionID.transactionValidStartOrThrow().seconds() >= epochSeconds) {
-            submittedTxns.add(transactionID);
+            submittedTxns.put(transactionID, TxStatus.SUBMITTED);
         }
     }
 
@@ -77,7 +92,22 @@ public final class DeduplicationCacheImpl implements DeduplicationCache {
         // if the transactionID is still valid
         final var epochSeconds = approxEarliestValidStartSecond();
         removeTransactionsOlderThan(epochSeconds);
-        return submittedTxns.contains(transactionID);
+        return submittedTxns.containsKey(transactionID);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public void markStale(@NonNull TransactionID transactionID) {
+        submittedTxns.computeIfPresent(transactionID, (key, value) -> TxStatus.STALE);
+    }
+
+    @Override
+    public TxStatus getTxStatus(@NonNull TransactionID transactionID) {
+        // We will prune the set here as well. By pruning before looking up, we are sure that we only return true
+        // if the transactionID is still valid
+        final var epochSeconds = approxEarliestValidStartSecond();
+        removeTransactionsOlderThan(epochSeconds);
+        return submittedTxns.get(transactionID);
     }
 
     /** {@inheritDoc} */
@@ -105,7 +135,7 @@ public final class DeduplicationCacheImpl implements DeduplicationCache {
      * @param earliestEpochSecond The earliest epoch second that should be kept in the cache.
      */
     private void removeTransactionsOlderThan(final long earliestEpochSecond) {
-        final var itr = submittedTxns.iterator();
+        final var itr = submittedTxns.keySet().iterator();
         while (itr.hasNext()) {
             final var txId = itr.next();
             if (txId.transactionValidStartOrThrow().seconds() < earliestEpochSecond) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/RecordCacheImpl.java
@@ -2,6 +2,7 @@
 package com.hedera.node.app.state.recordcache;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.STALE;
 import static com.hedera.hapi.util.HapiUtils.TIMESTAMP_COMPARATOR;
 import static com.hedera.hapi.util.HapiUtils.isBefore;
 import static com.hedera.node.app.spi.records.RecordCache.matchesExceptNonce;
@@ -29,6 +30,7 @@ import com.hedera.node.app.spi.records.RecordSource;
 import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.state.HederaRecordCache;
 import com.hedera.node.app.state.WorkingStateAccessor;
+import com.hedera.node.app.state.recordcache.DeduplicationCacheImpl.TxStatus;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LedgerConfig;
@@ -102,6 +104,11 @@ public class RecordCacheImpl implements HederaRecordCache {
     private static final HistorySource EMPTY_HISTORY_SOURCE = new HistorySource();
 
     /**
+     * This receipt source is used whenever a transaction is known to be stale in the deduplication cache.
+     */
+    private static final ReceiptSource STALE_RECEIPT_SOURCE = new StaleReceiptSource();
+
+    /**
      * Used for looking up fee collection account for a node that failed due diligence. This must be looked up dynamically.
      */
     private final NetworkInfo networkInfo;
@@ -131,6 +138,35 @@ public class RecordCacheImpl implements HederaRecordCache {
      * The list of transaction receipts for the current round.
      */
     private final List<TransactionReceiptEntry> transactionReceipts = new ArrayList<>();
+
+    /**
+     * A ReceiptSource implementation that provides the stale receipt for a transaction ID.
+     */
+    private record StaleReceiptSource() implements ReceiptSource {
+        @Override
+        public @NonNull TransactionReceipt priorityReceipt(@NonNull final TransactionID txnId) {
+            requireNonNull(txnId);
+            return TransactionReceipt.newBuilder().status(STALE).build();
+        }
+
+        @Override
+        public @Nullable TransactionReceipt childReceipt(@NonNull final TransactionID txnId) {
+            requireNonNull(txnId);
+            return null;
+        }
+
+        @Override
+        public @NonNull List<TransactionReceipt> duplicateReceipts(@NonNull final TransactionID txnId) {
+            requireNonNull(txnId);
+            return emptyList();
+        }
+
+        @Override
+        public @NonNull List<TransactionReceipt> childReceipts(@NonNull final TransactionID txnId) {
+            requireNonNull(txnId);
+            return emptyList();
+        }
+    }
 
     /**
      * Contains history of transactions submitted with the same "base" {@link TransactionID};
@@ -472,9 +508,17 @@ public class RecordCacheImpl implements HederaRecordCache {
     public @Nullable ReceiptSource getReceipts(@NonNull final TransactionID txnId) {
         requireNonNull(txnId);
         final var historySource = historySources.get(txnId);
-        return historySource != null
-                ? historySource
-                : (deduplicationCache.contains(txnId) ? EMPTY_HISTORY_SOURCE : null);
+        if (historySource != null) {
+            return historySource;
+        }
+        TxStatus status = deduplicationCache.getTxStatus(txnId);
+        if (status == TxStatus.STALE) {
+            return STALE_RECEIPT_SOURCE;
+        } else if (status == TxStatus.SUBMITTED) {
+            return EMPTY_HISTORY_SOURCE;
+        } else {
+            return null;
+        }
     }
 
     @NonNull

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -26,6 +26,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.WAITING_FOR_LEDGER_ID;
 import static com.hedera.hapi.util.HapiUtils.isHollow;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateFalsePreCheck;
 import static com.hedera.node.app.spi.workflows.PreCheckException.validateTruePreCheck;
+import static com.hedera.node.app.state.recordcache.DeduplicationCacheImpl.TxStatus.SUBMITTED;
 import static com.hedera.node.app.workflows.InnerTransaction.NO;
 import static com.hedera.node.app.workflows.InnerTransaction.YES;
 import static com.hedera.node.app.workflows.handle.dispatch.DispatchValidator.WorkflowCheck.INGEST;
@@ -275,8 +276,8 @@ public final class IngestChecker {
         // will convert that to INVALID_TRANSACTION_BODY.
         assert functionality != HederaFunctionality.NONE;
 
-        // 3. Deduplicate
-        if (deduplicationCache.contains(txInfo.transactionID())) {
+        // 3. Deduplicate the transaction and check for staleness
+        if (deduplicationCache.getTxStatus(txInfo.transactionID()) == SUBMITTED) {
             throw new PreCheckException(DUPLICATE_TRANSACTION);
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
@@ -8,6 +8,7 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.state.DeduplicationCache;
+import com.hedera.node.app.state.recordcache.DeduplicationCacheImpl.TxStatus;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LedgerConfig;
@@ -142,7 +143,9 @@ public class SubmissionManager {
             // before we got here. But if it ever does happen, for any reason, we want it to happen BEFORE we submit,
             // and BEFORE we record the transaction as a duplicate.
             final var txId = txBody.transactionIDOrThrow();
-            if (submittedTxns.contains(txId)) {
+            TxStatus txStatus = submittedTxns.getTxStatus(txId);
+            if (txStatus == TxStatus.SUBMITTED) {
+                // If the transaction is already submitted, we do not want to submit it again.
                 throw new PreCheckException(DUPLICATE_TRANSACTION);
             }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/RecordCacheImplTest.java
@@ -5,6 +5,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.ACCOUNT_IS_IMMUTABLE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.STALE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNKNOWN;
 import static com.hedera.node.app.state.HederaRecordCache.DuplicateCheckResult.NO_DUPLICATE;
@@ -735,5 +736,62 @@ final class RecordCacheImplTest extends AppTestBase {
             // Then we can check for a duplicate by transaction ID
             assertThat(cache.hasDuplicate(txId, currentNodeId)).isEqualTo(SAME_NODE);
         }
+    }
+
+    @Test
+    @DisplayName("getReceipts returns STALE_RECEIPT_SOURCE for stale transactions")
+    void getReceiptsForStaleTransaction() {
+        final var cache = new RecordCacheImpl(dedupeCache, wsa, props, networkInfo);
+        // Given a transaction marked as stale
+        final var now = Instant.now();
+        final var txnId = TransactionID.newBuilder()
+                .transactionValidStart(
+                        Timestamp.newBuilder().seconds(now.getEpochSecond()).build())
+                .build();
+        dedupeCache.add(txnId);
+        dedupeCache.markStale(txnId);
+
+        // When getting receipts
+        final var result = cache.getReceipts(txnId);
+
+        // Then it returns the STALE_RECEIPT_SOURCE
+        assertThat(result.priorityReceipt(txnId).status() == STALE).isTrue();
+    }
+
+    @Test
+    @DisplayName("getReceipts returns EMPTY_HISTORY_SOURCE for submitted transactions")
+    void getReceiptsForSubmittedTransaction() {
+        final var cache = new RecordCacheImpl(dedupeCache, wsa, props, networkInfo);
+        // Given a transaction marked as stale
+        final var now = Instant.now();
+        final var txnId = TransactionID.newBuilder()
+                .transactionValidStart(
+                        Timestamp.newBuilder().seconds(now.getEpochSecond()).build())
+                .build();
+        dedupeCache.add(txnId);
+
+        // When getting receipts
+        final var result = cache.getReceipts(txnId);
+
+        // Then it returns the EMPTY_HISTORY_SOURCE
+        assertThat(result.priorityReceipt(txnId).status() == UNKNOWN).isTrue();
+    }
+
+    @Test
+    @DisplayName("getReceipts returns null for unknown transactions")
+    void getReceiptsForUnknownTransaction() {
+        final var cache = new RecordCacheImpl(dedupeCache, wsa, props, networkInfo);
+        // Given a transaction marked as stale
+        final var now = Instant.now();
+        final var txnId = TransactionID.newBuilder()
+                .transactionValidStart(
+                        Timestamp.newBuilder().seconds(now.getEpochSecond()).build())
+                .build();
+
+        // When getting receipts
+        final var result = cache.getReceipts(txnId);
+
+        // Then it returns null
+        assertThat(result).isNull();
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/EmbeddedReason.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/EmbeddedReason.java
@@ -18,4 +18,8 @@ public enum EmbeddedReason {
      * The test manipulates the software version of the simulated consensus event for a transaction.
      */
     MANIPULATES_EVENT_VERSION,
+    /**
+     * The test manipulates the workflow of submitted transactions.
+     */
+    MANIPULATES_WORKFLOW,
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -6,6 +6,7 @@ import static com.hedera.services.bdd.junit.hedera.ExternalPath.ADDRESS_BOOK;
 import static com.hedera.services.bdd.junit.hedera.embedded.fakes.FakePlatformContext.PLATFORM_CONFIG;
 import static com.swirlds.platform.system.InitTrigger.GENESIS;
 import static com.swirlds.platform.system.InitTrigger.RESTART;
+import static com.swirlds.platform.system.transaction.TransactionWrapperUtils.createAppPayloadWrapper;
 import static java.util.Objects.requireNonNull;
 import static java.util.Spliterators.spliteratorUnknownSize;
 import static java.util.stream.Collectors.toMap;
@@ -16,6 +17,7 @@ import static org.hiero.consensus.roster.RosterUtils.rosterFrom;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.platform.event.GossipEvent;
 import com.hedera.node.app.Hedera;
 import com.hedera.node.app.ServicesMain;
 import com.hedera.node.app.fixtures.state.FakeServiceMigrator;
@@ -28,9 +30,11 @@ import com.hedera.node.internal.network.Network;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.AbstractFakePlatform;
+import com.hedera.services.bdd.junit.hedera.embedded.fakes.FakeEvent;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.FakeHintsService;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.FakeHistoryService;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.LapsingBlockHashSigner;
+import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Query;
 import com.hederahashgraph.api.proto.java.Response;
@@ -53,15 +57,18 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.constructable.ConstructableRegistry;
 import org.hiero.base.crypto.Hash;
+import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.roster.AddressBook;
 
@@ -107,6 +114,8 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
     protected Hedera hedera;
     protected SemanticVersion version;
     protected boolean blockStreamEnabled;
+
+    protected AtomicBoolean allEventsStale = new AtomicBoolean(false);
 
     /**
      * Non-final because the compiler can't tell that the {@link com.hedera.node.app.Hedera.HintsServiceFactory} lambda we give the
@@ -365,5 +374,23 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
         return new AddressBook(stream(spliteratorUnknownSize(addressBook.iterator(), 0), false)
                 .map(address -> address.copySetSigCert(sigCert))
                 .toList());
+    }
+
+    @Override
+    public void triggerStaleEventCallbackForTransaction(@NonNull Transaction transaction) {
+        requireNonNull(transaction);
+        final var serializedSignedTx = HapiTxnOp.serializedSignedTxFrom(transaction);
+        final FakeEvent fakeStaleEvent =
+                new FakeEvent(defaultNodeId, now(), createAppPayloadWrapper(serializedSignedTx));
+        hedera.staleEventCallback(new PlatformEvent(new GossipEvent(
+                fakeStaleEvent.getEventCore(),
+                fakeStaleEvent.getSignature(),
+                List.of(Bytes.wrap(serializedSignedTx)),
+                List.of())));
+    }
+
+    @Override
+    public void considerAllEventsStale(boolean considerAllEventsStale) {
+        allEventsStale.set(considerAllEventsStale);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
@@ -204,6 +204,9 @@ class ConcurrentEmbeddedHedera extends AbstractEmbeddedHedera implements Embedde
                 // Now drain all events that will go in the next round and pre-handle them
                 final List<FakeEvent> newEvents = new ArrayList<>();
                 queue.drainTo(newEvents);
+                if (allEventsStale.get()) {
+                    newEvents.clear();
+                }
                 newEvents.forEach(event -> hedera.onPreHandle(event, state, NOOP_STATE_SIG_CALLBACK));
                 prehandledEvents.addAll(newEvents);
             } catch (Throwable t) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
@@ -129,4 +129,16 @@ public interface EmbeddedHedera {
      * @return the response to the transaction
      */
     TransactionResponse submit(Transaction transaction, AccountID nodeAccountId, long eventBirthRound);
+
+    /**
+     * Triggers the stale event callback for a given transaction.
+     * @param transaction the transaction for which to trigger the stale event callback
+     */
+    void triggerStaleEventCallbackForTransaction(@NonNull Transaction transaction);
+
+    /**
+     * Sets whether all events should be considered stale.
+     * @param considerAllEventsStale true if all events should be considered stale, false otherwise
+     */
+    void considerAllEventsStale(boolean considerAllEventsStale);
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/HapiTxnOp.java
@@ -891,6 +891,14 @@ public abstract class HapiTxnOp<T extends HapiTxnOp<T>> extends HapiSpecOperatio
         return self();
     }
 
+    /**
+     * Returns the transaction that was submitted by this operation.
+     * @return the submitted transaction
+     */
+    public Transaction getSubmittedTransaction() {
+        return txnSubmitted;
+    }
+
     public TransactionReceipt getLastReceipt() {
         return lastReceipt;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/records/StaleEventTest.java
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.records;
+
+import static com.hedera.services.bdd.junit.EmbeddedReason.MANIPULATES_WORKFLOW;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getReceipt;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.usableTxnIdNamed;
+import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.STALE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.services.bdd.junit.EmbeddedHapiTest;
+import com.hedera.services.bdd.junit.hedera.embedded.EmbeddedNetwork;
+import com.hedera.services.bdd.spec.queries.meta.HapiGetReceipt;
+import com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
+import com.hederahashgraph.api.proto.java.TransactionID;
+import java.time.Duration;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+
+/**
+ * Tests that a transaction submitted to a node can be resubmitted after it has gone through ingest, submitted to
+ * the platform, the event becomes stale, and then app receives a stale event notification.
+ */
+public class StaleEventTest {
+
+    @EmbeddedHapiTest(MANIPULATES_WORKFLOW)
+    final Stream<DynamicTest> transactionFromStaleEventCanBeResubmitted() {
+        return hapiTest(
+                newKeyNamed("alice"),
+                cryptoCreate("alice").balance(ONE_MILLION_HBARS),
+                usableTxnIdNamed("txnId").payerId("alice"),
+                doingContextual(spec -> {
+                    final var transfer = new HapiCryptoTransfer(
+                                    HapiCryptoTransfer.tinyBarsFromTo("alice", FUNDING, ONE_HUNDRED_HBARS))
+                            .signedBy("alice")
+                            .txnId("txnId")
+                            .fireAndForget();
+                    try {
+                        final var embeddedNetwork = (EmbeddedNetwork) spec.targetNetworkOrThrow();
+                        embeddedNetwork.embeddedHederaOrThrow().considerAllEventsStale(true);
+                        TransactionID txId = spec.registry().getTxnId("txnId");
+                        // Execute the HapiCryptoTransfer, it should be silently ignored in a stale FakeEvent however,
+                        // it will be added to the DeduplicationCache
+                        transfer.execFor(spec);
+
+                        Thread.sleep(Duration.ofSeconds(1));
+
+                        embeddedNetwork.embeddedHederaOrThrow().considerAllEventsStale(false);
+
+                        HapiGetReceipt hapiGetReceipt = getReceipt(txId);
+                        hapiGetReceipt.execFor(spec);
+                        assertEquals(
+                                ResponseCodeEnum.UNKNOWN,
+                                hapiGetReceipt
+                                        .getResponse()
+                                        .getTransactionGetReceipt()
+                                        .getReceipt()
+                                        .getStatus());
+
+                        // Now inject a stale event containing the same txn; expect receipt query to return
+                        // STALE, client can resubmit the transaction
+                        embeddedNetwork
+                                .embeddedHederaOrThrow()
+                                .triggerStaleEventCallbackForTransaction(transfer.getSubmittedTransaction());
+                        HapiGetReceipt nextReceipt = getReceipt("txnId");
+                        nextReceipt.execFor(spec);
+
+                        assertEquals(
+                                STALE,
+                                nextReceipt
+                                        .getResponse()
+                                        .getTransactionGetReceipt()
+                                        .getReceipt()
+                                        .getStatus());
+
+                        // Now resubmit the transaction, it should succeed
+                        transfer.execFor(spec);
+
+                        Thread.sleep(Duration.ofSeconds(1));
+                        HapiGetReceipt finalReceipt = getReceipt("txnId");
+                        finalReceipt.execFor(spec);
+                        assertEquals(
+                                SUCCESS,
+                                finalReceipt
+                                        .getResponse()
+                                        .getTransactionGetReceipt()
+                                        .getReceipt()
+                                        .getStatus());
+                    } catch (Throwable e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/Browser.java
@@ -317,6 +317,7 @@ public class Browser {
                 builder.withConsensusSnapshotOverrideCallback(guiEventStorage::handleSnapshotOverride);
             }
             builder.withSystemTransactionEncoderCallback(appMain::encodeSystemTransaction);
+            builder.withStaleEventCallback(appMain::staleEventCallback);
 
             // Build platform using the Inversion of Control pattern by injecting all needed
             // dependencies into the PlatformBuilder.

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/system/SwirldMain.java
@@ -11,6 +11,7 @@ import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.function.Function;
+import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
 
 /**
@@ -114,4 +115,12 @@ public interface SwirldMain<T extends MerkleNodeState> extends Runnable {
      */
     @NonNull
     Bytes encodeSystemTransaction(@NonNull final StateSignatureTransaction transaction);
+
+    /**
+     * Callback invoked by the platform when an event is detected to be stale.
+     * Applications may use this to update any in-flight bookkeeping for the transactions in the stale event (for example, to update
+     * receipt status or enable re-submission of the transaction).
+     * @param platformEvent the stale event that was detected
+     */
+    default void staleEventCallback(@NonNull PlatformEvent platformEvent) {}
 }


### PR DESCRIPTION
**Description**:
This PR cherry-picks commit 11e6dc7 for release/0.65.

This pull request introduces support for a callback in execution layer for events which are stale. The main changes add a new STALE status code, update the deduplication cache to track and manage stale transactions, and ensure the system can report and allow resubmission of such transactions. Additional changes update related logic and tests to accommodate this new status.

**Related issue(s)**:

Fixes #19710 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
