### PR TITLE
ci: Remove milestone check from PR Formatting workflow

### DIFF
--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -40,21 +40,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  milestone-check:
-    name: Milestone Check
-    runs-on: hiero-network-node-linux-medium
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
-        with:
-          egress-policy: audit
-
-      - name: Check Milestone
-        if: ${{ github.event.pull_request.milestone == null }}
-        run: |
-          echo "Milestone is not set. Failing the workflow."
-          exit 1
-
   assignee-check:
     name: Assignee Check
     runs-on: hiero-network-node-linux-medium


### PR DESCRIPTION
## Description

This pull request simplifies the workflow configuration by removing the milestone check job from the `.github/workflows/flow-pull-request-formatting.yaml` file. This means that pull requests will no longer be required to have a milestone set for this workflow to pass.

Workflow configuration simplification:

* Removed the entire `milestone-check` job, including runner hardening and milestone validation steps, from `.github/workflows/flow-pull-request-formatting.yaml`.

### Related issue(s)

Resolves #20715 

