### PR TITLE
chore: Replace tag-sdlt-passing tag-sdlpt-passing with appropriate tag-*-result

### DIFF
--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -236,11 +236,11 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - verify-tag
-      - tag-sdlt-passing
+      - tag-sdlt-result
       - run-single-day-longevity-nlg-test
       - get-commit-info
     if: ${{ (needs.verify-tag.result == 'success' &&
-      needs.tag-sdlt-passing.result == 'success' &&
+      needs.tag-sdlt-result.result == 'success' &&
       needs.run-single-day-longevity-nlg-test.outputs.result == 'success' &&
       needs.get-commit-info.result == 'success') &&
       inputs.disable-notifications != true && !cancelled() }}
@@ -302,7 +302,7 @@ jobs:
                         },
                         {
                           "type": "plain_text",
-                          "text": "${{ needs.tag-sdlt-passing.result }}"
+                          "text": "${{ needs.tag-sdlt-result.result }}"
                         }
                       ]
                     },
@@ -361,10 +361,10 @@ jobs:
     needs:
       - verify-tag
       - run-single-day-longevity-nlg-test
-      - tag-sdlt-passing
+      - tag-sdlt-result
       - get-commit-info
     if: ${{ (needs.verify-tag.result != 'success' ||
-      needs.tag-sdlt-passing.result != 'success' ||
+      needs.tag-sdlt-result.result != 'success' ||
       needs.run-single-day-longevity-nlg-test.outputs.result != 'success' ||
       needs.get-commit-info.result != 'success') &&
       inputs.disable-notifications != true && !cancelled() && always() }}
@@ -455,7 +455,7 @@ jobs:
                       },
                       {
                         "type": "plain_text",
-                        "text": "${{ needs.tag-sdlt-passing.result }}"
+                        "text": "${{ needs.tag-sdlt-result.result }}"
                       },
                       {
                         "type": "plain_text",

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -182,11 +182,11 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - verify-tag
-      - tag-sdlt-passing
+      - tag-sdlt-result
       - run-single-day-longevity-nlg-test
       - get-commit-info
     if: ${{ (needs.verify-tag.result == 'success' &&
-      needs.tag-sdlt-passing.result == 'success' &&
+      needs.tag-sdlt-result.result == 'success' &&
       needs.run-single-day-longevity-nlg-test.outputs.result == 'success' &&
       needs.get-commit-info.result == 'success') &&
       !cancelled() }}
@@ -248,7 +248,7 @@ jobs:
                         },
                         {
                           "type": "plain_text",
-                          "text": "${{ needs.tag-sdlt-passing.result }}"
+                          "text": "${{ needs.tag-sdlt-result.result }}"
                         }
                       ]
                     },
@@ -307,10 +307,10 @@ jobs:
     needs:
       - verify-tag
       - run-single-day-longevity-nlg-test
-      - tag-sdlt-passing
+      - tag-sdlt-result
       - get-commit-info
     if: ${{ (needs.verify-tag.result != 'success' ||
-      needs.tag-sdlt-passing.result != 'success' ||
+      needs.tag-sdlt-result.result != 'success' ||
       needs.run-single-day-longevity-nlg-test.outputs.result != 'success' ||
       needs.get-commit-info.result != 'success') &&
       !cancelled() && always() }}
@@ -401,7 +401,7 @@ jobs:
                       },
                       {
                         "type": "plain_text",
-                        "text": "${{ needs.tag-sdlt-passing.result }}"
+                        "text": "${{ needs.tag-sdlt-result.result }}"
                       },
                       {
                         "type": "plain_text",

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -241,11 +241,11 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - verify-tag
-      - tag-sdpt-passing
+      - tag-sdpt-result
       - run-single-day-performance-test
       - get-commit-info
     if: ${{ (needs.verify-tag.result == 'success' &&
-      needs.tag-sdpt-passing.result == 'success' &&
+      needs.tag-sdpt-result.result == 'success' &&
       needs.run-single-day-performance-test.outputs.result == 'success' &&
       needs.get-commit-info.result == 'success') &&
       inputs.disable-notifications != true && !cancelled() }}
@@ -307,7 +307,7 @@ jobs:
                         },
                         {
                           "type": "plain_text",
-                          "text": "${{ needs.tag-sdpt-passing.result }}"
+                          "text": "${{ needs.tag-sdpt-result.result }}"
                         }
                       ]
                     },
@@ -366,10 +366,10 @@ jobs:
     needs:
       - verify-tag
       - run-single-day-performance-test
-      - tag-sdpt-passing
+      - tag-sdpt-result
       - get-commit-info
     if: ${{ (needs.verify-tag.result != 'success' ||
-      needs.tag-sdpt-passing.result != 'success' ||
+      needs.tag-sdpt-result.result != 'success' ||
       needs.run-single-day-performance-test.outputs.result != 'success' ||
       needs.get-commit-info.result != 'success') &&
       inputs.disable-notifications != true && !cancelled() && always() }}
@@ -460,7 +460,7 @@ jobs:
                       },
                       {
                         "type": "plain_text",
-                        "text": "${{ needs.tag-sdpt-passing.result }}"
+                        "text": "${{ needs.tag-sdpt-result.result }}"
                       },
                       {
                         "type": "plain_text",

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -182,11 +182,11 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - verify-tag
-      - tag-sdpt-passing
+      - tag-sdpt-result
       - run-single-day-performance-test
       - get-commit-info
     if: ${{ (needs.verify-tag.result == 'success' &&
-      needs.tag-sdpt-passing.result == 'success' &&
+      needs.tag-sdpt-result.result == 'success' &&
       needs.run-single-day-performance-test.outputs.result == 'success' &&
       needs.get-commit-info.result == 'success') &&
       !cancelled() }}
@@ -248,7 +248,7 @@ jobs:
                         },
                         {
                           "type": "plain_text",
-                          "text": "${{ needs.tag-sdpt-passing.result }}"
+                          "text": "${{ needs.tag-sdpt-result.result }}"
                         }
                       ]
                     },
@@ -307,10 +307,10 @@ jobs:
     needs:
       - verify-tag
       - run-single-day-performance-test
-      - tag-sdpt-passing
+      - tag-sdpt-result
       - get-commit-info
     if: ${{ (needs.verify-tag.result != 'success' ||
-      needs.tag-sdpt-passing.result != 'success' ||
+      needs.tag-sdpt-result.result != 'success' ||
       needs.run-single-day-performance-test.outputs.result != 'success' ||
       needs.get-commit-info.result != 'success') &&
       !cancelled() && always() }}
@@ -401,7 +401,7 @@ jobs:
                       },
                       {
                         "type": "plain_text",
-                        "text": "${{ needs.tag-sdpt-passing.result }}"
+                        "text": "${{ needs.tag-sdpt-result.result }}"
                       },
                       {
                         "type": "plain_text",


### PR DESCRIPTION
**Description**:

This pull request updates the workflow job dependencies and output references in several GitHub Actions YAML files to use the new result job names (`tag-sdlt-result` and `tag-sdpt-result`) instead of the previous passing job names (`tag-sdlt-passing` and `tag-sdpt-passing`). This change ensures consistency in job naming and correct referencing throughout the workflows for both single-day longevity and performance test controllers, in both regular and adhoc variants.

**Workflow job dependency and output reference updates:**

* Longevity test controller workflows:
  - Updated all job dependencies and output references from `tag-sdlt-passing` to `tag-sdlt-result` in `.github/workflows/zxf-single-day-longevity-test-controller.yaml` and `.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml`. [[1]](diffhunk://#diff-a4f906182f2d4a24b8cd798cc5c0e3cd4f0f79d9b10923dda9e7c34229af8359L185-R189) [[2]](diffhunk://#diff-a4f906182f2d4a24b8cd798cc5c0e3cd4f0f79d9b10923dda9e7c34229af8359L251-R251) [[3]](diffhunk://#diff-a4f906182f2d4a24b8cd798cc5c0e3cd4f0f79d9b10923dda9e7c34229af8359L310-R313) [[4]](diffhunk://#diff-a4f906182f2d4a24b8cd798cc5c0e3cd4f0f79d9b10923dda9e7c34229af8359L404-R404) [[5]](diffhunk://#diff-2e0dfedf7abd9a7bac567fb3fa1ad4ebc474dabccd234d16f4f49569fe4646dcL239-R243) [[6]](diffhunk://#diff-2e0dfedf7abd9a7bac567fb3fa1ad4ebc474dabccd234d16f4f49569fe4646dcL305-R305) [[7]](diffhunk://#diff-2e0dfedf7abd9a7bac567fb3fa1ad4ebc474dabccd234d16f4f49569fe4646dcL364-R367) [[8]](diffhunk://#diff-2e0dfedf7abd9a7bac567fb3fa1ad4ebc474dabccd234d16f4f49569fe4646dcL458-R458)

* Performance test controller workflows:
  - Updated all job dependencies and output references from `tag-sdpt-passing` to `tag-sdpt-result` in `.github/workflows/zxf-single-day-performance-test-controller.yaml` and `.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml`. [[1]](diffhunk://#diff-af0846566d395a9cd891f76bc1bafbafa2ab4155371d913cf568171aeab667cfL185-R189) [[2]](diffhunk://#diff-af0846566d395a9cd891f76bc1bafbafa2ab4155371d913cf568171aeab667cfL251-R251) [[3]](diffhunk://#diff-af0846566d395a9cd891f76bc1bafbafa2ab4155371d913cf568171aeab667cfL310-R313) [[4]](diffhunk://#diff-af0846566d395a9cd891f76bc1bafbafa2ab4155371d913cf568171aeab667cfL404-R404) [[5]](diffhunk://#diff-61a2acc1fa0f26dc209dc44c563665ab8a24eafa766d77d87309f8f2584d9947L244-R248) [[6]](diffhunk://#diff-61a2acc1fa0f26dc209dc44c563665ab8a24eafa766d77d87309f8f2584d9947L310-R310) [[7]](diffhunk://#diff-61a2acc1fa0f26dc209dc44c563665ab8a24eafa766d77d87309f8f2584d9947L369-R372) [[8]](diffhunk://#diff-61a2acc1fa0f26dc209dc44c563665ab8a24eafa766d77d87309f8f2584d9947L463-R463)

**Related issue(s)**:

Fixes #20668 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] [Tested](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/17011607314) #SDPT_Contorller
