### PR TITLE
ci: add missing secret to mirror node regression workflow call

### DIFF
--- a/.github/workflows/zxf-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/zxf-dry-run-extended-test-suite.yaml
@@ -141,6 +141,7 @@ jobs:
       solo-version: ${{ vars.CITR_SOLO_VERSION }}
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
 
   json-rpc-relay-regression-panel:
     name: JSON-RPC Relay Regression Panel


### PR DESCRIPTION
**Description**:

Add a missing secret to the mirror node regression workflow call inside XTS Dry Run workflow.

**Related Issue(s)**:

Fixes #20930
