### PR TITLE
feat: Keep sending events when unhealthy

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowgraphSynchronizer.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/ShadowgraphSynchronizer.java
@@ -18,6 +18,7 @@ import com.swirlds.common.threading.pool.ParallelExecutionException;
 import com.swirlds.common.threading.pool.ParallelExecutor;
 import com.swirlds.platform.gossip.IntakeEventCounter;
 import com.swirlds.platform.gossip.SyncException;
+import com.swirlds.platform.gossip.shadowgraph.SyncUtils.TipsInfo;
 import com.swirlds.platform.gossip.sync.config.SyncConfig;
 import com.swirlds.platform.metrics.SyncMetrics;
 import com.swirlds.platform.network.Connection;
@@ -25,6 +26,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -87,22 +89,24 @@ public class ShadowgraphSynchronizer extends AbstractShadowgraphSynchronizer {
                 fallenBehindManager,
                 intakeEventCounter);
         this.executor = Objects.requireNonNull(executor);
-
-        final SyncConfig syncConfig = platformContext.getConfiguration().getConfigData(SyncConfig.class);
     }
 
     /**
      * Executes a sync using the supplied connection.
      *
-     * @param platformContext the platform context
-     * @param connection      the connection to use
+     * @param platformContext      the platform context
+     * @param connection           the connection to use
+     * @param ignoreIncomingEvents we should ignore events coming from peer
      * @return true if the sync was successful, false if it was aborted
      */
-    public boolean synchronize(@NonNull final PlatformContext platformContext, @NonNull final Connection connection)
+    public boolean synchronize(
+            @NonNull final PlatformContext platformContext,
+            @NonNull final Connection connection,
+            final boolean ignoreIncomingEvents)
             throws IOException, ParallelExecutionException, SyncException, InterruptedException {
         logger.info(SYNC_INFO.getMarker(), "{} sync start", connection.getDescription());
         try {
-            return reserveSynchronize(platformContext, connection);
+            return reserveSynchronize(platformContext, connection, ignoreIncomingEvents);
         } finally {
             logger.info(SYNC_INFO.getMarker(), "{} sync end", connection.getDescription());
         }
@@ -111,12 +115,15 @@ public class ShadowgraphSynchronizer extends AbstractShadowgraphSynchronizer {
     /**
      * Executes a sync using the supplied connection.
      *
-     * @param platformContext the platform context
-     * @param connection      the connection to use
+     * @param platformContext      the platform context
+     * @param connection           the connection to use
+     * @param ignoreIncomingEvents we should ignore events coming from peer
      * @return true if the sync was successful, false if it was aborted
      */
     private boolean reserveSynchronize(
-            @NonNull final PlatformContext platformContext, @NonNull final Connection connection)
+            @NonNull final PlatformContext platformContext,
+            @NonNull final Connection connection,
+            final boolean ignoreIncomingEvents)
             throws IOException, ParallelExecutionException, SyncException {
 
         // accumulates time points for each step in the execution of a single gossip session, used for stats
@@ -164,37 +171,47 @@ public class ShadowgraphSynchronizer extends AbstractShadowgraphSynchronizer {
             // Step 2: each peer tells the other which of the other's tips it already has.
 
             timing.setTimePoint(2);
-            final List<Boolean> theirBooleans = readWriteParallel(
+            final TipsInfo tipsInfo = readWriteParallel(
                     readMyTipsTheyHave(connection, myTips.size()),
-                    writeTheirTipsIHave(connection, theirTipsIHave),
+                    writeTheirTipsIHave(connection, theirTipsIHave, ignoreIncomingEvents),
                     connection);
             timing.setTimePoint(3);
 
             // Add each tip they know to the known set
-            final List<ShadowEvent> knownTips = getMyTipsTheyKnow(connection, myTips, theirBooleans);
+            final List<ShadowEvent> knownTips = getMyTipsTheyKnow(connection, myTips, tipsInfo.theirTips());
             eventsTheyHave.addAll(knownTips);
 
-            // create a send list based on the known set
-            sendList = createSendList(
-                    connection.getSelfId(), eventsTheyHave, myWindow, theirTipsAndEventWindow.eventWindow());
+            if (tipsInfo.dontSentEvents()) {
+                sendList = Collections.emptyList();
+            } else {
+                // create a send list based on the known set
+                sendList = createSendList(
+                        connection.getSelfId(), eventsTheyHave, myWindow, theirTipsAndEventWindow.eventWindow());
+            }
         }
 
         final SyncConfig syncConfig = platformContext.getConfiguration().getConfigData(SyncConfig.class);
 
         return sendAndReceiveEvents(
-                connection, timing, sendList, syncConfig.syncKeepalivePeriod(), syncConfig.maxSyncTime());
+                connection,
+                timing,
+                sendList,
+                syncConfig.syncKeepalivePeriod(),
+                syncConfig.maxSyncTime(),
+                ignoreIncomingEvents);
     }
 
     /**
      * By this point in time, we have figured out which events we want to send the peer, and the peer has figured out
      * which events it wants to send us. In parallel, send and receive those events.
      *
-     * @param connection          the connection to use
-     * @param timing              metrics that track sync timing
-     * @param sendList            the events to send
-     * @param syncKeepAlivePeriod the period at which the reading thread should send keepalive messages
-     * @param maxSyncTime         the maximum amount of time to spend syncing with a peer, syncs that take longer than
-     *                            this will be aborted
+     * @param connection           the connection to use
+     * @param timing               metrics that track sync timing
+     * @param sendList             the events to send
+     * @param syncKeepAlivePeriod  the period at which the reading thread should send keepalive messages
+     * @param maxSyncTime          the maximum amount of time to spend syncing with a peer, syncs that take longer than
+     *                             this will be aborted
+     * @param ignoreIncomingEvents discard incoming events because we are unhealthy
      * @return true if the phase was successful, false if it was aborted
      * @throws ParallelExecutionException if anything goes wrong
      */
@@ -203,7 +220,8 @@ public class ShadowgraphSynchronizer extends AbstractShadowgraphSynchronizer {
             @NonNull final SyncTiming timing,
             @NonNull final List<PlatformEvent> sendList,
             @NonNull final Duration syncKeepAlivePeriod,
-            @NonNull final Duration maxSyncTime)
+            @NonNull final Duration maxSyncTime,
+            final boolean ignoreIncomingEvents)
             throws ParallelExecutionException {
 
         Objects.requireNonNull(connection);
@@ -222,7 +240,8 @@ public class ShadowgraphSynchronizer extends AbstractShadowgraphSynchronizer {
                         syncMetrics,
                         eventReadingDone,
                         intakeEventCounter,
-                        maxSyncTime),
+                        maxSyncTime,
+                        ignoreIncomingEvents),
                 sendEventsTheyNeed(connection, sendList, eventReadingDone, writeAborted, syncKeepAlivePeriod),
                 connection);
         if (eventsRead < 0 || writeAborted.get()) {

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/SyncUtils.java
@@ -126,13 +126,16 @@ public final class SyncUtils {
      * Tell the sync peer which of their tips I have. The complementary function to
      * {@link #readMyTipsTheyHave(Connection, int)}.
      *
-     * @param connection     the connection to write to
-     * @param theirTipsIHave for each tip they sent me, write true if I have it, false otherwise. Order corresponds to
-     *                       the order in which they sent me their tips.
+     * @param connection           the connection to write to
+     * @param theirTipsIHave       for each tip they sent me, write true if I have it, false otherwise. Order
+     *                             corresponds to the order in which they sent me their tips.
+     * @param ignoreIncomingEvents
      * @return a {@link Callable} that writes the booleans
      */
-    public static Callable<Void> writeTheirTipsIHave(final Connection connection, final List<Boolean> theirTipsIHave) {
+    public static Callable<Void> writeTheirTipsIHave(
+            final Connection connection, final List<Boolean> theirTipsIHave, final boolean ignoreIncomingEvents) {
         return () -> {
+            connection.getDos().writeBoolean(ignoreIncomingEvents);
             connection.getDos().writeBooleanList(theirTipsIHave);
             connection.getDos().flush();
             if (logger.isDebugEnabled(SYNC_INFO.getMarker())) {
@@ -146,16 +149,19 @@ public final class SyncUtils {
         };
     }
 
+    record TipsInfo(boolean dontSentEvents, @NonNull List<Boolean> theirTips) {}
+
     /**
      * Read from the peer which of my tips they have. The complementary function to
-     * {@link #writeTheirTipsIHave(Connection, List)}.
+     * {@link #writeTheirTipsIHave(Connection, List, boolean)}.
      *
      * @param connection   the connection to read from
      * @param numberOfTips the number of tips I sent them
      * @return a {@link Callable} that reads the booleans
      */
-    public static Callable<List<Boolean>> readMyTipsTheyHave(final Connection connection, final int numberOfTips) {
+    public static Callable<TipsInfo> readMyTipsTheyHave(final Connection connection, final int numberOfTips) {
         return () -> {
+            final boolean dontSendEvents = connection.getDis().readBoolean();
             final List<Boolean> booleans = connection.getDis().readBooleanList(numberOfTips);
             if (booleans == null) {
                 throw new SyncException(connection, "peer sent null booleans");
@@ -167,13 +173,14 @@ public final class SyncUtils {
                         connection::getDescription,
                         () -> SyncLogging.toShortBooleans(booleans));
             }
-            return booleans;
+            return new TipsInfo(dontSendEvents, booleans);
         };
     }
 
     /**
      * Send the events the peer needs. The complementary function to
-     * {@link #readEventsINeed(Connection, Consumer, int, SyncMetrics, CountDownLatch, IntakeEventCounter, Duration)}.
+     * {@link #readEventsINeed(Connection, Consumer, int, SyncMetrics, CountDownLatch, IntakeEventCounter, Duration,
+     * boolean)}.
      *
      * @param connection          the connection to write to
      * @param events              the events to write
@@ -240,14 +247,15 @@ public final class SyncUtils {
      * Read events from the peer that I need. The complementary function to
      * {@link #sendEventsTheyNeed(Connection, List, CountDownLatch, AtomicBoolean, Duration)}.
      *
-     * @param connection         the connection to read from
-     * @param eventHandler       the consumer of received events
-     * @param maxEventCount      the maximum number of events to read, or 0 for no limit
-     * @param syncMetrics        tracks event reading metrics
-     * @param eventReadingDone   used to notify the writing thread that reading is done
-     * @param intakeEventCounter keeps track of the number of events in the intake pipeline from each peer
-     * @param maxSyncTime        the maximum amount of time to spend syncing with a peer, syncs that take longer than
-     *                           this will be aborted
+     * @param connection           the connection to read from
+     * @param eventHandler         the consumer of received events
+     * @param maxEventCount        the maximum number of events to read, or 0 for no limit
+     * @param syncMetrics          tracks event reading metrics
+     * @param eventReadingDone     used to notify the writing thread that reading is done
+     * @param intakeEventCounter   keeps track of the number of events in the intake pipeline from each peer
+     * @param maxSyncTime          the maximum amount of time to spend syncing with a peer, syncs that take longer than
+     *                             this will be aborted
+     * @param ignoreIncomingEvents discard incoming events because we are unhealthy
      * @return A {@link Callable} that executes this part of the sync
      */
     public static Callable<Integer> readEventsINeed(
@@ -257,7 +265,8 @@ public final class SyncUtils {
             final SyncMetrics syncMetrics,
             final CountDownLatch eventReadingDone,
             @NonNull final IntakeEventCounter intakeEventCounter,
-            @NonNull final Duration maxSyncTime) {
+            @NonNull final Duration maxSyncTime,
+            final boolean ignoreIncomingEvents) {
 
         return () -> {
             if (logger.isDebugEnabled(SYNC_INFO.getMarker())) {
@@ -267,6 +276,7 @@ public final class SyncUtils {
             try {
                 final long startTime = System.nanoTime();
                 int count = 0;
+                boolean firstWrongEvent = false;
                 while (true) {
                     // readByte() will throw a timeout exception if the socket timeout is exceeded
                     final byte next = connection.getDis().readByte();
@@ -282,13 +292,24 @@ public final class SyncUtils {
                                 }
                             }
                             final GossipEvent gossipEvent = connection.getDis().readPbjRecord(GossipEvent.PROTOBUF);
-                            final PlatformEvent platformEvent = new PlatformEvent(gossipEvent);
 
-                            platformEvent.setSenderId(connection.getOtherId());
-                            intakeEventCounter.eventEnteredIntakePipeline(connection.getOtherId());
+                            if (ignoreIncomingEvents) {
+                                if (!firstWrongEvent) {
+                                    logger.warn(
+                                            SYNC_INFO.getMarker(),
+                                            "We have asked for no events, but still received an event from {}",
+                                            connection.getDescription());
+                                    firstWrongEvent = true;
+                                }
+                            } else {
+                                final PlatformEvent platformEvent = new PlatformEvent(gossipEvent);
 
-                            eventHandler.accept(platformEvent);
-                            eventsRead++;
+                                platformEvent.setSenderId(connection.getOtherId());
+                                intakeEventCounter.eventEnteredIntakePipeline(connection.getOtherId());
+
+                                eventHandler.accept(platformEvent);
+                                eventsRead++;
+                            }
                         }
                         case ByteConstants.COMM_EVENT_ABORT -> {
                             logger.info(
@@ -472,7 +493,7 @@ public final class SyncUtils {
      *
      * @return the number of event creators that have more than one tip.
      */
-    public static int computeMultiTipCount(Iterable<ShadowEvent> tips) {
+    public static int computeMultiTipCount(final Iterable<ShadowEvent> tips) {
         // The number of tips per creator encountered when iterating over the sending tips
         final Map<NodeId, Integer> tipCountByCreator = new HashMap<>();
 
@@ -558,7 +579,7 @@ public final class SyncUtils {
      * For each tip sent to the peer, determine if they have that event. If they have it, add it to the list that is
      * returned.
      *
-     * @param peerId    the peer node id
+     * @param peerId         the peer node id
      * @param myTips         the tips we sent them
      * @param myTipsTheyHave a list of booleans corresponding to our tips in the order they were sent. True if they have
      *                       the event, false if they don't
@@ -614,7 +635,7 @@ public final class SyncUtils {
     /**
      * Deserialize an event window from the given input stream.
      *
-     * @param in          the input stream
+     * @param in the input stream
      * @return the deserialized event window
      */
     @NonNull

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/config/SyncConfig.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/config/SyncConfig.java
@@ -50,14 +50,17 @@ import java.time.Duration;
  * @param fairMaxConcurrentSyncs             maximum number of concurrent syncs running after which we won't initiate
  *                                           any more outgoing syncs (but can accept incoming ones) if set &lt;= 0,
  *                                           disabled entire fair sync logic (syncs will always be initiated if no other
- *                                           reasons block them) if set &gt; 0 and &lt;= 1, this number is set as a ratio of
- *                                           total number of nodes in the network if &gt; 1, ceiling of that number is used
- *                                           as limit of concurrent syncs
+ *                                           reasons block them) if set &gt; 0 and &lt;= 1, this number is set as a
+ *                                           ratio of total number of nodes in the network if &gt; 1, ceiling of that
+ *                                           number is used as limit of concurrent syncs
  * @param fairMinimalRoundRobinSize          minimal number of synchronizations which happened in the past and are not
  *                                           currently running which has to be breached before sync against same peer
- *                                           can be considered if set &gt; 0 and &lt;= 1, this number is set as a ratio of
- *                                           total number of nodes in the network if &gt; 1, ceiling of that number is used
- *                                           as minimal round robin size
+ *                                           can be considered if set &gt; 0 and &lt;= 1, this number is set as a ratio
+ *                                           of total number of nodes in the network if &gt; 1, ceiling of that number
+ *                                           is used as minimal round robin size
+ * @param keepSendingEventsWhenUnhealthy     when enabled, instead of completely reducing number of syncs when system is
+ *                                           unhealthy, we will just stop receiving and processing remote events, while
+ *                                           we still continue sending our own events
  */
 @ConfigData("sync")
 public record SyncConfig(
@@ -79,4 +82,5 @@ public record SyncConfig(
         @ConfigProperty(defaultValue = "5ms") Duration rpcIdleWritePollTimeout,
         @ConfigProperty(defaultValue = "5ms") Duration rpcIdleDispatchPollTimeout,
         @ConfigProperty(defaultValue = "-1") double fairMaxConcurrentSyncs,
-        @ConfigProperty(defaultValue = "0.3") double fairMinimalRoundRobinSize) {}
+        @ConfigProperty(defaultValue = "0.3") double fairMinimalRoundRobinSize,
+        @ConfigProperty(defaultValue = "true") boolean keepSendingEventsWhenUnhealthy) {}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/protocol/SyncPeerProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/sync/protocol/SyncPeerProtocol.java
@@ -10,6 +10,7 @@ import com.swirlds.platform.gossip.IntakeEventCounter;
 import com.swirlds.platform.gossip.SyncException;
 import com.swirlds.platform.gossip.permits.SyncPermitProvider;
 import com.swirlds.platform.gossip.shadowgraph.ShadowgraphSynchronizer;
+import com.swirlds.platform.gossip.sync.config.SyncConfig;
 import com.swirlds.platform.metrics.SyncMetrics;
 import com.swirlds.platform.network.Connection;
 import com.swirlds.platform.network.NetworkProtocolException;
@@ -70,6 +71,12 @@ public class SyncPeerProtocol implements PeerProtocol {
     private final BooleanSupplier gossipHalted;
 
     /**
+     * When enabled, instead of completely reducing number of syncs when system is unhealthy, we will just stop
+     * receiving and processing remote events, while we still continue sending our own events
+     */
+    private final boolean keepSendingEventsWhenUnhealthy;
+
+    /**
      * The last time this protocol executed
      */
     private Instant lastSyncTime = Instant.MIN;
@@ -120,6 +127,10 @@ public class SyncPeerProtocol implements PeerProtocol {
         this.sleepAfterSync = Objects.requireNonNull(sleepAfterSync);
         this.syncMetrics = Objects.requireNonNull(syncMetrics);
         this.platformStatusSupplier = Objects.requireNonNull(platformStatusSupplier);
+        this.keepSendingEventsWhenUnhealthy = platformContext
+                .getConfiguration()
+                .getConfigData(SyncConfig.class)
+                .keepSendingEventsWhenUnhealthy();
     }
 
     /**
@@ -240,7 +251,8 @@ public class SyncPeerProtocol implements PeerProtocol {
             throws NetworkProtocolException, IOException, InterruptedException {
 
         try {
-            synchronizer.synchronize(platformContext, connection);
+            synchronizer.synchronize(
+                    platformContext, connection, !permitProvider.isHealthy() && keepSendingEventsWhenUnhealthy);
         } catch (final ParallelExecutionException | SyncException e) {
             if (Utilities.isRootCauseSuppliedType(e, IOException.class)) {
                 throw new IOException(e);

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/protocol/SyncPeerProtocolFactoryTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/network/protocol/SyncPeerProtocolFactoryTests.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 
 import com.swirlds.base.test.fixtures.time.FakeTime;
@@ -517,7 +518,7 @@ class SyncPeerProtocolFactoryTests {
         final PeerProtocol peerProtocol = syncProtocol.createPeerInstance(peerId);
 
         // mock synchronize to throw a ParallelExecutionException
-        Mockito.when(shadowGraphSynchronizer.synchronize(any(), any()))
+        Mockito.when(shadowGraphSynchronizer.synchronize(any(), any(), anyBoolean()))
                 .thenThrow(new ParallelExecutionException(mock(Throwable.class)));
 
         assertEquals(2, countAvailablePermits(syncProtocol.getPermitProvider()));
@@ -545,7 +546,7 @@ class SyncPeerProtocolFactoryTests {
         final PeerProtocol peerProtocol = syncProtocol.createPeerInstance(peerId);
 
         // mock synchronize to throw a ParallelExecutionException with root cause being an IOException
-        Mockito.when(shadowGraphSynchronizer.synchronize(any(), any()))
+        Mockito.when(shadowGraphSynchronizer.synchronize(any(), any(), anyBoolean()))
                 .thenThrow(new ParallelExecutionException(new IOException()));
 
         assertEquals(2, countAvailablePermits(syncProtocol.getPermitProvider()));
@@ -572,7 +573,8 @@ class SyncPeerProtocolFactoryTests {
         final PeerProtocol peerProtocol = syncProtocol.createPeerInstance(peerId);
 
         // mock synchronize to throw a SyncException
-        Mockito.when(shadowGraphSynchronizer.synchronize(any(), any())).thenThrow(new SyncException(""));
+        Mockito.when(shadowGraphSynchronizer.synchronize(any(), any(), anyBoolean()))
+                .thenThrow(new SyncException(""));
 
         assertEquals(2, countAvailablePermits(syncProtocol.getPermitProvider()));
         peerProtocol.shouldAccept();

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/sync/Synchronizer.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/sync/Synchronizer.java
@@ -27,8 +27,8 @@ public class Synchronizer {
 
     /**
      * Performs synchronization between the caller and listener nodes.
-     *
-     * The {@link ShadowgraphSynchronizer#synchronize(PlatformContext, Connection)} method is
+     * <br/>
+     * The {@link ShadowgraphSynchronizer#synchronize(PlatformContext, Connection, boolean)} method is
      * invoked on each node in parallel using the {@link ParallelExecutor}.
      *
      * @throws Exception
@@ -50,7 +50,7 @@ public class Synchronizer {
                 () -> {
                     try {
                         final boolean synchronize =
-                                caller.getSynchronizer().synchronize(platformContext, caller.getConnection());
+                                caller.getSynchronizer().synchronize(platformContext, caller.getConnection(), false);
                         caller.setSynchronizerReturn(synchronize);
                     } catch (final Exception e) {
                         caller.setSynchronizerReturn(null);
@@ -64,8 +64,8 @@ public class Synchronizer {
                 () -> {
                     try {
                         if (listener.isCanAcceptSync()) {
-                            final boolean synchronize =
-                                    listener.getSynchronizer().synchronize(platformContext, listener.getConnection());
+                            final boolean synchronize = listener.getSynchronizer()
+                                    .synchronize(platformContext, listener.getConnection(), false);
                             listener.setSynchronizerReturn(synchronize);
                         }
                     } catch (final Exception e) {


### PR DESCRIPTION
**Description**:

Change sync logic to always send events, even when we are struggling (i.e. too much backpressure or new idea below), but do not receive events

**Related issue(s)**:

Fixes #20663 

**Notes for reviewer**:
It is a hotfix for the release issue with stale events. For exact explanation and context please check 0.65 release channel, will update the PR with more details when there is time.


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
