### PR TITLE
ci: Turn off incident creation on deploy release artifact for now.

### DIFF
--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -383,22 +383,6 @@ jobs:
           external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           environments: "CITR"
 
-      - name: Report Failure (Rootly)
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        continue-on-error: true # continue on error so we can get the slack reporting
-        with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
-          title: "${{ steps.rootly-summary.outputs.title }}"
-          kind: "normal"
-          create_public_incident: "false"
-          summary: "${{ steps.rootly-summary.outputs.summary }}"
-          severity: "Triage Event"
-          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: "CI/CD Workflows"
-          teams: "Platform CI"
-
       - name: Build Slack Payload Message
         id: payload
         run: |


### PR DESCRIPTION
## Description

This pull request makes a small change to the deployment workflow configuration by removing the step that generates incidents in Rootly for failures. This simplifies the workflow and eliminates external incident reporting for this job.

### Related Issue(s)

Closes #20904