### PR TITLE
fix: Fall back to `parseAndCheck()` if `parseSignedAndCheck()` is `INVALID_TX`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -514,8 +514,12 @@ public class TransactionChecker {
                 throw new PreCheckException(TRANSACTION_HAS_UNKNOWN_FIELDS);
             }
 
-            // Either the protobuf was malformed, or something else failed during parsing
-            logger.warn("ParseException while parsing protobuf", e);
+            final var parseError = e.getMessage() == null ? "" : e.getMessage();
+            // 0.65-only check to avoid warning about a serialized Transaction found in PCES immediately post-upgrade
+            if (!parseError.startsWith("java.io.IOException: Bad tag [26], field [3] wireType [2]")) {
+                // Either the protobuf was malformed, or something else failed during parsing
+                logger.warn("ParseException while parsing protobuf", e);
+            }
             throw new PreCheckException(parseErrorCode);
         }
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -230,6 +230,8 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             final Transaction platformTx = createAppPayloadWrapper(randomByteArray(123));
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenThrow(new PreCheckException(INVALID_TRANSACTION));
+            when(transactionChecker.parseAndCheck(any(Bytes.class), anyInt()))
+                    .thenThrow(new PreCheckException(INVALID_TRANSACTION));
 
             // When we try to pre-handle the transaction
             workflow.preHandle(storeFactory, NODE_1.asInfo(), Stream.of(platformTx), txns -> {});

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip1127Test.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableHip1127Test.java
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.integration;
+
+import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
+import static com.hedera.services.bdd.junit.RepeatableReason.USES_STATE_SIGNATURE_TRANSACTION_CALLBACK;
+import static com.hedera.services.bdd.junit.TestTags.INTEGRATION;
+import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
+import static com.hedera.services.bdd.junit.hedera.embedded.EmbeddedMode.REPEATABLE;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertHgcaaLogDoesNotContain;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
+import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
+import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+
+import com.hedera.services.bdd.junit.RepeatableHapiTest;
+import com.hedera.services.bdd.junit.TargetEmbeddedMode;
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Tag;
+
+@Order(10)
+@Tag(INTEGRATION)
+@TargetEmbeddedMode(REPEATABLE)
+public class RepeatableHip1127Test {
+    @RepeatableHapiTest(USES_STATE_SIGNATURE_TRANSACTION_CALLBACK)
+    Stream<DynamicTest> preHip1127TxEncodingStillAccepted() {
+        final AtomicReference<String> bypassNodeId = new AtomicReference<>();
+        return hapiTest(
+                sourcingContextual(spec -> {
+                    bypassNodeId.set(asAccountString(
+                            fromPbj(spec.getNetworkNodes().getLast().getAccountId())));
+                    return cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, bypassNodeId.get(), ONE_HUNDRED_HBARS));
+                }),
+                doingContextual(spec -> spec.repeatableEmbeddedHederaOrThrow().bypassNextWithPreHip1127TxFormat()),
+                sourcing(() -> cryptoTransfer(tinyBarsFromTo(DEFAULT_PAYER, FUNDING, 1))
+                        .setNode(bypassNodeId.get())
+                        .hasAnyStatusAtAll()),
+                assertHgcaaLogDoesNotContain(byNodeId(0), "WARN", Duration.ofSeconds(1)),
+                assertHgcaaLogDoesNotContain(byNodeId(0), "ERROR", Duration.ofSeconds(1)));
+    }
+}


### PR DESCRIPTION
**Description**:
 - Closes #20856 
    * Reproduces the scenario and verifies fix (including no `WARN` or `ERROR` logs) in a new `@RepeatableHapiTest` that temporarily switches to submitting with 0.64 message encoding.
 - 👉 This is a _0.65-only fix_, there is no corresponding PR to `main`.