### PR TITLE
chore: Do not receive events when unhealthy in RPC sync

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/platform/message/gossip_sync_data.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/platform/message/gossip_sync_data.proto
@@ -52,4 +52,11 @@ message GossipSyncData {
    */
   repeated bytes tips = 2;
 
+  /**
+   * Sender of this message is NOT interested in receiving any events as part of this sync.
+   * It might be in process of shutting down, unhealthy or any other reason - it might sent its own events outside,
+   * but no events should be sent to it.
+   */
+  bool skipSendingEvents = 3;
+
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/rpc/SyncData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/rpc/SyncData.java
@@ -14,7 +14,7 @@ import org.hiero.consensus.model.hashgraph.EventWindow;
  * @param eventWindow event window we see
  * @param tipHashes tips of our hashgraph
  */
-public record SyncData(EventWindow eventWindow, List<Hash> tipHashes) {
+public record SyncData(EventWindow eventWindow, List<Hash> tipHashes, boolean ignoreIncomingEvents) {
 
     /**
      * Convert protobuf communication version of class to internal one
@@ -32,7 +32,7 @@ public record SyncData(EventWindow eventWindow, List<Hash> tipHashes) {
                 gossipWindow.expiredThreshold());
         final var tips =
                 syncData.tips().stream().map(it -> new Hash(it.toByteArray())).collect(Collectors.toList());
-        return new SyncData(eventWindow, tips);
+        return new SyncData(eventWindow, tips, syncData.skipSendingEvents());
     }
 
     /**
@@ -47,6 +47,7 @@ public record SyncData(EventWindow eventWindow, List<Hash> tipHashes) {
                 .latestConsensusRound(eventWindow.latestConsensusRound())
                 .build());
         builder.tips(tipHashes.stream().map(Hash::getBytes).collect(Collectors.toList()));
+        builder.skipSendingEvents(ignoreIncomingEvents);
         return builder.build();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/rpc/SyncData.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/rpc/SyncData.java
@@ -13,8 +13,9 @@ import org.hiero.consensus.model.hashgraph.EventWindow;
  * Wrapper class for representing combination of event window and tip hashes used in the rpc sync protocol
  * @param eventWindow event window we see
  * @param tipHashes tips of our hashgraph
+ * @param dontReceiveEvents we don't want to be sent any events from the peer due to the health of the system
  */
-public record SyncData(EventWindow eventWindow, List<Hash> tipHashes, boolean ignoreIncomingEvents) {
+public record SyncData(EventWindow eventWindow, List<Hash> tipHashes, boolean dontReceiveEvents) {
 
     /**
      * Convert protobuf communication version of class to internal one
@@ -47,7 +48,7 @@ public record SyncData(EventWindow eventWindow, List<Hash> tipHashes, boolean ig
                 .latestConsensusRound(eventWindow.latestConsensusRound())
                 .build());
         builder.tips(tipHashes.stream().map(Hash::getBytes).collect(Collectors.toList()));
-        builder.skipSendingEvents(ignoreIncomingEvents);
+        builder.skipSendingEvents(dontReceiveEvents);
         return builder.build();
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
@@ -227,7 +227,7 @@ public class RpcPeerHandler implements GossipRpcReceiver {
         state.eventsTheyHave.addAll(knownTips);
         this.syncMetrics.reportSyncPhase(peerId, SyncPhase.EXCHANGING_EVENTS);
 
-        if (!state.remoteSyncData.ignoreIncomingEvents()) {
+        if (!state.remoteSyncData.dontReceiveEvents()) {
             // create a send list based on the known set
             final List<PlatformEvent> sendList = sharedShadowgraphSynchronizer.createSendList(
                     selfId, state.eventsTheyHave, state.mySyncData.eventWindow(), state.remoteSyncData.eventWindow());
@@ -245,7 +245,7 @@ public class RpcPeerHandler implements GossipRpcReceiver {
     @Override
     public void receiveEvents(@NonNull final List<GossipEvent> gossipEvents) {
         final SyncData mySyncData = state.mySyncData;
-        if (mySyncData != null && mySyncData.ignoreIncomingEvents()) {
+        if (mySyncData != null && mySyncData.dontReceiveEvents()) {
             // we ignore all incoming events - they should not be sent to us in first place
             logger.warn(
                     SYNC_INFO.getMarker(), "We have asked for no events, but still received an event from {}", peerId);

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/gossip/shadowgraph/RpcPeerHandler.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.gossip.shadowgraph;
 
+import static com.swirlds.logging.legacy.LogMarker.SYNC_INFO;
 import static com.swirlds.platform.gossip.shadowgraph.SyncUtils.getMyTipsTheyKnow;
 import static com.swirlds.platform.gossip.shadowgraph.SyncUtils.getTheirTipsIHave;
 import static org.hiero.base.CompareTo.isGreaterThanOrEqualTo;
@@ -139,20 +140,22 @@ public class RpcPeerHandler implements GossipRpcReceiver {
      * Start synchronization with remote side, if all checks are successful (things like enough time has passed since
      * last synchronization, remote side has not fallen behind etc
      *
-     * @param systemHealthy health of the system
-     * @return true if we should continue dispatching messages, false if system is unhealthy, and we are in proper place
-     * to break rpc conversation
+     * @param wantToExit           set to true if for some external reasons we would like to exit sync loop
+     * @param ignoreIncomingEvents we are in some kind of reduced capability state (for example caused by system being
+     *                             unhealthy) and we shouldn't be processing/requesting incoming events
+     * @return true if we should continue dispatching messages, false if we are in proper place to break rpc
+     * conversation
      */
     // dispatch thread
-    public boolean checkForPeriodicActions(final boolean systemHealthy) {
+    public boolean checkForPeriodicActions(final boolean wantToExit, final boolean ignoreIncomingEvents) {
         if (!isSyncCooldownComplete()) {
             this.syncMetrics.doNotSyncCooldown();
-            return systemHealthy;
+            return !wantToExit;
         }
 
         if (state.peerIsBehind) {
             this.syncMetrics.doNotSyncPeerFallenBehind();
-            return systemHealthy;
+            return !wantToExit;
         }
 
         if (state.peerStillSendingEvents) {
@@ -162,11 +165,11 @@ public class RpcPeerHandler implements GossipRpcReceiver {
 
         if (this.intakeEventCounter.hasUnprocessedEvents(peerId)) {
             this.syncMetrics.doNotSyncIntakeCounter();
-            return systemHealthy;
+            return !wantToExit;
         }
 
         if (state.mySyncData == null) {
-            if (systemHealthy) {
+            if (!wantToExit) {
                 if (state.remoteSyncData == null) {
                     if (!syncGuard.isSyncAllowed(peerId)) {
                         this.syncMetrics.doNotSyncFairSelector();
@@ -178,9 +181,9 @@ public class RpcPeerHandler implements GossipRpcReceiver {
                 }
                 // we have received remote sync request, so we want to reply, or sync selector told us it is our
                 // time to initiate sync
-                sendSyncData();
+                sendSyncData(ignoreIncomingEvents);
             }
-            return systemHealthy;
+            return !wantToExit;
         } else {
             this.syncMetrics.doNotSyncAlreadyStarted();
             return true;
@@ -224,11 +227,14 @@ public class RpcPeerHandler implements GossipRpcReceiver {
         state.eventsTheyHave.addAll(knownTips);
         this.syncMetrics.reportSyncPhase(peerId, SyncPhase.EXCHANGING_EVENTS);
 
-        // create a send list based on the known set
-        final List<PlatformEvent> sendList = sharedShadowgraphSynchronizer.createSendList(
-                selfId, state.eventsTheyHave, state.mySyncData.eventWindow(), state.remoteSyncData.eventWindow());
-        sender.sendEvents(sendList.stream().map(PlatformEvent::getGossipEvent).collect(Collectors.toList()));
-        outgoingEventsCounter += sendList.size();
+        if (!state.remoteSyncData.ignoreIncomingEvents()) {
+            // create a send list based on the known set
+            final List<PlatformEvent> sendList = sharedShadowgraphSynchronizer.createSendList(
+                    selfId, state.eventsTheyHave, state.mySyncData.eventWindow(), state.remoteSyncData.eventWindow());
+            sender.sendEvents(
+                    sendList.stream().map(PlatformEvent::getGossipEvent).collect(Collectors.toList()));
+            outgoingEventsCounter += sendList.size();
+        }
         sender.sendEndOfEvents();
         finishedSendingEvents();
     }
@@ -238,6 +244,13 @@ public class RpcPeerHandler implements GossipRpcReceiver {
      */
     @Override
     public void receiveEvents(@NonNull final List<GossipEvent> gossipEvents) {
+        final SyncData mySyncData = state.mySyncData;
+        if (mySyncData != null && mySyncData.ignoreIncomingEvents()) {
+            // we ignore all incoming events - they should not be sent to us in first place
+            logger.warn(
+                    SYNC_INFO.getMarker(), "We have asked for no events, but still received an event from {}", peerId);
+            return;
+        }
         // this is one of two important parts of the code to keep outside critical section - receiving events
         final long start = time.nanoTime();
         incomingEventsCounter += gossipEvents.size();
@@ -322,14 +335,14 @@ public class RpcPeerHandler implements GossipRpcReceiver {
         }
     }
 
-    private void sendSyncData() {
+    private void sendSyncData(final boolean ignoreIncomingEvents) {
         syncMetrics.syncStarted();
         this.syncMetrics.reportSyncPhase(peerId, SyncPhase.EXCHANGING_WINDOWS);
         state.shadowWindow = sharedShadowgraphSynchronizer.reserveEventWindow();
         state.myTips = sharedShadowgraphSynchronizer.getTips();
         final List<Hash> tipHashes =
                 state.myTips.stream().map(ShadowEvent::getEventBaseHash).collect(Collectors.toList());
-        state.mySyncData = new SyncData(state.shadowWindow.getEventWindow(), tipHashes);
+        state.mySyncData = new SyncData(state.shadowWindow.getEventWindow(), tipHashes, ignoreIncomingEvents);
         sender.sendSyncData(state.mySyncData);
         this.syncMetrics.outgoingSyncRequestSent();
 

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/rpc/RpcPeerProtocol.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/network/protocol/rpc/RpcPeerProtocol.java
@@ -83,6 +83,8 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
      */
     private final RpcPingHandler pingHandler;
 
+    private final boolean keepSendingEventsWhenUnhealthy;
+
     /**
      * State machine for rpc exchange process (mostly sync process)
      */
@@ -200,6 +202,7 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
         this.idleDispatchPollTimeoutMs = syncConfig.rpcIdleDispatchPollTimeout().toMillis();
         this.idleWritePollTimeoutMs = syncConfig.rpcIdleWritePollTimeout().toMillis();
         this.pingHandler = new RpcPingHandler(time, networkMetrics, remotePeerId, this);
+        this.keepSendingEventsWhenUnhealthy = syncConfig.keepSendingEventsWhenUnhealthy();
     }
 
     /**
@@ -283,7 +286,7 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
                     () -> readMessages(connection),
                     () -> writeMessages(connection));
         } catch (final ParallelExecutionException e) {
-            logger.error(NETWORK.getMarker(), "Failure during communication with node {}", remotePeerId, e);
+            logger.warn(NETWORK.getMarker(), "Failure during communication with node {}", remotePeerId, e);
         } finally {
             permitProvider.release();
             previousPhase = syncMetrics.reportSyncPhase(remotePeerId, SyncPhase.OUTSIDE_OF_RPC);
@@ -309,10 +312,11 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
                     }
                     message.run();
                 }
-
                 // permitProvider health indicates that system is overloaded, and we are getting backpressure; we need
                 // to give up on spamming network and/or reading new messages and let things settle down
-                if (!rpcPeerHandler.checkForPeriodicActions(permitProvider.isHealthy())) {
+                final boolean wantToExit =
+                        gossipHalted.get() || (!permitProvider.isHealthy() && !keepSendingEventsWhenUnhealthy);
+                if (!rpcPeerHandler.checkForPeriodicActions(wantToExit, !permitProvider.isHealthy())) {
                     // handler told us we are ok to stop processing messages right now due to platform not being healthy
                     processMessages = false;
                 }

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/shadowgraph/RpcShadowgraphSynchronizerTest.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/gossip/shadowgraph/RpcShadowgraphSynchronizerTest.java
@@ -39,7 +39,10 @@ import org.mockito.Mockito;
 class RpcShadowgraphSynchronizerTest {
 
     static final int NUM_NODES = 10;
-    public static final SyncData EMPTY_SYNC_MESSAGE = new SyncData(EventWindow.getGenesisEventWindow(), List.of());
+    public static final SyncData EMPTY_SYNC_MESSAGE =
+            new SyncData(EventWindow.getGenesisEventWindow(), List.of(), false);
+    public static final SyncData EMPTY_SYNC_MESSAGE_IGNORE_EVENTS =
+            new SyncData(EventWindow.getGenesisEventWindow(), List.of(), true);
     private PlatformContext platformContext;
     private SyncMetrics syncMetrics;
     private FallenBehindManagerImpl fallenBehindManager;
@@ -100,7 +103,7 @@ class RpcShadowgraphSynchronizerTest {
     void createPeerHandlerStartSync() {
         var otherNodeId = NodeId.of(5);
         var conversation = synchronizer.createPeerHandler(gossipSender, otherNodeId);
-        conversation.checkForPeriodicActions(true);
+        conversation.checkForPeriodicActions(false, false);
         Mockito.verify(gossipSender).sendSyncData(any());
     }
 
@@ -108,7 +111,7 @@ class RpcShadowgraphSynchronizerTest {
     void fullEmptySync() {
         var otherNodeId = NodeId.of(5);
         var conversation = synchronizer.createPeerHandler(gossipSender, otherNodeId);
-        conversation.checkForPeriodicActions(true);
+        conversation.checkForPeriodicActions(false, false);
         Mockito.verify(gossipSender).sendSyncData(any());
         conversation.receiveSyncData(EMPTY_SYNC_MESSAGE);
         Mockito.verify(gossipSender).sendTips(List.of());
@@ -119,12 +122,25 @@ class RpcShadowgraphSynchronizerTest {
     }
 
     @Test
+    void fullEmptySyncIgnoreEvents() {
+        var otherNodeId = NodeId.of(5);
+        var conversation = synchronizer.createPeerHandler(gossipSender, otherNodeId);
+        conversation.checkForPeriodicActions(false, true);
+        Mockito.verify(gossipSender).sendSyncData(any());
+        conversation.receiveSyncData(EMPTY_SYNC_MESSAGE_IGNORE_EVENTS);
+        Mockito.verify(gossipSender).sendTips(List.of());
+        conversation.receiveTips(List.of());
+        Mockito.verify(gossipSender).sendEndOfEvents();
+        Mockito.verifyNoMoreInteractions(gossipSender);
+    }
+
+    @Test
     void testFallenBehind() {
         var otherNodeId = NodeId.of(5);
         var conversation = synchronizer.createPeerHandler(gossipSender, otherNodeId);
-        conversation.checkForPeriodicActions(true);
+        conversation.checkForPeriodicActions(false, false);
         Mockito.verify(gossipSender).sendSyncData(any());
-        conversation.receiveSyncData(new SyncData(new EventWindow(100, 101, 10, 5), List.of()));
+        conversation.receiveSyncData(new SyncData(new EventWindow(100, 101, 10, 5), List.of(), false));
         Mockito.verify(lagReporter).accept(100.0);
         Mockito.verify(gossipSender).breakConversation();
         Mockito.verifyNoMoreInteractions(gossipSender);
@@ -136,8 +152,8 @@ class RpcShadowgraphSynchronizerTest {
         for (int i = 2; i <= 5; i++) {
             var otherNodeId = NodeId.of(i);
             var conversation = synchronizer.createPeerHandler(gossipSender, otherNodeId);
-            conversation.checkForPeriodicActions(true);
-            conversation.receiveSyncData(new SyncData(new EventWindow(20 + i, 20 + i, 10, 5), List.of()));
+            conversation.checkForPeriodicActions(false, false);
+            conversation.receiveSyncData(new SyncData(new EventWindow(20 + i, 20 + i, 10, 5), List.of(), false));
             Mockito.verify(lagReporter).accept(21 + i / 2.0);
         }
     }
@@ -147,8 +163,8 @@ class RpcShadowgraphSynchronizerTest {
         for (int i = 5; i >= 2; i--) {
             var otherNodeId = NodeId.of(i);
             var conversation = synchronizer.createPeerHandler(gossipSender, otherNodeId);
-            conversation.checkForPeriodicActions(true);
-            conversation.receiveSyncData(new SyncData(new EventWindow(20 + i, 20 + i, 10, 5), List.of()));
+            conversation.checkForPeriodicActions(false, false);
+            conversation.receiveSyncData(new SyncData(new EventWindow(20 + i, 20 + i, 10, 5), List.of(), false));
             if (i != 2) {
                 Mockito.reset(lagReporter);
             }
@@ -162,21 +178,21 @@ class RpcShadowgraphSynchronizerTest {
         var otherNodeId = NodeId.of(5);
         var conversation = synchronizer.createPeerHandler(gossipSender, otherNodeId);
         // we don't want to start sync in unhealthy state
-        assertFalse(conversation.checkForPeriodicActions(false));
+        assertFalse(conversation.checkForPeriodicActions(true, false));
         Mockito.verifyNoMoreInteractions(gossipSender);
 
         // we are now healthy, so start sync
-        assertTrue(conversation.checkForPeriodicActions(true));
+        assertTrue(conversation.checkForPeriodicActions(false, false));
         Mockito.verify(gossipSender).sendSyncData(any());
 
         // event if system is unhealthy, we need to finish sync
-        assertTrue(conversation.checkForPeriodicActions(false));
-        conversation.receiveSyncData(new SyncData(new EventWindow(100, 101, 10, 5), List.of()));
+        assertTrue(conversation.checkForPeriodicActions(true, false));
+        conversation.receiveSyncData(new SyncData(new EventWindow(100, 101, 10, 5), List.of(), false));
         Mockito.verify(gossipSender).breakConversation();
         Mockito.verify(statusSubmitter).submitStatusAction(new FallenBehindAction());
 
         // if sync is finished, we shouldn't be starting new one if system is unhealthy
-        assertFalse(conversation.checkForPeriodicActions(false));
+        assertFalse(conversation.checkForPeriodicActions(true, false));
         Mockito.verifyNoMoreInteractions(gossipSender);
     }
 
@@ -185,21 +201,21 @@ class RpcShadowgraphSynchronizerTest {
         var otherNodeId = NodeId.of(5);
         var conversation = synchronizer.createPeerHandler(gossipSender, otherNodeId);
         synchronizer.updateEventWindow(new EventWindow(100, 101, 10, 5));
-        conversation.checkForPeriodicActions(true);
+        conversation.checkForPeriodicActions(false, false);
         Mockito.verify(gossipSender).sendSyncData(any());
         conversation.receiveSyncData(EMPTY_SYNC_MESSAGE);
         ((FakeTime) this.platformContext.getTime()).tick(Duration.ofSeconds(10));
-        conversation.checkForPeriodicActions(true);
+        conversation.checkForPeriodicActions(false, false);
         ((FakeTime) this.platformContext.getTime()).tick(Duration.ofSeconds(10));
-        conversation.checkForPeriodicActions(true);
+        conversation.checkForPeriodicActions(false, false);
         ((FakeTime) this.platformContext.getTime()).tick(Duration.ofSeconds(10));
-        conversation.checkForPeriodicActions(true);
+        conversation.checkForPeriodicActions(false, false);
         ((FakeTime) this.platformContext.getTime()).tick(Duration.ofSeconds(10));
         Mockito.verifyNoMoreInteractions(gossipSender);
         Mockito.clearInvocations(gossipSender);
-        conversation.receiveSyncData(new SyncData(new EventWindow(100, 101, 10, 5), List.of()));
+        conversation.receiveSyncData(new SyncData(new EventWindow(100, 101, 10, 5), List.of(), false));
         ((FakeTime) this.platformContext.getTime()).tick(Duration.ofSeconds(10));
-        conversation.checkForPeriodicActions(true);
+        conversation.checkForPeriodicActions(false, false);
         Mockito.verify(gossipSender).sendSyncData(any());
     }
 }


### PR DESCRIPTION
**Description**:
Change sync logic to always send events, even when we are struggling (i.e. too much backpressure or new idea below), but do not receive events. This is a port of #20663 to RPC sync.

**Related issue(s)**:

Fixes #20666 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
