### PR TITLE
chore: Use FakeTime in TurtleNode Logs

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/logging/internal/LogConfigHelper.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/logging/internal/LogConfigHelper.java
@@ -91,7 +91,9 @@ public final class LogConfigHelper {
     @NonNull
     public static FilterComponentBuilder createNodeOnlyFilter(
             @NonNull final ConfigurationBuilder<BuiltConfiguration> builder, @NonNull final NodeId nodeId) {
-        final KeyValuePairComponentBuilder keyValuePair = builder.newKeyValuePair("nodeId", Long.toString(nodeId.id()));
+        // Create JSON formatted value to match what TurtleNode sets in ThreadContext
+        final String jsonNodeId = NodeId.JSON.toJSON(nodeId);
+        final KeyValuePairComponentBuilder keyValuePair = builder.newKeyValuePair("nodeId", jsonNodeId);
 
         return builder.newFilter("ThreadContextMapFilter", Result.NEUTRAL, Result.DENY)
                 .addComponent(keyValuePair);
@@ -109,7 +111,9 @@ public final class LogConfigHelper {
     @NonNull
     public static FilterComponentBuilder createExcludeNodeFilter(
             @NonNull final ConfigurationBuilder<BuiltConfiguration> builder, @NonNull final NodeId nodeId) {
-        final KeyValuePairComponentBuilder keyValuePair = builder.newKeyValuePair("nodeId", Long.toString(nodeId.id()));
+        // Create JSON formatted value to match what TurtleNode sets in ThreadContext
+        final String jsonNodeId = NodeId.JSON.toJSON(nodeId);
+        final KeyValuePairComponentBuilder keyValuePair = builder.newKeyValuePair("nodeId", jsonNodeId);
 
         return builder.newFilter("ThreadContextMapFilter", Result.DENY, Result.NEUTRAL)
                 .addComponent(keyValuePair);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleInstrumentedNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleInstrumentedNode.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.otter.fixtures.InstrumentedNode;
 import org.hiero.otter.fixtures.turtle.gossip.SimulatedNetwork;
+import org.hiero.otter.fixtures.turtle.logging.TurtleLogging;
 
 /**
  * An implementation of {@link InstrumentedNode} for the Turtle framework.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -31,6 +31,7 @@ import org.hiero.otter.fixtures.internal.network.MeshTopologyImpl;
 import org.hiero.otter.fixtures.network.Topology;
 import org.hiero.otter.fixtures.network.Topology.ConnectionData;
 import org.hiero.otter.fixtures.turtle.gossip.SimulatedNetwork;
+import org.hiero.otter.fixtures.turtle.logging.TurtleLogging;
 
 /**
  * An implementation of {@link Network} that is based on the Turtle framework.

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNode.java
@@ -68,6 +68,7 @@ import org.hiero.otter.fixtures.result.SingleNodePlatformStatusResult;
 import org.hiero.otter.fixtures.result.SingleNodeReconnectResult;
 import org.hiero.otter.fixtures.turtle.gossip.SimulatedGossip;
 import org.hiero.otter.fixtures.turtle.gossip.SimulatedNetwork;
+import org.hiero.otter.fixtures.turtle.logging.TurtleLogging;
 import org.hiero.otter.fixtures.util.SecureRandomBuilder;
 
 /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -24,6 +24,8 @@ import org.hiero.otter.fixtures.TestEnvironment;
 import org.hiero.otter.fixtures.TimeManager;
 import org.hiero.otter.fixtures.TransactionGenerator;
 import org.hiero.otter.fixtures.logging.internal.InMemorySubscriptionManager;
+import org.hiero.otter.fixtures.turtle.logging.TurtleLogClock;
+import org.hiero.otter.fixtures.turtle.logging.TurtleLogging;
 
 /**
  * A test environment for the Turtle framework.
@@ -32,6 +34,12 @@ import org.hiero.otter.fixtures.logging.internal.InMemorySubscriptionManager;
  * network, time manager, etc. for tests running on the Turtle framework.
  */
 public class TurtleTestEnvironment implements TestEnvironment {
+
+    static {
+        // Set custom clock property BEFORE any Log4j2 initialization
+        // This ensures the TurtleClock is used for all log timestamps
+        System.setProperty("log4j.Clock", "org.hiero.otter.fixtures.turtle.logging.TurtleClock");
+    }
 
     private static final Logger log = LogManager.getLogger(TurtleTestEnvironment.class);
 
@@ -57,11 +65,14 @@ public class TurtleTestEnvironment implements TestEnvironment {
             log.warn("Failed to delete directory: {}", rootOutputDirectory, ex);
         }
 
-        final TurtleLogging logging = new TurtleLogging(rootOutputDirectory);
-
         final Randotron randotron = randomSeed == 0L ? Randotron.create() : Randotron.create(randomSeed);
 
         final FakeTime time = new FakeTime(randotron.nextInstant(), Duration.ZERO);
+
+        // Set the fake time for turtle nodes BEFORE configuring logging
+        TurtleLogClock.setFakeTime(time);
+
+        final TurtleLogging logging = new TurtleLogging(rootOutputDirectory);
 
         RuntimeObjectRegistry.reset();
         RuntimeObjectRegistry.initialize(time);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleTestEnvironment.java
@@ -38,7 +38,7 @@ public class TurtleTestEnvironment implements TestEnvironment {
     static {
         // Set custom clock property BEFORE any Log4j2 initialization
         // This ensures the TurtleClock is used for all log timestamps
-        System.setProperty("log4j.Clock", "org.hiero.otter.fixtures.turtle.logging.TurtleClock");
+        System.setProperty("log4j.Clock", TurtleLogClock.class.getName());
     }
 
     private static final Logger log = LogManager.getLogger(TurtleTestEnvironment.class);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/logging/TurtleLogClock.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/logging/TurtleLogClock.java
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.fixtures.turtle.logging;
+
+import com.swirlds.base.time.Time;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import org.apache.logging.log4j.ThreadContext;
+
+/**
+ * Custom Log4j2 Clock implementation that provides context-aware time sources.
+ *
+ * <p>This clock uses different time sources based on the thread context:
+ * <ul>
+ *   <li>For TurtleNode threads (with nodeId in ThreadContext): Uses FakeTime for simulated timestamps</li>
+ *   <li>For other threads (TurtleTestEnvironment, etc.): Uses System time for real timestamps</li>
+ * </ul>
+ */
+public class TurtleLogClock implements org.apache.logging.log4j.core.util.Clock {
+
+    private static volatile Time fakeTime = Time.getCurrent();
+    private static final Time systemTime = Time.getCurrent();
+
+    /**
+     * Required no-argument constructor for Log4j2 ClockFactory.
+     */
+    public TurtleLogClock() {
+        // Log4j2 will instantiate this
+        System.out.println("TurtleClock instantiated");
+    }
+
+    /**
+     * Set the fake Time instance to be used by turtle nodes.
+     *
+     * @param time the Time instance to use for simulated log timestamps
+     */
+    public static void setFakeTime(@NonNull final Time time) {
+        fakeTime = time;
+    }
+
+    @Override
+    public long currentTimeMillis() {
+        // Check if we're in a TurtleNode thread (has nodeId in ThreadContext)
+        final String nodeId = ThreadContext.get("nodeId");
+
+        if (nodeId != null && !nodeId.isEmpty()) {
+            // We're in a TurtleNode thread - use fake time for simulation
+            return fakeTime.now().toEpochMilli();
+        } else {
+            // We're in TurtleTestEnvironment or other thread - use system time
+            return systemTime.now().toEpochMilli();
+        }
+    }
+}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/logging/TurtleLogClock.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/logging/TurtleLogClock.java
@@ -24,7 +24,6 @@ public class TurtleLogClock implements org.apache.logging.log4j.core.util.Clock 
      */
     public TurtleLogClock() {
         // Log4j2 will instantiate this
-        System.out.println("TurtleClock instantiated");
     }
 
     /**

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/logging/TurtleLogConfigBuilder.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/logging/TurtleLogConfigBuilder.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package org.hiero.otter.fixtures.turtle;
+package org.hiero.otter.fixtures.turtle.logging;
 
 import static java.util.Objects.requireNonNull;
 import static org.hiero.otter.fixtures.logging.internal.LogConfigHelper.DEFAULT_PATTERN;

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/logging/TurtleLogging.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/logging/TurtleLogging.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package org.hiero.otter.fixtures.turtle;
+package org.hiero.otter.fixtures.turtle.logging;
 
 import static java.util.Objects.requireNonNull;
 


### PR DESCRIPTION
## Overview

Implemented a custom Log4j2 clock to enable simulated time timestamps in turtle test logs while maintaining real timestamps for test environment logging.

###   Key Changes

  1. TurtleLogClock.java (NEW)
  - Custom Log4j2 Clock implementation with context-aware time sources that provide fake time for Turtle Node threads and real time for all other threads.

  2. TurtleTestEnvironment.java
  - Added static block: Sets `log4j.Clock` system property before any Log4j2 initialization
  - Updated constructor: Calls `TurtleLogClock.setFakeTime()` to configure simulated time

  3. LogConfigHelper.java
  - Updated node filters: Changed from plain node ID strings to JSON format to match TurtleNode `ThreadContext` values

### Problem Solved
  - Empty `swirlds.log` files: Fixed `ThreadContext` key/value mismatch that was causing all log events to be filtered out
  - System timestamps in tests: Replaced with simulated `FakeTime` timestamps for consistent test behavior
  - Log4j2 initialization timing: Resolved early initialization preventing custom clock usage


Fixes #19823 

