### PR TITLE
ci: fix cn logs folder list ls command (non blocking)

### DIFF
--- a/.github/workflows/zxc-block-node-regression.yaml
+++ b/.github/workflows/zxc-block-node-regression.yaml
@@ -365,7 +365,7 @@ jobs:
           LOG_FOLDER=$(ls -1d "$BASE"/* | sort -r | head -n1)
           echo "Latest log folder is $LOG_FOLDER"
           echo "CN_LOG_FOLDER=$LOG_FOLDER" >> $GITHUB_ENV
-          ls -lR "${{ env.CN_LOG_FOLDER }}"
+          ls -lR "$LOG_FOLDER"
 
       - name: Upload BN and MN Logs
         if: always()


### PR DESCRIPTION
**Description**:
This is a small fix, for a failure to print `ls -lR ..` of log folder for CN logs dump, expected is 1 zip file found.
We know the Folder path is calculated correctly cause is used on the next step successfully and the logs are produced.
but is making the wf think it "fails" in this step. leaving the log since it might be useful for future debugging or troubleshooting.