### PR TITLE
ci: Integrate Rootly with MATS tests

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -174,14 +174,14 @@ jobs:
   deploy-ci-trigger:
     name: Trigger CI Flows
     runs-on: hiero-citr-linux-medium
-#needs:
-#  - mats-unit-tests
-#  - mats-gradle-determinism
-#  - mats-docker-determinism
-#if: ${{ (github.event_name == 'push') &&
-#  needs.mats-unit-tests.result == 'success' &&
-#  needs.mats-gradle-determinism.result == 'success' &&
-#  needs.mats-docker-determinism.result == 'success' }}
+    #needs:
+    #  - mats-unit-tests
+    #  - mats-gradle-determinism
+    #  - mats-docker-determinism
+    #if: ${{ (github.event_name == 'push') &&
+    #  needs.mats-unit-tests.result == 'success' &&
+    #  needs.mats-gradle-determinism.result == 'success' &&
+    #  needs.mats-docker-determinism.result == 'success' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -73,6 +73,8 @@ permissions:
 jobs:
   code:
     name: Compile Code
+    # TEST CODE
+    if: ${{ false }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     with:
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
@@ -85,6 +87,8 @@ jobs:
 
   dependency-check:
     name: Dependency (Module Info)
+    # TEST CODE
+    if: ${{ true }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     needs:
       - code
@@ -98,6 +102,8 @@ jobs:
 
   spotless:
     name: Spotless
+    # TEST CODE
+    if: ${{ true }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     needs:
       - code
@@ -112,6 +118,8 @@ jobs:
 
   mats-unit-tests:
     name: MATS - Unit Tests
+    # TEST CODE
+    if: ${{ true }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     needs:
       - dependency-check
@@ -147,7 +155,9 @@ jobs:
     needs:
       - dependency-check
       - spotless
-    if: ${{ github.event_name == 'push' || github.event.inputs.enable-gradle-determinism == 'true' }}
+    # TEST CODE
+
+    if: ${{ false && (github.event_name == 'push' || github.event.inputs.enable-gradle-determinism == 'true') }}
     with:
       ref: ${{ github.event.inputs.ref || '' }}
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
@@ -162,7 +172,7 @@ jobs:
     needs:
       - dependency-check
       - spotless
-    if: ${{ github.event_name == 'push' || github.event.inputs.enable-docker-determinism == 'true' }}
+    if: ${{ false && (github.event_name == 'push' || github.event.inputs.enable-docker-determinism == 'true') }}
     with:
       ref: ${{ github.event.inputs.ref || '' }}
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
@@ -178,10 +188,10 @@ jobs:
       - mats-unit-tests
       - mats-gradle-determinism
       - mats-docker-determinism
-    if: ${{ (github.event_name == 'push') &&
+    if: ${{ false && ( (github.event_name == 'push') &&
       needs.mats-unit-tests.result == 'success' &&
       needs.mats-gradle-determinism.result == 'success' &&
-      needs.mats-docker-determinism.result == 'success' }}
+      needs.mats-docker-determinism.result == 'success') }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -290,7 +300,8 @@ jobs:
         id: set-rootly-parameters
         run: |
           CREATE_INCIDENT='true'
-          ROOTLY_SERVICE_NAME="CITR General"
+          # ROOTLY_SERVICE_NAME="CITR General"
+          ROOTLY_SERVICE_NAME="CI/CD Workflows" # test code
           if [[ "${{ needs.deploy-ci-trigger.result != 'success' }}" ]]; then
             CREATE_INCIDENT='false'
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
@@ -362,134 +373,133 @@ jobs:
           incident_types: "Platform CI"
           services: ${{ steps.set-rootly-parameters.outputs.service }}
           teams: "Platform CI"
-
-      - name: Build Slack Payload Message
-        id: payload
-        run: |
-          cat <<EOF > slack_payload.json
-          {
-            "attachments": [
-              {
-                "color": "#FF0000",
-                "blocks": [
-                  {
-                    "type": "header",
-                    "text": {
-                      "type": "plain_text",
-                      "text": ":exclamation: Hiero Consensus Node - MATS Error Report",
-                      "emoji": true
-                    }
-                  },
-                  {
-                    "type": "divider"
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "*MATS Job Resulted in failure on `main`. See status below.*"
-                    },
-                    "fields": [
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Code Compiles*: ${{ needs.code.result }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Dependency (Module Info)*: ${{ needs.dependency-check.result }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Spotless*: ${{ needs.spotless.result }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*MATS - Unit Tests*: ${{ needs.mats-unit-tests.result }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*MATS - Gradle Determinism*: ${{ needs.mats-gradle-determinism.result }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*MATS - Docker Determinism*: ${{ needs.mats-docker-determinism.result }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Deploy CI Triggers*: ${{ needs.deploy-ci-trigger.result }}"
-                      }
-                    ]
-                  },
-                  {
-                    "type": "divider"
-                  },
-                  {
-                    "type": "section",
-                    "text": {
-                      "type": "mrkdwn",
-                      "text": "*Workflow and Commit Information*"
-                    },
-                    "fields": [
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Source Commit*:"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.fetch-commit-info.outputs.commit-hash }}>"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Commit author*:"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "${{ steps.fetch-commit-info.outputs.commit-author }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Slack user*:"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "${{ steps.find-commit-author-slack.outputs.slack-user-id }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Workflow run ID*:"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": " ${{ github.run_id }}"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "*Workflow run URL*:"
-                      },
-                      {
-                        "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-          EOF
-
-      - name: Report failure (slack citr-operations)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json
-
-      - name: Report failure (slack release-team)
-        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-        with:
-          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload-templated: true
-          payload-file-path: slack_payload.json
+#      - name: Build Slack Payload Message
+#        id: payload
+#        run: |
+#          cat <<EOF > slack_payload.json
+#          {
+#            "attachments": [
+#              {
+#                "color": "#FF0000",
+#                "blocks": [
+#                  {
+#                    "type": "header",
+#                    "text": {
+#                      "type": "plain_text",
+#                      "text": ":exclamation: Hiero Consensus Node - MATS Error Report",
+#                      "emoji": true
+#                    }
+#                  },
+#                  {
+#                    "type": "divider"
+#                  },
+#                  {
+#                    "type": "section",
+#                    "text": {
+#                      "type": "mrkdwn",
+#                      "text": "*MATS Job Resulted in failure on `main`. See status below.*"
+#                    },
+#                    "fields": [
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*Code Compiles*: ${{ needs.code.result }}"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*Dependency (Module Info)*: ${{ needs.dependency-check.result }}"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*Spotless*: ${{ needs.spotless.result }}"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*MATS - Unit Tests*: ${{ needs.mats-unit-tests.result }}"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*MATS - Gradle Determinism*: ${{ needs.mats-gradle-determinism.result }}"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*MATS - Docker Determinism*: ${{ needs.mats-docker-determinism.result }}"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*Deploy CI Triggers*: ${{ needs.deploy-ci-trigger.result }}"
+#                      }
+#                    ]
+#                  },
+#                  {
+#                    "type": "divider"
+#                  },
+#                  {
+#                    "type": "section",
+#                    "text": {
+#                      "type": "mrkdwn",
+#                      "text": "*Workflow and Commit Information*"
+#                    },
+#                    "fields": [
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*Source Commit*:"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "<${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.fetch-commit-info.outputs.commit-hash }}>"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*Commit author*:"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "${{ steps.fetch-commit-info.outputs.commit-author }}"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*Slack user*:"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "${{ steps.find-commit-author-slack.outputs.slack-user-id }}"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*Workflow run ID*:"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": " ${{ github.run_id }}"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "*Workflow run URL*:"
+#                      },
+#                      {
+#                        "type": "mrkdwn",
+#                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
+#                      }
+#                    ]
+#                  }
+#                ]
+#              }
+#            ]
+#          }
+#          EOF
+#
+#      - name: Report failure (slack citr-operations)
+#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+#        with:
+#          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload-templated: true
+#          payload-file-path: slack_payload.json
+#
+#      - name: Report failure (slack release-team)
+#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+#        with:
+#          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
+#          webhook-type: incoming-webhook
+#          payload-templated: true
+#          payload-file-path: slack_payload.json

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -73,22 +73,18 @@ permissions:
 jobs:
   code:
     name: Compile Code
-    # TEST CODE
-    if: ${{ false }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     with:
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
       enable-spotless-check: false
     secrets:
-      access-token: ${{ secrets.GITHUB_TOKEN }}
-      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
-      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+      access-token: '' #'${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: '' #'${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: '' #'${{ secrets.GRADLE_CACHE_PASSWORD }}
 
   dependency-check:
     name: Dependency (Module Info)
-    # TEST CODE
-    if: ${{ true }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     needs:
       - code
@@ -102,8 +98,6 @@ jobs:
 
   spotless:
     name: Spotless
-    # TEST CODE
-    if: ${{ true }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     needs:
       - code
@@ -118,8 +112,6 @@ jobs:
 
   mats-unit-tests:
     name: MATS - Unit Tests
-    # TEST CODE
-    if: ${{ true }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     needs:
       - dependency-check
@@ -155,9 +147,7 @@ jobs:
     needs:
       - dependency-check
       - spotless
-    # TEST CODE
-
-    if: ${{ false && (github.event_name == 'push' || github.event.inputs.enable-gradle-determinism == 'true') }}
+    if: ${{ github.event_name == 'push' || github.event.inputs.enable-gradle-determinism == 'true' }}
     with:
       ref: ${{ github.event.inputs.ref || '' }}
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
@@ -172,7 +162,7 @@ jobs:
     needs:
       - dependency-check
       - spotless
-    if: ${{ false && (github.event_name == 'push' || github.event.inputs.enable-docker-determinism == 'true') }}
+    if: ${{ github.event_name == 'push' || github.event.inputs.enable-docker-determinism == 'true' }}
     with:
       ref: ${{ github.event.inputs.ref || '' }}
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
@@ -188,10 +178,10 @@ jobs:
       - mats-unit-tests
       - mats-gradle-determinism
       - mats-docker-determinism
-    if: ${{ false && ( (github.event_name == 'push') &&
+    if: ${{ (github.event_name == 'push') &&
       needs.mats-unit-tests.result == 'success' &&
       needs.mats-gradle-determinism.result == 'success' &&
-      needs.mats-docker-determinism.result == 'success') }}
+      needs.mats-docker-determinism.result == 'success' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -229,7 +219,8 @@ jobs:
       needs.mats-gradle-determinism.result != 'success' ||
       needs.mats-docker-determinism.result != 'success' ||
       needs.deploy-ci-trigger.result != 'success') &&
-      !inputs.dry-run-enabled && always() }}
+      !inputs.dry-run-enabled &&
+      !cancelled() && always() }}
 
     steps:
       - name: Harden Runner
@@ -299,9 +290,8 @@ jobs:
         id: set-rootly-parameters
         run: |
           CREATE_INCIDENT='true'
-          # ROOTLY_SERVICE_NAME="CITR General"
-          ROOTLY_SERVICE_NAME="CI/CD Workflows" # test code
-          if [[ "${{ needs.deploy-ci-trigger.result == 'failure' }}" }} ]]; then
+          ROOTLY_SERVICE_NAME="CITR General"
+          if [[ "${{ needs.deploy-ci-trigger.result == 'failure' }}" ]]; then
             CREATE_INCIDENT='false'
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
           fi
@@ -372,6 +362,7 @@ jobs:
           incident_types: "Platform CI"
           services: ${{ steps.set-rootly-parameters.outputs.service }}
           teams: "Platform CI"
+
 #      - name: Build Slack Payload Message
 #        id: payload
 #        run: |

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -286,6 +286,83 @@ jobs:
           fi
           echo "slack-user-id=${SLACK_USER_ID}" >> "${GITHUB_OUTPUT}"
 
+      - name: Set Rootly Parameters
+        id: set-rootly-parameters
+        run: |
+          CREATE_INCIDENT='true'
+          ROOTLY_SERVICE_NAME="CITR General"
+          if [[ "${{ needs.deploy-ci-trigger.result != 'success' }}" ]]; then
+            CREATE_INCIDENT='false'
+            ROOTLY_SERVICE_NAME="CI/CD Workflows"
+          fi
+          echo "service=${ROOTLY_SERVICE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "create-incident=${CREATE_INCIDENT}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build Rootly Summary
+        id: rootly-summary
+        run: |
+          title="MATS Error Report ${{ github.event.inputs.ref || '' }}"
+          echo "title=${title}" >> "${GITHUB_OUTPUT}"
+          {
+            echo 'summary<<EOF'
+            echo "------------------------------------"
+            echo "Status of each jobs:"
+            echo "- Code Compiles: ${{ needs.code.result }}"
+            echo "- Dependency (Module Info): ${{ needs.dependency-check.result }}"
+            echo "- Spotless: ${{ needs.spotless.result }}"
+            echo "- MATS - Unit Tests: ${{ needs.mats-unit-tests.result }}"
+            echo "- MATS - Gradle Determinism: ${{ needs.mats-gradle-determinism.result }}"
+            echo "- MATS - Docker Determinism: ${{ needs.mats-docker-determinism.result }}"
+            echo "- Deploy CI Triggers: ${{ needs.deploy-ci-trigger.result }}"
+            echo "------------------------------------"
+            echo "Commit information:"
+            echo "- Author: ${{ steps.find-commit-author-slack.outputs.slack-user-id }}"
+            echo "- Commit: <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.event.inputs.ref || github.sha }}>"
+            echo "- Workflow: <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
+            echo EOF
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Log Rootly Summary
+        run: |
+          echo "## Rootly Summary:"
+          echo "### Title: ${{ steps.rootly-summary.outputs.title }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${{ steps.rootly-summary.outputs.summary }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### Rootly Service" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${{ steps.set-rootly-parameters.outputs.service }}" >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Create Rootly Alert
+        id: create-rootly-alert
+        uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        continue-on-error: true
+        with:
+          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
+          summary: "${{ steps.rootly-summary.outputs.title }}"
+          details: "${{ steps.rootly-summary.outputs.summary }}"
+          notification_target_type: "Service"
+          notification_target: ${{ steps.set-rootly-parameters.outputs.service }}
+          set_as_noise: "true"
+          alert_urgency: "High"
+          external_id: ${{ github.run_id }}
+          external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          environments: "CITR"
+
+      - name: Report Failure (Rootly)
+        if: ${{ steps.set-rootly-parameters.outputs.create-incident == 'true' }}
+        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
+        continue-on-error: true # continue on error so we can get the slack reporting
+        with:
+          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
+          title: "${{ steps.rootly-summary.outputs.title }}"
+          kind: "normal"
+          create_public_incident: "false"
+          summary: "${{ steps.rootly-summary.outputs.summary }}"
+          severity: "Triage Event"
+          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
+          environments: "CITR"
+          incident_types: "Platform CI"
+          services: ${{ steps.set-rootly-parameters.outputs.service }}
+          teams: "Platform CI"
+
       - name: Build Slack Payload Message
         id: payload
         run: |

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -229,8 +229,7 @@ jobs:
       needs.mats-gradle-determinism.result != 'success' ||
       needs.mats-docker-determinism.result != 'success' ||
       needs.deploy-ci-trigger.result != 'success') &&
-      !inputs.dry-run-enabled &&
-      !cancelled() && always() }}
+      !inputs.dry-run-enabled && always() }}
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -302,7 +302,7 @@ jobs:
           CREATE_INCIDENT='true'
           # ROOTLY_SERVICE_NAME="CITR General"
           ROOTLY_SERVICE_NAME="CI/CD Workflows" # test code
-          if [[ "${{ needs.deploy-ci-trigger.result != 'success' }}" ]]; then
+          if [[ "${{ needs.deploy-ci-trigger.result != 'success' }}" && "${{ needs.deploy-ci-trigger.result != 'skipped' }} ]]; then
             CREATE_INCIDENT='false'
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
           fi

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -174,14 +174,14 @@ jobs:
   deploy-ci-trigger:
     name: Trigger CI Flows
     runs-on: hiero-citr-linux-medium
-    needs:
-      - mats-unit-tests
-      - mats-gradle-determinism
-      - mats-docker-determinism
-    if: ${{ (github.event_name == 'push') &&
-      needs.mats-unit-tests.result == 'success' &&
-      needs.mats-gradle-determinism.result == 'success' &&
-      needs.mats-docker-determinism.result == 'success' }}
+#needs:
+#  - mats-unit-tests
+#  - mats-gradle-determinism
+#  - mats-docker-determinism
+#if: ${{ (github.event_name == 'push') &&
+#  needs.mats-unit-tests.result == 'success' &&
+#  needs.mats-gradle-determinism.result == 'success' &&
+#  needs.mats-docker-determinism.result == 'success' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -73,7 +73,6 @@ permissions:
 jobs:
   code:
     name: Compile Code
-    if: ${{ false }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     with:
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
@@ -188,6 +187,9 @@ jobs:
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
+
+      - name: Induce Failure
+        run: exit 1
 
       - name: Trigger ZXF Deploy Production Release
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -174,22 +174,19 @@ jobs:
   deploy-ci-trigger:
     name: Trigger CI Flows
     runs-on: hiero-citr-linux-medium
-    #needs:
-    #  - mats-unit-tests
-    #  - mats-gradle-determinism
-    #  - mats-docker-determinism
-    #if: ${{ (github.event_name == 'push') &&
-    #  needs.mats-unit-tests.result == 'success' &&
-    #  needs.mats-gradle-determinism.result == 'success' &&
-    #  needs.mats-docker-determinism.result == 'success' }}
+    needs:
+      - mats-unit-tests
+      - mats-gradle-determinism
+      - mats-docker-determinism
+    if: ${{ (github.event_name == 'push') &&
+      needs.mats-unit-tests.result == 'success' &&
+      needs.mats-gradle-determinism.result == 'success' &&
+      needs.mats-docker-determinism.result == 'success' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
-
-      - name: Induce Failure
-        run: exit 1
 
       - name: Trigger ZXF Deploy Production Release
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
@@ -367,133 +364,134 @@ jobs:
           incident_types: "Platform CI"
           services: ${{ steps.set-rootly-parameters.outputs.service }}
           teams: "Platform CI"
-#      - name: Build Slack Payload Message
-#        id: payload
-#        run: |
-#          cat <<EOF > slack_payload.json
-#          {
-#            "attachments": [
-#              {
-#                "color": "#FF0000",
-#                "blocks": [
-#                  {
-#                    "type": "header",
-#                    "text": {
-#                      "type": "plain_text",
-#                      "text": ":exclamation: Hiero Consensus Node - MATS Error Report",
-#                      "emoji": true
-#                    }
-#                  },
-#                  {
-#                    "type": "divider"
-#                  },
-#                  {
-#                    "type": "section",
-#                    "text": {
-#                      "type": "mrkdwn",
-#                      "text": "*MATS Job Resulted in failure on `main`. See status below.*"
-#                    },
-#                    "fields": [
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*Code Compiles*: ${{ needs.code.result }}"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*Dependency (Module Info)*: ${{ needs.dependency-check.result }}"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*Spotless*: ${{ needs.spotless.result }}"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*MATS - Unit Tests*: ${{ needs.mats-unit-tests.result }}"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*MATS - Gradle Determinism*: ${{ needs.mats-gradle-determinism.result }}"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*MATS - Docker Determinism*: ${{ needs.mats-docker-determinism.result }}"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*Deploy CI Triggers*: ${{ needs.deploy-ci-trigger.result }}"
-#                      }
-#                    ]
-#                  },
-#                  {
-#                    "type": "divider"
-#                  },
-#                  {
-#                    "type": "section",
-#                    "text": {
-#                      "type": "mrkdwn",
-#                      "text": "*Workflow and Commit Information*"
-#                    },
-#                    "fields": [
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*Source Commit*:"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "<${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.fetch-commit-info.outputs.commit-hash }}>"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*Commit author*:"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "${{ steps.fetch-commit-info.outputs.commit-author }}"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*Slack user*:"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "${{ steps.find-commit-author-slack.outputs.slack-user-id }}"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*Workflow run ID*:"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": " ${{ github.run_id }}"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "*Workflow run URL*:"
-#                      },
-#                      {
-#                        "type": "mrkdwn",
-#                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
-#                      }
-#                    ]
-#                  }
-#                ]
-#              }
-#            ]
-#          }
-#          EOF
-#
-#      - name: Report failure (slack citr-operations)
-#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-#        with:
-#          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload-templated: true
-#          payload-file-path: slack_payload.json
-#
-#      - name: Report failure (slack release-team)
-#        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
-#        with:
-#          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
-#          webhook-type: incoming-webhook
-#          payload-templated: true
-#          payload-file-path: slack_payload.json
+
+      - name: Build Slack Payload Message
+        id: payload
+        run: |
+          cat <<EOF > slack_payload.json
+          {
+            "attachments": [
+              {
+                "color": "#FF0000",
+                "blocks": [
+                  {
+                    "type": "header",
+                    "text": {
+                      "type": "plain_text",
+                      "text": ":exclamation: Hiero Consensus Node - MATS Error Report",
+                      "emoji": true
+                    }
+                  },
+                  {
+                    "type": "divider"
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*MATS Job Resulted in failure on `main`. See status below.*"
+                    },
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Code Compiles*: ${{ needs.code.result }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Dependency (Module Info)*: ${{ needs.dependency-check.result }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Spotless*: ${{ needs.spotless.result }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*MATS - Unit Tests*: ${{ needs.mats-unit-tests.result }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*MATS - Gradle Determinism*: ${{ needs.mats-gradle-determinism.result }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*MATS - Docker Determinism*: ${{ needs.mats-docker-determinism.result }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Deploy CI Triggers*: ${{ needs.deploy-ci-trigger.result }}"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "divider"
+                  },
+                  {
+                    "type": "section",
+                    "text": {
+                      "type": "mrkdwn",
+                      "text": "*Workflow and Commit Information*"
+                    },
+                    "fields": [
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Source Commit*:"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/commit/${{ steps.fetch-commit-info.outputs.commit-hash }}>"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Commit author*:"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "${{ steps.fetch-commit-info.outputs.commit-author }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Slack user*:"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "${{ steps.find-commit-author-slack.outputs.slack-user-id }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Workflow run ID*:"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": " ${{ github.run_id }}"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "*Workflow run URL*:"
+                      },
+                      {
+                        "type": "mrkdwn",
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}>"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+          EOF
+
+      - name: Report failure (slack citr-operations)
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json
+
+      - name: Report failure (slack release-team)
+        uses: slackapi/slack-github-action@b0fa283ad8fea605de13dc3f449259339835fc52 # v2.1.0
+        with:
+          webhook: ${{ secrets.SLACK_RELEASE_TEAM_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -302,7 +302,7 @@ jobs:
           CREATE_INCIDENT='true'
           # ROOTLY_SERVICE_NAME="CITR General"
           ROOTLY_SERVICE_NAME="CI/CD Workflows" # test code
-          if [[ "${{ needs.deploy-ci-trigger.result != 'success' }}" && "${{ needs.deploy-ci-trigger.result != 'skipped' }} ]]; then
+          if [[ "${{ needs.deploy-ci-trigger.result == 'failure' }}" }} ]]; then
             CREATE_INCIDENT='false'
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
           fi

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -294,7 +294,7 @@ jobs:
         run: |
           CREATE_INCIDENT='true'
           ROOTLY_SERVICE_NAME="CITR General"
-          if [[ "${{ needs.deploy-ci-trigger.result }}" == "failure" ]] || [[ "${{ needs.deploy-ci-trigger.result }}" == "cancelled" ]]; then
+          if [[ "${{ needs.deploy-ci-trigger.result }}" =~ ^(cancelled|failure)$ ]]; then
             CREATE_INCIDENT='false'
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
           fi

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -292,7 +292,7 @@ jobs:
         run: |
           CREATE_INCIDENT='true'
           ROOTLY_SERVICE_NAME="CITR General"
-          if [[ "${{ needs.deploy-ci-trigger.result == 'failure' }}" ]]; then
+          if [[ "${{ needs.deploy-ci-trigger.result }}" == "failure" ]] || [[ "${{ needs.deploy-ci-trigger.result }}" == "cancelled" ]]; then
             CREATE_INCIDENT='false'
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
           fi
@@ -330,6 +330,8 @@ jobs:
           echo "${{ steps.rootly-summary.outputs.summary }}" >> "${GITHUB_STEP_SUMMARY}"
           echo "### Rootly Service" >> "${GITHUB_STEP_SUMMARY}"
           echo "${{ steps.set-rootly-parameters.outputs.service }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### Create Rootly Incident?" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${{ steps.set-rootly-parameters.outputs.create-incident }}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Create Rootly Alert
         id: create-rootly-alert

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -73,15 +73,16 @@ permissions:
 jobs:
   code:
     name: Compile Code
+    if: ${{ false }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     with:
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
       enable-spotless-check: false
     secrets:
-      access-token: '' #'${{ secrets.GITHUB_TOKEN }}
-      gradle-cache-username: '' #'${{ secrets.GRADLE_CACHE_USERNAME }}
-      gradle-cache-password: '' #'${{ secrets.GRADLE_CACHE_PASSWORD }}
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
 
   dependency-check:
     name: Dependency (Module Info)

--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -367,7 +367,6 @@ jobs:
           incident_types: "Platform CI"
           services: ${{ steps.set-rootly-parameters.outputs.service }}
           teams: "Platform CI"
-
 #      - name: Build Slack Payload Message
 #        id: payload
 #        run: |

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -522,10 +522,10 @@ jobs:
         id: set-rootly-service
         run: |
           ROOTLY_SERVICE_NAME="CITR General"
-          if [[ ! "${{ needs.fetch-xts-candidate.result }}" =~ ^(success|skipped)$ ]] \
-            && [[ ! ${{ needs.tag-for-promotion.result }} =~ ^(success|skipped)$ ]]; then
+          if [[ "${{ needs.fetch-xts-candidate.result }}" =~ ^(cancelled|failure)$ ]] \
+            || [[ "${{ needs.tag-for-promotion.result }}" =~ ^(cancelled|failure)$ ]]; then
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
-          elif [[ ! "${{ needs.sdk-tck-regression-panel.result }}" =~ ^(success|skipped)$ ]]; then
+          elif [[ "${{ needs.sdk-tck-regression-panel.result }}" =~ ^(cancelled|failure)$ ]]; then
             ROOTLY_SERVICE_NAME="CITR TCK"
           fi
           echo "service=${ROOTLY_SERVICE_NAME}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -522,9 +522,10 @@ jobs:
         id: set-rootly-service
         run: |
           ROOTLY_SERVICE_NAME="CITR General"
-          if [[ "${{ needs.fetch-xts-candidate.result != 'success' || needs.tag-for-promotion.result != 'success' }}" ]]; then
+          if [[ ! "${{ needs.fetch-xts-candidate.result }}" =~ ^(success|skipped)$ ]] \
+            && [[ ! ${{ needs.tag-for-promotion.result }} =~ ^(success|skipped)$ ]]; then
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
-          elif [[ "${{ needs.sdk-tck-regression-panel.result != 'success' }}" ]]; then
+          elif [[ ! "${{ needs.sdk-tck-regression-panel.result }}" =~ ^(success|skipped)$ ]]; then
             ROOTLY_SERVICE_NAME="CITR TCK"
           fi
           echo "service=${ROOTLY_SERVICE_NAME}" >> "${GITHUB_OUTPUT}"


### PR DESCRIPTION
## Description

This pull request adds an automated integration with Rootly to the `node-flow-build-application.yaml` GitHub Actions workflow. The new steps generate a summary of job statuses, determine incident creation parameters, and trigger Rootly alerts and incidents based on workflow outcomes. This improves visibility and incident response for CI failures.

**Rootly Integration:**

* Added a step to set Rootly parameters (`CREATE_INCIDENT`, `ROOTLY_SERVICE_NAME`) based on the result of the `deploy-ci-trigger` job, allowing dynamic incident management.
* Implemented a step to build a Rootly summary, including job statuses and commit information, and output it for use in subsequent steps.
* Added a step to log the Rootly summary to the GitHub Actions job summary for easy review.

**Rootly Alerting and Incident Creation:**

* Integrated the `rootly-alert-action` to create a Rootly alert with detailed workflow and commit information, targeting the appropriate service.
* Added conditional incident reporting via the `rootly-incident-action` when an incident should be created, using the previously generated alert and summary details.

### Related issue(s)

Closes #20774