### PR TITLE
fix: cherry-pick: UnzipUtility constraints not needed

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/UnzipUtility.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/UnzipUtility.java
@@ -17,21 +17,11 @@ import org.apache.logging.log4j.Logger;
 
 /**
  * Utility class to unzip a zip file.
- * <p>
- * This class was copied from hedera-mono-service/src/main/java/com/hedera/node/app/service/mono/utils/UnzipUtility.java
- * Once we are wholly migrated to the modularized services, we can remove the other location.
  * */
 public final class UnzipUtility {
     private static final Logger log = LogManager.getLogger(UnzipUtility.class);
 
     private static final int BUFFER_SIZE = 4096;
-
-    // these constants are used to prevent Zip Bomb Attacks
-    private static final int THRESHOLD_ENTRIES = 10000; // max # of entries to allow in zip files
-    private static final int THRESHOLD_ZIP_SIZE = 1000000000; // 1 GB - max allowed total size of all uncompressed files
-    private static final int THRESHOLD_ENTRY_SIZE = 100000000; // 100 MB - max allowed size of one uncompressed file
-    // max allowed ratio between uncompressed and compressed file size
-    private static final double THRESHOLD_RATIO = 100;
 
     private UnzipUtility() {}
 
@@ -45,9 +35,6 @@ public final class UnzipUtility {
         requireNonNull(bytes);
         requireNonNull(dstDir);
 
-        int totalSizeArchive = 0; // total size of the zip archive once uncompressed
-        int totalEntryArchive = 0; // total number of entries in the zip archive
-
         try (final var zipIn = new ZipInputStream(new ByteArrayInputStream(bytes))) {
             ZipEntry entry = zipIn.getNextEntry();
 
@@ -55,10 +42,6 @@ public final class UnzipUtility {
                 throw new IOException("No zip entry found in bytes");
             }
             while (entry != null) {
-                totalEntryArchive++;
-                if (totalEntryArchive > THRESHOLD_ENTRIES) {
-                    throw new IOException("Zip file entry count exceeds threshold: " + THRESHOLD_ENTRIES);
-                }
                 Path filePath = dstDir.resolve(entry.getName());
                 final File fileOrDir = filePath.toFile();
                 final String canonicalPath = fileOrDir.getCanonicalPath();
@@ -72,10 +55,7 @@ public final class UnzipUtility {
                 }
 
                 if (!entry.isDirectory()) {
-                    totalSizeArchive += extractSingleFile(zipIn, filePath, entry.getCompressedSize());
-                    if (totalSizeArchive > THRESHOLD_ZIP_SIZE) {
-                        throw new IOException("Zip file size exceeds threshold: " + THRESHOLD_ZIP_SIZE);
-                    }
+                    extractSingleFile(zipIn, filePath);
                     log.info(" - Extracted update file {}", filePath);
                 } else {
                     if (!fileOrDir.exists() && !fileOrDir.mkdirs()) {
@@ -94,33 +74,19 @@ public final class UnzipUtility {
      *
      * @param inputStream Input stream of zip file content
      * @param filePath Output file name
-     * @param compressedSize Size of this zip entry while still compressed in bytes
-     * @return Size of this zip entry once uncompressed
      * @throws IOException if the file can't be written
      */
-    public static int extractSingleFile(
-            @NonNull ZipInputStream inputStream, @NonNull Path filePath, long compressedSize) throws IOException {
+    public static void extractSingleFile(@NonNull ZipInputStream inputStream, @NonNull Path filePath)
+            throws IOException {
         requireNonNull(inputStream);
         requireNonNull(filePath);
-        int totalSizeEntry = 0; // size of this zip entry once uncompressed
 
         try (var bos = new BufferedOutputStream(new FileOutputStream(filePath.toFile()))) {
             final var bytesIn = new byte[BUFFER_SIZE];
             int read;
             while ((read = inputStream.read(bytesIn)) != -1) {
-                totalSizeEntry += read;
-                if (totalSizeEntry > THRESHOLD_ENTRY_SIZE) {
-                    // the uncompressed file size is too large, could be a zip bomb attack
-                    throw new IOException("Zip bomb attack detected, aborting unzip!");
-                }
-                if ((double) totalSizeEntry / compressedSize > THRESHOLD_RATIO) {
-                    // the uncompressed file size is too large compared to the compressed size,
-                    // could be a zip bomb attack
-                    throw new IOException("Zip bomb attack detected, aborting unzip!");
-                }
                 bos.write(bytesIn, 0, read);
             }
         }
-        return totalSizeEntry;
     }
 }


### PR DESCRIPTION
**Description**:
This PR cherry-picks 9d25212 for release/0.65

`201M Oct 31  2018 hedera-cryptography-rpm-0.2.3-SNAPSHOT.jar` is > 100MB now and these checks in UnzipUtility are not necessary.

**Related issue(s)**:

Fixes #20687 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
