### PR TITLE
chore: use custom solo-cheetah image with fixed resource limits for CITR tests

### DIFF
--- a/.github/workflows/support/citr/init-containers-values7.yaml
+++ b/.github/workflows/support/citr/init-containers-values7.yaml
@@ -14,7 +14,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -25,7 +25,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -36,7 +36,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -47,7 +47,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -58,7 +58,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -69,7 +69,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -80,7 +80,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -90,39 +90,39 @@ defaults:
     recordStreamUploader:
       resources:
         requests:
-          cpu: 500m
-          memory: 375Mi
+          cpu: 2000m
+          memory: 750Mi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 750Mi
     eventStreamUploader:
       resources:
         requests:
-          cpu: 500m
-          memory: 375Mi
+          cpu: 2000m
+          memory: 750Mi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 750Mi
     recordStreamSidecarUploader:
       resources:
         requests:
-          cpu: 500m
-          memory: 375Mi
+          cpu: 2000m
+          memory: 750Mi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 750Mi
     blockstreamUploader:
       resources:
         requests:
-          cpu: 1000m
-          memory: 375Mi
+          cpu: 2000m
+          memory: 750Mi
         limits:
           cpu: 2000m
           memory: 750Mi
   root:
     resources:
       requests:
-        cpu: 18
+        cpu: 22
         memory: 256Gi
       limits:
         cpu: 22
@@ -224,3 +224,10 @@ envoyDeployment:
       operator: "Equal"
       value: "%NETWORK_ID%"
       effect: "NoSchedule"
+cheetah:
+  image:
+    tag: "0.3.4" # https://github.com/hashgraph/solo-cheetah/pkgs/container/solo-cheetah%2Fcheetah
+  maxProcessors: 10 # max number of concurrent processors for each pipeline
+  # whether cheetah should stop the pipelines if any error occurs; if false, it will continue with the expectation that the
+  # error may get fixed in the next run
+  stopOnError: false

--- a/.github/workflows/support/citr/init-containers-values8.yaml
+++ b/.github/workflows/support/citr/init-containers-values8.yaml
@@ -14,7 +14,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -25,7 +25,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -36,7 +36,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -47,7 +47,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -58,7 +58,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -69,7 +69,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -80,7 +80,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -91,7 +91,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -101,31 +101,31 @@ defaults:
     recordStreamUploader:
       resources:
         requests:
-          cpu: 500m
-          memory: 375Mi
+          cpu: 2000m
+          memory: 750Mi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 750Mi
     eventStreamUploader:
       resources:
         requests:
-          cpu: 500m
+          cpu: 2000m
           memory: 375Mi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 750Mi
     recordStreamSidecarUploader:
       resources:
         requests:
-          cpu: 500m
+          cpu: 2000m
           memory: 375Mi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 750Mi
     blockstreamUploader:
       resources:
         requests:
-          cpu: 1000m
+          cpu: 2000m
           memory: 375Mi
         limits:
           cpu: 2000m
@@ -133,7 +133,7 @@ defaults:
   root:
     resources:
       requests:
-        cpu: 18
+        cpu: 22
         memory: 256Gi
       limits:
         cpu: 22
@@ -235,3 +235,10 @@ envoyDeployment:
       operator: "Equal"
       value: "%NETWORK_ID%"
       effect: "NoSchedule"
+cheetah:
+  image:
+    tag: "0.3.4" # https://github.com/hashgraph/solo-cheetah/pkgs/container/solo-cheetah%2Fcheetah
+  maxProcessors: 10 # max number of concurrent processors for each pipeline
+  # whether cheetah should stop the pipelines if any error occurs; if false, it will continue with the expectation that the
+  # error may get fixed in the next run
+  stopOnError: false

--- a/.github/workflows/support/citr/init-containers-values9.yaml
+++ b/.github/workflows/support/citr/init-containers-values9.yaml
@@ -14,7 +14,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -25,7 +25,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -36,7 +36,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -47,7 +47,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -58,7 +58,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -69,7 +69,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -80,7 +80,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -91,7 +91,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -102,7 +102,7 @@ hedera:
       root:
         resources:
           requests:
-            cpu: 18
+            cpu: 22
             memory: 256Gi
           limits:
             cpu: 22
@@ -112,32 +112,32 @@ defaults:
     recordStreamUploader:
       resources:
         requests:
-          cpu: 500m
-          memory: 375Mi
+          cpu: 2000m
+          memory: 750Mi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 750Mi
     eventStreamUploader:
       resources:
         requests:
-          cpu: 500m
-          memory: 375Mi
+          cpu: 2000m
+          memory: 750Mi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 750Mi
     recordStreamSidecarUploader:
       resources:
         requests:
-          cpu: 500m
-          memory: 375Mi
+          cpu: 2000m
+          memory: 750Mi
         limits:
-          cpu: 1000m
+          cpu: 2000m
           memory: 750Mi
     blockstreamUploader:
       resources:
         requests:
-          cpu: 1000m
-          memory: 375Mi
+          cpu: 2000m
+          memory: 750Mi
         limits:
           cpu: 2000m
           memory: 750Mi
@@ -246,3 +246,10 @@ envoyDeployment:
       operator: "Equal"
       value: "%NETWORK_ID%"
       effect: "NoSchedule"
+cheetah:
+  image:
+    tag: "0.3.4" # https://github.com/hashgraph/solo-cheetah/pkgs/container/solo-cheetah%2Fcheetah
+  maxProcessors: 10 # max number of concurrent processors for each pipeline
+  # whether cheetah should stop the pipelines if any error occurs; if false, it will continue with the expectation that the
+  # error may get fixed in the next run
+  stopOnError: false


### PR DESCRIPTION
## Description

This pull request updates resource allocations and introduces a new configuration section across several YAML files used for CI/CD workflows. The main changes are increased CPU and memory requests for key containers and the addition of a new `cheetah` configuration block.

Resource allocation updates:

* Increased the `cpu` requests for all `hedera.root.resources.requests.cpu` entries from `18` to `22` in `init-containers-values7.yaml`, `init-containers-values8.yaml`, and `init-containers-values9.yaml` to provide more compute resources for the root container. [[1]](diffhunk://#diff-30db1ad4518b21d233e3fd7d8365004c6fec37309f88b5b252c8cf34604d18a7L17-R17) [[2]](diffhunk://#diff-30db1ad4518b21d233e3fd7d8365004c6fec37309f88b5b252c8cf34604d18a7L28-R28) [[3]](diffhunk://#diff-30db1ad4518b21d233e3fd7d8365004c6fec37309f88b5b252c8cf34604d18a7L39-R39) [[4]](diffhunk://#diff-30db1ad4518b21d233e3fd7d8365004c6fec37309f88b5b252c8cf34604d18a7L50-R50) [[5]](diffhunk://#diff-30db1ad4518b21d233e3fd7d8365004c6fec37309f88b5b252c8cf34604d18a7L61-R61) [[6]](diffhunk://#diff-30db1ad4518b21d233e3fd7d8365004c6fec37309f88b5b252c8cf34604d18a7L72-R72) [[7]](diffhunk://#diff-30db1ad4518b21d233e3fd7d8365004c6fec37309f88b5b252c8cf34604d18a7L83-R83) [[8]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5L17-R17) [[9]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5L28-R28) [[10]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5L39-R39) [[11]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5L50-R50) [[12]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5L61-R61) [[13]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5L72-R72) [[14]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5L83-R83) [[15]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5L94-R94) [[16]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL17-R17) [[17]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL28-R28) [[18]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL39-R39) [[19]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL50-R50) [[20]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL61-R61) [[21]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL72-R72) [[22]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL83-R83) [[23]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL94-R94) [[24]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL105-R105)
* Increased `cpu` and `memory` requests for `recordStreamUploader`, `eventStreamUploader`, `recordStreamSidecarUploader`, and `blockstreamUploader` containers, roughly quadrupling CPU and doubling memory allocations in all three YAML files. [[1]](diffhunk://#diff-30db1ad4518b21d233e3fd7d8365004c6fec37309f88b5b252c8cf34604d18a7L93-R125) [[2]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5L104-R136) [[3]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caL115-R140)

New configuration addition:

* Added a new `cheetah` section with image tag, processor limits, and error handling configuration to each YAML file, enabling configuration of the solo-cheetah pipeline runner. [[1]](diffhunk://#diff-30db1ad4518b21d233e3fd7d8365004c6fec37309f88b5b252c8cf34604d18a7R227-R233) [[2]](diffhunk://#diff-12bdb534a81251696aba29a4851900f3bbe83d4ca79d35d5efa02bb6fea184a5R238-R244) [[3]](diffhunk://#diff-a024a74097ae860d030bd6a2c0517e02aa938539ff01ebbaf4c47d6500b385caR249-R255)

### Related Issues

- Closes #20762 