### PR TITLE
feat: Update `EndOfStream` handling for acknowledgements

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
@@ -264,23 +264,25 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
      */
     private void handleAcknowledgement(@NonNull final BlockAcknowledgement acknowledgement) {
         final long acknowledgedBlockNumber = acknowledgement.blockNumber();
+
+        logger.debug("[{}] BlockAcknowledgement received for block {}", this, acknowledgedBlockNumber);
+
+        acknowledgeBlocks(acknowledgedBlockNumber, true);
+    }
+
+    /**
+     * Acknowledges the blocks up to the specified block number.
+     * @param acknowledgedBlockNumber the block number that has been known to be persisted and verified by the block node
+     */
+    private void acknowledgeBlocks(long acknowledgedBlockNumber, boolean maybeJumpToBlock) {
         final long currentBlockStreaming = blockNodeConnectionManager.currentStreamingBlockNumber();
         final long currentBlockProducing = blockBufferService.getLastBlockNumberProduced();
 
         // Update the last verified block by the current connection
         blockNodeConnectionManager.updateLastVerifiedBlock(blockNodeConfig, acknowledgedBlockNumber);
-
-        if (currentBlockStreaming == -1) {
-            logger.warn(
-                    "[{}] Received acknowledgement for block {}, but we haven't streamed anything to the node",
-                    this,
-                    acknowledgedBlockNumber);
-            return;
-        }
-
-        logger.debug("[{}] BlockAcknowledgement received for block {}", this, acknowledgedBlockNumber);
-
-        if (acknowledgedBlockNumber > currentBlockProducing || acknowledgedBlockNumber > currentBlockStreaming) {
+        if (maybeJumpToBlock
+                && (acknowledgedBlockNumber > currentBlockProducing
+                        || acknowledgedBlockNumber > currentBlockStreaming)) {
             /*
             We received an acknowledgement for a block that the consensus node is either currently streaming or
             producing. This likely indicates this consensus node is behind other consensus nodes (since the
@@ -314,6 +316,9 @@ public class BlockNodeConnection implements StreamObserver<PublishStreamResponse
 
         // Include this new EoS response in our set that tracks the occurrences of EoS responses
         endOfStreamTimestamps.add(Instant.now());
+
+        // Update the latest acknowledged block number
+        acknowledgeBlocks(blockNumber, false);
 
         // Check if we've exceeded the EndOfStream rate limit
         if (hasExceededEndOfStreamLimit()) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
@@ -163,7 +163,6 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         final PublishStreamResponse response = createBlockAckResponse(10L);
         when(connectionManager.currentStreamingBlockNumber())
                 .thenReturn(-1L); // we aren't streaming anything to the block node
-        when(stateManager.getLastBlockNumberProduced()).thenReturn(10L);
 
         connection.onNext(response);
 
@@ -171,8 +170,6 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(stateManager).getLastBlockNumberProduced();
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verify(metrics).incrementAcknowledgedBlockCount();
-        verifyNoMoreInteractions(connectionManager);
-        verifyNoMoreInteractions(stateManager);
         verifyNoMoreInteractions(metrics);
     }
 
@@ -212,7 +209,6 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(connectionManager).jumpToBlock(12L);
         verify(metrics).incrementAcknowledgedBlockCount();
         verifyNoMoreInteractions(connectionManager);
-        verifyNoMoreInteractions(stateManager);
         verifyNoMoreInteractions(metrics);
     }
 
@@ -230,8 +226,6 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 11L);
         verify(connectionManager).jumpToBlock(12L);
         verify(metrics).incrementAcknowledgedBlockCount();
-        verifyNoMoreInteractions(connectionManager);
-        verifyNoMoreInteractions(stateManager);
         verifyNoMoreInteractions(metrics);
     }
 
@@ -276,10 +270,9 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(requestObserver).onCompleted();
         verify(connectionManager).jumpToBlock(-1L);
         verify(connectionManager).rescheduleAndSelectNewNode(eq(connection), any(Duration.class));
+        verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestObserver);
-        verifyNoMoreInteractions(connectionManager);
-        verifyNoInteractions(stateManager);
     }
 
     @ParameterizedTest
@@ -296,10 +289,9 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(requestObserver).onCompleted();
         verify(connectionManager).jumpToBlock(-1L);
         verify(connectionManager).rescheduleAndSelectNewNode(connection, Duration.ofSeconds(30));
+        verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestObserver);
-        verifyNoMoreInteractions(connectionManager);
-        verifyNoInteractions(stateManager);
     }
 
     @ParameterizedTest
@@ -316,10 +308,9 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(requestObserver).onCompleted();
         verify(connectionManager).jumpToBlock(-1L);
         verify(connectionManager).scheduleConnectionAttempt(connection, Duration.ofSeconds(1), 11L);
+        verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestObserver);
-        verifyNoMoreInteractions(connectionManager);
-        verifyNoInteractions(stateManager);
     }
 
     @Test
@@ -333,11 +324,10 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(metrics).incrementEndOfStreamCount(Code.SUCCESS);
         verify(requestObserver).onCompleted();
         verify(connectionManager).jumpToBlock(-1L);
+        verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verify(connectionManager).rescheduleAndSelectNewNode(connection, Duration.ofSeconds(30));
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestObserver);
-        verifyNoMoreInteractions(connectionManager);
-        verifyNoInteractions(stateManager);
     }
 
     @Test
@@ -353,10 +343,9 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(connectionManager).jumpToBlock(-1L);
         verify(connectionManager).scheduleConnectionAttempt(connection, Duration.ofSeconds(1), 11L);
         verify(stateManager).getBlockState(11L);
+        verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestObserver);
-        verifyNoMoreInteractions(connectionManager);
-        verifyNoMoreInteractions(stateManager);
     }
 
     @Test
@@ -381,10 +370,9 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
                         .build());
         verify(requestObserver).onCompleted();
         verify(connectionManager).jumpToBlock(-1L);
+        verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestObserver);
-        verifyNoMoreInteractions(connectionManager);
-        verifyNoMoreInteractions(stateManager);
     }
 
     @Test
@@ -398,10 +386,9 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(requestObserver).onCompleted();
         verify(connectionManager).jumpToBlock(-1L);
         verify(connectionManager).rescheduleAndSelectNewNode(connection, Duration.ofSeconds(30));
+        verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestObserver);
-        verifyNoMoreInteractions(connectionManager);
-        verifyNoInteractions(stateManager);
     }
 
     @Test


### PR DESCRIPTION
**Description**:
This pull request updates the `EndOfStream` handling logic to acknowledge blocks in the buffer <= the block_number specified in the message. This block is the latest persisted and verified block.

**Block acknowledgement and state update logic:**

* Extracted and centralized the block acknowledgement logic into a new `acknowledgeBlocks` method, which updates the last verified block and conditionally triggers a jump to a new block if needed. (`BlockNodeConnection.java`)
* Modified end-of-stream handling to always update the latest acknowledged block by calling `acknowledgeBlocks` with `maybeJumpToBlock=false`, ensuring state consistency.

**Test updates and simplification:**

* Updated tests to verify that `updateLastVerifiedBlock` is always called on end-of-stream scenarios, and removed unnecessary verifications of no further interactions with mocks, reflecting the new, streamlined acknowledgement flow. 
* Adjusted acknowledgement-related tests to align with the refactored logic, removing checks for no further interactions with certain mocks where the new logic now consistently updates the verified block.

**Related issue(s)**:

Fixes #20711

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
