### PR TITLE
ci: Add rootly integration to zxcron-promote-build-candidate

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -166,9 +166,6 @@ jobs:
             gh run cancel "${{ github.run_id }}"
           fi
 
-          # Force a failure
-          exit 1
-
   extended-test-suite:
     name: Execute eXtended Test Suite
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
@@ -724,18 +721,18 @@ jobs:
           }
           EOF
 
-#      - name: Report failure (slack citr-operations)
-#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-#        with:
-#          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload-templated: true
-#          payload-file-path: slack_payload.json
-#
-#      - name: Report failure (slack release-team)
-#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-#        with:
-#          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload-templated: true
-#          payload-file-path: slack_payload.json
+      - name: Report failure (slack citr-operations)
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json
+
+      - name: Report failure (slack release-team)
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -165,7 +165,7 @@ jobs:
           else
             gh run cancel "${{ github.run_id }}"
           fi
-          
+
           # Force a failure
           exit 1
 

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -165,6 +165,9 @@ jobs:
           else
             gh run cancel "${{ github.run_id }}"
           fi
+          
+          # Force a failure
+          exit 1
 
   extended-test-suite:
     name: Execute eXtended Test Suite
@@ -721,18 +724,18 @@ jobs:
           }
           EOF
 
-      - name: Report failure (slack citr-operations)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json
+#      - name: Report failure (slack citr-operations)
+#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+#        with:
+#          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload-templated: true
+#          payload-file-path: slack_payload.json
+#
+#      - name: Report failure (slack release-team)
+#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+#        with:
+#          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload-templated: true
+#          payload-file-path: slack_payload.json

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -63,22 +63,19 @@ jobs:
 
             # Verify the commit is on main and continue
             if git branch --contains "${CANDIDATE_COMMIT}" | grep --quiet main >/dev/null 2>&1; then
-              # git push --delete origin $(git tag --list "${TAG_PATTERN}")
-              # git tag --delete $(git tag --list "${TAG_PATTERN}")
+              git push --delete origin $(git tag --list "${TAG_PATTERN}")
+              git tag --delete $(git tag --list "${TAG_PATTERN}")
               echo "build-candidate-exists=true" >> "${GITHUB_OUTPUT}"
               echo "build-candidate-commit=${CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
               echo "### Build Candidate Found" >>  "${GITHUB_STEP_SUMMARY}"
               echo "build-candidate-commit=${CANDIDATE_COMMIT}" >> "${GITHUB_STEP_SUMMARY}"
               echo "build-candidate-tag=${CANDIDATE_TAG}" >> "${GITHUB_STEP_SUMMARY}"
             else
-              # gh run cancel "${{ github.run_id }}"
+              gh run cancel "${{ github.run_id }}"
             fi
           else
-            # gh run cancel "${{ github.run_id }}"
+            gh run cancel "${{ github.run_id }}"
           fi
-
-          ## force a failure FOR TESTING
-          exit 1
 
   promote-build-candidate:
     name: Promote Build Candidate
@@ -400,18 +397,18 @@ jobs:
           }
           EOF
 
-#      - name: Report failure (slack citr-operations)
-#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-#        with:
-#          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload-templated: true
-#          payload-file-path: slack_payload.json
-#
-#      - name: Report failure (slack release-team)
-#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-#        with:
-#          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload-templated: true
-#          payload-file-path: slack_payload.json
+      - name: Report failure (slack citr-operations)
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json
+
+      - name: Report failure (slack release-team)
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -290,7 +290,7 @@ jobs:
         id: rootly-summary
         run: |
           summary="The Promote Build Candidate job failed"
-          if [[ -z "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}" ]]; then
+          if [[ -n "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}" ]]; then
             summary="The Promote Build Candidate job failed (${{ needs.promote-build-candidate.outputs.build-candidate-tag }})."
           fi
           echo "summary=${summary}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -76,7 +76,7 @@ jobs:
           else
             # gh run cancel "${{ github.run_id }}"
           fi
-          
+
           ## force a failure FOR TESTING
           exit 1
 
@@ -318,14 +318,14 @@ jobs:
       - name: Report Failure (Rootly)
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
         with:
-          api_key: ${{ secrets.ROOTLY_API_KEY }}
+          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: ${{ steps.rootly-summary.outputs.summary }}
           details: ${{ steps.rootly-summary.outputs.details }}
           notification_target_type: "Service"
-          notification_target: 'CI/CD Workflows'
-          set_as_noise: 'true'
-          alert_urgency: 'High'
-          environments: 'CITR'
+          notification_target: "CI/CD Workflows"
+          set_as_noise: "true"
+          alert_urgency: "High"
+          environments: "CITR"
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -271,12 +271,56 @@ jobs:
     needs:
       - determine-build-candidate
       - promote-build-candidate
-    if: ${{ (needs.determine-build-candidate.result != 'success' || needs.promote-build-candidate.result != 'success') && !cancelled() && always() }}
+      - deploy-ci-trigger
+      - report-promotion
+    if: ${{ (needs.determine-build-candidate.result != 'success' ||
+      needs.promote-build-candidate.result != 'success' ||
+      needs.deploy-ci-trigger.result != 'success' ||
+      needs.report-promotion != 'success') && !cancelled() && always() }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
+      - name: Build Rootly Summary
+        id: rootly-summary
+        run: |
+          summary="The Promote Build Candidate job failed (${{ needs.promote-build-candidate.outputs.build-candidate-tag }})."
+          echo "summary=${summary}" >> "${GITHUB_OUTPUT}"
+          {
+            echo 'details<<EOF'
+            echo "------------------------------------"
+            echo "Status of each job:"
+            echo "- Determine Build Candidate: ${{ needs.determine-build-candidate.result }}"
+            echo "- Promote Build Candidate: ${{ needs.promote-build-candidate.result }}"
+            echo "- Deploy CI Triggers: ${{ needs.deploy-ci-trigger.result }}"
+            echo "- Report Promotion: ${{ needs.report-promotion.result }}"
+            echo "------------------------------------"
+            echo "Commit information:"
+            echo "- Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.determine-build-candidate.outputs.build-candidate-commit }}>"
+            echo "- Workflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Log Rootly Summary
+        run: |
+          echo "## Rootly Summary:"
+          echo "### Summary: ${{ steps.rootly-summary.outputs.summary }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${{ steps.rootly-summary.outputs.details }}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Report Failure (Rootly)
+        uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        with:
+          api_key: ${{ secrets.ROOTLY_API_KEY }}
+          summary: ${{ steps.rootly-summary.outputs.summary }}
+          details: ${{ steps.rootly-summary.outputs.details }}
+          notification_target_type: Service
+          notification_target: CI/CD Workflows
+          set_as_noise: true
+          alert_urgency: High
+          environments: CITR
+          external_id: ${{ github.run_id }}
+          external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
       - name: Build Slack Payload Message
         id: payload

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -71,10 +71,10 @@ jobs:
               echo "build-candidate-commit=${CANDIDATE_COMMIT}" >> "${GITHUB_STEP_SUMMARY}"
               echo "build-candidate-tag=${CANDIDATE_TAG}" >> "${GITHUB_STEP_SUMMARY}"
             else
-              gh run cancel "${{ github.run_id }}"
+              # gh run cancel "${{ github.run_id }}"
             fi
           else
-            gh run cancel "${{ github.run_id }}"
+            # gh run cancel "${{ github.run_id }}"
           fi
           
           ## force a failure FOR TESTING

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -317,11 +317,11 @@ jobs:
           api_key: ${{ secrets.ROOTLY_API_KEY }}
           summary: ${{ steps.rootly-summary.outputs.summary }}
           details: ${{ steps.rootly-summary.outputs.details }}
-          notification_target_type: Service
-          notification_target: CI/CD Workflows
-          set_as_noise: true
-          alert_urgency: High
-          environments: CITR
+          notification_target_type: 'Service'
+          notification_target: 'CI/CD Workflows'
+          set_as_noise: 'true'
+          alert_urgency: 'High'
+          environments: 'CITR'
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -269,7 +269,7 @@ jobs:
             }
 
   report-failure:
-    name: Report XTS execution failure
+    name: Report Build Promotion failure
     runs-on: hiero-citr-linux-medium
     needs:
       - determine-build-candidate
@@ -285,10 +285,14 @@ jobs:
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
+
       - name: Build Rootly Summary
         id: rootly-summary
         run: |
-          summary="The Promote Build Candidate job failed (${{ needs.promote-build-candidate.outputs.build-candidate-tag }})."
+          summary="The Promote Build Candidate job failed"
+          if [[ -z "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}" ]]; then
+            summary="The Promote Build Candidate job failed (${{ needs.promote-build-candidate.outputs.build-candidate-tag }})."
+          fi
           echo "summary=${summary}" >> "${GITHUB_OUTPUT}"
           {
             echo 'details<<EOF'
@@ -317,7 +321,7 @@ jobs:
           api_key: ${{ secrets.ROOTLY_API_KEY }}
           summary: ${{ steps.rootly-summary.outputs.summary }}
           details: ${{ steps.rootly-summary.outputs.details }}
-          notification_target_type: 'Service'
+          notification_target_type: "Service"
           notification_target: 'CI/CD Workflows'
           set_as_noise: 'true'
           alert_urgency: 'High'

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -63,8 +63,8 @@ jobs:
 
             # Verify the commit is on main and continue
             if git branch --contains "${CANDIDATE_COMMIT}" | grep --quiet main >/dev/null 2>&1; then
-              git push --delete origin $(git tag --list "${TAG_PATTERN}")
-              git tag --delete $(git tag --list "${TAG_PATTERN}")
+              # git push --delete origin $(git tag --list "${TAG_PATTERN}")
+              # git tag --delete $(git tag --list "${TAG_PATTERN}")
               echo "build-candidate-exists=true" >> "${GITHUB_OUTPUT}"
               echo "build-candidate-commit=${CANDIDATE_COMMIT}" >> "${GITHUB_OUTPUT}"
               echo "### Build Candidate Found" >>  "${GITHUB_STEP_SUMMARY}"
@@ -76,6 +76,9 @@ jobs:
           else
             gh run cancel "${{ github.run_id }}"
           fi
+          
+          ## force a failure FOR TESTING
+          exit 1
 
   promote-build-candidate:
     name: Promote Build Candidate
@@ -393,18 +396,18 @@ jobs:
           }
           EOF
 
-      - name: Report failure (slack citr-operations)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json
+#      - name: Report failure (slack citr-operations)
+#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+#        with:
+#          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload-templated: true
+#          payload-file-path: slack_payload.json
+#
+#      - name: Report failure (slack release-team)
+#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+#        with:
+#          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload-templated: true
+#          payload-file-path: slack_payload.json

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -125,11 +125,11 @@ jobs:
           details: |
             The tagging of commit `${{ inputs.ref }}` for the Extended Test Suite (XTS) promotion has failed.
             Please investigate the issue to ensure the commit is properly tagged for further testing and deployment processes.
-          notification_target_type: Service
-          notification_target: CI/CD Workflows
-          set_as_noise: true
-          alert_urgency: High
-          environments: CITR
+          notification_target_type: 'Service'
+          notification_target: 'CI/CD Workflows'
+          set_as_noise: 'true'
+          alert_urgency: 'High'
+          environments: 'CITR'
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -120,16 +120,16 @@ jobs:
         if: ${{ !inputs.dry-run-enabled && !cancelled() && failure() && always() }}
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
         with:
-          api_key: ${{ secrets.ROOTLY_API_KEY }}
+          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: "Hiero Consensus Node - XTS Candidate Tagging Failed"
           details: |
             The tagging of commit `${{ inputs.ref }}` for the Extended Test Suite (XTS) promotion has failed.
             Please investigate the issue to ensure the commit is properly tagged for further testing and deployment processes.
-          notification_target_type: 'Service'
-          notification_target: 'CI/CD Workflows'
-          set_as_noise: 'true'
-          alert_urgency: 'High'
-          environments: 'CITR'
+          notification_target_type: "Service"
+          notification_target: "CI/CD Workflows"
+          set_as_noise: "true"
+          alert_urgency: "High"
+          environments: "CITR"
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 


### PR DESCRIPTION
## Description

This pull request enhances the failure reporting process in the `.github/workflows/zxcron-promote-build-candidate.yaml` workflow by improving the conditional logic and adding automated notifications and summaries. These changes help ensure that failures in any of the critical jobs are more visible and actionable.

**Workflow logic improvements:**

* Updated the `if` condition to check for failures in additional jobs (`deploy-ci-trigger` and `report-promotion`) alongside the existing ones, ensuring that failures in any step trigger the failure reporting process.
* Added `deploy-ci-trigger` and `report-promotion` to the `needs` list, so their results are included in the conditional checks and reporting.

**Automated failure notification and summary:**

* Added a `Build Rootly Summary` step to generate a detailed summary and status report for all relevant jobs, including commit and workflow information.
* Added a `Log Rootly Summary` step to output the generated summary to the GitHub Actions job summary for easier visibility.
* Integrated the `Report Failure (Rootly)` step to automatically send a high urgency alert to Rootly, targeting the CI/CD Workflows service, with all relevant details and links for incident tracking.

### Related Issue(s)

Closes #20780