### PR TITLE
chore: 20629: Default max VM size should be decreased to 1B

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -70,7 +70,7 @@ import com.swirlds.config.extensions.validators.DefaultConfigViolation;
  */
 @ConfigData("merkleDb")
 public record MerkleDbConfig(
-        @Positive @ConfigProperty(defaultValue = "4000000000") long maxNumOfKeys,
+        @Positive @ConfigProperty(defaultValue = "1000000000") long maxNumOfKeys,
         @Min(0) @ConfigProperty(defaultValue = "8388608") long hashesRamToDiskThreshold,
         @Positive @ConfigProperty(defaultValue = "1000000") int hashStoreRamBufferSize,
         @ConfigProperty(defaultValue = "true") boolean hashStoreRamOffHeapBuffers,


### PR DESCRIPTION

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/20629
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
