### PR TITLE
feat: update multipliers to reflect worst case

### DIFF
--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/OpsDurationConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/OpsDurationConfig.java
@@ -28,6 +28,6 @@ public record OpsDurationConfig(
                 List<LongPair> opsDurations129_to_192,
         @ConfigProperty(defaultValue = "240-26552,241-98859,242-2011,244-1596,245-11291,250-2091") @NetworkProperty
                 List<LongPair> opsDurations193_to_256,
-        @ConfigProperty(defaultValue = "566") @NetworkProperty long opsGasBasedDurationMultiplier,
+        @ConfigProperty(defaultValue = "1575") @NetworkProperty long opsGasBasedDurationMultiplier,
         @ConfigProperty(defaultValue = "1575") @NetworkProperty long precompileGasBasedDurationMultiplier,
-        @ConfigProperty(defaultValue = "566") @NetworkProperty long systemContractGasBasedDurationMultiplier) {}
+        @ConfigProperty(defaultValue = "1575") @NetworkProperty long systemContractGasBasedDurationMultiplier) {}

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/OpsDurationScheduleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/OpsDurationScheduleTest.java
@@ -15,9 +15,9 @@ class OpsDurationScheduleTest {
         assertEquals(123, opsDurationSchedule.opsDurationByOpCode()[1]);
         assertEquals(105, opsDurationSchedule.opsDurationByOpCode()[2]);
         assertEquals(2091, opsDurationSchedule.opsDurationByOpCode()[250]);
-        assertEquals(566, opsDurationSchedule.opsGasBasedDurationMultiplier());
+        assertEquals(1575, opsDurationSchedule.opsGasBasedDurationMultiplier());
         assertEquals(1575, opsDurationSchedule.precompileGasBasedDurationMultiplier());
-        assertEquals(566, opsDurationSchedule.systemContractGasBasedDurationMultiplier());
+        assertEquals(1575, opsDurationSchedule.systemContractGasBasedDurationMultiplier());
         assertEquals(100, opsDurationSchedule.multipliersDenominator());
     }
 }


### PR DESCRIPTION
**Description**:
Update multipliers used for ops duration when the value is not currently measure to reflect the worst case - 1575.