### PR TITLE
chore: 20681: Backport the fix for 20629 to release 0.65

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -70,7 +70,7 @@ import com.swirlds.config.extensions.validators.DefaultConfigViolation;
  */
 @ConfigData("merkleDb")
 public record MerkleDbConfig(
-        @Positive @ConfigProperty(defaultValue = "4000000000") long maxNumOfKeys,
+        @Positive @ConfigProperty(defaultValue = "1000000000") long maxNumOfKeys,
         @Min(0) @ConfigProperty(defaultValue = "8388608") long hashesRamToDiskThreshold,
         @Positive @ConfigProperty(defaultValue = "1000000") int hashStoreRamBufferSize,
         @ConfigProperty(defaultValue = "true") boolean hashStoreRamOffHeapBuffers,

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/config/MerkleDbConfig.java
@@ -70,7 +70,8 @@ import com.swirlds.config.extensions.validators.DefaultConfigViolation;
  */
 @ConfigData("merkleDb")
 public record MerkleDbConfig(
-        @Positive @ConfigProperty(defaultValue = "1000000000") long maxNumOfKeys,
+        @Positive @ConfigProperty(defaultValue = "1000000000") long initialCapacity,
+        @Positive @ConfigProperty(defaultValue = "4000000000") long maxNumOfKeys,
         @Min(0) @ConfigProperty(defaultValue = "8388608") long hashesRamToDiskThreshold,
         @Positive @ConfigProperty(defaultValue = "1000000") int hashStoreRamBufferSize,
         @ConfigProperty(defaultValue = "true") boolean hashStoreRamOffHeapBuffers,

--- a/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/config/ConfigUtils.java
+++ b/platform-sdk/swirlds-platform-core/src/testFixtures/java/com/swirlds/platform/test/fixtures/config/ConfigUtils.java
@@ -15,7 +15,7 @@ public final class ConfigUtils {
 
     public static final Configuration CONFIGURATION = ConfigurationBuilder.create()
             .withConfigDataType(MerkleDbConfig.class)
-            .withSource(new SimpleConfigSource().withValue(MerkleDbConfig_.MAX_NUM_OF_KEYS, "" + 65_536L))
+            .withSource(new SimpleConfigSource().withValue(MerkleDbConfig_.INITIAL_CAPACITY, "" + 65_536L))
             .withConfigDataType(VirtualMapConfig.class)
             .withConfigDataType(TemporaryFileConfig.class)
             .withConfigDataType(StateCommonConfig.class)

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/MerkleStateRoot.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/MerkleStateRoot.java
@@ -993,7 +993,7 @@ public abstract class MerkleStateRoot<T extends MerkleStateRoot<T>> extends Part
                     DigestType.SHA_384,
                     // FUTURE WORK: drop StateDefinition.maxKeysHint and load VM size
                     // from VirtualMapConfig.size instead
-                    merkleDbConfig.maxNumOfKeys(),
+                    merkleDbConfig.initialCapacity(),
                     merkleDbConfig.hashesRamToDiskThreshold());
             final var dsBuilder = new MerkleDbDataSourceBuilder(tableConfig, configuration);
             final var virtualMap = new VirtualMap(VM_LABEL, dsBuilder, configuration);

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapState.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapState.java
@@ -130,7 +130,7 @@ public abstract class VirtualMapState<T extends VirtualMapState<T>> implements S
                 (short) 1,
                 DigestType.SHA_384,
                 // FUTURE WORK: drop StateDefinition.maxKeysHint and load VM size from VirtualMapConfig.size instead
-                merkleDbConfig.maxNumOfKeys(),
+                merkleDbConfig.initialCapacity(),
                 merkleDbConfig.hashesRamToDiskThreshold());
         dsBuilder = new MerkleDbDataSourceBuilder(tableConfig, configuration);
 


### PR DESCRIPTION
Fix summary: backport of https://github.com/hiero-ledger/hiero-consensus-node/pull/20630 and https://github.com/hiero-ledger/hiero-consensus-node/pull/20692 to the `release/0.65` branch.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/20681
Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/20691
Signed-off-by: Artem Ananev <artem.ananev@swirldslabs.com>
