### PR TITLE
ci: Dynamically assign k8s-cluster value in SDPT/SDLT

### DIFF
--- a/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
@@ -34,13 +34,6 @@ on:
         default: ""
         type: string
         description: 'Add props to application.properties, e.g. "blockStream.streamMode=RECORDS". Newline is "\n"'
-      # For Adhoc runs, we use Chicago:                 k8s.pft.chi.lat.ope.eng.hashgraph.io
-      # For official Single Day tests, we use Dallas:   k8s.pft.dal.lat.ope.eng.hashgraph.io
-      kubernetes-cluster:
-        required: true
-        type: string
-        default: "k8s.pft.chi.lat.ope.eng.hashgraph.io"
-        description: "Kubernetes cluster to run"
       add-settings:
         required: false
         default: ""
@@ -83,6 +76,7 @@ jobs:
       Smartscore: ${{ steps.SmartContractLoadTestLogs.outputs.value }}
       namespace: ${{ steps.set-namespace.outputs.namespace }}
       commit-sha: ${{ steps.hederahash.outputs.sha }}
+      kubernetes-cluster: ${{ steps.set-k8s-cluster.outputs.kubernetes-cluster }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -93,6 +87,15 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Check Test Asset
+        id: set-k8s-cluster
+        run: |
+          K8S_CLUSTER="k8s.pft.dal.lat.ope.eng.hashgraph.io"
+          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]+$ ]]; then
+            K8S_CLUSTER="k8s.pft.chi.lat.ope.eng.hashgraph.io"
+          fi
+          echo "kubernetes-cluster=${K8S_CLUSTER}" >> "${GITHUB_OUTPUT}"
 
       - name: Install KubeCtl
         uses: step-security/setup-kubectl@2edbf6aff97d814e9dc52827498ac51fe972e6d0 # v4.0.0
@@ -117,7 +120,7 @@ jobs:
         with:
           proxy: hashgraph.teleport.sh:443
           token: gh-citr-performance-svcs-bot
-          kubernetes-cluster: ${{ inputs.kubernetes-cluster }}
+          kubernetes-cluster: ${{ steps.set-k8s-cluster.kubernetes-cluster }}
           certificate-ttl: 20h
 
       - name: Authenticate to Google Cloud
@@ -227,7 +230,7 @@ jobs:
       - name: Deploy with Solo
         env:
           NAMESPACE_ALIAS: ${{ inputs.test-asset }}
-          CONTEXT: hashgraph.teleport.sh-${{ inputs.kubernetes-cluster }}
+          CONTEXT: hashgraph.teleport.sh-${{ steps.set-k8s-cluster.kubernetes-cluster }}
         run: |
           set +x
           set +e

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -34,13 +34,6 @@ on:
         default: ""
         type: string
         description: 'Add props to application.properties, e.g. "blockStream.streamMode=RECORDS". Newline is "\n"'
-      # For Adhoc runs, we use Chicago:                 k8s.pft.chi.lat.ope.eng.hashgraph.io
-      # For official Single Day tests, we use Dallas:   k8s.pft.dal.lat.ope.eng.hashgraph.io
-      kubernetes-cluster:
-        required: true
-        default: "k8s.pft.chi.lat.ope.eng.hashgraph.io"
-        type: string
-        description: "Kubernetes cluster to run"
       add-settings:
         required: false
         default: ""
@@ -105,6 +98,7 @@ jobs:
       namespace: ${{ steps.set-namespace.outputs.namespace }}
       run-hcn-version: ${{ steps.set-namespace.outputs.run-hcn-version }}
       commit-sha: ${{ steps.hederahash.outputs.sha }}
+      kubernetes-cluster: ${{ steps.set-k8s-cluster.outputs.kubernetes-cluster }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -115,6 +109,15 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref }}
+
+      - name: Check Test Asset
+        id: set-k8s-cluster
+        run: |
+          K8S_CLUSTER="k8s.pft.dal.lat.ope.eng.hashgraph.io"
+          if [[ "${{ inputs.test-asset }}" =~ ^AdHoc(SD)?[0-9]+$ ]]; then
+            K8S_CLUSTER="k8s.pft.chi.lat.ope.eng.hashgraph.io"
+          fi
+          echo "kubernetes-cluster=${K8S_CLUSTER}" >> "${GITHUB_OUTPUT}"
 
       - name: Install KubeCtl
         uses: step-security/setup-kubectl@2edbf6aff97d814e9dc52827498ac51fe972e6d0 # v4.0.0
@@ -139,7 +142,7 @@ jobs:
         with:
           proxy: hashgraph.teleport.sh:443
           token: gh-citr-performance-svcs-bot
-          kubernetes-cluster: ${{ inputs.kubernetes-cluster }}
+          kubernetes-cluster: ${{ steps.set-k8s-cluster.kubernetes-cluster }}
           certificate-ttl: 168h
 
       - name: Authenticate to Google Cloud
@@ -249,7 +252,7 @@ jobs:
       - name: Deploy with Solo
         env:
           NAMESPACE_ALIAS: ${{ inputs.test-asset }}
-          CONTEXT: hashgraph.teleport.sh-${{ inputs.kubernetes-cluster }}
+          CONTEXT: hashgraph.teleport.sh-${{ steps.set-k8s-cluster.kubernetes-cluster }}
         run: |
           set +x
           set +e
@@ -678,7 +681,7 @@ jobs:
         with:
           proxy: hashgraph.teleport.sh:443
           token: gh-citr-performance-svcs-bot
-          kubernetes-cluster: ${{ inputs.kubernetes-cluster }}
+          kubernetes-cluster: ${{ needs.performance-tests-start.outputs.kubernetes-cluster }}
           certificate-ttl: 20h
 
       - name: Authenticate to Google Cloud
@@ -861,7 +864,7 @@ jobs:
         with:
           proxy: hashgraph.teleport.sh:443
           token: gh-citr-performance-svcs-bot
-          kubernetes-cluster: ${{ inputs.kubernetes-cluster }}
+          kubernetes-cluster: ${{ needs.performance-tests-start.outputs.kubernetes-cluster }}
           certificate-ttl: 20h
 
       - name: Authenticate to Google Cloud

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -128,7 +128,6 @@ jobs:
       nlg-accounts: "${{ inputs.nlg-accounts }}"
       nlg-time: "${{ inputs.nlg-time }}"
       add-app-props: "${{ inputs.add-app-props }}"
-      kubernetes-cluster: "k8s.pft.chi.lat.ope.eng.hashgraph.io"
       add-settings: "${{ inputs.add-settings }}"
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -74,7 +74,6 @@ jobs:
       nlg-accounts: "100000000"
       nlg-time: "960"
       add-app-props: ""
-      kubernetes-cluster: "k8s.pft.dal.lat.ope.eng.hashgraph.io"
       add-settings: ""
     secrets:
       slack-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -133,7 +133,6 @@ jobs:
       nlg-accounts: "${{ inputs.nlg-accounts }}"
       nlg-time: "${{ inputs.nlg-time }}"
       add-app-props: "${{ inputs.add-app-props }}"
-      kubernetes-cluster: "k8s.pft.chi.lat.ope.eng.hashgraph.io"
       add-settings: "${{ inputs.add-settings }}"
       crypto-bench-merkle-db-java-args: "${{ inputs.crypto-bench-merkle-db-java-args }}"
       crypto-bench-merkle-db-test-params: "${{ inputs.crypto-bench-merkle-db-test-params }}"

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -74,7 +74,6 @@ jobs:
       nlg-accounts: "100000000"
       nlg-time: "330"
       add-app-props: ""
-      kubernetes-cluster: "k8s.pft.dal.lat.ope.eng.hashgraph.io"
       add-settings: ""
       crypto-bench-merkle-db-java-args: "-XX:+UseZGC -XX:+ZGenerational -XX:ZAllocationSpikeTolerance=2 -XX:ConcGCThreads=14 -XX:ZMarkStackSpaceLimit=12g -XX:MaxDirectMemorySize=24g -Xmx90g"
       crypto-bench-merkle-db-test-params: "-p maxKey=500000000 -p numRecords=100000 -p keySize=24 -p recordSize=1024 -p numFiles=6000"


### PR DESCRIPTION
## Description

This pull request refactors how the Kubernetes cluster is selected and passed to various GitHub Actions workflows for single-day longevity and performance tests. Instead of specifying the cluster directly in workflow inputs or job environment variables, the cluster is now dynamically determined based on the `test-asset` input, ensuring that AdHoc runs use the Chicago cluster and official runs use the Dallas cluster. This change improves flexibility and reduces manual errors in cluster selection.

**Dynamic Kubernetes Cluster Selection**

* Removed the `kubernetes-cluster` input from workflow dispatch parameters in both `zxc-single-day-longevity-nlg-test.yaml` and `zxc-single-day-performance-test.yaml`, eliminating manual cluster specification. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L37-L43) [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L37-L43)
* Added a new job step (`set-k8s-cluster`) that sets the `kubernetes-cluster` output based on the `test-asset` input, defaulting to Dallas for official tests and switching to Chicago for AdHoc runs. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1R91-R99) [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6R113-R121)

**Cluster Propagation and Usage**

* Updated subsequent steps and job environments to use the dynamically determined `kubernetes-cluster` output instead of the static input, ensuring consistency throughout the workflow. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1R79) [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6R101)
* Changed references to the cluster in Solo deployment and Teleport authentication steps to use the new output, preventing mismatches and manual errors. [[1]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L120-R123) [[2]](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L230-R233) [[3]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L142-R145) [[4]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L252-R255)

**Controller Workflow Cleanup**

* Removed hardcoded `kubernetes-cluster` environment variables from controller workflows, further centralizing cluster selection logic. [[1]](diffhunk://#diff-2e0dfedf7abd9a7bac567fb3fa1ad4ebc474dabccd234d16f4f49569fe4646dcL131) [[2]](diffhunk://#diff-a4f906182f2d4a24b8cd798cc5c0e3cd4f0f79d9b10923dda9e7c34229af8359L77) [[3]](diffhunk://#diff-61a2acc1fa0f26dc209dc44c563665ab8a24eafa766d77d87309f8f2584d9947L136) [[4]](diffhunk://#diff-af0846566d395a9cd891f76bc1bafbafa2ab4155371d913cf568171aeab667cfL77)

**Performance Workflow Output Handling**

* Updated cluster references in performance test controller jobs to use outputs from the start job, ensuring correct cluster usage across dependent jobs. [[1]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L681-R684) [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L864-R867)

### Related Issue(s)

Closes #20963

### Testing

- [ ] Adhoc SD 9 Smoke Test