### PR TITLE
chore(20698): Invert PlatformWiring and PlatformCoordinator relationship

### DIFF
--- a/platform-sdk/consensus-otter-docker-app/src/testFixtures/java/org/hiero/consensus/otter/docker/app/platform/ConsensusNodeManager.java
+++ b/platform-sdk/consensus-otter-docker-app/src/testFixtures/java/org/hiero/consensus/otter/docker/app/platform/ConsensusNodeManager.java
@@ -30,7 +30,7 @@ import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.test.fixtures.state.TestingAppStateInitializer;
 import com.swirlds.platform.util.BootstrapUtils;
-import com.swirlds.platform.wiring.PlatformWiring;
+import com.swirlds.platform.wiring.PlatformComponents;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.nio.file.Path;
@@ -150,8 +150,10 @@ public class ConsensusNodeManager {
         final PlatformBuildingBlocks blocks = componentBuilder.getBuildingBlocks();
 
         // Wiring: Forward consensus rounds to registered listeners
-        final PlatformWiring wiring = blocks.platformWiring();
-        wiring.getConsensusEngineOutputWire()
+        final PlatformComponents platformComponents = blocks.platformComponents();
+        platformComponents
+                .consensusEngineWiring()
+                .consensusRoundsOutputWire()
                 .solderTo("dockerApp", "consensusRounds", this::notifyConsensusRoundListeners);
 
         platform = componentBuilder.build();

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -102,7 +102,7 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
     private OtterExecutionLayer executionLayer;
 
     @Nullable
-    private PlatformComponents platformComponents;
+    private PlatformComponents platformComponent;
 
     /**
      * Constructor of {@link TurtleNode}.
@@ -232,125 +232,14 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
                     .withMetricsDocumentationEnabled(false)
                     .withGossip(network.getGossipInstance(legacyNodeId));
 
-            platformComponents= platformBuildingBlocks.platformComponents();
+            platformComponent = platformBuildingBlocks.platformComponents();
 
-            platformComponents
-                    .consensusEngineWiring()
-                    .getOutputWire()
-                    .solderTo("nodeConsensusRoundsCollector", "consensusRounds", resultsCollector::addConsensusRounds);
-
-            platformComponents
-                    .statusStateMachineWiring()
-                    .getOutputWire()
-                    .solderTo("nodePlatformStatusCollector", "platformStatus", this::handlePlatformStatusChange);
-
-            InMemorySubscriptionManager.INSTANCE.subscribe(logEntry -> {
-                if (Objects.equals(logEntry.nodeId(), selfId)) {
-                    resultsCollector.addLogEntry(logEntry);
-                }
-                return lifeCycle == DESTROYED ? UNSUBSCRIBE : CONTINUE;
-            });
-
-            platform = platformComponentBuilder.build();
-            platformStatus = PlatformStatus.STARTING_UP;
-            platform.start();
-
-            lifeCycle = RUNNING;
-
-        } finally {
-            ThreadContext.remove(THREAD_CONTEXT_NODE_ID);
-        }
-    }
-
-    @Override
-    private void doStartNode() {
-
-        final Configuration currentConfiguration = nodeConfiguration.current();
-        final org.hiero.consensus.model.node.NodeId legacyNodeId =
-                org.hiero.consensus.model.node.NodeId.of(selfId.id());
-
-            setupGlobalMetrics(currentConfiguration);
-
-            final PathsConfig pathsConfig = currentConfiguration.getConfigData(PathsConfig.class);
-            final Path markerFilesDir = pathsConfig.getMarkerFilesDir();
-            if (markerFilesDir != null) {
-                markerFileObserver.startObserving(markerFilesDir);
-            }
-
-            final PlatformStateFacade platformStateFacade = new PlatformStateFacade();
-            MerkleDb.resetDefaultInstancePath();
-            final Metrics metrics = getMetricsProvider().createPlatformMetrics(legacyNodeId);
-            final FileSystemManager fileSystemManager = FileSystemManager.create(currentConfiguration);
-            final RecycleBin recycleBin = RecycleBin.create(
-                    metrics, currentConfiguration, getStaticThreadManager(), time, fileSystemManager, legacyNodeId);
-
-            platformContext = TestPlatformContextBuilder.create()
-                    .withTime(time)
-                    .withConfiguration(currentConfiguration)
-                    .withFileSystemManager(fileSystemManager)
-                    .withMetrics(metrics)
-                    .withRecycleBin(recycleBin)
-                    .build();
-
-            model = WiringModelBuilder.create(platformContext.getMetrics(), time)
-                    .withDeterministicModeEnabled(true)
-                    .withUncaughtExceptionHandler((t, e) -> fail("Unexpected exception in wiring framework", e))
-                    .build();
-
-            final HashedReservedSignedState reservedState = loadInitialState(
-                    recycleBin,
-                    version,
-                    () -> OtterAppState.createGenesisState(currentConfiguration, roster, metrics, version),
-                    OtterApp.APP_NAME,
-                    OtterApp.SWIRLD_NAME,
-                    legacyNodeId,
-                    platformStateFacade,
-                    platformContext,
-                    OtterAppState::new);
-            final ReservedSignedState initialState = reservedState.state();
-
-            final State state = initialState.get().getState();
-            final RosterHistory rosterHistory = RosterUtils.createRosterHistory(state);
-            final String eventStreamLoc = selfId.toString();
-
-            this.executionLayer = new OtterExecutionLayer(platformContext.getMetrics());
-
-            final PlatformBuilder platformBuilder = PlatformBuilder.create(
-                            OtterApp.APP_NAME,
-                            OtterApp.SWIRLD_NAME,
-                            version,
-                            initialState,
-                            OtterApp.INSTANCE,
-                            legacyNodeId,
-                            eventStreamLoc,
-                            rosterHistory,
-                            platformStateFacade,
-                            OtterAppState::new)
-                    .withPlatformContext(platformContext)
-                    .withConfiguration(currentConfiguration)
-                    .withKeysAndCerts(keysAndCerts)
-                    .withExecutionLayer(executionLayer)
-                    .withModel(model)
-                    .withSecureRandomSupplier(new SecureRandomBuilder(randotron.nextLong()));
-
-            final PlatformComponentBuilder platformComponentBuilder = platformBuilder.buildComponentBuilder();
-            final PlatformBuildingBlocks platformBuildingBlocks = platformComponentBuilder.getBuildingBlocks();
-
-            final SimulatedGossip gossip = network.getGossipInstance(legacyNodeId);
-            gossip.provideIntakeEventCounter(platformBuildingBlocks.intakeEventCounter());
-
-            platformComponentBuilder
-                    .withMetricsDocumentationEnabled(false)
-                    .withGossip(network.getGossipInstance(legacyNodeId));
-
-            platformComponents = platformBuildingBlocks.platformComponents();
-
-            platformComponents
+            platformComponent
                     .consensusEngineWiring()
                     .consensusRoundsOutputWire()
                     .solderTo("nodeConsensusRoundsCollector", "consensusRounds", resultsCollector::addConsensusRounds);
 
-            platformComponents
+            platformComponent
                     .statusStateMachineWiring()
                     .getOutputWire()
                     .solderTo("nodePlatformStatusCollector", "platformStatus", this::handlePlatformStatusChange);
@@ -388,7 +277,7 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
                 }
                 platformStatus = null;
                 platform = null;
-                platformWiring = null;
+                platformComponent = null;
                 model = null;
             }
             lifeCycle = SHUTDOWN;

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -347,12 +347,12 @@ public class TurtleNode extends AbstractNode implements Node, TurtleTimeManager.
 
             platformComponents
                     .consensusEngineWiring()
-                .consensusRoundsOutputWire()
+                    .consensusRoundsOutputWire()
                     .solderTo("nodeConsensusRoundsCollector", "consensusRounds", resultsCollector::addConsensusRounds);
 
             platformComponents
                     .statusStateMachineWiring()
-                .getOutputWire()
+                    .getOutputWire()
                     .solderTo("nodePlatformStatusCollector", "platformStatus", this::handlePlatformStatusChange);
 
             InMemorySubscriptionManager.INSTANCE.subscribe(logEntry -> {

--- a/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/component/ComponentWiring.java
+++ b/platform-sdk/swirlds-component-framework/src/main/java/com/swirlds/component/framework/component/ComponentWiring.java
@@ -810,4 +810,13 @@ public class ComponentWiring<COMPONENT_TYPE, OUTPUT_TYPE> {
     public String getSchedulerName() {
         return scheduler.getName();
     }
+    /**
+     * Get the type of the scheduler that is running this component.
+     *
+     * @return the type of the scheduler
+     */
+    @NonNull
+    public TaskSchedulerType getSchedulerType() {
+        return scheduler.getType();
+    }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/ReconnectStateLoader.java
@@ -150,7 +150,7 @@ public class ReconnectStateLoader {
             platformCoordinator.registerPcesDiscontinuity(signedState.getRound());
 
             // Notify any listeners that the reconnect has been completed
-            platformCoordinator.sendAppNotifications(signedState);
+            platformCoordinator.sendReconnectCompleteNotification(signedState);
 
         } catch (final RuntimeException e) {
             logger.debug(RECONNECT.getMarker(), "`loadReconnectState` : FAILED, reason: {}", e.getMessage());

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java
@@ -39,6 +39,7 @@ import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.system.Platform;
 import com.swirlds.platform.system.status.StatusActionSubmitter;
+import com.swirlds.platform.wiring.PlatformComponents;
 import com.swirlds.platform.wiring.PlatformWiring;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -477,10 +478,12 @@ public final class PlatformBuilder {
             };
         }
 
-        final PlatformWiring platformWiring = new PlatformWiring(platformContext, model, callbacks, execution);
+        var platformComponentWiring = PlatformComponents.create(platformContext, model, callbacks);
+
+        PlatformWiring.wire(platformContext, execution, platformComponentWiring);
 
         final PlatformBuildingBlocks buildingBlocks = new PlatformBuildingBlocks(
-                platformWiring,
+                platformComponentWiring,
                 platformContext,
                 model,
                 keysAndCerts,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuildingBlocks.java
@@ -20,7 +20,7 @@ import com.swirlds.platform.state.service.PlatformStateFacade;
 import com.swirlds.platform.state.signed.ReservedSignedState;
 import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.system.status.StatusActionSubmitter;
-import com.swirlds.platform.wiring.PlatformWiring;
+import com.swirlds.platform.wiring.PlatformComponents;
 import com.swirlds.virtualmap.VirtualMap;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -38,7 +38,7 @@ import org.hiero.consensus.roster.RosterHistory;
  * This record contains core utilities and basic objects needed to build a platform. It should not contain any platform
  * components.
  *
- * @param platformWiring                         the wiring for this platform
+ * @param platformComponents                         the wiring for this platform
  * @param platformContext                        the context for this platform
  * @param model                                  the wiring model for this platform
  * @param keysAndCerts                           an object holding all the public/private key pairs and the CSPRNG state
@@ -88,7 +88,7 @@ import org.hiero.consensus.roster.RosterHistory;
  * @param createStateFromVirtualMap              a function to instantiate the state object from a Virtual Map
  */
 public record PlatformBuildingBlocks(
-        @NonNull PlatformWiring platformWiring,
+        @NonNull PlatformComponents platformComponents,
         @NonNull PlatformContext platformContext,
         @NonNull WiringModel model,
         @NonNull KeysAndCerts keysAndCerts,
@@ -121,7 +121,7 @@ public record PlatformBuildingBlocks(
         @NonNull Function<VirtualMap, MerkleNodeState> createStateFromVirtualMap) {
 
     public PlatformBuildingBlocks {
-        requireNonNull(platformWiring);
+        requireNonNull(platformComponents);
         requireNonNull(platformContext);
         requireNonNull(model);
         requireNonNull(keysAndCerts);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/DiagramCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/DiagramCommand.java
@@ -15,6 +15,7 @@ import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.platform.builder.ApplicationCallbacks;
 import com.swirlds.platform.config.DefaultConfiguration;
 import com.swirlds.platform.util.VirtualTerminal;
+import com.swirlds.platform.wiring.PlatformComponents;
 import com.swirlds.platform.wiring.PlatformWiring;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -106,12 +107,12 @@ public final class DiagramCommand extends AbstractCommand {
         final WiringModel model = WiringModelBuilder.create(platformContext.getMetrics(), platformContext.getTime())
                 .build();
 
-        final PlatformWiring platformWiring =
-                new PlatformWiring(platformContext, model, callbacks, new NoOpExecutionLayer());
+        final PlatformComponents platformComponents = PlatformComponents.create(platformContext, model, callbacks);
 
-        final String diagramString = platformWiring
-                .getModel()
-                .generateWiringDiagram(parseGroups(), parseSubstitutions(), parseManualLinks(), !lessMystery);
+        PlatformWiring.wire(platformContext, new NoOpExecutionLayer(), platformComponents);
+
+        final String diagramString =
+                model.generateWiringDiagram(parseGroups(), parseSubstitutions(), parseManualLinks(), !lessMystery);
 
         final VirtualTerminal terminal = new VirtualTerminal()
                 .setProgressIndicatorEnabled(false)
@@ -119,7 +120,7 @@ public final class DiagramCommand extends AbstractCommand {
                 .setPrintStdout(true)
                 .setPrintStderr(true);
 
-        final Path temporaryMermaidFile = Path.of("platformWiring.mmd");
+        final Path temporaryMermaidFile = Path.of("platformComponentWiring.mmd");
 
         if (Files.exists(temporaryMermaidFile)) {
             Files.delete(temporaryMermaidFile);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/DiagramCommand.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/cli/DiagramCommand.java
@@ -120,7 +120,7 @@ public final class DiagramCommand extends AbstractCommand {
                 .setPrintStdout(true)
                 .setPrintStderr(true);
 
-        final Path temporaryMermaidFile = Path.of("platformComponentWiring.mmd");
+        final Path temporaryMermaidFile = Path.of("platformWiring.mmd");
 
         if (Files.exists(temporaryMermaidFile)) {
             Files.delete(temporaryMermaidFile);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformComponents.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformComponents.java
@@ -168,7 +168,7 @@ public record PlatformComponents(
     }
 
     /**
-     * Constructor.
+     * Creates a new instance of PlatformComponents.
      *
      * @param platformContext      the platform context
      * @param model                the wiring model
@@ -182,8 +182,10 @@ public record PlatformComponents(
 
         Objects.requireNonNull(platformContext);
         Objects.requireNonNull(model);
+        Objects.requireNonNull(applicationCallbacks);
 
-        var config = platformContext.getConfiguration().getConfigData(PlatformSchedulersConfig.class);
+        final PlatformSchedulersConfig config =
+                platformContext.getConfiguration().getConfigData(PlatformSchedulersConfig.class);
 
         final ComponentWiring<EventHasher, PlatformEvent> eventHasherWiring =
                 new ComponentWiring<>(model, EventHasher.class, config.eventHasher());
@@ -264,12 +266,10 @@ public record PlatformComponents(
         final boolean publishSnapshotOverrides = applicationCallbacks.snapshotOverrideConsumer() != null;
         final boolean publishStaleEvents = applicationCallbacks.staleEventConsumer() != null;
 
-        final TaskSchedulerConfiguration publisherConfiguration;
-        if (publishPreconsensusEvents || publishSnapshotOverrides || publishStaleEvents) {
-            publisherConfiguration = config.platformPublisher();
-        } else {
-            publisherConfiguration = NO_OP_CONFIGURATION;
-        }
+        final TaskSchedulerConfiguration publisherConfiguration =
+                (publishPreconsensusEvents || publishSnapshotOverrides || publishStaleEvents)
+                        ? config.platformPublisher()
+                        : NO_OP_CONFIGURATION;
         final ComponentWiring<PlatformPublisher, Void> platformPublisherWiring =
                 new ComponentWiring<>(model, PlatformPublisher.class, publisherConfiguration);
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformComponents.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformComponents.java
@@ -1,0 +1,324 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.platform.wiring;
+
+import static com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration.DIRECT_THREADSAFE_CONFIGURATION;
+import static com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration.NO_OP_CONFIGURATION;
+
+import com.hedera.hapi.platform.event.StateSignatureTransaction;
+import com.swirlds.common.context.PlatformContext;
+import com.swirlds.component.framework.component.ComponentWiring;
+import com.swirlds.component.framework.model.WiringModel;
+import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
+import com.swirlds.platform.SwirldsPlatform;
+import com.swirlds.platform.builder.ApplicationCallbacks;
+import com.swirlds.platform.builder.PlatformComponentBuilder;
+import com.swirlds.platform.components.AppNotifier;
+import com.swirlds.platform.components.EventWindowManager;
+import com.swirlds.platform.components.SavedStateController;
+import com.swirlds.platform.components.appcomm.CompleteStateNotificationWithCleanup;
+import com.swirlds.platform.components.appcomm.LatestCompleteStateNotifier;
+import com.swirlds.platform.event.branching.BranchDetector;
+import com.swirlds.platform.event.branching.BranchReporter;
+import com.swirlds.platform.event.deduplication.EventDeduplicator;
+import com.swirlds.platform.event.orphan.OrphanBuffer;
+import com.swirlds.platform.event.preconsensus.InlinePcesWriter;
+import com.swirlds.platform.event.preconsensus.PcesReplayer;
+import com.swirlds.platform.event.stream.ConsensusEventStream;
+import com.swirlds.platform.event.validation.EventSignatureValidator;
+import com.swirlds.platform.event.validation.InternalEventValidator;
+import com.swirlds.platform.eventhandling.StateWithHashComplexity;
+import com.swirlds.platform.eventhandling.TransactionHandler;
+import com.swirlds.platform.eventhandling.TransactionHandlerResult;
+import com.swirlds.platform.eventhandling.TransactionPrehandler;
+import com.swirlds.platform.publisher.PlatformPublisher;
+import com.swirlds.platform.state.hasher.StateHasher;
+import com.swirlds.platform.state.hashlogger.HashLogger;
+import com.swirlds.platform.state.iss.IssDetector;
+import com.swirlds.platform.state.iss.IssHandler;
+import com.swirlds.platform.state.nexus.LatestCompleteStateNexus;
+import com.swirlds.platform.state.nexus.SignedStateNexus;
+import com.swirlds.platform.state.signed.ReservedSignedState;
+import com.swirlds.platform.state.signed.SignedStateSentinel;
+import com.swirlds.platform.state.signed.StateGarbageCollector;
+import com.swirlds.platform.state.signed.StateSignatureCollector;
+import com.swirlds.platform.state.signer.StateSigner;
+import com.swirlds.platform.state.snapshot.StateSnapshotManager;
+import com.swirlds.platform.system.status.StatusStateMachine;
+import com.swirlds.platform.wiring.components.ConsensusWiring;
+import com.swirlds.platform.wiring.components.GossipWiring;
+import com.swirlds.platform.wiring.components.PcesReplayerWiring;
+import com.swirlds.platform.wiring.components.RunningEventHashOverrideWiring;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.List;
+import java.util.Objects;
+import java.util.Queue;
+import org.hiero.consensus.crypto.EventHasher;
+import org.hiero.consensus.event.creator.impl.EventCreationManager;
+import org.hiero.consensus.model.event.PlatformEvent;
+import org.hiero.consensus.model.hashgraph.ConsensusRound;
+import org.hiero.consensus.model.hashgraph.EventWindow;
+import org.hiero.consensus.model.notification.IssNotification;
+import org.hiero.consensus.model.state.StateSavingResult;
+import org.hiero.consensus.model.status.PlatformStatus;
+import org.hiero.consensus.model.transaction.ScopedSystemTransaction;
+
+/**
+ * Encapsulates wiring for {@link SwirldsPlatform}.
+ */
+public record PlatformComponents(
+        WiringModel model,
+        ComponentWiring<StateSigner, StateSignatureTransaction> stateSignerWiring,
+        ComponentWiring<ConsensusEventStream, Void> consensusEventStreamWiring,
+        ComponentWiring<IssHandler, Void> issHandlerWiring,
+        ComponentWiring<LatestCompleteStateNotifier, CompleteStateNotificationWithCleanup>
+                latestCompleteStateNotifierWiring,
+        ComponentWiring<SignedStateNexus, Void> latestImmutableStateNexusWiring,
+        ComponentWiring<LatestCompleteStateNexus, Void> latestCompleteStateNexusWiring,
+        ComponentWiring<SavedStateController, StateWithHashComplexity> savedStateControllerWiring,
+        ComponentWiring<StateGarbageCollector, Void> stateGarbageCollectorWiring,
+        ComponentWiring<SignedStateSentinel, Void> signedStateSentinelWiring,
+        PcesReplayerWiring pcesReplayerWiring,
+        GossipWiring gossipWiring,
+        ComponentWiring<StateSnapshotManager, StateSavingResult> stateSnapshotManagerWiring,
+        ComponentWiring<EventHasher, PlatformEvent> eventHasherWiring,
+        ComponentWiring<InternalEventValidator, PlatformEvent> internalEventValidatorWiring,
+        ComponentWiring<EventDeduplicator, PlatformEvent> eventDeduplicatorWiring,
+        ComponentWiring<EventSignatureValidator, PlatformEvent> eventSignatureValidatorWiring,
+        ComponentWiring<OrphanBuffer, List<PlatformEvent>> orphanBufferWiring,
+        ConsensusWiring consensusEngineWiring,
+        ComponentWiring<EventCreationManager, PlatformEvent> eventCreationManagerWiring,
+        ComponentWiring<InlinePcesWriter, PlatformEvent> pcesInlineWriterWiring,
+        ComponentWiring<TransactionPrehandler, Queue<ScopedSystemTransaction<StateSignatureTransaction>>>
+                applicationTransactionPrehandlerWiring,
+        ComponentWiring<StateSignatureCollector, List<ReservedSignedState>> stateSignatureCollectorWiring,
+        ComponentWiring<EventWindowManager, EventWindow> eventWindowManagerWiring,
+        ComponentWiring<TransactionHandler, TransactionHandlerResult> transactionHandlerWiring,
+        RunningEventHashOverrideWiring runningEventHashOverrideWiring,
+        ComponentWiring<IssDetector, List<IssNotification>> issDetectorWiring,
+        ComponentWiring<HashLogger, Void> hashLoggerWiring,
+        ComponentWiring<StateHasher, ReservedSignedState> stateHasherWiring,
+        ComponentWiring<AppNotifier, Void> notifierWiring,
+        ComponentWiring<PlatformPublisher, Void> platformPublisherWiring,
+        ComponentWiring<StatusStateMachine, PlatformStatus> statusStateMachineWiring,
+        ComponentWiring<BranchDetector, PlatformEvent> branchDetectorWiring,
+        ComponentWiring<BranchReporter, Void> branchReporterWiring) {
+
+    /**
+     * Bind components to the wiring.
+     *
+     * @param builder                   builds platform components that need to be bound to wires
+     * @param pcesReplayer              the PCES replayer to bind
+     * @param stateSignatureCollector   the signed state manager to bind
+     * @param eventWindowManager        the event window manager to bind
+     * @param latestImmutableStateNexus the latest immutable state nexus to bind
+     * @param latestCompleteStateNexus  the latest complete state nexus to bind
+     * @param savedStateController      the saved state controller to bind
+     * @param notifier                  the notifier to bind
+     * @param platformPublisher         the platform publisher to bind
+     */
+    public void bind(
+            @NonNull final PlatformComponentBuilder builder,
+            @NonNull final PcesReplayer pcesReplayer,
+            @NonNull final StateSignatureCollector stateSignatureCollector,
+            @NonNull final EventWindowManager eventWindowManager,
+            @Nullable final InlinePcesWriter inlinePcesWriter,
+            @NonNull final SignedStateNexus latestImmutableStateNexus,
+            @NonNull final LatestCompleteStateNexus latestCompleteStateNexus,
+            @NonNull final SavedStateController savedStateController,
+            @NonNull final AppNotifier notifier,
+            @NonNull final PlatformPublisher platformPublisher) {
+
+        eventHasherWiring.bind(builder::buildEventHasher);
+        internalEventValidatorWiring.bind(builder::buildInternalEventValidator);
+        eventDeduplicatorWiring.bind(builder::buildEventDeduplicator);
+        eventSignatureValidatorWiring.bind(builder::buildEventSignatureValidator);
+        orphanBufferWiring.bind(builder::buildOrphanBuffer);
+        consensusEngineWiring.bind(builder::buildConsensusEngine);
+        stateSnapshotManagerWiring.bind(builder::buildStateSnapshotManager);
+        stateSignerWiring.bind(builder::buildStateSigner);
+        pcesReplayerWiring.bind(pcesReplayer);
+        if (inlinePcesWriter != null) {
+            pcesInlineWriterWiring.bind(inlinePcesWriter);
+        } else {
+            pcesInlineWriterWiring.bind(builder::buildInlinePcesWriter);
+        }
+        eventCreationManagerWiring.bind(builder::buildEventCreationManager);
+        stateSignatureCollectorWiring.bind(stateSignatureCollector);
+        eventWindowManagerWiring.bind(eventWindowManager);
+        applicationTransactionPrehandlerWiring.bind(builder::buildTransactionPrehandler);
+        transactionHandlerWiring.bind(builder::buildTransactionHandler);
+        consensusEventStreamWiring.bind(builder::buildConsensusEventStream);
+        issDetectorWiring.bind(builder::buildIssDetector);
+        issHandlerWiring.bind(builder::buildIssHandler);
+        hashLoggerWiring.bind(builder::buildHashLogger);
+        latestCompleteStateNotifierWiring.bind(builder::buildLatestCompleteStateNotifier);
+        latestImmutableStateNexusWiring.bind(latestImmutableStateNexus);
+        latestCompleteStateNexusWiring.bind(latestCompleteStateNexus);
+        savedStateControllerWiring.bind(savedStateController);
+        stateHasherWiring.bind(builder::buildStateHasher);
+        notifierWiring.bind(notifier);
+        platformPublisherWiring.bind(platformPublisher);
+        stateGarbageCollectorWiring.bind(builder::buildStateGarbageCollector);
+        statusStateMachineWiring.bind(builder::buildStatusStateMachine);
+        signedStateSentinelWiring.bind(builder::buildSignedStateSentinel);
+        gossipWiring.bind(builder.buildGossip());
+        branchDetectorWiring.bind(builder::buildBranchDetector);
+        branchReporterWiring.bind(builder::buildBranchReporter);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param platformContext      the platform context
+     * @param model                the wiring model
+     * @param applicationCallbacks the application callbacks (some wires are only created if the application wants a
+     *                             callback for something)
+     */
+    public static PlatformComponents create(
+            @NonNull final PlatformContext platformContext,
+            @NonNull final WiringModel model,
+            @NonNull final ApplicationCallbacks applicationCallbacks) {
+
+        Objects.requireNonNull(platformContext);
+        Objects.requireNonNull(model);
+
+        var config = platformContext.getConfiguration().getConfigData(PlatformSchedulersConfig.class);
+
+        final ComponentWiring<EventHasher, PlatformEvent> eventHasherWiring =
+                new ComponentWiring<>(model, EventHasher.class, config.eventHasher());
+
+        final ComponentWiring<InternalEventValidator, PlatformEvent> internalEventValidatorWiring =
+                new ComponentWiring<>(model, InternalEventValidator.class, config.internalEventValidator());
+        final ComponentWiring<EventDeduplicator, PlatformEvent> eventDeduplicatorWiring =
+                new ComponentWiring<>(model, EventDeduplicator.class, config.eventDeduplicator());
+        final ComponentWiring<EventSignatureValidator, PlatformEvent> eventSignatureValidatorWiring =
+                new ComponentWiring<>(model, EventSignatureValidator.class, config.eventSignatureValidator());
+        final ComponentWiring<OrphanBuffer, List<PlatformEvent>> orphanBufferWiring =
+                new ComponentWiring<>(model, OrphanBuffer.class, config.orphanBuffer());
+        final ConsensusWiring consensusEngineWiring = ConsensusWiring.create(model, config.consensusEngine());
+
+        final ComponentWiring<EventCreationManager, PlatformEvent> eventCreationManagerWiring =
+                new ComponentWiring<>(model, EventCreationManager.class, config.eventCreationManager());
+
+        final ComponentWiring<TransactionPrehandler, Queue<ScopedSystemTransaction<StateSignatureTransaction>>>
+                applicationTransactionPrehandlerWiring = new ComponentWiring<>(
+                        model, TransactionPrehandler.class, config.applicationTransactionPrehandler());
+        final ComponentWiring<StateSignatureCollector, List<ReservedSignedState>> stateSignatureCollectorWiring =
+                new ComponentWiring<>(model, StateSignatureCollector.class, config.stateSignatureCollector());
+        final ComponentWiring<StateSnapshotManager, StateSavingResult> stateSnapshotManagerWiring =
+                new ComponentWiring<>(model, StateSnapshotManager.class, config.stateSnapshotManager());
+        final ComponentWiring<StateSigner, StateSignatureTransaction> stateSignerWiring =
+                new ComponentWiring<>(model, StateSigner.class, config.stateSigner());
+        final ComponentWiring<TransactionHandler, TransactionHandlerResult> transactionHandlerWiring =
+                new ComponentWiring<>(
+                        model,
+                        TransactionHandler.class,
+                        config.transactionHandler(),
+                        data -> data instanceof final ConsensusRound consensusRound
+                                ? Math.max(consensusRound.getNumAppTransactions(), 1)
+                                : 1);
+        final ComponentWiring<ConsensusEventStream, Void> consensusEventStreamWiring =
+                new ComponentWiring<>(model, ConsensusEventStream.class, config.consensusEventStream());
+        final RunningEventHashOverrideWiring runningEventHashOverrideWiring =
+                RunningEventHashOverrideWiring.create(model);
+
+        final ComponentWiring<StateHasher, ReservedSignedState> stateHasherWiring = new ComponentWiring<>(
+                model,
+                StateHasher.class,
+                config.stateHasher(),
+                data -> data instanceof final StateWithHashComplexity swhc ? swhc.hashComplexity() : 1);
+
+        final GossipWiring gossipWiring = new GossipWiring(platformContext, model);
+
+        final PcesReplayerWiring pcesReplayerWiring = PcesReplayerWiring.create(model);
+
+        final ComponentWiring<InlinePcesWriter, PlatformEvent> pcesInlineWriterWiring =
+                new ComponentWiring<>(model, InlinePcesWriter.class, config.pcesInlineWriter());
+
+        final ComponentWiring<EventWindowManager, EventWindow> eventWindowManagerWiring =
+                new ComponentWiring<>(model, EventWindowManager.class, DIRECT_THREADSAFE_CONFIGURATION);
+
+        final ComponentWiring<IssDetector, List<IssNotification>> issDetectorWiring =
+                new ComponentWiring<>(model, IssDetector.class, config.issDetector());
+        final ComponentWiring<IssHandler, Void> issHandlerWiring =
+                new ComponentWiring<>(model, IssHandler.class, config.issHandler());
+        final ComponentWiring<HashLogger, Void> hashLoggerWiring =
+                new ComponentWiring<>(model, HashLogger.class, config.hashLogger());
+
+        final ComponentWiring<LatestCompleteStateNotifier, CompleteStateNotificationWithCleanup>
+                latestCompleteStateNotifierWiring = new ComponentWiring<>(
+                        model, LatestCompleteStateNotifier.class, config.latestCompleteStateNotifier());
+
+        final ComponentWiring<SignedStateNexus, Void> latestImmutableStateNexusWiring =
+                new ComponentWiring<>(model, SignedStateNexus.class, DIRECT_THREADSAFE_CONFIGURATION);
+        final ComponentWiring<LatestCompleteStateNexus, Void> latestCompleteStateNexusWiring =
+                new ComponentWiring<>(model, LatestCompleteStateNexus.class, DIRECT_THREADSAFE_CONFIGURATION);
+        final ComponentWiring<SavedStateController, StateWithHashComplexity> savedStateControllerWiring =
+                new ComponentWiring<>(model, SavedStateController.class, DIRECT_THREADSAFE_CONFIGURATION);
+
+        final ComponentWiring<AppNotifier, Void> notifierWiring =
+                new ComponentWiring<>(model, AppNotifier.class, DIRECT_THREADSAFE_CONFIGURATION);
+
+        final boolean publishPreconsensusEvents = applicationCallbacks.preconsensusEventConsumer() != null;
+        final boolean publishSnapshotOverrides = applicationCallbacks.snapshotOverrideConsumer() != null;
+        final boolean publishStaleEvents = applicationCallbacks.staleEventConsumer() != null;
+
+        final TaskSchedulerConfiguration publisherConfiguration;
+        if (publishPreconsensusEvents || publishSnapshotOverrides || publishStaleEvents) {
+            publisherConfiguration = config.platformPublisher();
+        } else {
+            publisherConfiguration = NO_OP_CONFIGURATION;
+        }
+        final ComponentWiring<PlatformPublisher, Void> platformPublisherWiring =
+                new ComponentWiring<>(model, PlatformPublisher.class, publisherConfiguration);
+
+        final ComponentWiring<StateGarbageCollector, Void> stateGarbageCollectorWiring =
+                new ComponentWiring<>(model, StateGarbageCollector.class, config.stateGarbageCollector());
+        final ComponentWiring<SignedStateSentinel, Void> signedStateSentinelWiring =
+                new ComponentWiring<>(model, SignedStateSentinel.class, config.signedStateSentinel());
+        final ComponentWiring<StatusStateMachine, PlatformStatus> statusStateMachineWiring =
+                new ComponentWiring<>(model, StatusStateMachine.class, config.statusStateMachine());
+
+        final ComponentWiring<BranchDetector, PlatformEvent> branchDetectorWiring =
+                new ComponentWiring<>(model, BranchDetector.class, config.branchDetector());
+        final ComponentWiring<BranchReporter, Void> branchReporterWiring =
+                new ComponentWiring<>(model, BranchReporter.class, config.branchReporter());
+
+        return new PlatformComponents(
+                model,
+                stateSignerWiring,
+                consensusEventStreamWiring,
+                issHandlerWiring,
+                latestCompleteStateNotifierWiring,
+                latestImmutableStateNexusWiring,
+                latestCompleteStateNexusWiring,
+                savedStateControllerWiring,
+                stateGarbageCollectorWiring,
+                signedStateSentinelWiring,
+                pcesReplayerWiring,
+                gossipWiring,
+                stateSnapshotManagerWiring,
+                eventHasherWiring,
+                internalEventValidatorWiring,
+                eventDeduplicatorWiring,
+                eventSignatureValidatorWiring,
+                orphanBufferWiring,
+                consensusEngineWiring,
+                eventCreationManagerWiring,
+                pcesInlineWriterWiring,
+                applicationTransactionPrehandlerWiring,
+                stateSignatureCollectorWiring,
+                eventWindowManagerWiring,
+                transactionHandlerWiring,
+                runningEventHashOverrideWiring,
+                issDetectorWiring,
+                hashLoggerWiring,
+                stateHasherWiring,
+                notifierWiring,
+                platformPublisherWiring,
+                statusStateMachineWiring,
+                branchDetectorWiring,
+                branchReporterWiring);
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
@@ -312,7 +312,7 @@ public record PlatformCoordinator(@NonNull PlatformComponents components) implem
     /**
      * @see AppNotifier#sendReconnectCompleteNotification
      */
-    public void sendAppNotifications(@NonNull final SignedState signedState) {
+    public void sendReconnectCompleteNotification(@NonNull final SignedState signedState) {
         components
                 .notifierWiring()
                 .getInputWire(AppNotifier::sendReconnectCompleteNotification)

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
@@ -1,121 +1,50 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.wiring;
 
-import com.hedera.hapi.platform.event.StateSignatureTransaction;
-import com.swirlds.component.framework.component.ComponentWiring;
+import com.hedera.hapi.platform.state.ConsensusSnapshot;
+import com.swirlds.common.io.IOIterator;
+import com.swirlds.common.stream.RunningEventHashOverride;
+import com.swirlds.component.framework.schedulers.builders.TaskSchedulerType;
+import com.swirlds.platform.components.AppNotifier;
+import com.swirlds.platform.components.EventWindowManager;
 import com.swirlds.platform.components.consensus.ConsensusEngine;
-import com.swirlds.platform.components.consensus.ConsensusEngineOutput;
 import com.swirlds.platform.event.branching.BranchDetector;
 import com.swirlds.platform.event.branching.BranchReporter;
 import com.swirlds.platform.event.deduplication.EventDeduplicator;
 import com.swirlds.platform.event.orphan.OrphanBuffer;
 import com.swirlds.platform.event.preconsensus.InlinePcesWriter;
 import com.swirlds.platform.event.validation.EventSignatureValidator;
-import com.swirlds.platform.event.validation.InternalEventValidator;
-import com.swirlds.platform.eventhandling.TransactionHandler;
-import com.swirlds.platform.eventhandling.TransactionHandlerResult;
-import com.swirlds.platform.eventhandling.TransactionPrehandler;
-import com.swirlds.platform.state.hasher.StateHasher;
+import com.swirlds.platform.listeners.ReconnectCompleteNotification;
+import com.swirlds.platform.publisher.PlatformPublisher;
+import com.swirlds.platform.state.hashlogger.HashLogger;
+import com.swirlds.platform.state.iss.IssDetector;
 import com.swirlds.platform.state.signed.ReservedSignedState;
+import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.StateSignatureCollector;
+import com.swirlds.platform.state.snapshot.StateDumpRequest;
+import com.swirlds.platform.state.snapshot.StateSnapshotManager;
+import com.swirlds.platform.system.status.StatusActionSubmitter;
 import com.swirlds.platform.system.status.StatusStateMachine;
-import com.swirlds.platform.wiring.components.GossipWiring;
+import com.swirlds.platform.system.status.actions.PlatformStatusAction;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.List;
 import java.util.Objects;
-import java.util.Queue;
 import org.hiero.consensus.event.creator.impl.EventCreationManager;
 import org.hiero.consensus.model.event.PlatformEvent;
-import org.hiero.consensus.model.status.PlatformStatus;
-import org.hiero.consensus.model.transaction.ScopedSystemTransaction;
+import org.hiero.consensus.model.hashgraph.EventWindow;
+import org.hiero.consensus.roster.RosterHistory;
 
 /**
- * Responsible for coordinating the clearing of the platform wiring objects.
+ * Responsible for coordinating activities through the component's wire for the platform.
+ *
+ * @param components
  */
-public class PlatformCoordinator {
-
-    /**
-     * Flushes the event hasher.
-     */
-    private final Runnable flushTheEventHasher;
-
-    private final ComponentWiring<InternalEventValidator, PlatformEvent> internalEventValidatorWiring;
-    private final ComponentWiring<EventDeduplicator, PlatformEvent> eventDeduplicatorWiring;
-    private final ComponentWiring<EventSignatureValidator, PlatformEvent> eventSignatureValidatorWiring;
-    private final ComponentWiring<OrphanBuffer, List<PlatformEvent>> orphanBufferWiring;
-    private final GossipWiring gossipWiring;
-    private final ComponentWiring<ConsensusEngine, ConsensusEngineOutput> consensusEngineWiring;
-    private final ComponentWiring<EventCreationManager, PlatformEvent> eventCreationManagerWiring;
-    private final ComponentWiring<TransactionPrehandler, Queue<ScopedSystemTransaction<StateSignatureTransaction>>>
-            applicationTransactionPrehandlerWiring;
-    private final ComponentWiring<StateSignatureCollector, List<ReservedSignedState>> stateSignatureCollectorWiring;
-    private final ComponentWiring<TransactionHandler, TransactionHandlerResult> transactionHandlerWiring;
-    private final ComponentWiring<StateHasher, ReservedSignedState> stateHasherWiring;
-    private final ComponentWiring<StatusStateMachine, PlatformStatus> statusStateMachineWiring;
-    private final ComponentWiring<BranchDetector, PlatformEvent> branchDetectorWiring;
-    private final ComponentWiring<BranchReporter, Void> branchReporterWiring;
-    private final ComponentWiring<InlinePcesWriter, PlatformEvent> pcesInlineWriterWiring;
+public record PlatformCoordinator(@NonNull PlatformComponents components) implements StatusActionSubmitter {
 
     /**
      * Constructor
-     *
-     * @param flushTheEventHasher                    a lambda that flushes the event hasher
-     * @param internalEventValidatorWiring           the internal event validator wiring
-     * @param eventDeduplicatorWiring                the event deduplicator wiring
-     * @param eventSignatureValidatorWiring          the event signature validator wiring
-     * @param orphanBufferWiring                     the orphan buffer wiring
-     * @param gossipWiring                           gossip wiring
-     * @param consensusEngineWiring                  the consensus engine wiring
-     * @param eventCreationManagerWiring             the event creation manager wiring
-     * @param applicationTransactionPrehandlerWiring the application transaction prehandler wiring
-     * @param stateSignatureCollectorWiring          the system transaction prehandler wiring
-     * @param transactionHandlerWiring               the transaction handler wiring
-     * @param stateHasherWiring                      the state hasher wiring
-     * @param statusStateMachineWiring               the status state machine wiring
-     * @param branchDetectorWiring                   the branch detector wiring
-     * @param branchReporterWiring                   the branch reporter wiring
-     * @param pcesInlineWriterWiring                 the inline PCES writer wiring
      */
-    public PlatformCoordinator(
-            @NonNull final Runnable flushTheEventHasher,
-            @NonNull final ComponentWiring<InternalEventValidator, PlatformEvent> internalEventValidatorWiring,
-            @NonNull final ComponentWiring<EventDeduplicator, PlatformEvent> eventDeduplicatorWiring,
-            @NonNull final ComponentWiring<EventSignatureValidator, PlatformEvent> eventSignatureValidatorWiring,
-            @NonNull final ComponentWiring<OrphanBuffer, List<PlatformEvent>> orphanBufferWiring,
-            @NonNull final GossipWiring gossipWiring,
-            @NonNull final ComponentWiring<ConsensusEngine, ConsensusEngineOutput> consensusEngineWiring,
-            @NonNull final ComponentWiring<EventCreationManager, PlatformEvent> eventCreationManagerWiring,
-            @NonNull
-                    final ComponentWiring<
-                                    TransactionPrehandler, Queue<ScopedSystemTransaction<StateSignatureTransaction>>>
-                            applicationTransactionPrehandlerWiring,
-            @NonNull
-                    final ComponentWiring<StateSignatureCollector, List<ReservedSignedState>>
-                            stateSignatureCollectorWiring,
-            @NonNull final ComponentWiring<TransactionHandler, TransactionHandlerResult> transactionHandlerWiring,
-            @NonNull final ComponentWiring<StateHasher, ReservedSignedState> stateHasherWiring,
-            @NonNull final ComponentWiring<StatusStateMachine, PlatformStatus> statusStateMachineWiring,
-            @NonNull final ComponentWiring<BranchDetector, PlatformEvent> branchDetectorWiring,
-            @NonNull final ComponentWiring<BranchReporter, Void> branchReporterWiring,
-            @Nullable final ComponentWiring<InlinePcesWriter, PlatformEvent> pcesInlineWriterWiring) {
-
-        this.flushTheEventHasher = Objects.requireNonNull(flushTheEventHasher);
-        this.internalEventValidatorWiring = Objects.requireNonNull(internalEventValidatorWiring);
-        this.eventDeduplicatorWiring = Objects.requireNonNull(eventDeduplicatorWiring);
-        this.eventSignatureValidatorWiring = Objects.requireNonNull(eventSignatureValidatorWiring);
-        this.orphanBufferWiring = Objects.requireNonNull(orphanBufferWiring);
-        this.gossipWiring = Objects.requireNonNull(gossipWiring);
-        this.consensusEngineWiring = Objects.requireNonNull(consensusEngineWiring);
-        this.eventCreationManagerWiring = Objects.requireNonNull(eventCreationManagerWiring);
-        this.applicationTransactionPrehandlerWiring = Objects.requireNonNull(applicationTransactionPrehandlerWiring);
-        this.stateSignatureCollectorWiring = Objects.requireNonNull(stateSignatureCollectorWiring);
-        this.transactionHandlerWiring = Objects.requireNonNull(transactionHandlerWiring);
-        this.stateHasherWiring = Objects.requireNonNull(stateHasherWiring);
-        this.statusStateMachineWiring = Objects.requireNonNull(statusStateMachineWiring);
-        this.branchDetectorWiring = Objects.requireNonNull(branchDetectorWiring);
-        this.branchReporterWiring = Objects.requireNonNull(branchReporterWiring);
-        this.pcesInlineWriterWiring = pcesInlineWriterWiring;
+    public PlatformCoordinator {
+        Objects.requireNonNull(components);
     }
 
     /**
@@ -129,19 +58,17 @@ public class PlatformCoordinator {
         // lines without understanding the implications of doing so. Consult the wiring diagram when deciding
         // whether to change the order of these lines.
 
-        flushTheEventHasher.run();
-        internalEventValidatorWiring.flush();
-        eventDeduplicatorWiring.flush();
-        eventSignatureValidatorWiring.flush();
-        orphanBufferWiring.flush();
-        if (pcesInlineWriterWiring != null) {
-            pcesInlineWriterWiring.flush();
-        }
-        gossipWiring.flush();
-        consensusEngineWiring.flush();
-        applicationTransactionPrehandlerWiring.flush();
-        eventCreationManagerWiring.flush();
-        branchDetectorWiring.flush();
+        components.eventHasherWiring().flush();
+        components.internalEventValidatorWiring().flush();
+        components.eventDeduplicatorWiring().flush();
+        components.eventSignatureValidatorWiring().flush();
+        components.orphanBufferWiring().flush();
+        components.pcesInlineWriterWiring().flush();
+        components.gossipWiring().flush();
+        components.consensusEngineWiring().flush();
+        components.applicationTransactionPrehandlerWiring().flush();
+        components.eventCreationManagerWiring().flush();
+        components.branchDetectorWiring().flush();
     }
 
     /**
@@ -156,47 +83,277 @@ public class PlatformCoordinator {
 
         // Phase 0: flush the status state machine.
         // When reconnecting, this will force us to adopt a status that will halt event creation and gossip.
-        statusStateMachineWiring.flush();
+        components.statusStateMachineWiring().flush();
 
         // Phase 1: squelch
         // Break cycles in the system. Flush squelched components just in case there is a task being executed when
         // squelch is activated.
-        consensusEngineWiring.startSquelching();
-        consensusEngineWiring.flush();
-        eventCreationManagerWiring.startSquelching();
-        eventCreationManagerWiring.flush();
+        components.consensusEngineWiring().startSquelching();
+        components.consensusEngineWiring().flush();
+        components.eventCreationManagerWiring().startSquelching();
+        components.eventCreationManagerWiring().flush();
 
         // Also squelch the transaction handler. It isn't strictly necessary to do this to prevent dataflow through
         // the system, but it prevents the transaction handler from wasting time handling rounds that don't need to
         // be handled.
-        transactionHandlerWiring.startSquelching();
-        transactionHandlerWiring.flush();
+        components.transactionHandlerWiring().startSquelching();
+        components.transactionHandlerWiring().flush();
 
         // Phase 2: flush
         // All cycles have been broken via squelching, so now it's time to flush everything out of the system.
         flushIntakePipeline();
-        stateHasherWiring.flush();
-        stateSignatureCollectorWiring.flush();
-        transactionHandlerWiring.flush();
-        branchDetectorWiring.flush();
-        branchReporterWiring.flush();
+        components.stateHasherWiring().flush();
+        components.stateSignatureCollectorWiring().flush();
+        components.transactionHandlerWiring().flush();
+        components.branchDetectorWiring().flush();
+        components.branchReporterWiring().flush();
 
         // Phase 3: stop squelching
         // Once everything has been flushed out of the system, it's safe to stop squelching.
-        consensusEngineWiring.stopSquelching();
-        eventCreationManagerWiring.stopSquelching();
-        transactionHandlerWiring.stopSquelching();
+        components.consensusEngineWiring().stopSquelching();
+        components.eventCreationManagerWiring().stopSquelching();
+        components.transactionHandlerWiring().stopSquelching();
 
         // Phase 4: clear
         // Data is no longer moving through the system. Clear all the internal data structures in the wiring objects.
-        eventDeduplicatorWiring.getInputWire(EventDeduplicator::clear).inject(NoInput.getInstance());
-        orphanBufferWiring.getInputWire(OrphanBuffer::clear).inject(NoInput.getInstance());
-        gossipWiring.getClearInput().inject(NoInput.getInstance());
-        stateSignatureCollectorWiring
+        components
+                .eventDeduplicatorWiring()
+                .getInputWire(EventDeduplicator::clear)
+                .inject(NoInput.getInstance());
+        components.orphanBufferWiring().getInputWire(OrphanBuffer::clear).inject(NoInput.getInstance());
+        components.gossipWiring().getClearInput().inject(NoInput.getInstance());
+        components
+                .stateSignatureCollectorWiring()
                 .getInputWire(StateSignatureCollector::clear)
                 .inject(NoInput.getInstance());
-        eventCreationManagerWiring.getInputWire(EventCreationManager::clear).inject(NoInput.getInstance());
-        branchDetectorWiring.getInputWire(BranchDetector::clear).inject(NoInput.getInstance());
-        branchReporterWiring.getInputWire(BranchReporter::clear).inject(NoInput.getInstance());
+        components
+                .eventCreationManagerWiring()
+                .getInputWire(EventCreationManager::clear)
+                .inject(NoInput.getInstance());
+        components.branchDetectorWiring().getInputWire(BranchDetector::clear).inject(NoInput.getInstance());
+        components.branchReporterWiring().getInputWire(BranchReporter::clear).inject(NoInput.getInstance());
+    }
+
+    /**
+     * Start gossiping.
+     */
+    public void startGossip() {
+        components.gossipWiring().getStartInput().inject(NoInput.getInstance());
+    }
+
+    /**
+     * Forward a state to the hash logger.
+     *
+     * @param signedState the state to forward
+     */
+    public void sendStateToHashLogger(@NonNull final SignedState signedState) {
+        if (signedState.getState().getHash() != null) {
+            final ReservedSignedState stateReservedForHasher = signedState.reserve("logging state hash");
+
+            final boolean offerResult = components
+                    .hashLoggerWiring()
+                    .getInputWire(HashLogger::logHashes)
+                    .offer(stateReservedForHasher);
+            if (!offerResult) {
+                stateReservedForHasher.close();
+            }
+        }
+    }
+
+    /**
+     * Update the running hash for all components that need it.
+     *
+     * @param runningHashUpdate the object containing necessary information to update the running hash
+     */
+    public void updateRunningHash(@NonNull final RunningEventHashOverride runningHashUpdate) {
+        components.runningEventHashOverrideWiring().runningHashUpdateInput().inject(runningHashUpdate);
+    }
+
+    /**
+     * Pass an overriding state to the ISS detector.
+     *
+     * @param state the overriding state
+     */
+    public void overrideIssDetectorState(@NonNull final ReservedSignedState state) {
+        components
+                .issDetectorWiring()
+                .getInputWire(IssDetector::overridingState)
+                .put(state);
+    }
+
+    /**
+     * Signal the end of the preconsensus replay to the ISS detector.
+     */
+    public void signalEndOfPcesReplay() {
+        components
+                .issDetectorWiring()
+                .getInputWire(IssDetector::signalEndOfPreconsensusReplay)
+                .put(NoInput.getInstance());
+    }
+
+    /**
+     * Get the status action submitter.
+     *
+     * @return the status action submitter
+     */
+    @NonNull
+    public StatusActionSubmitter getStatusActionSubmitter() {
+        return action -> components
+                .statusStateMachineWiring()
+                .getInputWire(StatusStateMachine::submitStatusAction)
+                .put(action);
+    }
+
+    /**
+     * Inject a new event window into all components that need it.
+     *
+     * @param eventWindow the new event window
+     */
+    public void updateEventWindow(@NonNull final EventWindow eventWindow) {
+        // Future work: this method can merge with consensusSnapshotOverride
+        components
+                .eventWindowManagerWiring()
+                .getInputWire(EventWindowManager::updateEventWindow)
+                .inject(eventWindow);
+
+        // Since there is asynchronous access to the shadowgraph, it's important to ensure that
+        // it has fully ingested the new event window before continuing.
+        components.gossipWiring().flush();
+    }
+
+    /**
+     * Inject a new consensus snapshot into all components that need it. This will happen at restart and reconnect
+     * boundaries.
+     *
+     * @param consensusSnapshot the new consensus snapshot
+     */
+    public void consensusSnapshotOverride(@NonNull final ConsensusSnapshot consensusSnapshot) {
+        components
+                .consensusEngineWiring()
+                .getInputWire(ConsensusEngine::outOfBandSnapshotUpdate)
+                .inject(consensusSnapshot);
+
+        if (components.platformPublisherWiring().getSchedulerType() != TaskSchedulerType.NO_OP) {
+            components
+                    .platformPublisherWiring()
+                    .getInputWire(PlatformPublisher::publishSnapshotOverride)
+                    .inject(consensusSnapshot);
+        }
+    }
+
+    /**
+     * Flush the transaction handler.
+     */
+    public void flushTransactionHandler() {
+        components.transactionHandlerWiring().flush();
+    }
+
+    /**
+     * Flush the state hasher.
+     */
+    public void flushStateHasher() {
+        components.stateHasherWiring().flush();
+    }
+
+    /**
+     * Start the wiring framework.
+     */
+    public void start() {
+        components.model().start();
+    }
+
+    /**
+     * Stop the wiring framework.
+     */
+    public void stop() {
+        components.model().stop();
+    }
+
+    /**
+     * @see StatusStateMachine#submitStatusAction
+     */
+    public void submitStatusAction(@NonNull final PlatformStatusAction action) {
+        components
+                .statusStateMachineWiring()
+                .getInputWire(StatusStateMachine::submitStatusAction)
+                .put(action);
+    }
+
+    /**
+     * @see StateSignatureCollector#addReservedState
+     */
+    public void putSignatureCollectorState(@NonNull final ReservedSignedState reserve) {
+        components
+                .stateSignatureCollectorWiring()
+                .getInputWire(StateSignatureCollector::addReservedState)
+                .put(reserve);
+    }
+
+    /**
+     * @see EventSignatureValidator#updateRosterHistory
+     */
+    public void injectRosterHistory(@NonNull final RosterHistory rosterHistory) {
+        components
+                .eventSignatureValidatorWiring()
+                .getInputWire(EventSignatureValidator::updateRosterHistory)
+                .inject(rosterHistory);
+    }
+
+    /**
+     * @see InlinePcesWriter#registerDiscontinuity
+     */
+    public void registerPcesDiscontinuity(final long round) {
+        components
+                .pcesInlineWriterWiring()
+                .getInputWire(InlinePcesWriter::registerDiscontinuity)
+                .inject(round);
+    }
+
+    /**
+     * @see AppNotifier#sendReconnectCompleteNotification
+     */
+    public void sendAppNotifications(@NonNull final SignedState signedState) {
+        components
+                .notifierWiring()
+                .getInputWire(AppNotifier::sendReconnectCompleteNotification)
+                .put(new ReconnectCompleteNotification(
+                        signedState.getRound(), signedState.getConsensusTimestamp(), signedState.getState()));
+    }
+
+    /**
+     * @see InlinePcesWriter#setMinimumAncientIdentifierToStore
+     */
+    public void injectPcesMinimumGenerationToStore(@NonNull final long minimumGenerationNonAncientForOldestState) {
+        components
+                .pcesInlineWriterWiring()
+                .getInputWire(InlinePcesWriter::setMinimumAncientIdentifierToStore)
+                .inject(minimumGenerationNonAncientForOldestState);
+    }
+
+    /**
+     * @see com.swirlds.platform.event.preconsensus.PcesReplayer#replayPces
+     */
+    public void injectPcesReplayerIterator(@NonNull final IOIterator<PlatformEvent> iterator) {
+        components.pcesReplayerWiring().pcesIteratorInputWire().inject(iterator);
+    }
+
+    /**
+     * @see StateSnapshotManager#dumpStateTask
+     */
+    public void dumpStateToDisk(@NonNull final StateDumpRequest request) {
+        components
+                .stateSnapshotManagerWiring()
+                .getInputWire(StateSnapshotManager::dumpStateTask)
+                .put(request);
+    }
+
+    /**
+     * @see StateSignatureCollector#addReservedState(ReservedSignedState)
+     */
+    public void injectSignatureCollectorState(@NonNull final ReservedSignedState reservedSignedState) {
+        components
+                .stateSignatureCollectorWiring()
+                .getInputWire(StateSignatureCollector::addReservedState)
+                .put(reservedSignedState);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -47,6 +47,7 @@ import com.swirlds.platform.system.state.notifications.StateHashedNotification;
 import com.swirlds.platform.system.status.PlatformStatusConfig;
 import com.swirlds.platform.system.status.StatusStateMachine;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
 import java.util.Queue;
 import org.hiero.consensus.crypto.EventHasher;
 import org.hiero.consensus.event.creator.impl.EventCreationManager;
@@ -66,106 +67,146 @@ public class PlatformWiring {
      * Wire the components together.
      */
     public static void wire(
-            PlatformContext platformContext, @NonNull final ExecutionLayer execution, PlatformComponents w) {
+            @NonNull final PlatformContext platformContext,
+            @NonNull final ExecutionLayer execution,
+            @NonNull final PlatformComponents components) {
+        Objects.requireNonNull(platformContext);
+        Objects.requireNonNull(execution);
+        Objects.requireNonNull(components);
+
         final InputWire<PlatformEvent> hasherInputWire =
-                w.eventHasherWiring().getInputWire(EventHasher::hashEvent, "unhashed event");
-        w.gossipWiring().getEventOutput().solderTo(hasherInputWire);
+                components.eventHasherWiring().getInputWire(EventHasher::hashEvent, "unhashed event");
+        components.gossipWiring().getEventOutput().solderTo(hasherInputWire);
 
-        w.gossipWiring()
+        components.gossipWiring()
                 .getSyncLagOutput()
-                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::reportSyncRoundLag));
+                .solderTo(components.eventCreationManagerWiring().getInputWire(EventCreationManager::reportSyncRoundLag));
 
-        w.eventHasherWiring()
+        components.eventHasherWiring()
                 .getOutputWire()
-                .solderTo(w.internalEventValidatorWiring().getInputWire(InternalEventValidator::validateEvent));
+                .solderTo(
+                        components.internalEventValidatorWiring().getInputWire(InternalEventValidator::validateEvent));
 
-        w.internalEventValidatorWiring()
+        components
+                .internalEventValidatorWiring()
                 .getOutputWire()
-                .solderTo(w.eventDeduplicatorWiring().getInputWire(EventDeduplicator::handleEvent));
-        w.eventDeduplicatorWiring()
+                .solderTo(components.eventDeduplicatorWiring().getInputWire(EventDeduplicator::handleEvent));
+        components
+                .eventDeduplicatorWiring()
                 .getOutputWire()
-                .solderTo(w.eventSignatureValidatorWiring().getInputWire(EventSignatureValidator::validateSignature));
-        w.eventSignatureValidatorWiring()
+                .solderTo(components
+                        .eventSignatureValidatorWiring()
+                        .getInputWire(EventSignatureValidator::validateSignature));
+        components
+                .eventSignatureValidatorWiring()
                 .getOutputWire()
-                .solderTo(w.orphanBufferWiring().getInputWire(OrphanBuffer::handleEvent));
+                .solderTo(components.orphanBufferWiring().getInputWire(OrphanBuffer::handleEvent));
         final OutputWire<PlatformEvent> splitOrphanBufferOutput =
-                w.orphanBufferWiring().getSplitOutput();
+                components.orphanBufferWiring().getSplitOutput();
 
-        splitOrphanBufferOutput.solderTo(w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::writeEvent));
+        splitOrphanBufferOutput.solderTo(
+                components.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::writeEvent));
 
         // Make sure that an event is persisted before being sent to consensus. This avoids the situation where we
         // reach consensus with events that might be lost due to a crash
-        w.pcesInlineWriterWiring()
+        components
+                .pcesInlineWriterWiring()
                 .getOutputWire()
-                .solderTo(w.consensusEngineWiring().componentWiring().getInputWire(ConsensusEngine::addEvent));
+                .solderTo(components.consensusEngineWiring().componentWiring().getInputWire(ConsensusEngine::addEvent));
 
         // Make sure events are persisted before being gossipped. This prevents accidental branching in the case
         // where an event is created, gossipped, and then the node crashes before the event is persisted.
         // After restart, a node will not be aware of this event, so it can create a branch
-        w.pcesInlineWriterWiring().getOutputWire().solderTo(w.gossipWiring().getEventInput(), INJECT);
+        components
+                .pcesInlineWriterWiring()
+                .getOutputWire()
+                .solderTo(components.gossipWiring().getEventInput(), INJECT);
 
         // Avoid using events as parents before they are persisted
-        w.pcesInlineWriterWiring()
+        components
+                .pcesInlineWriterWiring()
                 .getOutputWire()
-                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::registerEvent));
+                .solderTo(components.eventCreationManagerWiring().getInputWire(EventCreationManager::registerEvent));
 
-        w.model()
+        components
+                .model()
                 .getHealthMonitorWire()
-                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::reportUnhealthyDuration));
+                .solderTo(components
+                        .eventCreationManagerWiring()
+                        .getInputWire(EventCreationManager::reportUnhealthyDuration));
 
-        w.model().getHealthMonitorWire().solderTo(w.gossipWiring().getSystemHealthInput());
-        w.model().getHealthMonitorWire()
+        components
+                .model()
+                .getHealthMonitorWire()
+                .solderTo(components.gossipWiring().getSystemHealthInput());
+        components.model().getHealthMonitorWire()
                 .solderTo("executionHealthInput", "healthyDuration", execution::reportUnhealthyDuration);
 
-        splitOrphanBufferOutput.solderTo(w.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));
-        w.branchDetectorWiring()
+        splitOrphanBufferOutput.solderTo(
+                components.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));
+        components
+                .branchDetectorWiring()
                 .getOutputWire()
-                .solderTo(w.branchReporterWiring().getInputWire(BranchReporter::reportBranch));
+                .solderTo(components.branchReporterWiring().getInputWire(BranchReporter::reportBranch));
 
         final double eventCreationHeartbeatFrequency = platformContext
                 .getConfiguration()
                 .getConfigData(EventCreationConfig.class)
                 .creationAttemptRate();
-        w.model()
+        components
+                .model()
                 .buildHeartbeatWire(eventCreationHeartbeatFrequency)
-                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::maybeCreateEvent), OFFER);
-        w.model()
+                .solderTo(
+                        components.eventCreationManagerWiring().getInputWire(EventCreationManager::maybeCreateEvent),
+                        OFFER);
+        components
+                .model()
                 .buildHeartbeatWire(platformContext
                         .getConfiguration()
                         .getConfigData(PlatformStatusConfig.class)
                         .statusStateMachineHeartbeatPeriod())
-                .solderTo(w.statusStateMachineWiring().getInputWire(StatusStateMachine::heartbeat), OFFER);
+                .solderTo(components.statusStateMachineWiring().getInputWire(StatusStateMachine::heartbeat), OFFER);
 
-        w.eventCreationManagerWiring()
+        components
+                .eventCreationManagerWiring()
                 .getOutputWire()
-                .solderTo(w.internalEventValidatorWiring().getInputWire(InternalEventValidator::validateEvent), INJECT);
+                .solderTo(
+                        components.internalEventValidatorWiring().getInputWire(InternalEventValidator::validateEvent),
+                        INJECT);
 
-        if (w.platformPublisherWiring().getSchedulerType() != NO_OP) {
-            final OutputWire<PlatformEvent> staleEvent = w.consensusEngineWiring()
+        if (components.platformPublisherWiring().getSchedulerType() != NO_OP) {
+            final OutputWire<PlatformEvent> staleEvent = components
+                    .consensusEngineWiring()
                     .getOutputWire()
                     .buildTransformer("staleEvents", "consensusEngineOutput", ConsensusEngineOutput::staleEvents)
                     .buildSplitter("staleEventsSplitter", "stale events");
-            staleEvent.solderTo(w.platformPublisherWiring().getInputWire(PlatformPublisher::publishStaleEvent));
+            staleEvent.solderTo(
+                    components.platformPublisherWiring().getInputWire(PlatformPublisher::publishStaleEvent));
         }
 
         // an output wire that filters out only pre-consensus events from the consensus engine
-        final OutputWire<PlatformEvent> consEngineAddedEvents = w.consensusEngineWiring()
+        final OutputWire<PlatformEvent> consEngineAddedEvents = components
+                .consensusEngineWiring()
                 .getOutputWire()
                 .buildTransformer(
                         "PreConsensusEvents", "consensusEngineOutput", ConsensusEngineOutput::preConsensusEvents)
                 .buildSplitter("PreConsensusEventsSplitter", "preConsensusEvents");
         // pre-handle gets pre-consensus events from the consensus engine
         // the consensus engine ensures that all pre-consensus events either reach consensus of become stale
-        consEngineAddedEvents.solderTo(w.applicationTransactionPrehandlerWiring()
+        consEngineAddedEvents.solderTo(components
+                .applicationTransactionPrehandlerWiring()
                 .getInputWire(TransactionPrehandler::prehandleApplicationTransactions));
 
-        w.applicationTransactionPrehandlerWiring()
+        components
+                .applicationTransactionPrehandlerWiring()
                 .getOutputWire()
-                .solderTo(w.stateSignatureCollectorWiring()
+                .solderTo(components
+                        .stateSignatureCollectorWiring()
                         .getInputWire(StateSignatureCollector::handlePreconsensusSignatures));
 
         // Split output of StateSignatureCollector into single ReservedSignedStates.
-        final OutputWire<ReservedSignedState> splitReservedSignedStateWire = w.stateSignatureCollectorWiring()
+        final OutputWire<ReservedSignedState> splitReservedSignedStateWire = components
+                .stateSignatureCollectorWiring()
                 .getOutputWire()
                 .buildSplitter("reservedStateSplitter", "reserved state lists");
         // Add another reservation to the signed states since we are soldering to two different input wires
@@ -174,7 +215,7 @@ public class PlatformWiring {
 
         // Future work: this should be a full component in its own right or folded in with the state file manager.
         final WireFilter<ReservedSignedState> saveToDiskFilter =
-                new WireFilter<>(w.model(), "saveToDiskFilter", "states", state -> {
+                new WireFilter<>(components.model(), "saveToDiskFilter", "states", state -> {
                     if (state.get().isStateToSave()) {
                         return true;
                     }
@@ -186,7 +227,7 @@ public class PlatformWiring {
 
         saveToDiskFilter
                 .getOutputWire()
-                .solderTo(w.stateSnapshotManagerWiring().getInputWire(StateSnapshotManager::saveStateTask));
+                .solderTo(components.stateSnapshotManagerWiring().getInputWire(StateSnapshotManager::saveStateTask));
 
         // Filter to complete states only and add a 3rd reservation since completes states are used in two input wires.
         final OutputWire<ReservedSignedState> completeReservedSignedStatesWire = allReservedSignedStatesWire
@@ -201,55 +242,59 @@ public class PlatformWiring {
                 })
                 .buildAdvancedTransformer(new SignedStateReserver("completeStatesReserver"));
         completeReservedSignedStatesWire.solderTo(
-                w.latestCompleteStateNexusWiring().getInputWire(LatestCompleteStateNexus::setStateIfNewer));
+                components.latestCompleteStateNexusWiring().getInputWire(LatestCompleteStateNexus::setStateIfNewer));
 
-        solderEventWindow(w);
+        solderEventWindow(components);
 
-        w.pcesReplayerWiring().eventOutput().solderTo(hasherInputWire);
+        components.pcesReplayerWiring().eventOutput().solderTo(hasherInputWire);
 
-        final OutputWire<ConsensusRound> consensusRoundOutputWire = w.consensusEngineWiring()
+        final OutputWire<ConsensusRound> consensusRoundOutputWire = components
+                .consensusEngineWiring()
                 .consensusRoundsOutputWire()
                 .buildSplitter("ConsensusRoundsSplitter", "consensus rounds");
 
-        w.pcesReplayerWiring()
+        components
+                .pcesReplayerWiring()
                 .doneStreamingPcesOutputWire()
-                .solderTo(w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::beginStreamingNewEvents));
+                .solderTo(components.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::beginStreamingNewEvents));
         // with inline PCES, the round bypasses the round durability buffer and goes directly to the round handler
         consensusRoundOutputWire.solderTo(
-                w.transactionHandlerWiring().getInputWire(TransactionHandler::handleConsensusRound));
+                components.transactionHandlerWiring().getInputWire(TransactionHandler::handleConsensusRound));
 
         consensusRoundOutputWire.solderTo(
-                w.eventWindowManagerWiring().getInputWire(EventWindowManager::extractEventWindow));
+                components.eventWindowManagerWiring().getInputWire(EventWindowManager::extractEventWindow));
 
         consensusRoundOutputWire
                 .buildTransformer("RoundsToCesEvents", "consensus rounds", ConsensusRound::getStreamedEvents)
-                .solderTo(w.consensusEventStreamWiring().getInputWire(ConsensusEventStream::addEvents));
+                .solderTo(components.consensusEventStreamWiring().getInputWire(ConsensusEventStream::addEvents));
 
         // The TransactionHandler output is split into two types: system transactions, and state with complexity.
         final OutputWire<Queue<ScopedSystemTransaction<StateSignatureTransaction>>>
-                transactionHandlerSysTxnsOutputWire = w.transactionHandlerWiring()
+                transactionHandlerSysTxnsOutputWire = components
+                        .transactionHandlerWiring()
                         .getOutputWire()
                         .buildTransformer(
                                 "getSystemTransactions",
                                 "transaction handler result",
                                 TransactionHandlerResult::systemTransactions);
+        transactionHandlerSysTxnsOutputWire.solderTo(components
+                .stateSignatureCollectorWiring()
+                .getInputWire(StateSignatureCollector::handlePostconsensusSignatures));
         transactionHandlerSysTxnsOutputWire.solderTo(
-                w.stateSignatureCollectorWiring().getInputWire(StateSignatureCollector::handlePostconsensusSignatures));
-        transactionHandlerSysTxnsOutputWire.solderTo(
-                w.issDetectorWiring().getInputWire(IssDetector::handleStateSignatureTransactions));
+                components.issDetectorWiring().getInputWire(IssDetector::handleStateSignatureTransactions));
 
-        final OutputWire<StateWithHashComplexity> transactionHandlerStateWithComplexityOutput =
-                w.transactionHandlerWiring()
-                        .getOutputWire()
-                        .buildFilter(
-                                "notNullStateFilter",
-                                "transaction handler result",
-                                thr -> thr.stateWithHashComplexity() != null)
-                        .buildAdvancedTransformer(
-                                new StateWithHashComplexityReserver("postHandler_stateWithHashComplexityReserver"));
+        final OutputWire<StateWithHashComplexity> transactionHandlerStateWithComplexityOutput = components
+                .transactionHandlerWiring()
+                .getOutputWire()
+                .buildFilter(
+                        "notNullStateFilter",
+                        "transaction handler result",
+                        thr -> thr.stateWithHashComplexity() != null)
+                .buildAdvancedTransformer(
+                        new StateWithHashComplexityReserver("postHandler_stateWithHashComplexityReserver"));
 
         transactionHandlerStateWithComplexityOutput.solderTo(
-                w.savedStateControllerWiring().getInputWire(SavedStateController::markSavedState));
+                components.savedStateControllerWiring().getInputWire(SavedStateController::markSavedState));
 
         final OutputWire<ReservedSignedState> transactionHandlerStateOnlyOutput =
                 transactionHandlerStateWithComplexityOutput.buildAdvancedTransformer(
@@ -257,36 +302,44 @@ public class PlatformWiring {
                                 "postHandler_stateWithHashComplexityToStateReserver"));
 
         transactionHandlerStateOnlyOutput.solderTo(
-                w.latestImmutableStateNexusWiring().getInputWire(SignedStateNexus::setState));
+                components.latestImmutableStateNexusWiring().getInputWire(SignedStateNexus::setState));
         transactionHandlerStateOnlyOutput.solderTo(
-                w.stateGarbageCollectorWiring().getInputWire(StateGarbageCollector::registerState));
+                components.stateGarbageCollectorWiring().getInputWire(StateGarbageCollector::registerState));
 
-        w.savedStateControllerWiring()
+        components
+                .savedStateControllerWiring()
                 .getOutputWire()
-                .solderTo(w.stateHasherWiring().getInputWire(StateHasher::hashState));
+                .solderTo(components.stateHasherWiring().getInputWire(StateHasher::hashState));
 
         var config = platformContext.getConfiguration().getConfigData(PlatformSchedulersConfig.class);
-        w.model()
+        components
+                .model()
                 .buildHeartbeatWire(config.stateGarbageCollectorHeartbeatPeriod())
-                .solderTo(w.stateGarbageCollectorWiring().getInputWire(StateGarbageCollector::heartbeat), OFFER);
-        w.model()
+                .solderTo(
+                        components.stateGarbageCollectorWiring().getInputWire(StateGarbageCollector::heartbeat), OFFER);
+        components
+                .model()
                 .buildHeartbeatWire(config.signedStateSentinelHeartbeatPeriod())
-                .solderTo(w.signedStateSentinelWiring().getInputWire(SignedStateSentinel::checkSignedStates), OFFER);
+                .solderTo(
+                        components.signedStateSentinelWiring().getInputWire(SignedStateSentinel::checkSignedStates),
+                        OFFER);
 
         // The state hasher needs to pass its data through a bunch of transformers. Construct those here.
-        final OutputWire<ReservedSignedState> hashedStateOutputWire = w.stateHasherWiring()
+        final OutputWire<ReservedSignedState> hashedStateOutputWire = components
+                .stateHasherWiring()
                 .getOutputWire()
                 .buildAdvancedTransformer(new SignedStateReserver("postHasher_stateReserver"));
 
-        hashedStateOutputWire.solderTo(w.hashLoggerWiring().getInputWire(HashLogger::logHashes));
-        hashedStateOutputWire.solderTo(w.stateSignerWiring().getInputWire(StateSigner::signState));
-        hashedStateOutputWire.solderTo(w.issDetectorWiring().getInputWire(IssDetector::handleState));
+        hashedStateOutputWire.solderTo(components.hashLoggerWiring().getInputWire(HashLogger::logHashes));
+        hashedStateOutputWire.solderTo(components.stateSignerWiring().getInputWire(StateSigner::signState));
+        hashedStateOutputWire.solderTo(components.issDetectorWiring().getInputWire(IssDetector::handleState));
         hashedStateOutputWire
                 .buildTransformer("postHasher_notifier", "hashed states", StateHashedNotification::from)
-                .solderTo(w.notifierWiring().getInputWire(AppNotifier::sendStateHashedNotification));
+                .solderTo(components.notifierWiring().getInputWire(AppNotifier::sendStateHashedNotification));
 
         // send state signatures to execution
-        w.stateSignerWiring()
+        components
+                .stateSignerWiring()
                 .getOutputWire()
                 .solderTo("ExecutionSignatureSubmission", "state signatures", execution::submitStateSignature);
 
@@ -295,100 +348,130 @@ public class PlatformWiring {
 
         // Solder the state output as input to the state signature collector.
         hashedStateOutputWire.solderTo(
-                w.stateSignatureCollectorWiring().getInputWire(StateSignatureCollector::addReservedState));
+                components.stateSignatureCollectorWiring().getInputWire(StateSignatureCollector::addReservedState));
 
-        w.stateSnapshotManagerWiring()
+        components
+                .stateSnapshotManagerWiring()
                 .getTransformedOutput(StateSnapshotManager::extractOldestMinimumBirthRoundOnDisk)
                 .solderTo(
-                        w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::setMinimumAncientIdentifierToStore),
+                        components
+                                .pcesInlineWriterWiring()
+                                .getInputWire(InlinePcesWriter::setMinimumAncientIdentifierToStore),
                         INJECT);
 
-        w.stateSnapshotManagerWiring()
+        components
+                .stateSnapshotManagerWiring()
                 .getTransformedOutput(StateSnapshotManager::toStateWrittenToDiskAction)
-                .solderTo(w.statusStateMachineWiring().getInputWire(StatusStateMachine::submitStatusAction));
+                .solderTo(components.statusStateMachineWiring().getInputWire(StatusStateMachine::submitStatusAction));
 
-        w.runningEventHashOverrideWiring()
+        components
+                .runningEventHashOverrideWiring()
                 .runningHashUpdateOutput()
-                .solderTo(w.transactionHandlerWiring().getInputWire(TransactionHandler::updateLegacyRunningEventHash));
-        w.runningEventHashOverrideWiring()
+                .solderTo(components
+                        .transactionHandlerWiring()
+                        .getInputWire(TransactionHandler::updateLegacyRunningEventHash));
+        components
+                .runningEventHashOverrideWiring()
                 .runningHashUpdateOutput()
-                .solderTo(w.consensusEventStreamWiring().getInputWire(ConsensusEventStream::legacyHashOverride));
+                .solderTo(
+                        components.consensusEventStreamWiring().getInputWire(ConsensusEventStream::legacyHashOverride));
 
         final OutputWire<IssNotification> splitIssDetectorOutput =
-                w.issDetectorWiring().getSplitOutput();
-        splitIssDetectorOutput.solderTo(w.issHandlerWiring().getInputWire(IssHandler::issObserved));
-        w.issDetectorWiring()
+                components.issDetectorWiring().getSplitOutput();
+        splitIssDetectorOutput.solderTo(components.issHandlerWiring().getInputWire(IssHandler::issObserved));
+        components
+                .issDetectorWiring()
                 .getSplitAndTransformedOutput(IssDetector::getStatusAction)
-                .solderTo(w.statusStateMachineWiring().getInputWire(StatusStateMachine::submitStatusAction));
+                .solderTo(components.statusStateMachineWiring().getInputWire(StatusStateMachine::submitStatusAction));
 
-        completeReservedSignedStatesWire.solderTo(w.latestCompleteStateNotifierWiring()
+        completeReservedSignedStatesWire.solderTo(components
+                .latestCompleteStateNotifierWiring()
                 .getInputWire(LatestCompleteStateNotifier::latestCompleteStateHandler));
 
-        w.statusStateMachineWiring()
+        components
+                .statusStateMachineWiring()
                 .getOutputWire()
-                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::updatePlatformStatus));
-        w.statusStateMachineWiring()
+                .solderTo(components
+                        .eventCreationManagerWiring()
+                        .getInputWire(EventCreationManager::updatePlatformStatus));
+        components
+                .statusStateMachineWiring()
                 .getOutputWire()
                 .solderTo(
-                        w.consensusEngineWiring().componentWiring().getInputWire(ConsensusEngine::updatePlatformStatus),
+                        components
+                                .consensusEngineWiring()
+                                .componentWiring()
+                                .getInputWire(ConsensusEngine::updatePlatformStatus),
                         INJECT);
-        w.statusStateMachineWiring()
+        components
+                .statusStateMachineWiring()
                 .getOutputWire()
                 .solderTo("ExecutionStatusHandler", "status updates", execution::newPlatformStatus);
-        w.statusStateMachineWiring().getOutputWire().solderTo(w.gossipWiring().getPlatformStatusInput(), INJECT);
+        components
+                .statusStateMachineWiring()
+                .getOutputWire()
+                .solderTo(components.gossipWiring().getPlatformStatusInput(), INJECT);
 
-        solderNotifier(w);
+        solderNotifier(components);
 
-        if (w.platformPublisherWiring().getSchedulerType() != NO_OP) {
+        if (components.platformPublisherWiring().getSchedulerType() != NO_OP) {
             splitOrphanBufferOutput.solderTo(
-                    w.platformPublisherWiring().getInputWire(PlatformPublisher::publishPreconsensusEvent));
+                    components.platformPublisherWiring().getInputWire(PlatformPublisher::publishPreconsensusEvent));
         }
 
-        buildUnsolderedWires(w);
+        buildUnsolderedWires(components);
     }
 
     /**
      * Solder the EventWindow output to all components that need it.
      */
-    private static void solderEventWindow(PlatformComponents w) {
+    private static void solderEventWindow(final PlatformComponents components) {
         final OutputWire<EventWindow> eventWindowOutputWire =
-                w.eventWindowManagerWiring().getOutputWire();
+                components.eventWindowManagerWiring().getOutputWire();
 
         eventWindowOutputWire.solderTo(
-                w.eventDeduplicatorWiring().getInputWire(EventDeduplicator::setEventWindow), INJECT);
+                components.eventDeduplicatorWiring().getInputWire(EventDeduplicator::setEventWindow), INJECT);
         eventWindowOutputWire.solderTo(
-                w.eventSignatureValidatorWiring().getInputWire(EventSignatureValidator::setEventWindow), INJECT);
-        eventWindowOutputWire.solderTo(w.orphanBufferWiring().getInputWire(OrphanBuffer::setEventWindow), INJECT);
-        eventWindowOutputWire.solderTo(w.gossipWiring().getEventWindowInput(), INJECT);
+                components.eventSignatureValidatorWiring().getInputWire(EventSignatureValidator::setEventWindow),
+                INJECT);
         eventWindowOutputWire.solderTo(
-                w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::updateNonAncientEventBoundary), INJECT);
+                components.orphanBufferWiring().getInputWire(OrphanBuffer::setEventWindow), INJECT);
+        eventWindowOutputWire.solderTo(components.gossipWiring().getEventWindowInput(), INJECT);
         eventWindowOutputWire.solderTo(
-                w.eventCreationManagerWiring().getInputWire(EventCreationManager::setEventWindow), INJECT);
+                components.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::updateNonAncientEventBoundary),
+                INJECT);
         eventWindowOutputWire.solderTo(
-                w.latestCompleteStateNexusWiring().getInputWire(LatestCompleteStateNexus::updateEventWindow));
+                components.eventCreationManagerWiring().getInputWire(EventCreationManager::setEventWindow), INJECT);
         eventWindowOutputWire.solderTo(
-                w.branchDetectorWiring().getInputWire(BranchDetector::updateEventWindow), INJECT);
+                components.latestCompleteStateNexusWiring().getInputWire(LatestCompleteStateNexus::updateEventWindow));
         eventWindowOutputWire.solderTo(
-                w.branchReporterWiring().getInputWire(BranchReporter::updateEventWindow), INJECT);
+                components.branchDetectorWiring().getInputWire(BranchDetector::updateEventWindow), INJECT);
+        eventWindowOutputWire.solderTo(
+                components.branchReporterWiring().getInputWire(BranchReporter::updateEventWindow), INJECT);
     }
 
     /**
      * Solder notifications into the notifier.
      */
-    private static void solderNotifier(PlatformComponents w) {
-        w.latestCompleteStateNotifierWiring()
+    private static void solderNotifier(final PlatformComponents components) {
+        components
+                .latestCompleteStateNotifierWiring()
                 .getOutputWire()
-                .solderTo(w.notifierWiring().getInputWire(AppNotifier::sendLatestCompleteStateNotification));
-        w.stateSnapshotManagerWiring()
+                .solderTo(components.notifierWiring().getInputWire(AppNotifier::sendLatestCompleteStateNotification));
+        components
+                .stateSnapshotManagerWiring()
                 .getTransformedOutput(StateSnapshotManager::toNotification)
-                .solderTo(w.notifierWiring().getInputWire(AppNotifier::sendStateWrittenToDiskNotification), INJECT);
+                .solderTo(
+                        components.notifierWiring().getInputWire(AppNotifier::sendStateWrittenToDiskNotification),
+                        INJECT);
 
         final OutputWire<IssNotification> issNotificationOutputWire =
-                w.issDetectorWiring().getSplitOutput();
-        issNotificationOutputWire.solderTo(w.notifierWiring().getInputWire(AppNotifier::sendIssNotification));
-        w.statusStateMachineWiring()
+                components.issDetectorWiring().getSplitOutput();
+        issNotificationOutputWire.solderTo(components.notifierWiring().getInputWire(AppNotifier::sendIssNotification));
+        components
+                .statusStateMachineWiring()
                 .getOutputWire()
-                .solderTo(w.notifierWiring().getInputWire(AppNotifier::sendPlatformStatusChangeNotification));
+                .solderTo(components.notifierWiring().getInputWire(AppNotifier::sendPlatformStatusChangeNotification));
     }
 
     /**
@@ -396,24 +479,24 @@ public class PlatformWiring {
      * we are soldering things together, but there are a few wires that aren't soldered and aren't used until later in
      * the lifecycle. This method forces those wires to be built.
      */
-    private static void buildUnsolderedWires(PlatformComponents w) {
-        w.eventDeduplicatorWiring().getInputWire(EventDeduplicator::clear);
-        w.consensusEngineWiring().getInputWire(ConsensusEngine::outOfBandSnapshotUpdate);
-        if (w.platformPublisherWiring().getSchedulerType() != NO_OP) {
-            w.platformPublisherWiring().getInputWire(PlatformPublisher::publishSnapshotOverride);
+    private static void buildUnsolderedWires(final PlatformComponents components) {
+        components.eventDeduplicatorWiring().getInputWire(EventDeduplicator::clear);
+        components.consensusEngineWiring().getInputWire(ConsensusEngine::outOfBandSnapshotUpdate);
+        if (components.platformPublisherWiring().getSchedulerType() != NO_OP) {
+            components.platformPublisherWiring().getInputWire(PlatformPublisher::publishSnapshotOverride);
         }
-        w.eventCreationManagerWiring().getInputWire(EventCreationManager::clear);
-        w.notifierWiring().getInputWire(AppNotifier::sendReconnectCompleteNotification);
-        w.notifierWiring().getInputWire(AppNotifier::sendPlatformStatusChangeNotification);
-        w.eventSignatureValidatorWiring().getInputWire(EventSignatureValidator::updateRosterHistory);
-        w.eventWindowManagerWiring().getInputWire(EventWindowManager::updateEventWindow);
-        w.orphanBufferWiring().getInputWire(OrphanBuffer::clear);
-        w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::registerDiscontinuity);
-        w.stateSignatureCollectorWiring().getInputWire(StateSignatureCollector::clear);
-        w.issDetectorWiring().getInputWire(IssDetector::overridingState);
-        w.issDetectorWiring().getInputWire(IssDetector::signalEndOfPreconsensusReplay);
-        w.stateSnapshotManagerWiring().getInputWire(StateSnapshotManager::dumpStateTask);
-        w.branchDetectorWiring().getInputWire(BranchDetector::clear);
-        w.branchReporterWiring().getInputWire(BranchReporter::clear);
+        components.eventCreationManagerWiring().getInputWire(EventCreationManager::clear);
+        components.notifierWiring().getInputWire(AppNotifier::sendReconnectCompleteNotification);
+        components.notifierWiring().getInputWire(AppNotifier::sendPlatformStatusChangeNotification);
+        components.eventSignatureValidatorWiring().getInputWire(EventSignatureValidator::updateRosterHistory);
+        components.eventWindowManagerWiring().getInputWire(EventWindowManager::updateEventWindow);
+        components.orphanBufferWiring().getInputWire(OrphanBuffer::clear);
+        components.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::registerDiscontinuity);
+        components.stateSignatureCollectorWiring().getInputWire(StateSignatureCollector::clear);
+        components.issDetectorWiring().getInputWire(IssDetector::overridingState);
+        components.issDetectorWiring().getInputWire(IssDetector::signalEndOfPreconsensusReplay);
+        components.stateSnapshotManagerWiring().getInputWire(StateSnapshotManager::dumpStateTask);
+        components.branchDetectorWiring().getInputWire(BranchDetector::clear);
+        components.branchReporterWiring().getInputWire(BranchReporter::clear);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -1,30 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.wiring;
 
-import static com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration.DIRECT_THREADSAFE_CONFIGURATION;
-import static com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration.NO_OP_CONFIGURATION;
+import static com.swirlds.component.framework.schedulers.builders.TaskSchedulerType.NO_OP;
 import static com.swirlds.component.framework.wires.SolderType.INJECT;
 import static com.swirlds.component.framework.wires.SolderType.OFFER;
 
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
-import com.hedera.hapi.platform.state.ConsensusSnapshot;
 import com.swirlds.common.context.PlatformContext;
-import com.swirlds.common.io.IOIterator;
-import com.swirlds.common.stream.RunningEventHashOverride;
 import com.swirlds.component.framework.component.ComponentWiring;
-import com.swirlds.component.framework.model.WiringModel;
-import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
 import com.swirlds.component.framework.transformers.WireFilter;
 import com.swirlds.component.framework.wires.input.InputWire;
 import com.swirlds.component.framework.wires.output.OutputWire;
-import com.swirlds.component.framework.wires.output.StandardOutputWire;
-import com.swirlds.platform.builder.ApplicationCallbacks;
 import com.swirlds.platform.builder.ExecutionLayer;
-import com.swirlds.platform.builder.PlatformComponentBuilder;
 import com.swirlds.platform.components.AppNotifier;
 import com.swirlds.platform.components.EventWindowManager;
 import com.swirlds.platform.components.SavedStateController;
-import com.swirlds.platform.components.appcomm.CompleteStateNotificationWithCleanup;
 import com.swirlds.platform.components.appcomm.LatestCompleteStateNotifier;
 import com.swirlds.platform.components.consensus.ConsensusEngine;
 import com.swirlds.platform.components.consensus.ConsensusEngineOutput;
@@ -33,7 +23,6 @@ import com.swirlds.platform.event.branching.BranchReporter;
 import com.swirlds.platform.event.deduplication.EventDeduplicator;
 import com.swirlds.platform.event.orphan.OrphanBuffer;
 import com.swirlds.platform.event.preconsensus.InlinePcesWriter;
-import com.swirlds.platform.event.preconsensus.PcesReplayer;
 import com.swirlds.platform.event.stream.ConsensusEventStream;
 import com.swirlds.platform.event.validation.EventSignatureValidator;
 import com.swirlds.platform.event.validation.InternalEventValidator;
@@ -49,24 +38,15 @@ import com.swirlds.platform.state.iss.IssHandler;
 import com.swirlds.platform.state.nexus.LatestCompleteStateNexus;
 import com.swirlds.platform.state.nexus.SignedStateNexus;
 import com.swirlds.platform.state.signed.ReservedSignedState;
-import com.swirlds.platform.state.signed.SignedState;
 import com.swirlds.platform.state.signed.SignedStateSentinel;
 import com.swirlds.platform.state.signed.StateGarbageCollector;
 import com.swirlds.platform.state.signed.StateSignatureCollector;
 import com.swirlds.platform.state.signer.StateSigner;
-import com.swirlds.platform.state.snapshot.StateDumpRequest;
 import com.swirlds.platform.state.snapshot.StateSnapshotManager;
 import com.swirlds.platform.system.state.notifications.StateHashedNotification;
 import com.swirlds.platform.system.status.PlatformStatusConfig;
-import com.swirlds.platform.system.status.StatusActionSubmitter;
 import com.swirlds.platform.system.status.StatusStateMachine;
-import com.swirlds.platform.wiring.components.GossipWiring;
-import com.swirlds.platform.wiring.components.PcesReplayerWiring;
-import com.swirlds.platform.wiring.components.RunningEventHashOverrideWiring;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import edu.umd.cs.findbugs.annotations.Nullable;
-import java.util.List;
-import java.util.Objects;
 import java.util.Queue;
 import org.hiero.consensus.crypto.EventHasher;
 import org.hiero.consensus.event.creator.impl.EventCreationManager;
@@ -75,338 +55,117 @@ import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.notification.IssNotification;
-import org.hiero.consensus.model.state.StateSavingResult;
-import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.model.transaction.ScopedSystemTransaction;
-import org.hiero.consensus.roster.RosterHistory;
 
 /**
  * Encapsulates wiring for {@link com.swirlds.platform.SwirldsPlatform}.
  */
 public class PlatformWiring {
 
-    private final WiringModel model;
-
-    private final PlatformContext platformContext;
-    private final PlatformSchedulersConfig config;
-
-    private final ComponentWiring<EventHasher, PlatformEvent> eventHasherWiring;
-    private final ComponentWiring<InternalEventValidator, PlatformEvent> internalEventValidatorWiring;
-    private final ComponentWiring<EventDeduplicator, PlatformEvent> eventDeduplicatorWiring;
-    private final ComponentWiring<EventSignatureValidator, PlatformEvent> eventSignatureValidatorWiring;
-    private final ComponentWiring<OrphanBuffer, List<PlatformEvent>> orphanBufferWiring;
-    private final ComponentWiring<ConsensusEngine, ConsensusEngineOutput> consensusEngineWiring;
-    /** Output from the {@link #consensusEngineWiring} where only the consensus rounds are returned */
-    private final OutputWire<List<ConsensusRound>> consensusRoundsOutputWire;
-
-    private final ComponentWiring<EventCreationManager, PlatformEvent> eventCreationManagerWiring;
-    private final ComponentWiring<StateSnapshotManager, StateSavingResult> stateSnapshotManagerWiring;
-    private final ComponentWiring<StateSigner, StateSignatureTransaction> stateSignerWiring;
-    private final PcesReplayerWiring pcesReplayerWiring;
-    private final ComponentWiring<InlinePcesWriter, PlatformEvent> pcesInlineWriterWiring;
-    private final ComponentWiring<TransactionPrehandler, Queue<ScopedSystemTransaction<StateSignatureTransaction>>>
-            applicationTransactionPrehandlerWiring;
-    private final ComponentWiring<StateSignatureCollector, List<ReservedSignedState>> stateSignatureCollectorWiring;
-    private final GossipWiring gossipWiring;
-    private final ComponentWiring<EventWindowManager, EventWindow> eventWindowManagerWiring;
-    private final ComponentWiring<TransactionHandler, TransactionHandlerResult> transactionHandlerWiring;
-    private final ComponentWiring<ConsensusEventStream, Void> consensusEventStreamWiring;
-    private final RunningEventHashOverrideWiring runningEventHashOverrideWiring;
-    private final ComponentWiring<IssDetector, List<IssNotification>> issDetectorWiring;
-    private final ComponentWiring<IssHandler, Void> issHandlerWiring;
-    private final ComponentWiring<HashLogger, Void> hashLoggerWiring;
-    private final ComponentWiring<LatestCompleteStateNotifier, CompleteStateNotificationWithCleanup>
-            latestCompleteStateNotifierWiring;
-    private final ComponentWiring<SignedStateNexus, Void> latestImmutableStateNexusWiring;
-    private final ComponentWiring<LatestCompleteStateNexus, Void> latestCompleteStateNexusWiring;
-    private final ComponentWiring<SavedStateController, StateWithHashComplexity> savedStateControllerWiring;
-    private final ComponentWiring<StateHasher, ReservedSignedState> stateHasherWiring;
-    private final PlatformCoordinator platformCoordinator;
-    private final ComponentWiring<AppNotifier, Void> notifierWiring;
-    private final ComponentWiring<StateGarbageCollector, Void> stateGarbageCollectorWiring;
-    private final ComponentWiring<SignedStateSentinel, Void> signedStateSentinelWiring;
-    private final ComponentWiring<PlatformPublisher, Void> platformPublisherWiring;
-    private final boolean publishPreconsensusEvents;
-    private final boolean publishSnapshotOverrides;
-    private final boolean publishStaleEvents;
-    private final ExecutionLayer execution;
-    private final ComponentWiring<StatusStateMachine, PlatformStatus> statusStateMachineWiring;
-    private final ComponentWiring<BranchDetector, PlatformEvent> branchDetectorWiring;
-    private final ComponentWiring<BranchReporter, Void> branchReporterWiring;
-
-    /**
-     * Constructor.
-     *
-     * @param platformContext      the platform context
-     * @param model                the wiring model
-     * @param applicationCallbacks the application callbacks (some wires are only created if the application wants a
-     *                             callback for something)
-     * @param execution            the execution layer instance
-     */
-    public PlatformWiring(
-            @NonNull final PlatformContext platformContext,
-            @NonNull final WiringModel model,
-            @NonNull final ApplicationCallbacks applicationCallbacks,
-            @NonNull final ExecutionLayer execution) {
-
-        this.platformContext = Objects.requireNonNull(platformContext);
-        this.model = Objects.requireNonNull(model);
-        this.execution = Objects.requireNonNull(execution);
-
-        config = platformContext.getConfiguration().getConfigData(PlatformSchedulersConfig.class);
-
-        eventHasherWiring = new ComponentWiring<>(model, EventHasher.class, config.eventHasher());
-
-        internalEventValidatorWiring =
-                new ComponentWiring<>(model, InternalEventValidator.class, config.internalEventValidator());
-        eventDeduplicatorWiring = new ComponentWiring<>(model, EventDeduplicator.class, config.eventDeduplicator());
-        eventSignatureValidatorWiring =
-                new ComponentWiring<>(model, EventSignatureValidator.class, config.eventSignatureValidator());
-        orphanBufferWiring = new ComponentWiring<>(model, OrphanBuffer.class, config.orphanBuffer());
-        consensusEngineWiring = new ComponentWiring<>(model, ConsensusEngine.class, config.consensusEngine());
-        // output only consensus rounds
-        consensusRoundsOutputWire = consensusEngineWiring
-                .getOutputWire()
-                .buildTransformer("ConsensusRounds", "consensusEngineOutput", ConsensusEngineOutput::consensusRounds);
-
-        eventCreationManagerWiring =
-                new ComponentWiring<>(model, EventCreationManager.class, config.eventCreationManager());
-
-        applicationTransactionPrehandlerWiring =
-                new ComponentWiring<>(model, TransactionPrehandler.class, config.applicationTransactionPrehandler());
-        stateSignatureCollectorWiring =
-                new ComponentWiring<>(model, StateSignatureCollector.class, config.stateSignatureCollector());
-        stateSnapshotManagerWiring =
-                new ComponentWiring<>(model, StateSnapshotManager.class, config.stateSnapshotManager());
-        stateSignerWiring = new ComponentWiring<>(model, StateSigner.class, config.stateSigner());
-        transactionHandlerWiring = new ComponentWiring<>(
-                model,
-                TransactionHandler.class,
-                config.transactionHandler(),
-                data -> data instanceof final ConsensusRound consensusRound
-                        ? Math.max(consensusRound.getNumAppTransactions(), 1)
-                        : 1);
-        consensusEventStreamWiring =
-                new ComponentWiring<>(model, ConsensusEventStream.class, config.consensusEventStream());
-        runningEventHashOverrideWiring = RunningEventHashOverrideWiring.create(model);
-
-        stateHasherWiring = new ComponentWiring<>(
-                model,
-                StateHasher.class,
-                config.stateHasher(),
-                data -> data instanceof final StateWithHashComplexity swhc ? swhc.hashComplexity() : 1);
-
-        gossipWiring = new GossipWiring(platformContext, model);
-
-        pcesReplayerWiring = PcesReplayerWiring.create(model);
-
-        pcesInlineWriterWiring = new ComponentWiring<>(model, InlinePcesWriter.class, config.pcesInlineWriter());
-
-        eventWindowManagerWiring =
-                new ComponentWiring<>(model, EventWindowManager.class, DIRECT_THREADSAFE_CONFIGURATION);
-
-        issDetectorWiring = new ComponentWiring<>(model, IssDetector.class, config.issDetector());
-        issHandlerWiring = new ComponentWiring<>(model, IssHandler.class, config.issHandler());
-        hashLoggerWiring = new ComponentWiring<>(model, HashLogger.class, config.hashLogger());
-
-        latestCompleteStateNotifierWiring =
-                new ComponentWiring<>(model, LatestCompleteStateNotifier.class, config.latestCompleteStateNotifier());
-
-        latestImmutableStateNexusWiring =
-                new ComponentWiring<>(model, SignedStateNexus.class, DIRECT_THREADSAFE_CONFIGURATION);
-        latestCompleteStateNexusWiring =
-                new ComponentWiring<>(model, LatestCompleteStateNexus.class, DIRECT_THREADSAFE_CONFIGURATION);
-        savedStateControllerWiring =
-                new ComponentWiring<>(model, SavedStateController.class, DIRECT_THREADSAFE_CONFIGURATION);
-
-        notifierWiring = new ComponentWiring<>(model, AppNotifier.class, DIRECT_THREADSAFE_CONFIGURATION);
-
-        this.publishPreconsensusEvents = applicationCallbacks.preconsensusEventConsumer() != null;
-        this.publishSnapshotOverrides = applicationCallbacks.snapshotOverrideConsumer() != null;
-        this.publishStaleEvents = applicationCallbacks.staleEventConsumer() != null;
-
-        final TaskSchedulerConfiguration publisherConfiguration;
-        if (publishPreconsensusEvents || publishSnapshotOverrides || publishStaleEvents) {
-            publisherConfiguration = config.platformPublisher();
-        } else {
-            publisherConfiguration = NO_OP_CONFIGURATION;
-        }
-        platformPublisherWiring = new ComponentWiring<>(model, PlatformPublisher.class, publisherConfiguration);
-
-        stateGarbageCollectorWiring =
-                new ComponentWiring<>(model, StateGarbageCollector.class, config.stateGarbageCollector());
-        signedStateSentinelWiring =
-                new ComponentWiring<>(model, SignedStateSentinel.class, config.signedStateSentinel());
-        statusStateMachineWiring = new ComponentWiring<>(model, StatusStateMachine.class, config.statusStateMachine());
-
-        branchDetectorWiring = new ComponentWiring<>(model, BranchDetector.class, config.branchDetector());
-        branchReporterWiring = new ComponentWiring<>(model, BranchReporter.class, config.branchReporter());
-
-        platformCoordinator = new PlatformCoordinator(
-                eventHasherWiring::flush,
-                internalEventValidatorWiring,
-                eventDeduplicatorWiring,
-                eventSignatureValidatorWiring,
-                orphanBufferWiring,
-                gossipWiring,
-                consensusEngineWiring,
-                eventCreationManagerWiring,
-                applicationTransactionPrehandlerWiring,
-                stateSignatureCollectorWiring,
-                transactionHandlerWiring,
-                stateHasherWiring,
-                statusStateMachineWiring,
-                branchDetectorWiring,
-                branchReporterWiring,
-                pcesInlineWriterWiring);
-
-        wire();
-    }
-
-    /**
-     * Get the wiring model.
-     *
-     * @return the wiring model
-     */
-    @NonNull
-    public WiringModel getModel() {
-        return model;
-    }
-
-    /**
-     * Solder the EventWindow output to all components that need it.
-     */
-    private void solderEventWindow() {
-        final OutputWire<EventWindow> eventWindowOutputWire = eventWindowManagerWiring.getOutputWire();
-
-        eventWindowOutputWire.solderTo(eventDeduplicatorWiring.getInputWire(EventDeduplicator::setEventWindow), INJECT);
-        eventWindowOutputWire.solderTo(
-                eventSignatureValidatorWiring.getInputWire(EventSignatureValidator::setEventWindow), INJECT);
-        eventWindowOutputWire.solderTo(orphanBufferWiring.getInputWire(OrphanBuffer::setEventWindow), INJECT);
-        eventWindowOutputWire.solderTo(gossipWiring.getEventWindowInput(), INJECT);
-        eventWindowOutputWire.solderTo(
-                pcesInlineWriterWiring.getInputWire(InlinePcesWriter::updateNonAncientEventBoundary), INJECT);
-        eventWindowOutputWire.solderTo(
-                eventCreationManagerWiring.getInputWire(EventCreationManager::setEventWindow), INJECT);
-        eventWindowOutputWire.solderTo(
-                latestCompleteStateNexusWiring.getInputWire(LatestCompleteStateNexus::updateEventWindow));
-        eventWindowOutputWire.solderTo(branchDetectorWiring.getInputWire(BranchDetector::updateEventWindow), INJECT);
-        eventWindowOutputWire.solderTo(branchReporterWiring.getInputWire(BranchReporter::updateEventWindow), INJECT);
-    }
-
-    /**
-     * Solder notifications into the notifier.
-     */
-    private void solderNotifier() {
-        latestCompleteStateNotifierWiring
-                .getOutputWire()
-                .solderTo(notifierWiring.getInputWire(AppNotifier::sendLatestCompleteStateNotification));
-        stateSnapshotManagerWiring
-                .getTransformedOutput(StateSnapshotManager::toNotification)
-                .solderTo(notifierWiring.getInputWire(AppNotifier::sendStateWrittenToDiskNotification), INJECT);
-
-        final OutputWire<IssNotification> issNotificationOutputWire = issDetectorWiring.getSplitOutput();
-        issNotificationOutputWire.solderTo(notifierWiring.getInputWire(AppNotifier::sendIssNotification));
-        statusStateMachineWiring
-                .getOutputWire()
-                .solderTo(notifierWiring.getInputWire(AppNotifier::sendPlatformStatusChangeNotification));
-    }
-
     /**
      * Wire the components together.
      */
-    private void wire() {
+    public static void wire(
+            PlatformContext platformContext, @NonNull final ExecutionLayer execution, PlatformComponents w) {
         final InputWire<PlatformEvent> hasherInputWire =
-                eventHasherWiring.getInputWire(EventHasher::hashEvent, "unhashed event");
-        gossipWiring.getEventOutput().solderTo(hasherInputWire);
+                w.eventHasherWiring().getInputWire(EventHasher::hashEvent, "unhashed event");
+        w.gossipWiring().getEventOutput().solderTo(hasherInputWire);
 
-        gossipWiring
+        w.gossipWiring()
                 .getSyncLagOutput()
-                .solderTo(eventCreationManagerWiring.getInputWire(EventCreationManager::reportSyncRoundLag));
+                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::reportSyncRoundLag));
 
-        eventHasherWiring
+        w.eventHasherWiring()
                 .getOutputWire()
-                .solderTo(internalEventValidatorWiring.getInputWire(InternalEventValidator::validateEvent));
+                .solderTo(w.internalEventValidatorWiring().getInputWire(InternalEventValidator::validateEvent));
 
-        internalEventValidatorWiring
+        w.internalEventValidatorWiring()
                 .getOutputWire()
-                .solderTo(eventDeduplicatorWiring.getInputWire(EventDeduplicator::handleEvent));
-        eventDeduplicatorWiring
+                .solderTo(w.eventDeduplicatorWiring().getInputWire(EventDeduplicator::handleEvent));
+        w.eventDeduplicatorWiring()
                 .getOutputWire()
-                .solderTo(eventSignatureValidatorWiring.getInputWire(EventSignatureValidator::validateSignature));
-        eventSignatureValidatorWiring
+                .solderTo(w.eventSignatureValidatorWiring().getInputWire(EventSignatureValidator::validateSignature));
+        w.eventSignatureValidatorWiring()
                 .getOutputWire()
-                .solderTo(orphanBufferWiring.getInputWire(OrphanBuffer::handleEvent));
-        final OutputWire<PlatformEvent> splitOrphanBufferOutput = orphanBufferWiring.getSplitOutput();
+                .solderTo(w.orphanBufferWiring().getInputWire(OrphanBuffer::handleEvent));
+        final OutputWire<PlatformEvent> splitOrphanBufferOutput =
+                w.orphanBufferWiring().getSplitOutput();
 
-        splitOrphanBufferOutput.solderTo(pcesInlineWriterWiring.getInputWire(InlinePcesWriter::writeEvent));
+        splitOrphanBufferOutput.solderTo(w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::writeEvent));
 
         // Make sure that an event is persisted before being sent to consensus. This avoids the situation where we
         // reach consensus with events that might be lost due to a crash
-        pcesInlineWriterWiring.getOutputWire().solderTo(consensusEngineWiring.getInputWire(ConsensusEngine::addEvent));
+        w.pcesInlineWriterWiring()
+                .getOutputWire()
+                .solderTo(w.consensusEngineWiring().componentWiring().getInputWire(ConsensusEngine::addEvent));
 
         // Make sure events are persisted before being gossipped. This prevents accidental branching in the case
         // where an event is created, gossipped, and then the node crashes before the event is persisted.
         // After restart, a node will not be aware of this event, so it can create a branch
-        pcesInlineWriterWiring.getOutputWire().solderTo(gossipWiring.getEventInput(), INJECT);
+        w.pcesInlineWriterWiring().getOutputWire().solderTo(w.gossipWiring().getEventInput(), INJECT);
 
         // Avoid using events as parents before they are persisted
-        pcesInlineWriterWiring
+        w.pcesInlineWriterWiring()
                 .getOutputWire()
-                .solderTo(eventCreationManagerWiring.getInputWire(EventCreationManager::registerEvent));
+                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::registerEvent));
 
-        model.getHealthMonitorWire()
-                .solderTo(eventCreationManagerWiring.getInputWire(EventCreationManager::reportUnhealthyDuration));
+        w.model()
+                .getHealthMonitorWire()
+                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::reportUnhealthyDuration));
 
-        model.getHealthMonitorWire().solderTo(gossipWiring.getSystemHealthInput());
-        model.getHealthMonitorWire()
+        w.model().getHealthMonitorWire().solderTo(w.gossipWiring().getSystemHealthInput());
+        w.model().getHealthMonitorWire()
                 .solderTo("executionHealthInput", "healthyDuration", execution::reportUnhealthyDuration);
 
-        splitOrphanBufferOutput.solderTo(branchDetectorWiring.getInputWire(BranchDetector::checkForBranches));
-        branchDetectorWiring.getOutputWire().solderTo(branchReporterWiring.getInputWire(BranchReporter::reportBranch));
+        splitOrphanBufferOutput.solderTo(w.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));
+        w.branchDetectorWiring()
+                .getOutputWire()
+                .solderTo(w.branchReporterWiring().getInputWire(BranchReporter::reportBranch));
 
         final double eventCreationHeartbeatFrequency = platformContext
                 .getConfiguration()
                 .getConfigData(EventCreationConfig.class)
                 .creationAttemptRate();
-        model.buildHeartbeatWire(eventCreationHeartbeatFrequency)
-                .solderTo(eventCreationManagerWiring.getInputWire(EventCreationManager::maybeCreateEvent), OFFER);
-        model.buildHeartbeatWire(platformContext
+        w.model()
+                .buildHeartbeatWire(eventCreationHeartbeatFrequency)
+                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::maybeCreateEvent), OFFER);
+        w.model()
+                .buildHeartbeatWire(platformContext
                         .getConfiguration()
                         .getConfigData(PlatformStatusConfig.class)
                         .statusStateMachineHeartbeatPeriod())
-                .solderTo(statusStateMachineWiring.getInputWire(StatusStateMachine::heartbeat), OFFER);
+                .solderTo(w.statusStateMachineWiring().getInputWire(StatusStateMachine::heartbeat), OFFER);
 
-        eventCreationManagerWiring
+        w.eventCreationManagerWiring()
                 .getOutputWire()
-                .solderTo(internalEventValidatorWiring.getInputWire(InternalEventValidator::validateEvent), INJECT);
+                .solderTo(w.internalEventValidatorWiring().getInputWire(InternalEventValidator::validateEvent), INJECT);
 
-        if (publishStaleEvents) {
-            final OutputWire<PlatformEvent> staleEvent = consensusEngineWiring
+        if (w.platformPublisherWiring().getSchedulerType() != NO_OP) {
+            final OutputWire<PlatformEvent> staleEvent = w.consensusEngineWiring()
                     .getOutputWire()
                     .buildTransformer("staleEvents", "consensusEngineOutput", ConsensusEngineOutput::staleEvents)
                     .buildSplitter("staleEventsSplitter", "stale events");
-            staleEvent.solderTo(platformPublisherWiring.getInputWire(PlatformPublisher::publishStaleEvent));
+            staleEvent.solderTo(w.platformPublisherWiring().getInputWire(PlatformPublisher::publishStaleEvent));
         }
 
         // an output wire that filters out only pre-consensus events from the consensus engine
-        final OutputWire<PlatformEvent> consEngineAddedEvents = consensusEngineWiring
+        final OutputWire<PlatformEvent> consEngineAddedEvents = w.consensusEngineWiring()
                 .getOutputWire()
                 .buildTransformer(
                         "PreConsensusEvents", "consensusEngineOutput", ConsensusEngineOutput::preConsensusEvents)
                 .buildSplitter("PreConsensusEventsSplitter", "preConsensusEvents");
         // pre-handle gets pre-consensus events from the consensus engine
         // the consensus engine ensures that all pre-consensus events either reach consensus of become stale
-        consEngineAddedEvents.solderTo(applicationTransactionPrehandlerWiring.getInputWire(
-                TransactionPrehandler::prehandleApplicationTransactions));
+        consEngineAddedEvents.solderTo(w.applicationTransactionPrehandlerWiring()
+                .getInputWire(TransactionPrehandler::prehandleApplicationTransactions));
 
-        applicationTransactionPrehandlerWiring
+        w.applicationTransactionPrehandlerWiring()
                 .getOutputWire()
-                .solderTo(stateSignatureCollectorWiring.getInputWire(
-                        StateSignatureCollector::handlePreconsensusSignatures));
+                .solderTo(w.stateSignatureCollectorWiring()
+                        .getInputWire(StateSignatureCollector::handlePreconsensusSignatures));
 
         // Split output of StateSignatureCollector into single ReservedSignedStates.
-        final OutputWire<ReservedSignedState> splitReservedSignedStateWire = stateSignatureCollectorWiring
+        final OutputWire<ReservedSignedState> splitReservedSignedStateWire = w.stateSignatureCollectorWiring()
                 .getOutputWire()
                 .buildSplitter("reservedStateSplitter", "reserved state lists");
         // Add another reservation to the signed states since we are soldering to two different input wires
@@ -415,7 +174,7 @@ public class PlatformWiring {
 
         // Future work: this should be a full component in its own right or folded in with the state file manager.
         final WireFilter<ReservedSignedState> saveToDiskFilter =
-                new WireFilter<>(model, "saveToDiskFilter", "states", state -> {
+                new WireFilter<>(w.model(), "saveToDiskFilter", "states", state -> {
                     if (state.get().isStateToSave()) {
                         return true;
                     }
@@ -427,7 +186,7 @@ public class PlatformWiring {
 
         saveToDiskFilter
                 .getOutputWire()
-                .solderTo(stateSnapshotManagerWiring.getInputWire(StateSnapshotManager::saveStateTask));
+                .solderTo(w.stateSnapshotManagerWiring().getInputWire(StateSnapshotManager::saveStateTask));
 
         // Filter to complete states only and add a 3rd reservation since completes states are used in two input wires.
         final OutputWire<ReservedSignedState> completeReservedSignedStatesWire = allReservedSignedStatesWire
@@ -442,53 +201,55 @@ public class PlatformWiring {
                 })
                 .buildAdvancedTransformer(new SignedStateReserver("completeStatesReserver"));
         completeReservedSignedStatesWire.solderTo(
-                latestCompleteStateNexusWiring.getInputWire(LatestCompleteStateNexus::setStateIfNewer));
+                w.latestCompleteStateNexusWiring().getInputWire(LatestCompleteStateNexus::setStateIfNewer));
 
-        solderEventWindow();
+        solderEventWindow(w);
 
-        pcesReplayerWiring.eventOutput().solderTo(hasherInputWire);
+        w.pcesReplayerWiring().eventOutput().solderTo(hasherInputWire);
 
-        final OutputWire<ConsensusRound> consensusRoundOutputWire =
-                consensusRoundsOutputWire.buildSplitter("ConsensusRoundsSplitter", "consensus rounds");
+        final OutputWire<ConsensusRound> consensusRoundOutputWire = w.consensusEngineWiring()
+                .consensusRoundsOutputWire()
+                .buildSplitter("ConsensusRoundsSplitter", "consensus rounds");
 
-        pcesReplayerWiring
+        w.pcesReplayerWiring()
                 .doneStreamingPcesOutputWire()
-                .solderTo(pcesInlineWriterWiring.getInputWire(InlinePcesWriter::beginStreamingNewEvents));
+                .solderTo(w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::beginStreamingNewEvents));
         // with inline PCES, the round bypasses the round durability buffer and goes directly to the round handler
         consensusRoundOutputWire.solderTo(
-                transactionHandlerWiring.getInputWire(TransactionHandler::handleConsensusRound));
+                w.transactionHandlerWiring().getInputWire(TransactionHandler::handleConsensusRound));
 
         consensusRoundOutputWire.solderTo(
-                eventWindowManagerWiring.getInputWire(EventWindowManager::extractEventWindow));
+                w.eventWindowManagerWiring().getInputWire(EventWindowManager::extractEventWindow));
 
         consensusRoundOutputWire
                 .buildTransformer("RoundsToCesEvents", "consensus rounds", ConsensusRound::getStreamedEvents)
-                .solderTo(consensusEventStreamWiring.getInputWire(ConsensusEventStream::addEvents));
+                .solderTo(w.consensusEventStreamWiring().getInputWire(ConsensusEventStream::addEvents));
 
         // The TransactionHandler output is split into two types: system transactions, and state with complexity.
         final OutputWire<Queue<ScopedSystemTransaction<StateSignatureTransaction>>>
-                transactionHandlerSysTxnsOutputWire = transactionHandlerWiring
+                transactionHandlerSysTxnsOutputWire = w.transactionHandlerWiring()
                         .getOutputWire()
                         .buildTransformer(
                                 "getSystemTransactions",
                                 "transaction handler result",
                                 TransactionHandlerResult::systemTransactions);
         transactionHandlerSysTxnsOutputWire.solderTo(
-                stateSignatureCollectorWiring.getInputWire(StateSignatureCollector::handlePostconsensusSignatures));
+                w.stateSignatureCollectorWiring().getInputWire(StateSignatureCollector::handlePostconsensusSignatures));
         transactionHandlerSysTxnsOutputWire.solderTo(
-                issDetectorWiring.getInputWire(IssDetector::handleStateSignatureTransactions));
+                w.issDetectorWiring().getInputWire(IssDetector::handleStateSignatureTransactions));
 
-        final OutputWire<StateWithHashComplexity> transactionHandlerStateWithComplexityOutput = transactionHandlerWiring
-                .getOutputWire()
-                .buildFilter(
-                        "notNullStateFilter",
-                        "transaction handler result",
-                        thr -> thr.stateWithHashComplexity() != null)
-                .buildAdvancedTransformer(
-                        new StateWithHashComplexityReserver("postHandler_stateWithHashComplexityReserver"));
+        final OutputWire<StateWithHashComplexity> transactionHandlerStateWithComplexityOutput =
+                w.transactionHandlerWiring()
+                        .getOutputWire()
+                        .buildFilter(
+                                "notNullStateFilter",
+                                "transaction handler result",
+                                thr -> thr.stateWithHashComplexity() != null)
+                        .buildAdvancedTransformer(
+                                new StateWithHashComplexityReserver("postHandler_stateWithHashComplexityReserver"));
 
         transactionHandlerStateWithComplexityOutput.solderTo(
-                savedStateControllerWiring.getInputWire(SavedStateController::markSavedState));
+                w.savedStateControllerWiring().getInputWire(SavedStateController::markSavedState));
 
         final OutputWire<ReservedSignedState> transactionHandlerStateOnlyOutput =
                 transactionHandlerStateWithComplexityOutput.buildAdvancedTransformer(
@@ -496,31 +257,36 @@ public class PlatformWiring {
                                 "postHandler_stateWithHashComplexityToStateReserver"));
 
         transactionHandlerStateOnlyOutput.solderTo(
-                latestImmutableStateNexusWiring.getInputWire(SignedStateNexus::setState));
+                w.latestImmutableStateNexusWiring().getInputWire(SignedStateNexus::setState));
         transactionHandlerStateOnlyOutput.solderTo(
-                stateGarbageCollectorWiring.getInputWire(StateGarbageCollector::registerState));
+                w.stateGarbageCollectorWiring().getInputWire(StateGarbageCollector::registerState));
 
-        savedStateControllerWiring.getOutputWire().solderTo(stateHasherWiring.getInputWire(StateHasher::hashState));
+        w.savedStateControllerWiring()
+                .getOutputWire()
+                .solderTo(w.stateHasherWiring().getInputWire(StateHasher::hashState));
 
-        model.buildHeartbeatWire(config.stateGarbageCollectorHeartbeatPeriod())
-                .solderTo(stateGarbageCollectorWiring.getInputWire(StateGarbageCollector::heartbeat), OFFER);
-        model.buildHeartbeatWire(config.signedStateSentinelHeartbeatPeriod())
-                .solderTo(signedStateSentinelWiring.getInputWire(SignedStateSentinel::checkSignedStates), OFFER);
+        var config = platformContext.getConfiguration().getConfigData(PlatformSchedulersConfig.class);
+        w.model()
+                .buildHeartbeatWire(config.stateGarbageCollectorHeartbeatPeriod())
+                .solderTo(w.stateGarbageCollectorWiring().getInputWire(StateGarbageCollector::heartbeat), OFFER);
+        w.model()
+                .buildHeartbeatWire(config.signedStateSentinelHeartbeatPeriod())
+                .solderTo(w.signedStateSentinelWiring().getInputWire(SignedStateSentinel::checkSignedStates), OFFER);
 
         // The state hasher needs to pass its data through a bunch of transformers. Construct those here.
-        final OutputWire<ReservedSignedState> hashedStateOutputWire = stateHasherWiring
+        final OutputWire<ReservedSignedState> hashedStateOutputWire = w.stateHasherWiring()
                 .getOutputWire()
                 .buildAdvancedTransformer(new SignedStateReserver("postHasher_stateReserver"));
 
-        hashedStateOutputWire.solderTo(hashLoggerWiring.getInputWire(HashLogger::logHashes));
-        hashedStateOutputWire.solderTo(stateSignerWiring.getInputWire(StateSigner::signState));
-        hashedStateOutputWire.solderTo(issDetectorWiring.getInputWire(IssDetector::handleState));
+        hashedStateOutputWire.solderTo(w.hashLoggerWiring().getInputWire(HashLogger::logHashes));
+        hashedStateOutputWire.solderTo(w.stateSignerWiring().getInputWire(StateSigner::signState));
+        hashedStateOutputWire.solderTo(w.issDetectorWiring().getInputWire(IssDetector::handleState));
         hashedStateOutputWire
                 .buildTransformer("postHasher_notifier", "hashed states", StateHashedNotification::from)
-                .solderTo(notifierWiring.getInputWire(AppNotifier::sendStateHashedNotification));
+                .solderTo(w.notifierWiring().getInputWire(AppNotifier::sendStateHashedNotification));
 
         // send state signatures to execution
-        stateSignerWiring
+        w.stateSignerWiring()
                 .getOutputWire()
                 .solderTo("ExecutionSignatureSubmission", "state signatures", execution::submitStateSignature);
 
@@ -529,53 +295,100 @@ public class PlatformWiring {
 
         // Solder the state output as input to the state signature collector.
         hashedStateOutputWire.solderTo(
-                stateSignatureCollectorWiring.getInputWire(StateSignatureCollector::addReservedState));
+                w.stateSignatureCollectorWiring().getInputWire(StateSignatureCollector::addReservedState));
 
-        stateSnapshotManagerWiring
+        w.stateSnapshotManagerWiring()
                 .getTransformedOutput(StateSnapshotManager::extractOldestMinimumBirthRoundOnDisk)
                 .solderTo(
-                        pcesInlineWriterWiring.getInputWire(InlinePcesWriter::setMinimumAncientIdentifierToStore),
+                        w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::setMinimumAncientIdentifierToStore),
                         INJECT);
 
-        stateSnapshotManagerWiring
+        w.stateSnapshotManagerWiring()
                 .getTransformedOutput(StateSnapshotManager::toStateWrittenToDiskAction)
-                .solderTo(statusStateMachineWiring.getInputWire(StatusStateMachine::submitStatusAction));
+                .solderTo(w.statusStateMachineWiring().getInputWire(StatusStateMachine::submitStatusAction));
 
-        runningEventHashOverrideWiring
+        w.runningEventHashOverrideWiring()
                 .runningHashUpdateOutput()
-                .solderTo(transactionHandlerWiring.getInputWire(TransactionHandler::updateLegacyRunningEventHash));
-        runningEventHashOverrideWiring
+                .solderTo(w.transactionHandlerWiring().getInputWire(TransactionHandler::updateLegacyRunningEventHash));
+        w.runningEventHashOverrideWiring()
                 .runningHashUpdateOutput()
-                .solderTo(consensusEventStreamWiring.getInputWire(ConsensusEventStream::legacyHashOverride));
+                .solderTo(w.consensusEventStreamWiring().getInputWire(ConsensusEventStream::legacyHashOverride));
 
-        final OutputWire<IssNotification> splitIssDetectorOutput = issDetectorWiring.getSplitOutput();
-        splitIssDetectorOutput.solderTo(issHandlerWiring.getInputWire(IssHandler::issObserved));
-        issDetectorWiring
+        final OutputWire<IssNotification> splitIssDetectorOutput =
+                w.issDetectorWiring().getSplitOutput();
+        splitIssDetectorOutput.solderTo(w.issHandlerWiring().getInputWire(IssHandler::issObserved));
+        w.issDetectorWiring()
                 .getSplitAndTransformedOutput(IssDetector::getStatusAction)
-                .solderTo(statusStateMachineWiring.getInputWire(StatusStateMachine::submitStatusAction));
+                .solderTo(w.statusStateMachineWiring().getInputWire(StatusStateMachine::submitStatusAction));
 
-        completeReservedSignedStatesWire.solderTo(latestCompleteStateNotifierWiring.getInputWire(
-                LatestCompleteStateNotifier::latestCompleteStateHandler));
+        completeReservedSignedStatesWire.solderTo(w.latestCompleteStateNotifierWiring()
+                .getInputWire(LatestCompleteStateNotifier::latestCompleteStateHandler));
 
-        statusStateMachineWiring
+        w.statusStateMachineWiring()
                 .getOutputWire()
-                .solderTo(eventCreationManagerWiring.getInputWire(EventCreationManager::updatePlatformStatus));
-        statusStateMachineWiring
+                .solderTo(w.eventCreationManagerWiring().getInputWire(EventCreationManager::updatePlatformStatus));
+        w.statusStateMachineWiring()
                 .getOutputWire()
-                .solderTo(consensusEngineWiring.getInputWire(ConsensusEngine::updatePlatformStatus), INJECT);
-        statusStateMachineWiring
+                .solderTo(
+                        w.consensusEngineWiring().componentWiring().getInputWire(ConsensusEngine::updatePlatformStatus),
+                        INJECT);
+        w.statusStateMachineWiring()
                 .getOutputWire()
                 .solderTo("ExecutionStatusHandler", "status updates", execution::newPlatformStatus);
-        statusStateMachineWiring.getOutputWire().solderTo(gossipWiring.getPlatformStatusInput(), INJECT);
+        w.statusStateMachineWiring().getOutputWire().solderTo(w.gossipWiring().getPlatformStatusInput(), INJECT);
 
-        solderNotifier();
+        solderNotifier(w);
 
-        if (publishPreconsensusEvents) {
+        if (w.platformPublisherWiring().getSchedulerType() != NO_OP) {
             splitOrphanBufferOutput.solderTo(
-                    platformPublisherWiring.getInputWire(PlatformPublisher::publishPreconsensusEvent));
+                    w.platformPublisherWiring().getInputWire(PlatformPublisher::publishPreconsensusEvent));
         }
 
-        buildUnsolderedWires();
+        buildUnsolderedWires(w);
+    }
+
+    /**
+     * Solder the EventWindow output to all components that need it.
+     */
+    private static void solderEventWindow(PlatformComponents w) {
+        final OutputWire<EventWindow> eventWindowOutputWire =
+                w.eventWindowManagerWiring().getOutputWire();
+
+        eventWindowOutputWire.solderTo(
+                w.eventDeduplicatorWiring().getInputWire(EventDeduplicator::setEventWindow), INJECT);
+        eventWindowOutputWire.solderTo(
+                w.eventSignatureValidatorWiring().getInputWire(EventSignatureValidator::setEventWindow), INJECT);
+        eventWindowOutputWire.solderTo(w.orphanBufferWiring().getInputWire(OrphanBuffer::setEventWindow), INJECT);
+        eventWindowOutputWire.solderTo(w.gossipWiring().getEventWindowInput(), INJECT);
+        eventWindowOutputWire.solderTo(
+                w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::updateNonAncientEventBoundary), INJECT);
+        eventWindowOutputWire.solderTo(
+                w.eventCreationManagerWiring().getInputWire(EventCreationManager::setEventWindow), INJECT);
+        eventWindowOutputWire.solderTo(
+                w.latestCompleteStateNexusWiring().getInputWire(LatestCompleteStateNexus::updateEventWindow));
+        eventWindowOutputWire.solderTo(
+                w.branchDetectorWiring().getInputWire(BranchDetector::updateEventWindow), INJECT);
+        eventWindowOutputWire.solderTo(
+                w.branchReporterWiring().getInputWire(BranchReporter::updateEventWindow), INJECT);
+    }
+
+    /**
+     * Solder notifications into the notifier.
+     */
+    private static void solderNotifier(PlatformComponents w) {
+        w.latestCompleteStateNotifierWiring()
+                .getOutputWire()
+                .solderTo(w.notifierWiring().getInputWire(AppNotifier::sendLatestCompleteStateNotification));
+        w.stateSnapshotManagerWiring()
+                .getTransformedOutput(StateSnapshotManager::toNotification)
+                .solderTo(w.notifierWiring().getInputWire(AppNotifier::sendStateWrittenToDiskNotification), INJECT);
+
+        final OutputWire<IssNotification> issNotificationOutputWire =
+                w.issDetectorWiring().getSplitOutput();
+        issNotificationOutputWire.solderTo(w.notifierWiring().getInputWire(AppNotifier::sendIssNotification));
+        w.statusStateMachineWiring()
+                .getOutputWire()
+                .solderTo(w.notifierWiring().getInputWire(AppNotifier::sendPlatformStatusChangeNotification));
     }
 
     /**
@@ -583,338 +396,24 @@ public class PlatformWiring {
      * we are soldering things together, but there are a few wires that aren't soldered and aren't used until later in
      * the lifecycle. This method forces those wires to be built.
      */
-    private void buildUnsolderedWires() {
-        eventDeduplicatorWiring.getInputWire(EventDeduplicator::clear);
-        consensusEngineWiring.getInputWire(ConsensusEngine::outOfBandSnapshotUpdate);
-        if (publishSnapshotOverrides) {
-            platformPublisherWiring.getInputWire(PlatformPublisher::publishSnapshotOverride);
+    private static void buildUnsolderedWires(PlatformComponents w) {
+        w.eventDeduplicatorWiring().getInputWire(EventDeduplicator::clear);
+        w.consensusEngineWiring().getInputWire(ConsensusEngine::outOfBandSnapshotUpdate);
+        if (w.platformPublisherWiring().getSchedulerType() != NO_OP) {
+            w.platformPublisherWiring().getInputWire(PlatformPublisher::publishSnapshotOverride);
         }
-        eventCreationManagerWiring.getInputWire(EventCreationManager::clear);
-        notifierWiring.getInputWire(AppNotifier::sendReconnectCompleteNotification);
-        notifierWiring.getInputWire(AppNotifier::sendPlatformStatusChangeNotification);
-        eventSignatureValidatorWiring.getInputWire(EventSignatureValidator::updateRosterHistory);
-        eventWindowManagerWiring.getInputWire(EventWindowManager::updateEventWindow);
-        orphanBufferWiring.getInputWire(OrphanBuffer::clear);
-        pcesInlineWriterWiring.getInputWire(InlinePcesWriter::registerDiscontinuity);
-        stateSignatureCollectorWiring.getInputWire(StateSignatureCollector::clear);
-        issDetectorWiring.getInputWire(IssDetector::overridingState);
-        issDetectorWiring.getInputWire(IssDetector::signalEndOfPreconsensusReplay);
-        stateSnapshotManagerWiring.getInputWire(StateSnapshotManager::dumpStateTask);
-        branchDetectorWiring.getInputWire(BranchDetector::clear);
-        branchReporterWiring.getInputWire(BranchReporter::clear);
-    }
-
-    /**
-     * Bind components to the wiring.
-     *
-     * @param builder                   builds platform components that need to be bound to wires
-     * @param pcesReplayer              the PCES replayer to bind
-     * @param stateSignatureCollector   the signed state manager to bind
-     * @param eventWindowManager        the event window manager to bind
-     * @param latestImmutableStateNexus the latest immutable state nexus to bind
-     * @param latestCompleteStateNexus  the latest complete state nexus to bind
-     * @param savedStateController      the saved state controller to bind
-     * @param notifier                  the notifier to bind
-     * @param platformPublisher         the platform publisher to bind
-     */
-    public void bind(
-            @NonNull final PlatformComponentBuilder builder,
-            @NonNull final PcesReplayer pcesReplayer,
-            @NonNull final StateSignatureCollector stateSignatureCollector,
-            @NonNull final EventWindowManager eventWindowManager,
-            @Nullable final InlinePcesWriter inlinePcesWriter,
-            @NonNull final SignedStateNexus latestImmutableStateNexus,
-            @NonNull final LatestCompleteStateNexus latestCompleteStateNexus,
-            @NonNull final SavedStateController savedStateController,
-            @NonNull final AppNotifier notifier,
-            @NonNull final PlatformPublisher platformPublisher) {
-
-        eventHasherWiring.bind(builder::buildEventHasher);
-        internalEventValidatorWiring.bind(builder::buildInternalEventValidator);
-        eventDeduplicatorWiring.bind(builder::buildEventDeduplicator);
-        eventSignatureValidatorWiring.bind(builder::buildEventSignatureValidator);
-        orphanBufferWiring.bind(builder::buildOrphanBuffer);
-        consensusEngineWiring.bind(builder::buildConsensusEngine);
-        stateSnapshotManagerWiring.bind(builder::buildStateSnapshotManager);
-        stateSignerWiring.bind(builder::buildStateSigner);
-        pcesReplayerWiring.bind(pcesReplayer);
-        if (inlinePcesWriter != null) {
-            pcesInlineWriterWiring.bind(inlinePcesWriter);
-        } else {
-            pcesInlineWriterWiring.bind(builder::buildInlinePcesWriter);
-        }
-        eventCreationManagerWiring.bind(builder::buildEventCreationManager);
-        stateSignatureCollectorWiring.bind(stateSignatureCollector);
-        eventWindowManagerWiring.bind(eventWindowManager);
-        applicationTransactionPrehandlerWiring.bind(builder::buildTransactionPrehandler);
-        transactionHandlerWiring.bind(builder::buildTransactionHandler);
-        consensusEventStreamWiring.bind(builder::buildConsensusEventStream);
-        issDetectorWiring.bind(builder::buildIssDetector);
-        issHandlerWiring.bind(builder::buildIssHandler);
-        hashLoggerWiring.bind(builder::buildHashLogger);
-        latestCompleteStateNotifierWiring.bind(builder::buildLatestCompleteStateNotifier);
-        latestImmutableStateNexusWiring.bind(latestImmutableStateNexus);
-        latestCompleteStateNexusWiring.bind(latestCompleteStateNexus);
-        savedStateControllerWiring.bind(savedStateController);
-        stateHasherWiring.bind(builder::buildStateHasher);
-        notifierWiring.bind(notifier);
-        platformPublisherWiring.bind(platformPublisher);
-        stateGarbageCollectorWiring.bind(builder::buildStateGarbageCollector);
-        statusStateMachineWiring.bind(builder::buildStatusStateMachine);
-        signedStateSentinelWiring.bind(builder::buildSignedStateSentinel);
-        gossipWiring.bind(builder.buildGossip());
-        branchDetectorWiring.bind(builder::buildBranchDetector);
-        branchReporterWiring.bind(builder::buildBranchReporter);
-    }
-
-    /**
-     * Start gossiping.
-     */
-    public void startGossip() {
-        gossipWiring.getStartInput().inject(NoInput.getInstance());
-    }
-
-    /**
-     * Get the input wire for the roster history update.
-     * <p>
-     * Future work: this is a temporary hook to update the rosters in the new intake pipeline.
-     *
-     * @return the input wire for the roster history update.
-     */
-    @NonNull
-    public InputWire<RosterHistory> getRosterHistoryInput() {
-        return eventSignatureValidatorWiring.getInputWire(EventSignatureValidator::updateRosterHistory);
-    }
-
-    /**
-     * Get the input wire for dumping a state to disk
-     * <p>
-     * Future work: this is a temporary hook to allow the components to dump a state to disk, prior to the whole system
-     * being migrated to the new framework.
-     *
-     * @return the input wire for dumping a state to disk
-     */
-    @NonNull
-    public InputWire<StateDumpRequest> getDumpStateToDiskInput() {
-        return stateSnapshotManagerWiring.getInputWire(StateSnapshotManager::dumpStateTask);
-    }
-
-    /**
-     * @return the input wire for states that need their signatures collected
-     */
-    @NonNull
-    public InputWire<ReservedSignedState> getSignatureCollectorStateInput() {
-        return stateSignatureCollectorWiring.getInputWire(StateSignatureCollector::addReservedState);
-    }
-
-    /**
-     * Get the input wire for passing a PCES iterator to the replayer.
-     *
-     * @return the input wire for passing a PCES iterator to the replayer
-     */
-    @NonNull
-    public InputWire<IOIterator<PlatformEvent>> getPcesReplayerIteratorInput() {
-        return pcesReplayerWiring.pcesIteratorInputWire();
-    }
-
-    /**
-     * Get the output wire that the replayer uses to pass events from file into the intake pipeline.
-     *
-     * @return the output wire that the replayer uses to pass events from file into the intake pipeline
-     */
-    @NonNull
-    public StandardOutputWire<PlatformEvent> getPcesReplayerEventOutput() {
-        return pcesReplayerWiring.eventOutput();
-    }
-
-    /**
-     * Get the input wire that the hashlogger uses to accept the signed state.
-     *
-     * @return the input wire that the hashlogger uses to accept the signed state
-     */
-    @NonNull
-    public InputWire<ReservedSignedState> getHashLoggerInput() {
-        return hashLoggerWiring.getInputWire(HashLogger::logHashes);
-    }
-
-    /**
-     * Forward a state to the hash logger.
-     *
-     * @param signedState the state to forward
-     */
-    public void sendStateToHashLogger(@NonNull final SignedState signedState) {
-        if (signedState.getState().getHash() != null) {
-            final ReservedSignedState stateReservedForHasher = signedState.reserve("logging state hash");
-
-            final boolean offerResult = getHashLoggerInput().offer(stateReservedForHasher);
-            if (!offerResult) {
-                stateReservedForHasher.close();
-            }
-        }
-    }
-
-    /**
-     * Get the input wire for the PCES writer minimum generation to store
-     *
-     * @return the input wire for the PCES writer minimum generation to store
-     */
-    @NonNull
-    public InputWire<Long> getPcesMinimumGenerationToStoreInput() {
-        return pcesInlineWriterWiring.getInputWire(InlinePcesWriter::setMinimumAncientIdentifierToStore);
-    }
-
-    /**
-     * Get the input wire for the PCES writer to register a discontinuity
-     *
-     * @return the input wire for the PCES writer to register a discontinuity
-     */
-    @NonNull
-    public InputWire<Long> getPcesWriterRegisterDiscontinuityInput() {
-        return pcesInlineWriterWiring.getInputWire(InlinePcesWriter::registerDiscontinuity);
-    }
-
-    /**
-     * Get the wiring for the app notifier
-     *
-     * @return the wiring for the app notifier
-     */
-    @NonNull
-    public ComponentWiring<AppNotifier, Void> getNotifierWiring() {
-        return notifierWiring;
-    }
-
-    /**
-     * Get the output wire for consensus engine
-     *
-     * @return the wiring for the consensus engine
-     */
-    @NonNull
-    public OutputWire<List<ConsensusRound>> getConsensusEngineOutputWire() {
-        return consensusRoundsOutputWire;
-    }
-
-    /**
-     * Update the running hash for all components that need it.
-     *
-     * @param runningHashUpdate the object containing necessary information to update the running hash
-     */
-    public void updateRunningHash(@NonNull final RunningEventHashOverride runningHashUpdate) {
-        runningEventHashOverrideWiring.runningHashUpdateInput().inject(runningHashUpdate);
-    }
-
-    /**
-     * Pass an overriding state to the ISS detector.
-     *
-     * @param state the overriding state
-     */
-    public void overrideIssDetectorState(@NonNull final ReservedSignedState state) {
-        issDetectorWiring.getInputWire(IssDetector::overridingState).put(state);
-    }
-
-    /**
-     * Signal the end of the preconsensus replay to the ISS detector.
-     */
-    public void signalEndOfPcesReplay() {
-        issDetectorWiring
-                .getInputWire(IssDetector::signalEndOfPreconsensusReplay)
-                .put(NoInput.getInstance());
-    }
-
-    /**
-     * Get the status action submitter.
-     *
-     * @return the status action submitter
-     */
-    @NonNull
-    public StatusActionSubmitter getStatusActionSubmitter() {
-        return action -> statusStateMachineWiring
-                .getInputWire(StatusStateMachine::submitStatusAction)
-                .put(action);
-    }
-
-    /**
-     * Get the output wire for the status state machine.
-     *
-     * @return the output wire for the status state machine
-     */
-    @NonNull
-    public OutputWire<PlatformStatus> getStatusStateMachineOutputWire() {
-        return statusStateMachineWiring.getOutputWire();
-    }
-
-    /**
-     * Inject a new event window into all components that need it.
-     *
-     * @param eventWindow the new event window
-     */
-    public void updateEventWindow(@NonNull final EventWindow eventWindow) {
-        // Future work: this method can merge with consensusSnapshotOverride
-        eventWindowManagerWiring
-                .getInputWire(EventWindowManager::updateEventWindow)
-                .inject(eventWindow);
-
-        // Since there is asynchronous access to the shadowgraph, it's important to ensure that
-        // it has fully ingested the new event window before continuing.
-        gossipWiring.flush();
-    }
-
-    /**
-     * Inject a new consensus snapshot into all components that need it. This will happen at restart and reconnect
-     * boundaries.
-     *
-     * @param consensusSnapshot the new consensus snapshot
-     */
-    public void consensusSnapshotOverride(@NonNull final ConsensusSnapshot consensusSnapshot) {
-        consensusEngineWiring
-                .getInputWire(ConsensusEngine::outOfBandSnapshotUpdate)
-                .inject(consensusSnapshot);
-
-        if (publishSnapshotOverrides) {
-            platformPublisherWiring
-                    .getInputWire(PlatformPublisher::publishSnapshotOverride)
-                    .inject(consensusSnapshot);
-        }
-    }
-
-    /**
-     * Flush the intake pipeline.
-     */
-    public void flushIntakePipeline() {
-        platformCoordinator.flushIntakePipeline();
-    }
-
-    /**
-     * Flush the transaction handler.
-     */
-    public void flushTransactionHandler() {
-        transactionHandlerWiring.flush();
-    }
-
-    /**
-     * Flush the state hasher.
-     */
-    public void flushStateHasher() {
-        stateHasherWiring.flush();
-    }
-
-    /**
-     * Start the wiring framework.
-     */
-    public void start() {
-        model.start();
-    }
-
-    /**
-     * Stop the wiring framework.
-     */
-    public void stop() {
-        model.stop();
-    }
-
-    /**
-     * Clear all the wiring objects.
-     */
-    public void clear() {
-        platformCoordinator.clear();
+        w.eventCreationManagerWiring().getInputWire(EventCreationManager::clear);
+        w.notifierWiring().getInputWire(AppNotifier::sendReconnectCompleteNotification);
+        w.notifierWiring().getInputWire(AppNotifier::sendPlatformStatusChangeNotification);
+        w.eventSignatureValidatorWiring().getInputWire(EventSignatureValidator::updateRosterHistory);
+        w.eventWindowManagerWiring().getInputWire(EventWindowManager::updateEventWindow);
+        w.orphanBufferWiring().getInputWire(OrphanBuffer::clear);
+        w.pcesInlineWriterWiring().getInputWire(InlinePcesWriter::registerDiscontinuity);
+        w.stateSignatureCollectorWiring().getInputWire(StateSignatureCollector::clear);
+        w.issDetectorWiring().getInputWire(IssDetector::overridingState);
+        w.issDetectorWiring().getInputWire(IssDetector::signalEndOfPreconsensusReplay);
+        w.stateSnapshotManagerWiring().getInputWire(StateSnapshotManager::dumpStateTask);
+        w.branchDetectorWiring().getInputWire(BranchDetector::clear);
+        w.branchReporterWiring().getInputWire(BranchReporter::clear);
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -78,12 +78,14 @@ public class PlatformWiring {
                 components.eventHasherWiring().getInputWire(EventHasher::hashEvent, "unhashed event");
         components.gossipWiring().getEventOutput().solderTo(hasherInputWire);
 
-        components.gossipWiring()
+        components
+                .gossipWiring()
                 .getSyncLagOutput()
                 .solderTo(
                         components.eventCreationManagerWiring().getInputWire(EventCreationManager::reportSyncRoundLag));
 
-        components.eventHasherWiring()
+        components
+                .eventHasherWiring()
                 .getOutputWire()
                 .solderTo(
                         components.internalEventValidatorWiring().getInputWire(InternalEventValidator::validateEvent));
@@ -140,7 +142,9 @@ public class PlatformWiring {
                 .model()
                 .getHealthMonitorWire()
                 .solderTo(components.gossipWiring().getSystemHealthInput());
-        components.model().getHealthMonitorWire()
+        components
+                .model()
+                .getHealthMonitorWire()
                 .solderTo("executionHealthInput", "healthyDuration", execution::reportUnhealthyDuration);
 
         splitOrphanBufferOutput.solderTo(
@@ -173,7 +177,6 @@ public class PlatformWiring {
                 .branchDetectorWiring()
                 .getOutputWire()
                 .solderTo(components.branchReporterWiring().getInputWire(BranchReporter::reportBranch));
-
 
         final double eventCreationHeartbeatFrequency = platformContext
                 .getConfiguration()

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -132,15 +132,20 @@ public class PlatformWiring {
                 .solderTo(components.eventCreationManagerWiring().getInputWire(EventCreationManager::registerEvent));
 
         components
-                .model().getHealthMonitorWire()
-                .solderTo(components.eventCreationManagerWiring().getInputWire(EventCreationManager::reportUnhealthyDuration));
+                .model()
+                .getHealthMonitorWire()
+                .solderTo(components
+                        .eventCreationManagerWiring()
+                        .getInputWire(EventCreationManager::reportUnhealthyDuration));
 
         components
-                .model().getHealthMonitorWire().solderTo(components.gossipWiring().getSystemHealthInput());
+                .model()
+                .getHealthMonitorWire()
+                .solderTo(components.gossipWiring().getSystemHealthInput());
         components
-                .model().getHealthMonitorWire()
+                .model()
+                .getHealthMonitorWire()
                 .solderTo("executionHealthInput", "healthyDuration", execution::reportUnhealthyDuration);
-
 
         splitOrphanBufferOutput.solderTo(
                 components.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -80,7 +80,8 @@ public class PlatformWiring {
 
         components.gossipWiring()
                 .getSyncLagOutput()
-                .solderTo(components.eventCreationManagerWiring().getInputWire(EventCreationManager::reportSyncRoundLag));
+                .solderTo(
+                        components.eventCreationManagerWiring().getInputWire(EventCreationManager::reportSyncRoundLag));
 
         components.eventHasherWiring()
                 .getOutputWire()

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -150,6 +150,31 @@ public class PlatformWiring {
                 .getOutputWire()
                 .solderTo(components.branchReporterWiring().getInputWire(BranchReporter::reportBranch));
 
+        components
+                .model()
+                .getHealthMonitorWire()
+                .solderTo(components
+                        .eventCreationManagerWiring()
+                        .getInputWire(EventCreationManager::reportUnhealthyDuration));
+        components
+                .model()
+                .getHealthMonitorWire()
+                .solderTo(components.gossipWiring().getSystemHealthInput());
+        components
+                .model()
+                .getHealthMonitorWire()
+                .solderTo("executionHealthInput", "healthyDuration", execution::reportUnhealthyDuration);
+
+        splitOrphanBufferOutput.solderTo(
+                components.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));
+        splitOrphanBufferOutput.solderTo(
+                components.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));
+        components
+                .branchDetectorWiring()
+                .getOutputWire()
+                .solderTo(components.branchReporterWiring().getInputWire(BranchReporter::reportBranch));
+
+
         final double eventCreationHeartbeatFrequency = platformContext
                 .getConfiguration()
                 .getConfigData(EventCreationConfig.class)

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -147,13 +147,6 @@ public class PlatformWiring {
                 .getHealthMonitorWire()
                 .solderTo("executionHealthInput", "healthyDuration", execution::reportUnhealthyDuration);
 
-        splitOrphanBufferOutput.solderTo(
-                components.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));
-        components
-                .branchDetectorWiring()
-                .getOutputWire()
-                .solderTo(components.branchReporterWiring().getInputWire(BranchReporter::reportBranch));
-
         components
                 .model()
                 .getHealthMonitorWire()
@@ -169,8 +162,6 @@ public class PlatformWiring {
                 .getHealthMonitorWire()
                 .solderTo("executionHealthInput", "healthyDuration", execution::reportUnhealthyDuration);
 
-        splitOrphanBufferOutput.solderTo(
-                components.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));
         splitOrphanBufferOutput.solderTo(
                 components.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));
         components

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformWiring.java
@@ -132,35 +132,15 @@ public class PlatformWiring {
                 .solderTo(components.eventCreationManagerWiring().getInputWire(EventCreationManager::registerEvent));
 
         components
-                .model()
-                .getHealthMonitorWire()
-                .solderTo(components
-                        .eventCreationManagerWiring()
-                        .getInputWire(EventCreationManager::reportUnhealthyDuration));
+                .model().getHealthMonitorWire()
+                .solderTo(components.eventCreationManagerWiring().getInputWire(EventCreationManager::reportUnhealthyDuration));
 
         components
-                .model()
-                .getHealthMonitorWire()
-                .solderTo(components.gossipWiring().getSystemHealthInput());
+                .model().getHealthMonitorWire().solderTo(components.gossipWiring().getSystemHealthInput());
         components
-                .model()
-                .getHealthMonitorWire()
+                .model().getHealthMonitorWire()
                 .solderTo("executionHealthInput", "healthyDuration", execution::reportUnhealthyDuration);
 
-        components
-                .model()
-                .getHealthMonitorWire()
-                .solderTo(components
-                        .eventCreationManagerWiring()
-                        .getInputWire(EventCreationManager::reportUnhealthyDuration));
-        components
-                .model()
-                .getHealthMonitorWire()
-                .solderTo(components.gossipWiring().getSystemHealthInput());
-        components
-                .model()
-                .getHealthMonitorWire()
-                .solderTo("executionHealthInput", "healthyDuration", execution::reportUnhealthyDuration);
 
         splitOrphanBufferOutput.solderTo(
                 components.branchDetectorWiring().getInputWire(BranchDetector::checkForBranches));

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/ConsensusWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/ConsensusWiring.java
@@ -25,7 +25,14 @@ public record ConsensusWiring(
         @NonNull ComponentWiring<ConsensusEngine, ConsensusEngineOutput> componentWiring,
         @NonNull OutputWire<List<ConsensusRound>> consensusRoundsOutputWire) {
 
-    public static ConsensusWiring create(WiringModel model, TaskSchedulerConfiguration consensusEngineConfig) {
+    /**
+     * Creates the consensusWiring instance
+     * @param model  the wiring model
+     * @param consensusEngineConfig the configuration to use
+     * @return the new instance
+     */
+    @NonNull
+    public static ConsensusWiring create(@NonNull final  WiringModel model, @NonNull final TaskSchedulerConfiguration consensusEngineConfig) {
         final ComponentWiring<ConsensusEngine, ConsensusEngineOutput> consensusEngineWiring =
                 new ComponentWiring<>(model, ConsensusEngine.class, consensusEngineConfig);
         final OutputWire<List<ConsensusRound>> consensusRoundsOutputWire = consensusEngineWiring

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/ConsensusWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/ConsensusWiring.java
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.platform.wiring.components;
+
+import com.swirlds.component.framework.component.ComponentWiring;
+import com.swirlds.component.framework.model.WiringModel;
+import com.swirlds.component.framework.schedulers.builders.TaskSchedulerConfiguration;
+import com.swirlds.component.framework.wires.input.InputWire;
+import com.swirlds.component.framework.wires.output.OutputWire;
+import com.swirlds.platform.components.consensus.ConsensusEngine;
+import com.swirlds.platform.components.consensus.ConsensusEngineOutput;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.hiero.consensus.model.hashgraph.ConsensusRound;
+
+/**
+ * The wiring for the {@link ConsensusEngine}.
+ *
+ * @param componentWiring       the wiring
+ * @param consensusRoundsOutputWire the output wire that returns rounds
+ */
+public record ConsensusWiring(
+        @NonNull ComponentWiring<ConsensusEngine, ConsensusEngineOutput> componentWiring,
+        @NonNull OutputWire<List<ConsensusRound>> consensusRoundsOutputWire) {
+
+    public static ConsensusWiring create(WiringModel model, TaskSchedulerConfiguration consensusEngineConfig) {
+        final ComponentWiring<ConsensusEngine, ConsensusEngineOutput> consensusEngineWiring =
+                new ComponentWiring<>(model, ConsensusEngine.class, consensusEngineConfig);
+        final OutputWire<List<ConsensusRound>> consensusRoundsOutputWire = consensusEngineWiring
+                .getOutputWire()
+                .buildTransformer("ConsensusRounds", "consensusEngineOutput", ConsensusEngineOutput::consensusRounds);
+
+        return new ConsensusWiring(consensusEngineWiring, consensusRoundsOutputWire);
+    }
+
+    /**
+     * @see ComponentWiring#getInputWire(Consumer)
+     */
+    public <T> InputWire<T> getInputWire(final BiConsumer<ConsensusEngine, T> handler) {
+        return componentWiring.getInputWire(handler);
+    }
+
+    /**
+     * @see ComponentWiring#bind(Supplier)
+     */
+    public void bind(final Supplier<ConsensusEngine> engineSupplier) {
+        componentWiring.bind(engineSupplier);
+    }
+
+    /**
+     * @see ComponentWiring#getOutputWire()
+     */
+    public OutputWire<ConsensusEngineOutput> getOutputWire() {
+        return componentWiring.getOutputWire();
+    }
+
+    /**
+     * @see ComponentWiring#flush()
+     */
+    public void flush() {
+        componentWiring.flush();
+    }
+
+    /**
+     * @see ComponentWiring#startSquelching()
+     */
+    public void startSquelching() {
+        componentWiring.startSquelching();
+    }
+
+    /**
+     * @see ComponentWiring#stopSquelching()
+     */
+    public void stopSquelching() {
+        componentWiring.stopSquelching();
+    }
+}

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/ConsensusWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/ConsensusWiring.java
@@ -32,7 +32,8 @@ public record ConsensusWiring(
      * @return the new instance
      */
     @NonNull
-    public static ConsensusWiring create(@NonNull final  WiringModel model, @NonNull final TaskSchedulerConfiguration consensusEngineConfig) {
+    public static ConsensusWiring create(
+            @NonNull final WiringModel model, @NonNull final TaskSchedulerConfiguration consensusEngineConfig) {
         final ComponentWiring<ConsensusEngine, ConsensusEngineOutput> consensusEngineWiring =
                 new ComponentWiring<>(model, ConsensusEngine.class, consensusEngineConfig);
         final OutputWire<List<ConsensusRound>> consensusRoundsOutputWire = consensusEngineWiring

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/PassThroughWiring.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/components/PassThroughWiring.java
@@ -22,9 +22,8 @@ import java.util.function.Function;
  * of parked threads.
  * <p>
  * One example usage is in collecting hashes from the concurrent execution of the
- * {@link org.hiero.consensus.crypto.EventHasher}. The "postHashCollectorWiring" in
- * {@link com.swirlds.platform.wiring.PlatformWiring} is a pass through wiring object with a sequential scheduler that
- * shares a combined object counter with the preceding concurrent scheduler. Since the pair of schedulers share a
+ * {@link org.hiero.consensus.crypto.EventHasher}. The "postHashCollectorWiring" is a pass through wiring object with a sequential
+ * scheduler that shares a combined object counter with the preceding concurrent scheduler. Since the pair of schedulers share a
  * counter, the sequential scheduler does *not* apply backpressure to the concurrent scheduler. Instead, "finished"
  * hashing tasks will wait in the queue of the sequential scheduler until the next component in the pipeline is ready to
  * receive them. The concurrent scheduler will refuse to accept additional work based on the number of tasks that are

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/PlatformWiringTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/PlatformWiringTests.java
@@ -61,13 +61,13 @@ class PlatformWiringTests {
                 TestPlatformContextBuilder.create()
                         .withConfiguration(ConfigurationBuilder.create()
                                 .autoDiscoverExtensions()
-                                .withValue("platformWiring.inlinePces", "false")
+                                .withValue("platformComponentWiring.inlinePces", "false")
                                 .build())
                         .build(),
                 TestPlatformContextBuilder.create()
                         .withConfiguration(ConfigurationBuilder.create()
                                 .autoDiscoverExtensions()
-                                .withValue("platformWiring.inlinePces", "true")
+                                .withValue("platformComponentWiring.inlinePces", "true")
                                 .build())
                         .build());
     }
@@ -81,12 +81,14 @@ class PlatformWiringTests {
         final WiringModel model =
                 WiringModelBuilder.create(new NoOpMetrics(), Time.getCurrent()).build();
 
-        final PlatformWiring wiring =
-                new PlatformWiring(platformContext, model, applicationCallbacks, mock(ExecutionLayer.class));
+        final PlatformComponents platformComponents =
+                PlatformComponents.create(platformContext, model, applicationCallbacks);
+        PlatformWiring.wire(platformContext, mock(ExecutionLayer.class), platformComponents);
 
         final PlatformComponentBuilder componentBuilder =
                 new PlatformComponentBuilder(mock(PlatformBuildingBlocks.class));
 
+        final PlatformCoordinator coordinator = new PlatformCoordinator(platformComponents);
         componentBuilder
                 .withEventHasher(mock(EventHasher.class))
                 .withInternalEventValidator(mock(InternalEventValidator.class))
@@ -137,7 +139,7 @@ class PlatformWiringTests {
                     platformStatusInput.bindConsumer(platformStatus -> {});
                 });
 
-        wiring.bind(
+        platformComponents.bind(
                 componentBuilder,
                 mock(PcesReplayer.class),
                 mock(StateSignatureCollector.class),
@@ -149,8 +151,8 @@ class PlatformWiringTests {
                 mock(AppNotifier.class),
                 mock(PlatformPublisher.class));
 
-        wiring.start();
-        assertFalse(wiring.getModel().checkForUnboundInputWires());
-        wiring.stop();
+        coordinator.start();
+        assertFalse(model.checkForUnboundInputWires());
+        coordinator.stop();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/PlatformWiringTests.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/wiring/PlatformWiringTests.java
@@ -61,13 +61,13 @@ class PlatformWiringTests {
                 TestPlatformContextBuilder.create()
                         .withConfiguration(ConfigurationBuilder.create()
                                 .autoDiscoverExtensions()
-                                .withValue("platformComponentWiring.inlinePces", "false")
+                                .withValue("platformWiring.inlinePces", "false")
                                 .build())
                         .build(),
                 TestPlatformContextBuilder.create()
                         .withConfiguration(ConfigurationBuilder.create()
                                 .autoDiscoverExtensions()
-                                .withValue("platformComponentWiring.inlinePces", "true")
+                                .withValue("platformWiring.inlinePces", "true")
                                 .build())
                         .build());
     }


### PR DESCRIPTION
**Description**:
This PR breaks PlatformWiring into two different pieces and moves some of its responsibilities to PlatformCoordinator.


`PlatformCoordinator` repurposing. It now hosts all operations against the platform (e.g., start, stop, pause, and resume gossip, submit a status action, push a roster update, etc.) through its wires.
`PlatformWiring` becomes a static utility class with the responsibility of wiring the components.
`PlatformComponents` is a new record that holds a reference to all components in the platform.

**Related issue(s)**:

Fixes #20698

