### PR TITLE
chore: state validator keeps all read entities in memory, exhausts the Java heap

### DIFF
--- a/hedera-state-validator/src/main/java/module-info.java
+++ b/hedera-state-validator/src/main/java/module-info.java
@@ -7,6 +7,7 @@ module com.hedera.state.validator {
     requires com.hedera.node.app.service.file.impl;
     requires com.hedera.node.app.service.network.admin.impl;
     requires com.hedera.node.app.service.schedule.impl;
+    requires com.hedera.node.app.service.token;
     requires com.hedera.node.app.service.token.impl;
     requires com.hedera.node.app.service.util.impl;
     requires com.hedera.node.app.spi;

--- a/hedera-state-validator/src/main/java/module-info.java
+++ b/hedera-state-validator/src/main/java/module-info.java
@@ -7,8 +7,8 @@ module com.hedera.state.validator {
     requires com.hedera.node.app.service.file.impl;
     requires com.hedera.node.app.service.network.admin.impl;
     requires com.hedera.node.app.service.schedule.impl;
-    requires com.hedera.node.app.service.token;
     requires com.hedera.node.app.service.token.impl;
+    requires com.hedera.node.app.service.token;
     requires com.hedera.node.app.service.util.impl;
     requires com.hedera.node.app.spi;
     requires com.hedera.node.app.test.fixtures;


### PR DESCRIPTION
**Description**:
* verify existence of accounts and tokens directly in `VirtualMap`,  avoid caching read entities in `ReadableKVStateBase`

**Related issue(s)**:

Fixes #20865

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
