### PR TITLE
feat: 20609 Implemented export for all the states

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/platform/state/virtual_map_state.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/platform/state/virtual_map_state.proto
@@ -221,7 +221,7 @@ message StateKey {
     /**
      * A state identifier for the TSS encryption keys. 
      */    
-    proto.EntityNumber TssBaseService_I_TSS_ENCRYPTION_KEY = 35;
+    proto.EntityNumber TssBaseService_I_TSS_ENCRYPTION_KEYS = 35;
 
     /**
      * A state identifier for hinTS key sets. 
@@ -267,7 +267,7 @@ message StateKey {
     /**
      * Queue index for the round receipts queue.
      */
-    uint64 RecordCacheTransactionReceiptQueue = 126;
+    uint64 RecordCache_I_TransactionReceiptQueue = 126;
     
     /**
      * Queue index for the `150` upgrade file data.
@@ -514,7 +514,7 @@ message StateValue {
     /**
      * A state identifier for the TSS encryption keys.
      */
-    com.hedera.hapi.node.state.tss.TssEncryptionKeys TssBaseService_I_TSS_ENCRYPTION_KEY = 35;
+    com.hedera.hapi.node.state.tss.TssEncryptionKeys TssBaseService_I_TSS_ENCRYPTION_KEYS = 35;
 
     /**
      * A state identifier for hinTS key sets.
@@ -738,12 +738,12 @@ enum SingletonType {
   /**
    * A state identifier for the active hinTS construction. Singleton state.
    */
-  HintsService_I_ACTIVE_HINTS_CONSTRUCTION = 38;
+  HintsService_I_ACTIVE_HINT_CONSTRUCTION = 38;
   
   /**
    * A state identifier for the next hinTS construction. Singleton state.
    */
-  HintsService_I_NEXT_HINTS_CONSTRUCTION = 39;
+  HintsService_I_NEXT_HINT_CONSTRUCTION = 39;
 
   /**
    * A state identifier for the entity counts. Singleton state.

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -54,24 +54,24 @@ of a corrupted state.
 
 ## Export
 
-[ExportCommand](src/main/java/com/hedera/statevalidation/ExportCommand.java) allows you to export the state of a Hedera node into a JSON file(s).
+[ExportCommand](src/main/java/com/hedera/statevalidation/ExportCommand.java) allows you to export the state of a Hedera node into JSON file(s).
 
 ### Usage
 
-1. Download the state files
+1. Download the state files.
 2. Run the following command to execute the export:
 
    ```shell
    java -jar [-DmaxObjPerFile=X] [-Dsorted=true] [-DprettyPrint=true] ./validator-<version>.jar {path-to-state-round} export {path-to-result-dir} [{service_name}] [{state_key}]
    ```
 
-`-DmaxObjPerFile` option allows customizing the upper limit of objects per file
-`-Dsorted=true` enables a special mode which exports the data in a sorted way, may be helpful during differential testing
-`-DprettyPrint=true` enables human-readable result files
+- `-DmaxObjPerFile` option allows customizing the upper limit of objects per file.
+- `-Dsorted=true` enables a special mode which exports the data in a sorted way; this may be helpful during differential testing.
+- `-DprettyPrint=true` enables human-readable result files.
 
 Example entry:
 
-For an unsorted file
+For an unsorted file:
 
 ```json
 {"p":970084,"k":"{
@@ -121,31 +121,30 @@ where `k` is a key, and `v` is a value.
 
 Examples:
 
-Export all states to the current directory, jar file is located in the round directory:
+Export all states to the current directory (assuming the JAR file is located in the round directory):
 
 ```shell
 java -jar ./validator-0.65.0.jar . export .
 ```
 
-Export all states to the current directory, limits the number of objects per file to 100,000:
+Export all states to the current directory, limiting the number of objects per file to 100,000:
 
 ```shell
 java -jar -DmaxObjPerFile=100000 ./validator-0.65.0.jar /path/to/round export .
 ```
 
-Export all accounts to `/tmp/accounts`, limits the number of objects per file to 100,000:
+Export all accounts to `/tmp/accounts`, limiting the number of objects per file to 100,000 (paths are not included in resulting files, and account keys are sorted by byte representation lexicographically):
 
 ```shell
-java -jar -DmaxObjPerFile=100000 ./validator-0.65.0.jar /path/to/round export /path/to/result TokenService ACCOUNTS
+java -jar -Dsorted=true -DmaxObjPerFile=100000 ./validator-0.65.0.jar /path/to/round export /path/to/result AccountService ACCOUNTS
 ```
 
 Notes:
-- service name and state name should be both either omitted or specified
-- if service name / state name is specified the resulting file is `{service_name}_{state_key}_X.json` where `X` is an ordinal number in the series of such files
-- if service name / state name is not specified the resulting file is `exportedState_X.json`, where `X` is an ordinal number in the series of such files
-- if you export all the states, the exporter limits the number of objects per file to 1 million, to customize the limit use VM parameter `-DmaxObjPerFile`
-- if you export a single state keep in mind that the object count per file though consistent across multiple runs is likely to be uneven, some files may be even empty
-- order of entries is consistent across runs and ordered by path, unless `-Dsorted=true` is specified
-- in case of `-Dsorted=true` the data is sorted by the **byte representation of the key** which doesn't always map to the natural ordering. For example, varint encoding does not preserve numerical ordering under
-lexicographical byte comparison, particularly when values cross boundaries that affect the number of bytes or the leading byte values. However, it will produce a stable ordering across different versions of the state,
-and that is critically important for the differential testing
+- If the service name and state key are omitted, it will export all the states.
+- Service name and state key should both be either omitted or specified.
+- If service name/state key is specified, the resulting file is `{service_name}_{state_key}_X.json`, where `X` is an ordinal number in the series of such files.
+- If service name/state key is not specified, the resulting file is `exportedState_X.json`, where `X` is an ordinal number in the series of such files.
+- The exporter limits the number of objects per file to 1 million; to customize the limit, use VM parameter `-DmaxObjPerFile`.
+- If you export a single state in the `unsorted` mode, keep in mind that the object count per file—though consistent across multiple runs—is likely to be uneven.
+- Order of entries is consistent across runs and ordered by path, unless `-Dsorted=true` is specified.
+- In case of `-Dsorted=true`, the data is sorted by the **byte representation of the key**, which doesn't always map to natural ordering. For example, varint encoding does not preserve numerical ordering under lexicographical byte comparison, particularly when values cross boundaries that affect the number of bytes or the leading byte values. However, it will produce a stable ordering across different versions of the state, which is critically important for differential testing.

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ExportCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ExportCommand.java
@@ -53,10 +53,11 @@ public class ExportCommand implements Runnable {
             throw new RuntimeException(e);
         }
 
+        ((VirtualMap) state.getRoot()).getDataSource().stopAndDisableBackgroundCompaction();
+
         final boolean sorted = Boolean.parseBoolean(System.getProperty("sorted", "false"));
         if (sorted) {
             if (serviceName == null) {
-                ((VirtualMap) state.getRoot()).getDataSource().stopAndDisableBackgroundCompaction();
                 // processing all
                 final SortedJsonExporter exporter =
                         new SortedJsonExporter(resultDir, state, prepareServiceNameAndStateKeys());

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ExportCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ExportCommand.java
@@ -1,13 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.statevalidation;
 
+import com.hedera.hapi.platform.state.SingletonType;
+import com.hedera.hapi.platform.state.StateKey;
 import com.hedera.statevalidation.exporters.JsonExporter;
 import com.hedera.statevalidation.exporters.SortedJsonExporter;
 import com.hedera.statevalidation.parameterresolver.StateResolver;
+import com.swirlds.base.utility.Pair;
 import com.swirlds.platform.state.MerkleNodeState;
 import com.swirlds.platform.state.snapshot.DeserializedSignedState;
+import com.swirlds.virtualmap.VirtualMap;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import picocli.CommandLine;
 
 @CommandLine.Command(name = "export", description = "Exports the state")
@@ -47,13 +53,45 @@ public class ExportCommand implements Runnable {
             throw new RuntimeException(e);
         }
 
-        boolean sorted = Boolean.parseBoolean(System.getProperty("sorted", "false"));
+        final boolean sorted = Boolean.parseBoolean(System.getProperty("sorted", "false"));
         if (sorted) {
-            final SortedJsonExporter exporter = new SortedJsonExporter(resultDir, state, serviceName, stateName);
-            exporter.export();
+            if (serviceName == null) {
+                ((VirtualMap) state.getRoot()).getDataSource().stopAndDisableBackgroundCompaction();
+                // processing all
+                final SortedJsonExporter exporter =
+                        new SortedJsonExporter(resultDir, state, prepareServiceNameAndStateKeys());
+                exporter.export();
+            } else {
+                final SortedJsonExporter exporter = new SortedJsonExporter(resultDir, state, serviceName, stateName);
+                exporter.export();
+            }
         } else {
             final JsonExporter exporter = new JsonExporter(resultDir, state, serviceName, stateName);
             exporter.export();
+        }
+    }
+
+    private List<Pair<String, String>> prepareServiceNameAndStateKeys() {
+        List<Pair<String, String>> serviceNameAndStateKeys = new ArrayList<>();
+        for (StateKey.KeyOneOfType value : StateKey.KeyOneOfType.values()) {
+            extractStateName(value.protoName(), serviceNameAndStateKeys);
+        }
+        for (SingletonType singletonType : SingletonType.values()) {
+            extractStateName(singletonType.protoName(), serviceNameAndStateKeys);
+        }
+
+        return serviceNameAndStateKeys;
+    }
+
+    private static void extractStateName(String value, List<Pair<String, String>> serviceNameAndStateKeys) {
+        String[] serviceNameStateKey = value.split("_I_");
+        if (serviceNameStateKey[0].equals("FileService") && serviceNameStateKey[1].startsWith("UPGRADE_DATA_")) {
+            // UPGRADE_DATA_<num>
+            int num = Integer.parseInt(serviceNameStateKey[1].replace("UPGRADE_DATA_", ""));
+            serviceNameStateKey[1] = "UPGRADE_DATA[FileID[shardNum=0, realmNum=0, fileNum=%s]]".formatted(num);
+        }
+        if (serviceNameStateKey.length == 2) {
+            serviceNameAndStateKeys.add(Pair.of(serviceNameStateKey[0], serviceNameStateKey[1]));
         }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporters/SortedJsonExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporters/SortedJsonExporter.java
@@ -4,7 +4,6 @@ package com.hedera.statevalidation.exporters;
 import static com.hedera.pbj.runtime.ProtoParserTools.TAG_FIELD_OFFSET;
 import static com.hedera.statevalidation.ExportCommand.MAX_OBJ_PER_FILE;
 import static com.hedera.statevalidation.exporters.JsonExporter.write;
-import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.platform.state.SingletonType;
 import com.hedera.hapi.platform.state.StateKey;
@@ -14,6 +13,7 @@ import com.hedera.pbj.runtime.OneOf;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.base.utility.Pair;
 import com.swirlds.platform.state.MerkleNodeState;
 import com.swirlds.state.merkle.StateUtils;
 import com.swirlds.virtualmap.VirtualMap;
@@ -25,12 +25,14 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.LongStream;
@@ -48,62 +50,83 @@ public class SortedJsonExporter {
 
     private final File resultDir;
     private final MerkleNodeState state;
-    private final String serviceName;
-    private final String stateKeyName;
     private final ExecutorService executorService;
-    private final int expectedStateId;
+    private final Map<Integer, Set<Bytes>> keysByExpectedStateIds;
+    private final Map<Integer, Pair<String, String>> nameByStateId;
 
     public SortedJsonExporter(File resultDir, MerkleNodeState state, String serviceName, String stateKeyName) {
+        this(resultDir, state, List.of(Pair.of(serviceName, stateKeyName)));
+    }
+
+    public SortedJsonExporter(
+            File resultDir, MerkleNodeState state, List<Pair<String, String>> serviceNameStateKeyList) {
         this.resultDir = resultDir;
         this.state = state;
-        this.serviceName = requireNonNull(serviceName);
-        this.stateKeyName = requireNonNull(stateKeyName);
-        expectedStateId = StateUtils.stateIdFor(serviceName, stateKeyName);
+        keysByExpectedStateIds = new HashMap<>();
+        nameByStateId = new HashMap<>();
+        serviceNameStateKeyList.forEach(p -> {
+            int stateId = StateUtils.stateIdFor(p.left(), p.right());
+            final Comparator<Bytes> comparator;
+            if (stateId < StateKey.KeyOneOfType.RECORDCACHE_I_TRANSACTIONRECEIPTQUEUE.protoOrdinal()) {
+                comparator = (key1, key2) -> {
+                    ReadableSequentialData keyData1 = key1.toReadableSequentialData();
+                    keyData1.readVarInt(false); // read tag
+                    keyData1.readVarInt(false); // read value
+
+                    ReadableSequentialData keyData2 = key2.toReadableSequentialData();
+                    keyData2.readVarInt(false); // read tag
+                    keyData2.readVarInt(false); // read value
+
+                    return keyData1.readBytes((int) keyData1.remaining())
+                            .compareTo(keyData2.readBytes((int) keyData2.remaining()));
+                };
+            } else {
+                comparator = (key1, key2) -> {
+                    try {
+                        StateKey stateKey1 = StateKey.PROTOBUF.parse(key1);
+                        StateKey stateKey2 = StateKey.PROTOBUF.parse(key2);
+                        // queue metadata
+                        if (stateKey1.key().value() instanceof SingletonType) {
+                            return -1;
+                        }
+                        if (stateKey2.key().value() instanceof SingletonType) {
+                            return 1;
+                        }
+                        Long index1 = (Long) stateKey1.key().value();
+                        Long index2 = (Long) stateKey2.key().value();
+                        return index1.compareTo(index2);
+                    } catch (ParseException e) {
+                        throw new RuntimeException(e);
+                    }
+                };
+            }
+            keysByExpectedStateIds.computeIfAbsent(stateId, k -> new ConcurrentSkipListSet<>(comparator));
+            nameByStateId.put(stateId, p);
+        });
         executorService = Executors.newVirtualThreadPerTaskExecutor();
     }
 
     public void export() {
         final long startTimestamp = System.currentTimeMillis();
         final VirtualMap vm = (VirtualMap) state.getRoot();
-        ArrayList<Bytes> keys = collectKeys(vm);
-        if (keys.isEmpty()) {
-            throw new RuntimeException(String.format("No valid keys found in state %s_%s", serviceName, stateKeyName));
-        }
+        collectKeys(vm);
+        keysByExpectedStateIds.forEach((key, values) -> {
+            if (values.isEmpty()) {
+                Pair<String, String> namePair = nameByStateId.get(key);
+                System.out.printf("No valid keys found in state %s_%s%n", namePair.left(), namePair.right());
+            }
+        });
 
-        // do not sort queues
-        if (expectedStateId < StateKey.KeyOneOfType.RECORD_CACHE_TRANSACTION_RECEIPT_QUEUE.protoOrdinal()) {
-            parallelSort(keys, Comparator.naturalOrder());
-        } else {
-            parallelSort(keys, (key1, key2) -> {
-                try {
-                    StateKey stateKey1 = StateKey.PROTOBUF.parse(key1);
-                    StateKey stateKey2 = StateKey.PROTOBUF.parse(key2);
-                    // queue metadata
-                    if (stateKey1.key().value() instanceof SingletonType) {
-                        return -1;
-                    }
-                    if (stateKey2.key().value() instanceof SingletonType) {
-                        return 1;
-                    }
-                    Long index1 = (Long) stateKey1.key().value();
-                    Long index2 = (Long) stateKey2.key().value();
-                    return index1.compareTo(index2);
-                } catch (ParseException e) {
-                    throw new RuntimeException(e);
-                }
-            });
-        }
-
-        List<CompletableFuture<Void>> futures = traverseVmInParallel(keys);
+        List<CompletableFuture<Void>> futures = traverseVmInParallel();
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
         System.out.println("Export time: " + (System.currentTimeMillis() - startTimestamp) + "ms");
         executorService.close();
     }
 
-    private ArrayList<Bytes> collectKeys(final VirtualMap vm) {
+    private void collectKeys(final VirtualMap vm) {
         final VirtualMapMetadata metadata = vm.getMetadata();
-        final ArrayList<Bytes> keys = new ArrayList<>();
         LongStream.range(metadata.getFirstLeafPath(), metadata.getLastLeafPath() + 1)
+                .parallel()
                 .forEach(path -> {
                     VirtualLeafBytes leafRecord = vm.getRecords().findLeafRecord(path);
                     final Bytes keyBytes = leafRecord.keyBytes();
@@ -113,39 +136,30 @@ public class SortedJsonExporter {
                     if (actualStateId == 1) {
                         // it's a singleton, additional read is required
                         int singletonStateId = keyData.readVarInt(false);
-                        if (singletonStateId == expectedStateId) {
-                            keys.add(keyBytes);
+                        if (keysByExpectedStateIds.containsKey(singletonStateId)) {
+                            keysByExpectedStateIds.get(singletonStateId).add(keyBytes);
                         }
                         return;
                     }
-
-                    if (expectedStateId != -1 && expectedStateId != actualStateId) {
-                        return;
+                    if (keysByExpectedStateIds.containsKey(actualStateId)) {
+                        keysByExpectedStateIds.get(actualStateId).add(keyBytes);
                     }
-                    keys.add(keyBytes);
                 });
-        return keys;
     }
 
-    private static <T extends Comparable<? super T>> void parallelSort(ArrayList<T> list, Comparator<T> comparator) {
-        // falling back to a regular parallel sort which will create a copy of the array
-        T[] array = list.toArray((T[]) new Comparable[list.size()]);
-        Arrays.parallelSort(array, comparator);
-        for (int i = 0; i < list.size(); i++) {
-            list.set(i, array[i]);
-        }
-    }
-
-    private List<CompletableFuture<Void>> traverseVmInParallel(final List<Bytes> keys) {
+    private List<CompletableFuture<Void>> traverseVmInParallel() {
         List<CompletableFuture<Void>> futures = new ArrayList<>();
-        int writingParallelism = keys.size() / MAX_OBJ_PER_FILE;
-        for (int i = 0; i <= writingParallelism; i++) {
-            String fileName;
-            fileName = String.format(SINGLE_STATE_TMPL, serviceName, stateKeyName, i + 1);
-            int firstBatchIndex = i * MAX_OBJ_PER_FILE;
-            int lastBatchIndex = Math.min((i + 1) * MAX_OBJ_PER_FILE, keys.size() - 1);
-            futures.add(CompletableFuture.runAsync(
-                    () -> processRange(keys, fileName, firstBatchIndex, lastBatchIndex), executorService));
+        for (Map.Entry<Integer, Set<Bytes>> entry : keysByExpectedStateIds.entrySet()) {
+            final List<Bytes> keys = new ArrayList<>(entry.getValue());
+            final int writingParallelism = keys.size() / MAX_OBJ_PER_FILE;
+            final Pair<String, String> namePair = nameByStateId.get(entry.getKey());
+            for (int i = 0; i <= writingParallelism; i++) {
+                String fileName = String.format(SINGLE_STATE_TMPL, namePair.left(), namePair.right(), i + 1);
+                int firstBatchIndex = i * MAX_OBJ_PER_FILE;
+                int lastBatchIndex = Math.min((i + 1) * MAX_OBJ_PER_FILE, keys.size() - 1);
+                futures.add(CompletableFuture.runAsync(
+                        () -> processRange(keys, fileName, firstBatchIndex, lastBatchIndex), executorService));
+            }
         }
         return futures;
     }
@@ -153,6 +167,7 @@ public class SortedJsonExporter {
     private void processRange(final List<Bytes> keys, String fileName, int start, int end) {
         VirtualMap vm = (VirtualMap) state.getRoot();
         File file = new File(resultDir, fileName);
+        boolean emptyFile = true;
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
             for (int i = start; i <= end; i++) {
                 final Bytes keyBytes = keys.get(i);
@@ -175,12 +190,17 @@ public class SortedJsonExporter {
                                 "{\"k\":\"%s\", \"v\":%s}\n"
                                         .formatted(keyToJson(stateKey.key()), valueToJson(stateValue.value())));
                     }
+                    emptyFile = false;
                 } catch (ParseException e) {
                     throw new RuntimeException(e);
                 }
             }
         } catch (IOException e) {
             throw new RuntimeException(e);
+        }
+
+        if (emptyFile) {
+            file.delete();
         }
     }
 


### PR DESCRIPTION
**Description**:

PR highlights: 
-  adds support of exporting all the states in `sorted` mode. 
- fixes inconsistent naming 
- updates documentation 
- adds normalization of state key names
- replaces parallel sorting with `ConcurrentSkipListSet` which is a sorted data structure 
- adds clean up of empty files

Fixes #20609 
