### PR TITLE
ci(fix): Fix bug - SDPT/SDLT fail to create rootly incidents/alerts

### DIFF
--- a/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
@@ -50,6 +50,9 @@ on:
       slack-report-webhook:
         required: true
         description: "Slack webhook for SDLT outputs notifications"
+      rootly-api-token:
+        required: true
+        description: "Rootly API Token for creating alerts/incidents"
     outputs:
       result:
         description: "Result of the SDLT Run"
@@ -635,7 +638,7 @@ jobs:
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
         continue-on-error: true
         with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
+          api_key: ${{ secrets.rootly-api-token }}
           summary: ${{ steps.rootly-summary.outputs.title }}
           details: ${{ steps.rootly-summary.outputs.summary }}
           notification_target_type: "Service"
@@ -650,7 +653,7 @@ jobs:
         if: ${{ steps.check-test-asset.outputs.is-adhoc == 'false' }}
         uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
         with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
+          api_key: ${{ secrets.rootly-api-token }}
           title: ${{ steps.rootly-summary.outputs.title }}
           kind: "normal"
           create_public_incident: "false"

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -60,6 +60,9 @@ on:
       slack-report-webhook:
         required: true
         description: "Slack webhook for SDPT outputs notifications"
+      rootly-api-token:
+        required: true
+        description: "The rootly api token used for reporting"
     outputs:
       result:
         description: "Result of the SDPT Run"
@@ -1290,7 +1293,7 @@ jobs:
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
         continue-on-error: true
         with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
+          api_key: ${{ secrets.rootly-api-token}}
           summary: ${{ steps.rootly-summary.outputs.title }}
           details: ${{ steps.rootly-summary.outputs.summary }}
           notification_target_type: "Service"
@@ -1305,7 +1308,7 @@ jobs:
         if: ${{ steps.check-test-asset.outputs.is-adhoc == 'false' }}
         uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
         with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
+          api_key: ${{ secrets.rootly-api-token }}
           title: ${{ steps.rootly-summary.outputs.title }}
           kind: "normal"
           create_public_incident: "false"
@@ -1352,7 +1355,6 @@ jobs:
       - name: Build Slack Payload Message
         id: payload
         run: |
-
           report="\
             NftTransferLoadTest ${{ needs.performance-NftTransferLoadTest-report.outputs.NFTscore }} ${{ env.MinNFTscore }}\n\
             CryptoBench ${{ needs.performance-NftTransferLoadTest-report.outputs.MerkleDBscore }} ${{ env.MinMerkleDBscore }}\n\

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -132,6 +132,7 @@ jobs:
       add-settings: "${{ inputs.add-settings }}"
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+      rootly-api-token: ${{ secrets.ROOTLY_API_TOKEN }}
 
   tag-sdlt-result:
     name: Tag SDLT Result

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -78,6 +78,7 @@ jobs:
       add-settings: ""
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+      rootly-api-token: ${{ secrets.ROOTLY_API_TOKEN }}
 
   tag-sdlt-result:
     name: Tag SDLT Result

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -139,6 +139,7 @@ jobs:
       crypto-bench-merkle-db-test-params: "${{ inputs.crypto-bench-merkle-db-test-params }}"
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+      rootly-api-token: ${{ secrets.ROOTLY_API_TOKEN }}
 
   tag-sdpt-result:
     name: Tag SDPT Result

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -80,6 +80,7 @@ jobs:
       crypto-bench-merkle-db-test-params: "-p maxKey=500000000 -p numRecords=100000 -p keySize=24 -p recordSize=1024 -p numFiles=6000"
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+      rootly-api-token: ${{ secrets.ROOTLY_API_TOKEN }}
 
   tag-sdpt-result:
     name: Tag SDPT Result


### PR DESCRIPTION
## Description

This pull request updates several GitHub Actions workflow files to standardize the usage and naming of the Rootly API token secret across performance and longevity test pipelines. The main changes involve introducing a new `rootly-api-token` secret for workflows, updating references to the token in workflow steps, and ensuring the secret is passed correctly in all relevant controller jobs.

**Workflow configuration improvements:**

* Added a new `rootly-api-token` input to both `.github/workflows/zxc-single-day-longevity-nlg-test.yaml` and `.github/workflows/zxc-single-day-performance-test.yaml`, specifying it as a required secret for Rootly alert and incident reporting. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1R53-R55) [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6R63-R65)

**Secret usage standardization:**

* Updated all usages of the Rootly API token in workflow steps to reference `secrets.rootly-api-token` instead of `secrets.ROOTLY_API_TOKEN`, ensuring consistency across alert and incident actions in both longevity and performance test workflows. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L638-R641) [[2]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L653-R656) [[3]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L1293-R1296) [[4]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L1308-R1311)

**Controller workflow updates:**

* Passed the `rootly-api-token` secret to controller workflows for both longevity and performance tests, ensuring downstream jobs have access to the token. This change was made in `.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml`, `.github/workflows/zxf-single-day-longevity-test-controller.yaml`, `.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml`, and `.github/workflows/zxf-single-day-performance-test-controller.yaml`. [[1]](diffhunk://#diff-2e0dfedf7abd9a7bac567fb3fa1ad4ebc474dabccd234d16f4f49569fe4646dcR135) [[2]](diffhunk://#diff-a4f906182f2d4a24b8cd798cc5c0e3cd4f0f79d9b10923dda9e7c34229af8359R81) [[3]](diffhunk://#diff-61a2acc1fa0f26dc209dc44c563665ab8a24eafa766d77d87309f8f2584d9947R142) [[4]](diffhunk://#diff-af0846566d395a9cd891f76bc1bafbafa2ab4155371d913cf568171aeab667cfR83)

**Minor cleanup:**

* Removed an unnecessary blank line in the Slack payload message step in `.github/workflows/zxc-single-day-performance-test.yaml`.

### Related Issue(s)

Fixes #20954
