### PR TITLE
chore: Update incident_types

### DIFF
--- a/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
@@ -663,7 +663,7 @@ jobs:
           severity: "Triage Event"
           alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
           environments: "CITR"
-          incident_types: "Performance Engineering,Platform CI"
+          incident_types: "Platform CI"
           services: ${{ steps.set-rootly-service.outputs.service }}
           teams: "Performance Engineering,Platform CI"
 

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -1320,7 +1320,7 @@ jobs:
           severity: "Triage Event"
           alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
           environments: "CITR"
-          incident_types: "Performance Engineering,Platform CI"
+          incident_types: "Platform CI"
           services: ${{ steps.set-rootly-service.outputs.service }}
           teams: "Performance Engineering,Platform CI"
 

--- a/.github/workflows/zxf-single-day-canonical-test.yaml
+++ b/.github/workflows/zxf-single-day-canonical-test.yaml
@@ -381,6 +381,6 @@ jobs:
           severity: "Triage Event"
           alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
           environments: "CITR"
-          incident_types: "Platform CI,Performance Engineering"
+          incident_types: "Platform CI"
           services: ${{ steps.set-rootly-service.outputs.service }}
           teams: "Platform CI,Performance Engineering"


### PR DESCRIPTION
## Description

This pull request updates the incident type configuration in several GitHub workflow YAML files to streamline alert categorization. The main change is the removal of the "Performance Engineering" incident type from the `incident_types` field, leaving only "Platform CI". The "Performance Engineering" team is still listed under the `teams` field, so team notifications will continue as before.

Incident type configuration updates:

* [`.github/workflows/zxc-single-day-longevity-nlg-test.yaml`](diffhunk://#diff-befdc1fa53221eeedd361cfdf3addfb464624172fdcee35a0b5dece213e372f1L666-R666): Removed "Performance Engineering" from the `incident_types` field, now only "Platform CI" is specified.
* [`.github/workflows/zxc-single-day-performance-test.yaml`](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L1323-R1323): Removed "Performance Engineering" from the `incident_types` field, now only "Platform CI" is specified.
* [`.github/workflows/zxf-single-day-canonical-test.yaml`](diffhunk://#diff-b7a39c4deeb801b802a1a1fb09895cf39bd55abac5642cfaa8c953e3437b38d7L384-R384): Removed "Performance Engineering" from the `incident_types` field, now only "Platform CI" is specified.

### Related Issue(s)

Closes #21054 