### PR TITLE
ci(fix): Fix bug with control characters being interpreted in json output

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -146,7 +146,7 @@ jobs:
             # Commit list output (multiline)
             {
               echo 'commit-list<<EOF'
-              echo "${COMMIT_LIST}"
+              echo "${COMMIT_LIST//\`/}"
               echo EOF
             } >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
## Description

This pull request includes a minor update to the `.github/workflows/zxcron-extended-test-suite.yaml` workflow. The change ensures that backtick characters are removed from the commit list output before it is set as a GitHub Actions output variable.

### Related Issue(s)

- Fixes #21088 
