### PR TITLE
ci: Enable AdHocSD runners for Single Day Performance and Longevity Tests

### DIFF
--- a/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
@@ -7,7 +7,7 @@ on:
       test-asset:
         required: true
         default: "SDLT2"
-        description: "Longevity test on given Longevity Machine (AdHoc5,6,7 or SDLT2)"
+        description: "Longevity test on given Longevity Machine (AdHoc5,6,7, AdHocSD8,9, or SDLT2)"
         type: string
       ref:
         required: true
@@ -172,7 +172,7 @@ jobs:
           set +e
           #trim RUN_HCN_VERSION
           echo "RUN_HCN_VERSION=$(echo ${{ inputs.ref }} | awk '{print $1}')" >> "${GITHUB_ENV}"
-          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHoc|SDPT|SDLT)(\d+)$/')"
+          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHoc|AdHocSD|SDPT|SDLT)(\d+)$/')"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_ENV}"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_OUTPUT}"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_STEP_SUMMARY}"
@@ -263,6 +263,8 @@ jobs:
 
           if [[ "${NAMESPACE_ALIAS}" =~ ^SDLT[0-9]+$ ]]; then
             NETWORK_OWNER="single-day-longevity-test"
+          elif [[ "${NAMESPACE_ALIAS}" =~ ^AdHocSD[0-9]+$ ]]; then
+            NETWORK_OWNER="adhoc-single-day-test"
           else
             NETWORK_OWNER="adhoc-longevity-test"
           fi
@@ -344,6 +346,8 @@ jobs:
           sed -i -e "s@%NETWORK_ID%@${NETWORK_ID}@g" nlg-values.yaml
           if [[ "${NAMESPACE_ALIAS}" =~ ^SDLT[0-9]+$ ]]; then
             NETWORK_OWNER="single-day-longevity-test"
+          elif [[ "${NAMESPACE_ALIAS}" =~ ^AdHocSD[0-9]+$ ]]; then
+            NETWORK_OWNER="adhoc-single-day-test"
           else
             NETWORK_OWNER="adhoc-longevity-test"
           fi
@@ -586,7 +590,7 @@ jobs:
         id: check-test-asset
         run: |
           ADHOC="false"
-          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc[0-9]$ ]]; then
+          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]$ ]]; then
             ADHOC="true"
           fi
           echo "is-adhoc=${ADHOC}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
@@ -172,7 +172,7 @@ jobs:
           set +e
           #trim RUN_HCN_VERSION
           echo "RUN_HCN_VERSION=$(echo ${{ inputs.ref }} | awk '{print $1}')" >> "${GITHUB_ENV}"
-          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHoc|AdHocSD|SDPT|SDLT)(\d+)$/')"
+          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHocSD|AdHoc|SDPT|SDLT)(\d+)$/')"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_ENV}"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_OUTPUT}"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
@@ -590,7 +590,7 @@ jobs:
         id: check-test-asset
         run: |
           ADHOC="false"
-          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]$ ]]; then
+          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]+$ ]]; then
             ADHOC="true"
           fi
           echo "is-adhoc=${ADHOC}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -7,7 +7,7 @@ on:
       test-asset:
         required: true
         default: "AdHoc5"
-        description: "Performance test on machine: AdHoc5, 6, 7, or SDPT1"
+        description: "Performance test on machine: AdHoc5, 6, 7, AdHocSD8, 9 or SDPT1"
         type: string
       ref:
         required: true
@@ -71,7 +71,7 @@ permissions:
 
 env:
   NAMESPACE_PREFIX: solo-sdpt-n
-  DEFAULT_NAMESPACE: AdHoc5
+  DEFAULT_NAMESPACE: AdHocSD8
   DEFAULT_HCN_VERSION: main
   TIMEOUT_6H_LIMIT: 340
   GS_ROOT_DIR: gs://performance-engineering-reports/ephemeral/test_runs
@@ -194,7 +194,7 @@ jobs:
           set +e
           # trim the input ref
           echo "run-hcn-version=$(echo ${{ inputs.ref }} | awk '{print $1}')" >> "${GITHUB_OUTPUT}"
-          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHoc|SDPT)(\d+)$/')"
+          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHoc||AdHocSD|SDPT)(\d+)$/')"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_OUTPUT}"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_STEP_SUMMARY}"
 
@@ -285,6 +285,8 @@ jobs:
 
           if [[ "${NAMESPACE_ALIAS}" =~ ^SDPT[0-9]+$ ]]; then
             NETWORK_OWNER="single-day-perf-test"
+          elif [[ "${NAMESPACE_ALIAS}" =~ ^AdHocSD[0-9]+$ ]]; then
+            NETWORK_OWNER="adhoc-single-day-test"
           else
             NETWORK_OWNER="adhoc-performance-test"
           fi
@@ -366,6 +368,8 @@ jobs:
           sed -i -e "s@%NETWORK_ID%@${NETWORK_ID}@g" nlg-values.yaml
           if [[ "${NAMESPACE_ALIAS}" =~ ^SDPT[0-9]+$ ]]; then
             NETWORK_OWNER="single-day-perf-test"
+          elif [[ "${NAMESPACE_ALIAS}" =~ ^AdHocSD[0-9]+$ ]]; then
+            NETWORK_OWNER="adhoc-single-day-test"
           else
             NETWORK_OWNER="adhoc-performance-test"
           fi
@@ -375,6 +379,8 @@ jobs:
           sed -i -e "s@%NETWORK_ID%@${NETWORK_ID}@g" merkledb-values.yaml
           if [[ "${NAMESPACE_ALIAS}" =~ ^SDPT[0-9]+$ ]]; then
             NETWORK_OWNER="single-day-perf-test"
+          elif [[ "${NAMESPACE_ALIAS}" =~ ^AdHocSD[0-9]+$ ]]; then
+            NETWORK_OWNER="adhoc-single-day-test"
           else
             NETWORK_OWNER="adhoc-performance-test"
           fi
@@ -1232,7 +1238,7 @@ jobs:
         id: check-test-asset
         run: |
           ADHOC="false"
-          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc[0-9]$ ]]; then
+          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]$ ]]; then
             ADHOC="true"
           fi
           echo "is-adhoc=${ADHOC}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -194,7 +194,7 @@ jobs:
           set +e
           # trim the input ref
           echo "run-hcn-version=$(echo ${{ inputs.ref }} | awk '{print $1}')" >> "${GITHUB_OUTPUT}"
-          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHoc||AdHocSD|SDPT)(\d+)$/')"
+          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHoc|AdHocSD|SDPT|SDLT)(\d+)$/')"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_OUTPUT}"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_STEP_SUMMARY}"
 
@@ -1238,7 +1238,7 @@ jobs:
         id: check-test-asset
         run: |
           ADHOC="false"
-          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]$ ]]; then
+          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]+$ ]]; then
             ADHOC="true"
           fi
           echo "is-adhoc=${ADHOC}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -194,7 +194,7 @@ jobs:
           set +e
           # trim the input ref
           echo "run-hcn-version=$(echo ${{ inputs.ref }} | awk '{print $1}')" >> "${GITHUB_OUTPUT}"
-          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHoc|AdHocSD|SDPT|SDLT)(\d+)$/')"
+          n="$(echo "${{ inputs.test-asset }}" | perl -ne 'print "$2\n" if /^(AdHocSD|AdHoc|SDPT|SDLT)(\d+)$/')"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_OUTPUT}"
           echo "namespace=${NAMESPACE_PREFIX}${n}" >> "${GITHUB_STEP_SUMMARY}"
 

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -5,13 +5,15 @@ on:
     inputs:
       test-asset:
         required: true
-        default: "AdHoc5"
-        description: "Test on given Longevity Machine (AdHoc5, AdHoc6, AdHoc7)"
+        default: "AdHocSD8"
+        description: "Test on given Longevity Machine (AdHoc5, AdHoc6, AdHoc7, AdHocSD8, AdHocSD9)"
         type: choice
         options:
           - AdHoc5
           - AdHoc6
           - AdHoc7
+          - AdHocSD8
+          - AdHocSD9
       ref:
         required: true
         default: "main"

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -5,13 +5,15 @@ on:
     inputs:
       test-asset:
         required: true
-        default: "AdHoc7"
-        description: "Performance test on machine: AdHoc5, 6, 7"
+        default: "AdHocSD8"
+        description: "Performance test on machine: AdHoc5, 6, 7, AdHocSD8, 9"
         type: choice
         options:
           - AdHoc5
           - AdHoc6
           - AdHoc7
+          - AdHocSD8
+          - AdHocSD9
       ref:
         required: true
         default: "main"


### PR DESCRIPTION
## Description

This pull request updates several GitHub workflow YAML files to add support for new test machines (`AdHocSD8` and `AdHocSD9`) across both longevity and performance test pipelines. The changes ensure these new machines are recognized in input options, descriptions, environment variable parsing, and logic for assigning network owners. This improves test coverage and flexibility for running single-day tests on additional assets.

**Support for new test machines (`AdHocSD8`, `AdHocSD9`):**

* Updated the `test-asset` input descriptions and options in `.github/workflows/zxc-single-day-longevity-nlg-test.yaml`, `.github/workflows/zxc-single-day-performance-test.yaml`, `.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml`, and `.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml` to include `AdHocSD8` and `AdHocSD9`. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L10-R10) [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L10-R10) [[3]](diffhunk://#diff-2e0dfedf7abd9a7bac567fb3fa1ad4ebc474dabccd234d16f4f49569fe4646dcL8-R16) [[4]](diffhunk://#diff-61a2acc1fa0f26dc209dc44c563665ab8a24eafa766d77d87309f8f2584d9947L8-R16)

**Parsing and environment variable logic:**

* Modified regex and parsing logic in scripts to correctly extract numeric suffixes from new machine names (`AdHocSD8`, `AdHocSD9`) for namespace assignment. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L175-R175) [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L197-R197)
* Updated the check for "adhoc" assets to include both `AdHoc` and `AdHocSD` patterns. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L589-R593) [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L1235-R1241)

**Network owner assignment:**

* Added new conditional branches to assign the correct `NETWORK_OWNER` for `AdHocSD` assets in both longevity and performance test workflows. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1R266-R267) [[2]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1R349-R350) [[3]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6R288-R289) [[4]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6R371-R372) [[5]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6R382-R383)

**Default values and environment variables:**

* Changed default test asset to `AdHocSD8` in performance test workflows to reflect the addition of new machines. [[1]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L74-R74) [[2]](diffhunk://#diff-2e0dfedf7abd9a7bac567fb3fa1ad4ebc474dabccd234d16f4f49569fe4646dcL8-R16) [[3]](diffhunk://#diff-61a2acc1fa0f26dc209dc44c563665ab8a24eafa766d77d87309f8f2584d9947L8-R16)

These updates collectively ensure that the workflows can handle the new test assets seamlessly and assign resources and owners appropriately for each test run.

### Related Issue(s)

Closes #20911 