### PR TITLE
refactor: Logging in container should use `WORKING_DIR`

### DIFF
--- a/platform-sdk/consensus-otter-docker-app/src/testFixtures/java/org/hiero/consensus/otter/docker/app/DockerMain.java
+++ b/platform-sdk/consensus-otter-docker-app/src/testFixtures/java/org/hiero/consensus/otter/docker/app/DockerMain.java
@@ -5,7 +5,6 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import org.hiero.consensus.otter.docker.app.logging.DockerLogConfigBuilder;
 
@@ -17,6 +16,9 @@ import org.hiero.consensus.otter.docker.app.logging.DockerLogConfigBuilder;
  */
 public final class DockerMain {
 
+    /** Working dir where all files should be stored */
+    public static final Path WORKING_DIR = Path.of("/opt/DockerApp");
+
     /** Port on which the {@link org.hiero.otter.fixtures.container.proto.ContainerControlServiceGrpc} listens. */
     private static final int CONTAINER_CONTROL_SERVICE_PORT = 8080;
 
@@ -25,10 +27,6 @@ public final class DockerMain {
 
     /**
      * Constructs a {@link DockerMain} instance with a custom {@link ExecutorService}.
-     *
-     * @param dispatchExecutor the {@link ExecutorService} to use for managing threads in the gRPC server
-     * @param backgroundExecutor the {@link Executor} to use for background tasks
-     * @throws NullPointerException if {@code dispatchExecutor} is {@code null}
      */
     public DockerMain() {
         grpcServer = ServerBuilder.forPort(CONTAINER_CONTROL_SERVICE_PORT)
@@ -48,7 +46,7 @@ public final class DockerMain {
      * @throws InterruptedException if the server is interrupted while waiting for termination
      */
     public static void main(final String[] args) throws IOException, InterruptedException {
-        DockerLogConfigBuilder.configure(Path.of(""), null);
+        DockerLogConfigBuilder.configure(WORKING_DIR, null);
         new DockerMain().startGrpcServer();
     }
 

--- a/platform-sdk/consensus-otter-docker-app/src/testFixtures/java/org/hiero/consensus/otter/docker/app/DockerManager.java
+++ b/platform-sdk/consensus-otter-docker-app/src/testFixtures/java/org/hiero/consensus/otter/docker/app/DockerManager.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.otter.docker.app;
 
+import static org.hiero.consensus.otter.docker.app.DockerMain.WORKING_DIR;
+
 import com.google.protobuf.Empty;
 import com.hedera.hapi.platform.state.NodeId;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -9,7 +11,6 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
-import java.nio.file.Path;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.otter.docker.app.logging.DockerLogConfigBuilder;
@@ -62,7 +63,7 @@ public final class DockerManager extends ContainerControlServiceGrpc.ContainerCo
     public synchronized void init(
             @NonNull final InitRequest request, @NonNull final StreamObserver<Empty> responseObserver) {
         this.selfId = ProtobufConverter.toPbj(request.getSelfId());
-        DockerLogConfigBuilder.configure(Path.of(""), selfId);
+        DockerLogConfigBuilder.configure(WORKING_DIR, selfId);
 
         if (nodeManagerThread != null) {
             log.error(

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNode.java
@@ -317,6 +317,8 @@ public class ContainerNode extends AbstractNode implements Node, TimeTickReceive
                     Files.createDirectories(localFile.getParent());
                     container.copyFileFromContainer(containerFile.toString(), localFile.toString());
                 }
+            } else {
+                log.warn("No PCES files found in container");
             }
 
             return new SingleNodePcesResultImpl(selfId, nodeConfiguration.current(), localPcesDirectory);


### PR DESCRIPTION
Minor refactoring as follow up of #20617