### PR TITLE
fix(ci): Invalid syntax wheen assigning rootly title to bash variable

### DIFF
--- a/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
@@ -592,7 +592,7 @@ jobs:
       - name: Build Rootly Summary
         id: rootly-summary
         run: |
-          title: "The Single Day Longevity Test workflow failed (SDLT ${{ inputs.test-asset }} - ${{ inputs.ref }})"
+          title="The Single Day Longevity Test workflow failed (SDLT ${{ inputs.test-asset }} - ${{ inputs.ref }})"
           echo "title=${title}" >> "${GITHUB_OUTPUT}"
           {
             echo 'summary<<EOF'

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -1188,7 +1188,7 @@ jobs:
       - name: Build Rootly Summary
         id: rootly-summary
         run: |
-          title: "The Single Day Performance Test workflow failed (SDPT ${{ inputs.test-asset }} - ${{ inputs.ref }})"
+          title="The Single Day Performance Test workflow failed (SDPT ${{ inputs.test-asset }} - ${{ inputs.ref }})"
           echo "title=${title}" >> "${GITHUB_OUTPUT}"
           {
             echo 'summary<<EOF'


### PR DESCRIPTION
**Description**:

This pull request makes a small syntax adjustment to how the `title` variable is assigned in two GitHub Actions workflow files. The change improves consistency and correctness in shell scripting by switching from colon (`:`) to equals (`=`) for variable assignment.

- Changed variable assignment in the `Build Rootly Summary` step from `title: "..."` to `title="..."` in both `.github/workflows/zxc-single-day-longevity-nlg-test.yaml` [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L595-R595) and `.github/workflows/zxc-single-day-performance-test.yaml` [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L1191-R1191).

**Related issue(s)**:

Fixes #20868

