### PR TITLE
chore: replace input.ref with github.ref in single day controllers

### DIFF
--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -161,7 +161,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-performance-test-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: main # ensure we are always using the workflow definition from the main branch
+          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the main branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "ref": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"
@@ -172,7 +172,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-longevity-test-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: main # ensure we are always using the workflow definition from the main branch
+          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the main branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "ref": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"
@@ -183,7 +183,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-canonical-test.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: main # ensure we are always using the workflow definition from the main branch
+          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the main branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "build-tag": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -14,11 +14,6 @@ on:
           - AdHoc7
           - AdHocSD8
           - AdHocSD9
-      ref:
-        required: true
-        default: "main"
-        description: "Version of hiero-consensus-node: branch, tag, commit"
-        type: string
       nlg-accounts: #'-R -c 32 -a 100000000 -T 1000 -n 100000 -S hot -p 50 -tt 1m
         required: true
         default: "100000"
@@ -89,13 +84,13 @@ jobs:
       - name: Checkout Consensus Node
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Verify Tag
         id: verify-tag
         env:
           PROMOTED_GREP_PATTERN: "build-(.{5})" # Pattern to match build tags (e.g., build-12345)
-          CHECK_TAG: "${{ inputs.ref }}"
+          CHECK_TAG: "${{ github.ref }}"
         run: |
           # Ensure the tag that we received is a build tag
           # if the tag is a build tag then we can parse out the build number (the last 5 characters)
@@ -123,7 +118,7 @@ jobs:
     if: ${{ needs.verify-tag.result == 'success' || inputs.disable-notifications == true }}
     with:
       test-asset: "${{ inputs.test-asset }}"
-      ref: "${{ inputs.ref }}"
+      ref: "${{ github.ref }}"
       solo-version: "${{ vars.CITR_SOLO_VERSION }}"
       nlg-accounts: "${{ inputs.nlg-accounts }}"
       nlg-time: "${{ inputs.nlg-time }}"
@@ -151,7 +146,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -212,7 +207,7 @@ jobs:
         id: find-commit-author-slack
         continue-on-error: true
         env:
-          BUILD_TAG: ${{ inputs.ref }}
+          BUILD_TAG: ${{ github.ref }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
         run: |
           # Extract the commit and user information from the build tag
@@ -270,7 +265,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":tada: SDLT - Single Day Longevity Test (${{ inputs.ref }}) Passed",
+                        "text": ":tada: SDLT - Single Day Longevity Test (${{ github.ref }}) Passed",
                         "emoji": true
                       }
                     },
@@ -326,7 +321,7 @@ jobs:
                         },
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -385,7 +380,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Collect run logs in a log file
@@ -479,7 +474,7 @@ jobs:
                     "type": "header",
                     "text": {
                       "type": "plain_text",
-                      "text": ":grey_exclamation: SDLT - Single Day Longevity Test (${{ inputs.ref }}) Failed",
+                      "text": ":grey_exclamation: SDLT - Single Day Longevity Test (${{ github.ref }}) Failed",
                       "emoji": true
                     }
                   },
@@ -543,7 +538,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                       },
                       {
                         "type": "mrkdwn",

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -2,12 +2,6 @@
 name: "ZXF: [CITR] Single Day Longevity Test Controller"
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        required: true
-        default: "main"
-        description: "Version of hiero-consensus-node: branch, tag, commit"
-        type: string
 
 defaults:
   run:
@@ -35,13 +29,13 @@ jobs:
       - name: Checkout Consensus Node
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Verify Tag
         id: verify-tag
         env:
           PROMOTED_GREP_PATTERN: "build-(.{5})" # Pattern to match build tags (e.g., build-12345)
-          CHECK_TAG: "${{ inputs.ref }}"
+          CHECK_TAG: "${{ github.ref }}"
         run: |
           # Ensure the tag that we received is a build tag
           # if the tag is a build tag then we can parse out the build number (the last 5 characters)
@@ -69,7 +63,7 @@ jobs:
     if: ${{ needs.verify-tag.result == 'success' }}
     with:
       test-asset: "SDLT2"
-      ref: "${{ inputs.ref }}"
+      ref: "${{ github.ref }}"
       solo-version: "${{ vars.CITR_SOLO_VERSION }}"
       nlg-accounts: "100000000"
       nlg-time: "960"
@@ -96,7 +90,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -151,13 +145,13 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Find Commit Author in Slack
         id: find-commit-author-slack
         continue-on-error: true
         env:
-          BUILD_TAG: ${{ inputs.ref }}
+          BUILD_TAG: ${{ github.ref }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
         run: |
           # Extract the commit and user information from the build tag
@@ -215,7 +209,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":tada: SDLT - Single Day Longevity Test (${{ inputs.ref }}) Passed",
+                        "text": ":tada: SDLT - Single Day Longevity Test (${{ github.ref }}) Passed",
                         "emoji": true
                       }
                     },
@@ -271,7 +265,7 @@ jobs:
                         },
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -330,7 +324,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Collect run logs in a log file
@@ -443,7 +437,7 @@ jobs:
                     "type": "header",
                     "text": {
                       "type": "plain_text",
-                      "text": ":grey_exclamation: SDLT - Single Day Longevity Test (${{ inputs.ref }}) Failed",
+                      "text": ":grey_exclamation: SDLT - Single Day Longevity Test (${{ github.ref }}) Failed",
                       "emoji": true
                     }
                   },
@@ -507,7 +501,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                       },
                       {
                         "type": "mrkdwn",

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -14,11 +14,6 @@ on:
           - AdHoc7
           - AdHocSD8
           - AdHocSD9
-      ref:
-        required: true
-        default: "main"
-        description: "Version of hiero-consensus-node: branch, tag, commit"
-        type: string
       nlg-accounts: #'-R -c 32 -a 100000000 -T 1000 -n 100000 -S hot -p 50 -tt 1m
         required: true
         default: "100000"
@@ -94,13 +89,13 @@ jobs:
       - name: Checkout Consensus Node
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Verify Tag
         id: verify-tag
         env:
           PROMOTED_GREP_PATTERN: "build-(.{5})" # Pattern to match build tags (e.g., build-12345)
-          CHECK_TAG: "${{ inputs.ref }}"
+          CHECK_TAG: "${{ github.ref }}"
         run: |
           # Ensure the tag that we received is a build tag
           # if the tag is a build tag then we can parse out the build number (the last 5 characters)
@@ -128,7 +123,7 @@ jobs:
     if: ${{ needs.verify-tag.result == 'success' || inputs.disable-notifications == true }}
     with:
       test-asset: "${{ inputs.test-asset }}"
-      ref: "${{ inputs.ref }}"
+      ref: "${{ github.ref }}"
       solo-version: "${{ vars.CITR_SOLO_VERSION }}"
       nlg-accounts: "${{ inputs.nlg-accounts }}"
       nlg-time: "${{ inputs.nlg-time }}"
@@ -158,7 +153,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -222,7 +217,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
         run: |
           # Extract the commit and user information from the build tag
-          COMMIT=$(git rev-list -n 1 "${{ inputs.ref }}")
+          COMMIT=$(git rev-list -n 1 "${{ github.ref }}")
           EMAIL=$(git log -1 --pretty=format:'%ae' "${COMMIT}")
           AUTHOR=$(git log -1 --pretty=format:'%an' "${COMMIT}")
           SLACK_USER_ID=$(curl -s -X GET "https://slack.com/api/users.list" \
@@ -332,7 +327,7 @@ jobs:
                         },
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -391,7 +386,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Collect run logs in a log file
@@ -549,7 +544,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                       },
                       {
                         "type": "mrkdwn",

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -2,12 +2,6 @@
 name: "ZXF: [CITR] Single Day Performance Test Controller (SDPT)"
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        required: true
-        default: "main"
-        description: "Version of hiero-consensus-node: branch, tag, commit"
-        type: string
 
 defaults:
   run:
@@ -35,13 +29,13 @@ jobs:
       - name: Checkout Consensus Node
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Verify Tag
         id: verify-tag
         env:
           PROMOTED_GREP_PATTERN: "build-(.{5})" # Pattern to match build tags (e.g., build-12345)
-          CHECK_TAG: "${{ inputs.ref }}"
+          CHECK_TAG: "${{ github.ref }}"
         run: |
           # Ensure the tag that we received is a build tag
           # if the tag is a build tag then we can parse out the build number (the last 5 characters)
@@ -69,7 +63,7 @@ jobs:
     if: ${{ needs.verify-tag.result == 'success' }}
     with:
       test-asset: "SDPT1"
-      ref: "${{ inputs.ref }}"
+      ref: "${{ github.ref }}"
       solo-version: "${{ vars.CITR_SOLO_VERSION }}"
       nlg-accounts: "100000000"
       nlg-time: "330"
@@ -98,7 +92,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -161,7 +155,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
         run: |
           # Extract the commit and user information from the build tag
-          COMMIT=$(git rev-list -n 1 "${{ inputs.ref }}")
+          COMMIT=$(git rev-list -n 1 "${{ github.ref }}")
           EMAIL=$(git log -1 --pretty=format:'%ae' "${COMMIT}")
           AUTHOR=$(git log -1 --pretty=format:'%an' "${COMMIT}")
           SLACK_USER_ID=$(curl -s -X GET "https://slack.com/api/users.list" \
@@ -215,7 +209,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":tada: SDPT - Single Day Performance Test (${{ inputs.ref }}) Passed",
+                        "text": ":tada: SDPT - Single Day Performance Test (${{ github.ref }}) Passed",
                         "emoji": true
                       }
                     },
@@ -271,7 +265,7 @@ jobs:
                         },
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -330,7 +324,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Collect run logs in a log file
@@ -443,7 +437,7 @@ jobs:
                     "type": "header",
                     "text": {
                       "type": "plain_text",
-                      "text": ":grey_exclamation: SDPT - Single Day Performance Test (${{ inputs.ref }}) Failed",
+                      "text": ":grey_exclamation: SDPT - Single Day Performance Test (${{ github.ref }}) Failed",
                       "emoji": true
                     }
                   },
@@ -507,7 +501,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                       },
                       {
                         "type": "mrkdwn",


### PR DESCRIPTION
**Description**:

Replace `input.ref` with `github.ref` in all 4 single day controller workflows.

**Related Issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/20829