### PR TITLE
ci: add fail tags to single day test workflows

### DIFF
--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -130,13 +130,13 @@ jobs:
       add-settings: "${{ inputs.add-settings }}"
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
-  tag-sdlt-passing:
-    name: Tag SDLT Passing
+
+  tag-sdlt-result:
+    name: Tag SDLT Result
     runs-on: hiero-citr-linux-medium
     needs:
       - run-single-day-longevity-nlg-test
       - verify-tag
-    if: ${{ needs.run-single-day-longevity-nlg-test.outputs.result  == 'success' && inputs.disable-notifications != true }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -167,10 +167,10 @@ jobs:
 
           if [ "$RESULT" == "success" ]; then
             TAG_NAME="sdlt-pass-${BUILD_NUM}"
-            MSG="Single Day Performance Test passed for build-${BUILD_NUM}"
+            MSG="Single Day Longevity Test passed for build-${BUILD_NUM}"
           elif [ "$RESULT" == "failure" ]; then
             TAG_NAME="sdlt-fail-${BUILD_NUM}"
-            MSG="Single Day Performance Test FAILED for build-${BUILD_NUM}"
+            MSG="Single Day Longevity Test FAILED for build-${BUILD_NUM}"
           else
             echo "No tag will be applied. Test result was: $RESULT" >> "${GITHUB_STEP_SUMMARY}"
             exit 0

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -137,6 +137,7 @@ jobs:
     needs:
       - run-single-day-longevity-nlg-test
       - verify-tag
+    if: ${{ inputs.disable-notifications != true }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -160,14 +160,27 @@ jobs:
           gpg_private_key: ${{ secrets.SVCS_GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.SVCS_GPG_KEY_PASSPHRASE }}
 
-      - name: Tag SDLT Passing
+      - name: Tag SDLT Result
         run: |
-          TAG_NAME="sdlt-pass-${{ needs.verify-tag.outputs.build-number }}"
-          git tag --annotate "${TAG_NAME}" --message "Single Day Performance Test passed for build-${{ needs.verify-tag.outputs.build-number }}"
+          RESULT="${{ needs.run-single-day-longevity-nlg-test.outputs.result }}"
+          BUILD_NUM="${{ needs.verify-tag.outputs.build-number }}"
+
+          if [ "$RESULT" == "success" ]; then
+            TAG_NAME="sdlt-pass-${BUILD_NUM}"
+            MSG="Single Day Performance Test passed for build-${BUILD_NUM}"
+          elif [ "$RESULT" == "failure" ]; then
+            TAG_NAME="sdlt-fail-${BUILD_NUM}"
+            MSG="Single Day Performance Test FAILED for build-${BUILD_NUM}"
+          else
+            echo "No tag will be applied. Test result was: $RESULT" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          git tag --annotate "${TAG_NAME}" --message "${MSG}"
           git push --set-upstream origin --tags
 
-          echo "### SDLT Pass - Tag Information" >> "${GITHUB_STEP_SUMMARY}"
-          echo "SDLT Passing Tag: ${TAG_NAME}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### SDLT Result - Tag Information" >> "${GITHUB_STEP_SUMMARY}"
+          echo "SDLT Tag: ${TAG_NAME}" >> "${GITHUB_STEP_SUMMARY}"
 
   get-commit-info:
     name: Get Commit Information

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -78,13 +78,12 @@ jobs:
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
-  tag-sdlt-passing:
-    name: Tag SDLT Passing
+  tag-sdlt-result:
+    name: Tag SDLT Result
     runs-on: hiero-citr-linux-medium
     needs:
       - run-single-day-longevity-nlg-test
       - verify-tag
-    if: ${{ needs.run-single-day-longevity-nlg-test.outputs.result  == 'success' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -115,10 +114,10 @@ jobs:
 
           if [ "$RESULT" == "success" ]; then
             TAG_NAME="sdlt-pass-${BUILD_NUM}"
-            MSG="Single Day Performance Test passed for build-${BUILD_NUM}"
+            MSG="Single Day Longevity Test passed for build-${BUILD_NUM}"
           elif [ "$RESULT" == "failure" ]; then
             TAG_NAME="sdlt-fail-${BUILD_NUM}"
-            MSG="Single Day Performance Test FAILED for build-${BUILD_NUM}"
+            MSG="Single Day Longevity Test FAILED for build-${BUILD_NUM}"
           else
             echo "No tag will be applied. Test result was: $RESULT" >> "${GITHUB_STEP_SUMMARY}"
             exit 0

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -108,14 +108,27 @@ jobs:
           gpg_private_key: ${{ secrets.SVCS_GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.SVCS_GPG_KEY_PASSPHRASE }}
 
-      - name: Tag SDLT Passing
+      - name: Tag SDLT Result
         run: |
-          TAG_NAME="sdlt-pass-${{ needs.verify-tag.outputs.build-number }}"
-          git tag --annotate "${TAG_NAME}" --message "Single Day Performance Test passed for build-${{ needs.verify-tag.outputs.build-number }}"
+          RESULT="${{ needs.run-single-day-longevity-nlg-test.outputs.result }}"
+          BUILD_NUM="${{ needs.verify-tag.outputs.build-number }}"
+
+          if [ "$RESULT" == "success" ]; then
+            TAG_NAME="sdlt-pass-${BUILD_NUM}"
+            MSG="Single Day Performance Test passed for build-${BUILD_NUM}"
+          elif [ "$RESULT" == "failure" ]; then
+            TAG_NAME="sdlt-fail-${BUILD_NUM}"
+            MSG="Single Day Performance Test FAILED for build-${BUILD_NUM}"
+          else
+            echo "No tag will be applied. Test result was: $RESULT" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          git tag --annotate "${TAG_NAME}" --message "${MSG}"
           git push --set-upstream origin --tags
 
-          echo "### SDLT Pass - Tag Information" >> "${GITHUB_STEP_SUMMARY}"
-          echo "SDLT Passing Tag: ${TAG_NAME}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### SDLT Result - Tag Information" >> "${GITHUB_STEP_SUMMARY}"
+          echo "SDLT Tag: ${TAG_NAME}" >> "${GITHUB_STEP_SUMMARY}"
 
   get-commit-info:
     name: Get Commit Information

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -137,13 +137,13 @@ jobs:
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
-  tag-sdpt-passing:
-    name: Tag SDPT Passing
+  tag-sdpt-result:
+    name: Tag SDPT Result
     runs-on: hiero-citr-linux-medium
     needs:
       - run-single-day-performance-test
       - verify-tag
-    if: ${{ needs.run-single-day-performance-test.outputs.result  == 'success' && inputs.disable-notifications != true }}
+    if: ${{ inputs.disable-notifications != true }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -167,14 +167,27 @@ jobs:
           gpg_private_key: ${{ secrets.SVCS_GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.SVCS_GPG_KEY_PASSPHRASE }}
 
-      - name: Tag SDPT Passing
+      - name: Tag SDPT Result
         run: |
-          TAG_NAME="sdpt-pass-${{ needs.verify-tag.outputs.build-number }}"
-          git tag --annotate "${TAG_NAME}" --message "Single Day Performance Test passed for build-${{ needs.verify-tag.outputs.build-number }}"
+          RESULT="${{ needs.run-single-day-performance-test.outputs.result }}"
+          BUILD_NUM="${{ needs.verify-tag.outputs.build-number }}"
+
+          if [ "$RESULT" == "success" ]; then
+            TAG_NAME="sdpt-pass-${BUILD_NUM}"
+            MSG="Single Day Performance Test passed for build-${BUILD_NUM}"
+          elif [ "$RESULT" == "failure" ]; then
+            TAG_NAME="sdpt-fail-${BUILD_NUM}"
+            MSG="Single Day Performance Test FAILED for build-${BUILD_NUM}"
+          else
+            echo "No tag will be applied. Test result was: $RESULT" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          git tag --annotate "${TAG_NAME}" --message "${MSG}"
           git push --set-upstream origin --tags
 
-          echo "### SDPT Pass - Tag Information" >> "${GITHUB_STEP_SUMMARY}"
-          echo "SDPT Passing Tag: ${TAG_NAME}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### SDPT Result - Tag Information" >> "${GITHUB_STEP_SUMMARY}"
+          echo "SDPT Tag: ${TAG_NAME}" >> "${GITHUB_STEP_SUMMARY}"
 
   get-commit-info:
     name: Get Commit Information

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -80,13 +80,12 @@ jobs:
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
-  tag-sdpt-passing:
-    name: Tag SDPT Passing
+  tag-sdpt-result:
+    name: Tag SDPT Result
     runs-on: hiero-citr-linux-medium
     needs:
       - run-single-day-performance-test
       - verify-tag
-    if: ${{ needs.run-single-day-performance-test.outputs.result  == 'success' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -110,14 +109,27 @@ jobs:
           gpg_private_key: ${{ secrets.SVCS_GPG_KEY_CONTENTS }}
           passphrase: ${{ secrets.SVCS_GPG_KEY_PASSPHRASE }}
 
-      - name: Tag SDPT Passing
+      - name: Tag SDPT Result
         run: |
-          TAG_NAME="sdpt-pass-${{ needs.verify-tag.outputs.build-number }}"
-          git tag --annotate "${TAG_NAME}" --message "Single Day Performance Test passed for build-${{ needs.verify-tag.outputs.build-number }}"
+          RESULT="${{ needs.run-single-day-performance-test.outputs.result }}"
+          BUILD_NUM="${{ needs.verify-tag.outputs.build-number }}"
+
+          if [ "$RESULT" == "success" ]; then
+            TAG_NAME="sdpt-pass-${BUILD_NUM}"
+            MSG="Single Day Performance Test passed for build-${BUILD_NUM}"
+          elif [ "$RESULT" == "failure" ]; then
+            TAG_NAME="sdpt-fail-${BUILD_NUM}"
+            MSG="Single Day Performance Test FAILED for build-${BUILD_NUM}"
+          else
+            echo "No tag will be applied. Test result was: $RESULT" >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          git tag --annotate "${TAG_NAME}" --message "${MSG}"
           git push --set-upstream origin --tags
 
-          echo "### SDPT Pass - Tag Information" >> "${GITHUB_STEP_SUMMARY}"
-          echo "SDPT Passing Tag: ${TAG_NAME}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### SDPT Result - Tag Information" >> "${GITHUB_STEP_SUMMARY}"
+          echo "SDPT Tag: ${TAG_NAME}" >> "${GITHUB_STEP_SUMMARY}"
 
   get-commit-info:
     name: Get Commit Information


### PR DESCRIPTION
**Description**:

Add a new set of tags indicating when builds fail the single day test workflows.

**Related Issue(s)**:

Fixes #20541
