### PR TITLE
chore(cherry pick): add CI-related PRs to release 0.66 branch

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -292,7 +292,8 @@ jobs:
         id: set-rootly-parameters
         run: |
           ROOTLY_SERVICE_NAME="CITR General"
-          if [[ "${{ needs.deploy-ci-trigger.result }}" =~ ^(cancelled|failure)$ ]]; then
+          if [[ "${{ needs.deploy-ci-trigger.result }}" =~ ^(cancelled|failure)$ ]] \
+            || [[ "${{ needs.mats-unit-tests.outputs.failure-mode }}" == "workflow" ]]; then
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
           fi
           echo "service=${ROOTLY_SERVICE_NAME}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/node-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/node-flow-deploy-release-artifact.yaml
@@ -24,7 +24,7 @@ defaults:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
   actions: read
 
 jobs:

--- a/.github/workflows/node-zxc-build-release-artifact.yaml
+++ b/.github/workflows/node-zxc-build-release-artifact.yaml
@@ -107,7 +107,7 @@ env:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   validate:
@@ -849,6 +849,28 @@ jobs:
         run: |
           SDK_ARCHIVE_DIR="${HOME}/sdk-archives"
           gsutil -m cp -r "${SDK_ARCHIVE_DIR}"/* gs://platform-sdk-ci-release-artifacts/${RELEASE_TAG}/
+
+      - name: Set GH Create Release Flag
+        id: set-gh-release-flags
+        if: ${{ inputs.version-policy == 'specified' && inputs.dry-run-enabled != true && inputs.release-profile != 'none' && !cancelled() && !failure() }}
+        run: |
+          CREATE_RELEASE="false"
+          if [[ "${{ inputs.ref-name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Tag ${GITHUB_REF#refs/tags/} matches release tag pattern"
+            CREATE_RELEASE="true"
+          fi
+
+          echo "create-release=${CREATE_RELEASE}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create github release
+        if: ${{ steps.set-gh-release-flag.outputs.create-release == 'true' }}
+        uses: ncipollo/release-action@bcfe5470707e8832e12347755757cec0eb3c22af # v1.18.0
+        with:
+          tag: ${{ inputs.ref-name }}
+          prerelease: false
+          draft: false
+          generateReleaseNotes: true
+          skipIfReleaseExists: true
 
   send-notifications:
     name: Send Release Notifications

--- a/.github/workflows/node-zxc-compile-application-code.yaml
+++ b/.github/workflows/node-zxc-compile-application-code.yaml
@@ -148,6 +148,11 @@ on:
         description: "The Codecov token used to report code coverage."
         required: false
 
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.compile.outputs.failure-mode }}
+
 defaults:
   run:
     shell: bash
@@ -170,33 +175,41 @@ jobs:
   compile:
     name: ${{ inputs.custom-job-label || 'Compiles' }}
     runs-on: hiero-network-node-linux-large
+    outputs:
+      failure-mode: ${{ steps.calculate-failure-mode.outputs.failure-mode }}
     steps:
       - name: Harden Runner
+        id: harden-runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
         with:
           egress-policy: audit
 
       - name: Checkout Code
+        id: checkout-code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.ref || '' }}
 
       - name: Expand Shallow Clone for and Spotless
+        id: expand-shallow-clone
         if: ${{ (inputs.enable-unit-tests || inputs.enable-spotless-check) && !cancelled() }}
         run: git fetch --unshallow --no-recurse-submodules
 
       - name: Setup Java
+        id: setup-java
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
           distribution: ${{ inputs.java-distribution }}
           java-version: ${{ inputs.java-version }}
 
       - name: Setup Gradle
+        id: setup-gradle
         uses: gradle/actions/setup-gradle@ac638b010cf58a27ee6c972d7336334ccaf61c96 # v4.4.1
         with:
           cache-read-only: false
 
       - name: Setup NodeJS
+        id: setup-node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: ${{ inputs.node-version }}
@@ -206,10 +219,12 @@ jobs:
         run: ${GRADLE_EXEC} assemble :yahcli:assemble
 
       - name: Spotless Check
+        id: spotless-check
         if: ${{ inputs.enable-spotless-check && !cancelled() }}
         run: ${GRADLE_EXEC} spotlessCheck
 
       - name: Gradle Dependency Scopes Check
+        id: check-dependency-scopes
         if: ${{ inputs.enable-dependency-check && steps.gradle-build.conclusion == 'success' && !cancelled() }}
         run: ${GRADLE_EXEC} checkAllModuleInfo validatePomFiles --continue --no-build-cache
 
@@ -752,7 +767,7 @@ jobs:
         run: snyk --version
 
       - name: Snyk Scan
-        id: snyk
+        id: snyk-scan
         env:
           SNYK_TOKEN: ${{ secrets.snyk-token }}
         if: >-
@@ -824,3 +839,62 @@ jobs:
           echo "::group::Snyk Code Contents"
             cat snyk-code.json || true
           echo "::endgroup::"
+
+      - name: Check Results
+        id: calculate-failure-mode
+        if: ${{ always() }}
+        run: |
+          ci_cd_statuses=(
+            "${{ steps.harden-runner.outcome || 'skipped' }}"
+            "${{ steps.checkout-code.outcome || 'skipped' }}"
+            "${{ steps.expand-shallow-clone.outcome || 'skipped' }}"
+            "${{ steps.setup-java.outcome || 'skipped' }}"
+            "${{ steps.setup-gradle.outcome || 'skipped' }}"
+            "${{ steps.setup-node.outcome || 'skipped' }}"
+            "${{ steps.check-dependency-scopes.outcome || 'skipped' }}"
+            "${{ steps.snyk-scan.outcome || 'skipped' }}"
+            "${{ steps.snyk-code.outcome || 'skipped' }}"
+            "${{ steps.spotless-check.outcome || 'skipped' }}"
+          )
+
+          # We can break this down further to set additional failure modes
+          general_statuses=(
+            "${{ steps.gradle-build.outcome || 'skipped' }}"
+            "${{ steps.gradle-test.outcome || 'skipped' }}"
+            "${{ steps.gradle-timing-sensitive.outcome || 'skipped' }}"
+            "${{ steps.gradle-time-consuming.outcome || 'skipped' }}"
+            "${{ steps.gradle-hammer-tests.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-misc.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-misc-records.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-crypto.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-token.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-smart-contract.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-time-consuming.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-restart.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-iss.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-bn-communication.outcome || 'skipped' }}"
+            "${{ steps.gradle-hapi-nd-reconnect.outcome || 'skipped' }}"
+            "${{ steps.gradle-otter-tests.outcome || 'skipped' }}"
+          )
+
+          failure_mode="none"
+
+          has_failure() {
+            local arr=("$@")
+            for status in "${arr[@]}"; do
+              [[ "$status" == "failure" ]] && return 0
+            done
+            return 1
+          }
+
+          # General check first
+          if has_failure "${general_statuses[@]}"; then
+            failure_mode="general"
+          fi
+
+          # If no general failure, check CI/CD specific steps
+          if has_failure "${ci_cd_statuses[@]}"; then
+            failure_mode="workflow"
+          fi
+
+          echo "failure-mode=${failure_mode}" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-nlg-test.yaml
@@ -663,7 +663,7 @@ jobs:
           severity: "Triage Event"
           alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
           environments: "CITR"
-          incident_types: "Performance Engineering,Platform CI"
+          incident_types: "Platform CI"
           services: ${{ steps.set-rootly-service.outputs.service }}
           teams: "Performance Engineering,Platform CI"
 

--- a/.github/workflows/zxc-single-day-longevity-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-test.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "ZXC: [CITR] Single Day Longevity NLG Test"
+name: "ZXC: [CITR] Single Day Longevity Test"
 
 on:
   workflow_call:

--- a/.github/workflows/zxc-single-day-longevity-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-test.yaml
@@ -221,7 +221,7 @@ jobs:
 
       - name: Install Solo
         run: |
-          npm install -g "@hashgraph/solo@${{ inputs.solo-version }}"
+          npm install -g "@hashgraph/solo@${{ inputs.solo-version || 'latest' }}"
 
           # verify the installation
           solo --version

--- a/.github/workflows/zxc-single-day-longevity-test.yaml
+++ b/.github/workflows/zxc-single-day-longevity-test.yaml
@@ -651,22 +651,6 @@ jobs:
           external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           environments: "CITR"
 
-      - name: Create Rootly Incident
-        if: ${{ steps.check-test-asset.outputs.is-adhoc == 'false' }}
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        with:
-          api_key: ${{ secrets.rootly-api-token }}
-          title: ${{ steps.rootly-summary.outputs.title }}
-          kind: "normal"
-          create_public_incident: "false"
-          summary: ${{ steps.rootly-summary.outputs.summary }}
-          severity: "Triage Event"
-          alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Performance Engineering,Platform CI"
-
   longevity-report-to-Slack:
     runs-on: hiero-citr-linux-medium
     needs:

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -1320,7 +1320,7 @@ jobs:
           severity: "Triage Event"
           alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
           environments: "CITR"
-          incident_types: "Performance Engineering,Platform CI"
+          incident_types: "Platform CI"
           services: ${{ steps.set-rootly-service.outputs.service }}
           teams: "Performance Engineering,Platform CI"
 

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -245,7 +245,7 @@ jobs:
 
       - name: Install Solo
         run: |
-          npm install -g "@hashgraph/solo@${{ inputs.solo-version }}"
+          npm install -g "@hashgraph/solo@${{ inputs.solo-version || 'latest' }}"
 
           # verify the installation
           solo --version

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -1308,22 +1308,6 @@ jobs:
           external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           environments: "CITR"
 
-      - name: Create Rootly Incident
-        if: ${{ steps.check-test-asset.outputs.is-adhoc == 'false' }}
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        with:
-          api_key: ${{ secrets.rootly-api-token }}
-          title: ${{ steps.rootly-summary.outputs.title }}
-          kind: "normal"
-          create_public_incident: "false"
-          summary: ${{ steps.rootly-summary.outputs.summary }}
-          severity: "Triage Event"
-          alert_ids: ${{ steps.rootly-alert.outputs.alert_ids || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Performance Engineering,Platform CI"
-
   performance-report-to-slack:
     runs-on: hiero-citr-linux-medium
     needs:

--- a/.github/workflows/zxc-tck-regression.yaml
+++ b/.github/workflows/zxc-tck-regression.yaml
@@ -11,6 +11,10 @@ on:
         description: "The custom job name to use for the job:"
         required: false
         type: string
+      solo-version:
+        description: "The version of solo to install (if not specified, latest will be used):"
+        required: false
+        type: string
     secrets:
       access-token:
         description: "GitHub Access Token with write permissions to the repository."
@@ -151,7 +155,7 @@ jobs:
       # Install solo and configure to use the artifacts from
       # the hiero-consensus-node build
       - name: Install Solo
-        run: npm install -g @hashgraph/solo@0.37.1
+        run: npm install -g @hashgraph/solo@${{ inputs.solo-version || 'latest' }}
 
       # Set up kind; needed for configuring the solo environment
       - name: Setup Kind
@@ -177,7 +181,7 @@ jobs:
           solo network deploy -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}"
           solo node setup -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}" --local-build-path ./hedera-node/data
           solo node start -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}"
-          solo mirror-node deploy --deployment "${{ env.SOLO_DEPLOYMENT }}" --cluster-ref kind-${{ env.SOLO_CLUSTER_NAME }}
+          solo mirror-node deploy --deployment "${{ env.SOLO_DEPLOYMENT }}" --cluster-ref kind-${{ env.SOLO_CLUSTER_NAME }} --mirror-node-version "v0.138.0"
 
           kubectl port-forward svc/haproxy-node1-svc -n "${{ env.SOLO_NAMESPACE }}" 50211:non-tls-grpc-client-port &
           kubectl port-forward svc/mirror-monitor -n "${{ env.SOLO_NAMESPACE }}" 5600:http &

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -146,7 +146,7 @@ jobs:
             # Commit list output (multiline)
             {
               echo 'commit-list<<EOF'
-              echo "${COMMIT_LIST}"
+              echo "${COMMIT_LIST//\`/}"
               echo EOF
             } >> "${GITHUB_OUTPUT}"
 

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -622,22 +622,6 @@ jobs:
           external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           environments: "CITR"
 
-      - name: Create Rootly Incident
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        continue-on-error: true # continue on error so we can get the slack reporting
-        with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
-          title: "${{ steps.rootly-summary.outputs.title }}"
-          kind: "normal"
-          create_public_incident: "false"
-          summary: "${{ steps.rootly-summary.outputs.summary }}"
-          severity: "Triage Event"
-          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Platform CI"
-
       - name: Build Slack Payload Message
         id: payload
         run: |

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -243,6 +243,7 @@ jobs:
     with:
       ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }} # pass the xts-candidate tag to the JRS panel for checkout
       custom-job-name: "SDK TCK Regression"
+      solo-version: "v0.38.0"
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-tck-report-webhook: ${{ secrets.SLACK_TCK_MONITOR_WEBHOOK }}

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -567,7 +567,8 @@ jobs:
         run: |
           ROOTLY_SERVICE_NAME="CITR General"
           if [[ "${{ needs.fetch-xts-candidate.result }}" =~ ^(cancelled|failure)$ ]] \
-            || [[ "${{ needs.tag-for-promotion.result }}" =~ ^(cancelled|failure)$ ]]; then
+            || [[ "${{ needs.tag-for-promotion.result }}" =~ ^(cancelled|failure)$ ]] \
+            || [[ "${{ needs.extended-test-suite.outputs.failure-mode }}" == "workflow"; then
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
           elif [[ "${{ needs.sdk-tck-regression-panel.result }}" =~ ^(cancelled|failure)$ ]]; then
             ROOTLY_SERVICE_NAME="CITR TCK"

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -308,6 +308,7 @@ jobs:
 
       - name: Report Failure (Rootly)
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        continue-on-error: true
         with:
           api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: ${{ steps.rootly-summary.outputs.summary }}

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -163,9 +163,6 @@ jobs:
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
           ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
-          inputs: '{
-            "ref": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"
-            }'
 
       - name: "Trigger ZXF: [CITR] Single Day Longevity Test (SDLT)"
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
@@ -174,9 +171,6 @@ jobs:
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
           ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
-          inputs: '{
-            "ref": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"
-            }'
 
       - name: "Trigger ZXF: [CITR] Single Day Canonical Test (SDCT)"
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -161,7 +161,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-performance-test-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: main # ensure we are always using the workflow definition from the main branch
+          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "ref": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"
@@ -172,7 +172,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-longevity-test-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: main # ensure we are always using the workflow definition from the main branch
+          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "ref": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"
@@ -183,7 +183,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-canonical-test.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: main # ensure we are always using the workflow definition from the main branch
+          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "build-tag": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"

--- a/.github/workflows/zxf-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/zxf-dry-run-extended-test-suite.yaml
@@ -131,6 +131,7 @@ jobs:
     with:
       ref: ${{ inputs.commit_sha }} # pass the xts-candidate tag to the JRS panel for checkout
       custom-job-name: "Dry-Run: SDK TCK Regression"
+      solo-version: "v0.38.0"
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-tck-report-webhook: ${{ secrets.SLACK_TCK_MONITOR_WEBHOOK }}
@@ -155,6 +156,7 @@ jobs:
     with:
       ref: ${{ inputs.commit_sha }} # pass the xts-candidate tag to the RPC Relay panel for checkout
       custom-job-name: "JSON-RPC Relay Regression"
+      solo-version: ${{ vars.CITR_SOLO_VERSION }}
     secrets:
       access-token: ${{ secrets.GH_ACCESS_TOKEN }}
       slack-detailed-report-webhook: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}

--- a/.github/workflows/zxf-prepare-extended-test-suite.yaml
+++ b/.github/workflows/zxf-prepare-extended-test-suite.yaml
@@ -119,6 +119,7 @@ jobs:
       - name: Report Failure (Rootly)
         if: ${{ !inputs.dry-run-enabled && !cancelled() && failure() && always() }}
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        continue-on-error: true
         with:
           api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: "Hiero Consensus Node - XTS Candidate Tagging Failed"

--- a/.github/workflows/zxf-single-day-canonical-test.yaml
+++ b/.github/workflows/zxf-single-day-canonical-test.yaml
@@ -381,6 +381,6 @@ jobs:
           severity: "Triage Event"
           alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
           environments: "CITR"
-          incident_types: "Platform CI,Performance Engineering"
+          incident_types: "Platform CI"
           services: ${{ steps.set-rootly-service.outputs.service }}
           teams: "Platform CI,Performance Engineering"

--- a/.github/workflows/zxf-single-day-canonical-test.yaml
+++ b/.github/workflows/zxf-single-day-canonical-test.yaml
@@ -309,17 +309,6 @@ jobs:
           fi
           echo "service=${ROOTLY_SERVICE}" >> "${GITHUB_OUTPUT}"
 
-      - name: Set Incident Creation Flag
-        id: set-create-incident
-        run: |
-          CREATE_INCIDENT="false"
-          if [[ "${{ needs.canonical-test.outputs.start-canonical-test }}" == "failure" ]] \
-            || [[ "${{ needs.canonical-test.outputs.check-if-exist }}" == "failure" ]] \
-            || [[ "${{ needs.canonical-test.outputs.parameters }}" == "failure" ]]; then
-            CREATE_INCIDENT="true"
-          fi
-          echo "create=${CREATE_INCIDENT}" >> "${GITHUB_OUTPUT}"
-
       - name: Build Rootly Summary
         id: rootly-summary
         run: |
@@ -368,19 +357,3 @@ jobs:
           environments: "CITR"
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-      - name: Create Rootly Incident
-        if: ${{ steps.set-create-incident.outputs.create == 'true' }}
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
-          title: "${{ steps.rootly-summary.outputs.title }}"
-          kind: "normal"
-          create_public_incident: "false"
-          summary: "${{ steps.rootly-summary.outputs.summary }}"
-          severity: "Triage Event"
-          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Platform CI,Performance Engineering"

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -110,11 +110,11 @@ jobs:
             echo "Ref: ${CHECK_TAG}" >> "${GITHUB_STEP_SUMMARY}"
           fi
 
-  run-single-day-longevity-nlg-test:
+  run-single-day-longevity-test:
     name: Longevity Test
     needs:
       - verify-tag
-    uses: ./.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+    uses: ./.github/workflows/zxc-single-day-longevity-test.yaml
     if: ${{ needs.verify-tag.result == 'success' || inputs.disable-notifications == true }}
     with:
       test-asset: "${{ inputs.test-asset }}"
@@ -132,7 +132,7 @@ jobs:
     name: Tag SDLT Result
     runs-on: hiero-citr-linux-medium
     needs:
-      - run-single-day-longevity-nlg-test
+      - run-single-day-longevity-test
       - verify-tag
     if: ${{ inputs.disable-notifications != true }}
     steps:
@@ -160,7 +160,7 @@ jobs:
 
       - name: Tag SDLT Result
         run: |
-          RESULT="${{ needs.run-single-day-longevity-nlg-test.outputs.result }}"
+          RESULT="${{ needs.run-single-day-longevity-test.outputs.result }}"
           BUILD_NUM="${{ needs.verify-tag.outputs.build-number }}"
 
           # Skip tagging if no build number is found
@@ -243,11 +243,11 @@ jobs:
     needs:
       - verify-tag
       - tag-sdlt-result
-      - run-single-day-longevity-nlg-test
+      - run-single-day-longevity-test
       - get-commit-info
     if: ${{ (needs.verify-tag.result == 'success' &&
       needs.tag-sdlt-result.result == 'success' &&
-      needs.run-single-day-longevity-nlg-test.outputs.result == 'success' &&
+      needs.run-single-day-longevity-test.outputs.result == 'success' &&
       needs.get-commit-info.result == 'success') &&
       inputs.disable-notifications != true && !cancelled() }}
     steps:
@@ -300,7 +300,7 @@ jobs:
                         },
                         {
                           "type": "plain_text",
-                          "text": "${{ needs.run-single-day-longevity-nlg-test.outputs.result  }}"
+                          "text": "${{ needs.run-single-day-longevity-test.outputs.result  }}"
                         },
                         {
                           "type": "plain_text",
@@ -366,13 +366,13 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - verify-tag
-      - run-single-day-longevity-nlg-test
+      - run-single-day-longevity-test
       - tag-sdlt-result
       - get-commit-info
       - report-success
     if: ${{ (needs.verify-tag.result != 'success' ||
       needs.tag-sdlt-result.result != 'success' ||
-      needs.run-single-day-longevity-nlg-test.outputs.result != 'success' ||
+      needs.run-single-day-longevity-test.outputs.result != 'success' ||
       needs.get-commit-info.result != 'success' ||
       needs.report-success.result != 'success') &&
       inputs.disable-notifications != true && !cancelled() && always() }}
@@ -436,7 +436,7 @@ jobs:
             echo "------------------------------------"
             echo "Status of each job:"
             echo "- Verify Tag: ${{ needs.verify-tag.result }}"
-            echo "- Run Single Day Longevity Test: ${{ needs.run-single-day-longevity-nlg-test.outputs.result }}"
+            echo "- Run Single Day Longevity Test: ${{ needs.run-single-day-longevity-test.outputs.result }}"
             echo "- Tag SDLT Result: ${{ needs.tag-sdlt-result.result }}"
             echo "- Get Commit Info: ${{ needs.get-commit-info.result }}"
             echo "- Report Success: ${{ needs.report-success.result }}"
@@ -509,7 +509,7 @@ jobs:
                       },
                       {
                         "type": "plain_text",
-                        "text": "${{ needs.run-single-day-longevity-nlg-test.outputs.result }}"
+                        "text": "${{ needs.run-single-day-longevity-test.outputs.result }}"
                       },
                       {
                         "type": "plain_text",

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -14,11 +14,6 @@ on:
           - AdHoc7
           - AdHocSD8
           - AdHocSD9
-      ref:
-        required: true
-        default: "main"
-        description: "Version of hiero-consensus-node: branch, tag, commit"
-        type: string
       nlg-accounts: #'-R -c 32 -a 100000000 -T 1000 -n 100000 -S hot -p 50 -tt 1m
         required: true
         default: "100000"
@@ -89,13 +84,13 @@ jobs:
       - name: Checkout Consensus Node
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Verify Tag
         id: verify-tag
         env:
           PROMOTED_GREP_PATTERN: "build-(.{5})" # Pattern to match build tags (e.g., build-12345)
-          CHECK_TAG: "${{ inputs.ref }}"
+          CHECK_TAG: "${{ github.ref }}"
         run: |
           # Ensure the tag that we received is a build tag
           # if the tag is a build tag then we can parse out the build number (the last 5 characters)
@@ -123,7 +118,7 @@ jobs:
     if: ${{ needs.verify-tag.result == 'success' || inputs.disable-notifications == true }}
     with:
       test-asset: "${{ inputs.test-asset }}"
-      ref: "${{ inputs.ref }}"
+      ref: "${{ github.ref }}"
       solo-version: "${{ vars.CITR_SOLO_VERSION }}"
       nlg-accounts: "${{ inputs.nlg-accounts }}"
       nlg-time: "${{ inputs.nlg-time }}"
@@ -151,7 +146,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -219,7 +214,7 @@ jobs:
         id: find-commit-author-slack
         continue-on-error: true
         env:
-          BUILD_TAG: ${{ inputs.ref }}
+          BUILD_TAG: ${{ github.ref }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
         run: |
           # Extract the commit and user information from the build tag
@@ -277,7 +272,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":tada: SDLT - Single Day Longevity Test (${{ inputs.ref }}) Passed",
+                        "text": ":tada: SDLT - Single Day Longevity Test (${{ github.ref }}) Passed",
                         "emoji": true
                       }
                     },
@@ -333,7 +328,7 @@ jobs:
                         },
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -392,7 +387,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Collect run logs in a log file
@@ -486,7 +481,7 @@ jobs:
                     "type": "header",
                     "text": {
                       "type": "plain_text",
-                      "text": ":grey_exclamation: SDLT - Single Day Longevity Test (${{ inputs.ref }}) Failed",
+                      "text": ":grey_exclamation: SDLT - Single Day Longevity Test (${{ github.ref }}) Failed",
                       "emoji": true
                     }
                   },
@@ -550,7 +545,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                       },
                       {
                         "type": "mrkdwn",

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -168,6 +168,13 @@ jobs:
           RESULT="${{ needs.run-single-day-longevity-nlg-test.outputs.result }}"
           BUILD_NUM="${{ needs.verify-tag.outputs.build-number }}"
 
+          # Skip tagging if no build number is found
+          if [ -z "$BUILD_NUM" ]; then
+            echo "No build number found. Skipping tagging step." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          # Populate the SDLT tag name and message
           if [ "$RESULT" == "success" ]; then
             TAG_NAME="sdlt-pass-${BUILD_NUM}"
             MSG="Single Day Longevity Test passed for build-${BUILD_NUM}"

--- a/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller-adhoc.yaml
@@ -456,6 +456,7 @@ jobs:
       - name: Create Rootly Alert
         if: ${{ steps.set-alert-flag.outputs.create == 'true' }}
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        continue-on-error: true
         with:
           api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: ${{ steps.rootly-summary.outputs.summary }}

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -55,11 +55,11 @@ jobs:
             echo "Ref: ${CHECK_TAG}" >> "${GITHUB_STEP_SUMMARY}"
           fi
 
-  run-single-day-longevity-nlg-test:
+  run-single-day-longevity-test:
     name: Longevity Test
     needs:
       - verify-tag
-    uses: ./.github/workflows/zxc-single-day-longevity-nlg-test.yaml
+    uses: ./.github/workflows/zxc-single-day-longevity-test.yaml
     if: ${{ needs.verify-tag.result == 'success' }}
     with:
       test-asset: "SDLT2"
@@ -77,7 +77,7 @@ jobs:
     name: Tag SDLT Result
     runs-on: hiero-citr-linux-medium
     needs:
-      - run-single-day-longevity-nlg-test
+      - run-single-day-longevity-test
       - verify-tag
     steps:
       - name: Harden Runner
@@ -104,7 +104,7 @@ jobs:
 
       - name: Tag SDLT Result
         run: |
-          RESULT="${{ needs.run-single-day-longevity-nlg-test.outputs.result }}"
+          RESULT="${{ needs.run-single-day-longevity-test.outputs.result }}"
           BUILD_NUM="${{ needs.verify-tag.outputs.build-number }}"
 
           if [ "$RESULT" == "success" ]; then
@@ -180,11 +180,11 @@ jobs:
     needs:
       - verify-tag
       - tag-sdlt-result
-      - run-single-day-longevity-nlg-test
+      - run-single-day-longevity-test
       - get-commit-info
     if: ${{ (needs.verify-tag.result == 'success' &&
       needs.tag-sdlt-result.result == 'success' &&
-      needs.run-single-day-longevity-nlg-test.outputs.result == 'success' &&
+      needs.run-single-day-longevity-test.outputs.result == 'success' &&
       needs.get-commit-info.result == 'success') &&
       !cancelled() }}
     steps:
@@ -237,7 +237,7 @@ jobs:
                         },
                         {
                           "type": "plain_text",
-                          "text": "${{ needs.run-single-day-longevity-nlg-test.outputs.result  }}"
+                          "text": "${{ needs.run-single-day-longevity-test.outputs.result  }}"
                         },
                         {
                           "type": "plain_text",
@@ -303,13 +303,13 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - verify-tag
-      - run-single-day-longevity-nlg-test
+      - run-single-day-longevity-test
       - tag-sdlt-result
       - get-commit-info
       - report-success
     if: ${{ (needs.verify-tag.result != 'success' ||
       needs.tag-sdlt-result.result != 'success' ||
-      needs.run-single-day-longevity-nlg-test.outputs.result != 'success' ||
+      needs.run-single-day-longevity-test.outputs.result != 'success' ||
       needs.get-commit-info.result != 'success' ||
       needs.report-success.result != 'success') &&
       !cancelled() && always() }}
@@ -373,7 +373,7 @@ jobs:
             echo "------------------------------------"
             echo "Status of each job:"
             echo "- Verify Tag: ${{ needs.verify-tag.result }}"
-            echo "- Run Single Day Longevity Test: ${{ needs.run-single-day-longevity-nlg-test.outputs.result }}"
+            echo "- Run Single Day Longevity Test: ${{ needs.run-single-day-longevity-test.outputs.result }}"
             echo "- Tag SDLT Result: ${{ needs.tag-sdlt-result.result }}"
             echo "- Get Commit Info: ${{ needs.get-commit-info.result }}"
             echo "- Report Success: ${{ needs.report-success.result }}"
@@ -465,7 +465,7 @@ jobs:
                       },
                       {
                         "type": "plain_text",
-                        "text": "${{ needs.run-single-day-longevity-nlg-test.outputs.result }}"
+                        "text": "${{ needs.run-single-day-longevity-test.outputs.result }}"
                       },
                       {
                         "type": "plain_text",

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -408,22 +408,6 @@ jobs:
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - name: Create Rootly Incident
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        continue-on-error: true # continue on error so we can get the slack reporting
-        with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
-          title: "${{ steps.rootly-summary.outputs.title }}"
-          kind: "normal"
-          create_public_incident: "false"
-          summary: "${{ steps.rootly-summary.outputs.summary }}"
-          severity: "Triage Event"
-          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Platform CI,Performance Engineering"
-
       - name: Build Slack Payload Message
         id: payload
         run: |

--- a/.github/workflows/zxf-single-day-longevity-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-longevity-test-controller.yaml
@@ -2,12 +2,6 @@
 name: "ZXF: [CITR] Single Day Longevity Test Controller"
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        required: true
-        default: "main"
-        description: "Version of hiero-consensus-node: branch, tag, commit"
-        type: string
 
 defaults:
   run:
@@ -35,13 +29,13 @@ jobs:
       - name: Checkout Consensus Node
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Verify Tag
         id: verify-tag
         env:
           PROMOTED_GREP_PATTERN: "build-(.{5})" # Pattern to match build tags (e.g., build-12345)
-          CHECK_TAG: "${{ inputs.ref }}"
+          CHECK_TAG: "${{ github.ref }}"
         run: |
           # Ensure the tag that we received is a build tag
           # if the tag is a build tag then we can parse out the build number (the last 5 characters)
@@ -69,7 +63,7 @@ jobs:
     if: ${{ needs.verify-tag.result == 'success' }}
     with:
       test-asset: "SDLT2"
-      ref: "${{ inputs.ref }}"
+      ref: "${{ github.ref }}"
       solo-version: "${{ vars.CITR_SOLO_VERSION }}"
       nlg-accounts: "100000000"
       nlg-time: "960"
@@ -96,7 +90,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -151,13 +145,13 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Find Commit Author in Slack
         id: find-commit-author-slack
         continue-on-error: true
         env:
-          BUILD_TAG: ${{ inputs.ref }}
+          BUILD_TAG: ${{ github.ref }}
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
         run: |
           # Extract the commit and user information from the build tag
@@ -215,7 +209,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":tada: SDLT - Single Day Longevity Test (${{ inputs.ref }}) Passed",
+                        "text": ":tada: SDLT - Single Day Longevity Test (${{ github.ref }}) Passed",
                         "emoji": true
                       }
                     },
@@ -271,7 +265,7 @@ jobs:
                         },
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -330,7 +324,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Collect run logs in a log file
@@ -443,7 +437,7 @@ jobs:
                     "type": "header",
                     "text": {
                       "type": "plain_text",
-                      "text": ":grey_exclamation: SDLT - Single Day Longevity Test (${{ inputs.ref }}) Failed",
+                      "text": ":grey_exclamation: SDLT - Single Day Longevity Test (${{ github.ref }}) Failed",
                       "emoji": true
                     }
                   },
@@ -507,7 +501,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                       },
                       {
                         "type": "mrkdwn",

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -175,6 +175,13 @@ jobs:
           RESULT="${{ needs.run-single-day-performance-test.outputs.result }}"
           BUILD_NUM="${{ needs.verify-tag.outputs.build-number }}"
 
+          # Skip tagging if no build number is found
+          if [ -z "$BUILD_NUM" ]; then
+            echo "No build number found. Skipping tagging step." >> "${GITHUB_STEP_SUMMARY}"
+            exit 0
+          fi
+
+          # Populate the SDPT tag name and message
           if [ "$RESULT" == "success" ]; then
             TAG_NAME="sdpt-pass-${BUILD_NUM}"
             MSG="Single Day Performance Test passed for build-${BUILD_NUM}"

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -14,11 +14,6 @@ on:
           - AdHoc7
           - AdHocSD8
           - AdHocSD9
-      ref:
-        required: true
-        default: "main"
-        description: "Version of hiero-consensus-node: branch, tag, commit"
-        type: string
       nlg-accounts: #'-R -c 32 -a 100000000 -T 1000 -n 100000 -S hot -p 50 -tt 1m
         required: true
         default: "100000"
@@ -94,13 +89,13 @@ jobs:
       - name: Checkout Consensus Node
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Verify Tag
         id: verify-tag
         env:
           PROMOTED_GREP_PATTERN: "build-(.{5})" # Pattern to match build tags (e.g., build-12345)
-          CHECK_TAG: "${{ inputs.ref }}"
+          CHECK_TAG: "${{ github.ref }}"
         run: |
           # Ensure the tag that we received is a build tag
           # if the tag is a build tag then we can parse out the build number (the last 5 characters)
@@ -128,7 +123,7 @@ jobs:
     if: ${{ needs.verify-tag.result == 'success' || inputs.disable-notifications == true }}
     with:
       test-asset: "${{ inputs.test-asset }}"
-      ref: "${{ inputs.ref }}"
+      ref: "${{ github.ref }}"
       solo-version: "${{ vars.CITR_SOLO_VERSION }}"
       nlg-accounts: "${{ inputs.nlg-accounts }}"
       nlg-time: "${{ inputs.nlg-time }}"
@@ -158,7 +153,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -229,7 +224,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
         run: |
           # Extract the commit and user information from the build tag
-          COMMIT=$(git rev-list -n 1 "${{ inputs.ref }}")
+          COMMIT=$(git rev-list -n 1 "${{ github.ref }}")
           EMAIL=$(git log -1 --pretty=format:'%ae' "${COMMIT}")
           AUTHOR=$(git log -1 --pretty=format:'%an' "${COMMIT}")
           SLACK_USER_ID=$(curl -s -X GET "https://slack.com/api/users.list" \
@@ -339,7 +334,7 @@ jobs:
                         },
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -398,7 +393,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Collect run logs in a log file
@@ -556,7 +551,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                       },
                       {
                         "type": "mrkdwn",

--- a/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller-adhoc.yaml
@@ -462,6 +462,7 @@ jobs:
       - name: Create Rootly Alert
         if: ${{ steps.set-alert-flag.outputs.create == 'true' }}
         uses: pandaswhocode/rootly-alert-action@fdae1529e5aed62040016accf719a0ceb7dae57f # v1.0.0
+        continue-on-error: true
         with:
           api_key: ${{ secrets.ROOTLY_API_TOKEN }}
           summary: ${{ steps.rootly-summary.outputs.summary }}

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -2,12 +2,6 @@
 name: "ZXF: [CITR] Single Day Performance Test Controller (SDPT)"
 on:
   workflow_dispatch:
-    inputs:
-      ref:
-        required: true
-        default: "main"
-        description: "Version of hiero-consensus-node: branch, tag, commit"
-        type: string
 
 defaults:
   run:
@@ -35,13 +29,13 @@ jobs:
       - name: Checkout Consensus Node
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Verify Tag
         id: verify-tag
         env:
           PROMOTED_GREP_PATTERN: "build-(.{5})" # Pattern to match build tags (e.g., build-12345)
-          CHECK_TAG: "${{ inputs.ref }}"
+          CHECK_TAG: "${{ github.ref }}"
         run: |
           # Ensure the tag that we received is a build tag
           # if the tag is a build tag then we can parse out the build number (the last 5 characters)
@@ -69,7 +63,7 @@ jobs:
     if: ${{ needs.verify-tag.result == 'success' }}
     with:
       test-asset: "SDPT1"
-      ref: "${{ inputs.ref }}"
+      ref: "${{ github.ref }}"
       solo-version: "${{ vars.CITR_SOLO_VERSION }}"
       nlg-accounts: "100000000"
       nlg-time: "330"
@@ -98,7 +92,7 @@ jobs:
         with:
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
 
       - name: Import GPG Key
         id: gpg_importer
@@ -161,7 +155,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
         run: |
           # Extract the commit and user information from the build tag
-          COMMIT=$(git rev-list -n 1 "${{ inputs.ref }}")
+          COMMIT=$(git rev-list -n 1 "${{ github.ref }}")
           EMAIL=$(git log -1 --pretty=format:'%ae' "${COMMIT}")
           AUTHOR=$(git log -1 --pretty=format:'%an' "${COMMIT}")
           SLACK_USER_ID=$(curl -s -X GET "https://slack.com/api/users.list" \
@@ -215,7 +209,7 @@ jobs:
                       "type": "header",
                       "text": {
                         "type": "plain_text",
-                        "text": ":tada: SDPT - Single Day Performance Test (${{ inputs.ref }}) Passed",
+                        "text": ":tada: SDPT - Single Day Performance Test (${{ github.ref }}) Passed",
                         "emoji": true
                       }
                     },
@@ -271,7 +265,7 @@ jobs:
                         },
                         {
                           "type": "mrkdwn",
-                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                          "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                         },
                         {
                           "type": "mrkdwn",
@@ -330,7 +324,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: "0"
-          ref: ${{ inputs.ref }}
+          ref: ${{ github.ref }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: Collect run logs in a log file
@@ -443,7 +437,7 @@ jobs:
                     "type": "header",
                     "text": {
                       "type": "plain_text",
-                      "text": ":grey_exclamation: SDPT - Single Day Performance Test (${{ inputs.ref }}) Failed",
+                      "text": ":grey_exclamation: SDPT - Single Day Performance Test (${{ github.ref }}) Failed",
                       "emoji": true
                     }
                   },
@@ -507,7 +501,7 @@ jobs:
                       },
                       {
                         "type": "mrkdwn",
-                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ inputs.ref }}>"
+                        "text": "<${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref }}>"
                       },
                       {
                         "type": "mrkdwn",

--- a/.github/workflows/zxf-single-day-performance-test-controller.yaml
+++ b/.github/workflows/zxf-single-day-performance-test-controller.yaml
@@ -408,22 +408,6 @@ jobs:
           external_id: ${{ github.run_id }}
           external_url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
 
-      - name: Create Rootly Incident
-        uses: pandaswhocode/rootly-incident-action@4327542435bb4c8c48f15fba47efb87a28f8533f # v2.0.1
-        continue-on-error: true # continue on error so we can get the slack reporting
-        with:
-          api_key: ${{ secrets.ROOTLY_API_TOKEN }}
-          title: "${{ steps.rootly-summary.outputs.title }}"
-          kind: "normal"
-          create_public_incident: "false"
-          summary: "${{ steps.rootly-summary.outputs.summary }}"
-          severity: "Triage Event"
-          alert_ids: ${{ steps.create-rootly-alert.outputs.alert_id || '' }}
-          environments: "CITR"
-          incident_types: "Platform CI"
-          services: ${{ steps.set-rootly-service.outputs.service }}
-          teams: "Platform CI,Performance Engineering"
-
       - name: Build Slack Payload Message
         id: payload
         run: |


### PR DESCRIPTION
**Description**:

Add CI-related changes to the release/0.66 branch.

**Approved on Sep 18 2025**:

- [ci: Update SDPT and SDLT workflow to only tag when build ID is present](https://github.com/hiero-ledger/hiero-consensus-node/pull/20984), `3ac05f882891cbbc9b86e2777d96feff0418c104`
- [chore: Update incident_types](https://github.com/hiero-ledger/hiero-consensus-node/pull/21055), `785c4b9f6b9f5f9198aedaba42794fe2c413adc2`
- [chore: replace input.ref with github.ref in single day controllers](https://github.com/hiero-ledger/hiero-consensus-node/pull/20988), `5675961e64066aadb04cef05b01bcc10b1e5bf7f`
- [ci: Automatically generate the GH release](https://github.com/hiero-ledger/hiero-consensus-node/pull/20970), `2711159980a05df5b1c97027bf36c42aa36caa2b`
- [ci(fix): remove inputs from calls to SDPT and SDLT](https://github.com/hiero-ledger/hiero-consensus-node/pull/21081), `735b2d456fed71b25c9a0e24d3c33f05548c7c1f`
- [chore: rename all instances of longevity-nlg-test to longevity-test](https://github.com/hiero-ledger/hiero-consensus-node/pull/20875), `b58b61e33143c73a5e9ea644b4ce4e2c4da472ba`
- [ci(fix): Fix bug with control characters being interpreted in json output](https://github.com/hiero-ledger/hiero-consensus-node/pull/21091), `fc0d792c4e307c8244522da1661d353db2e0ea67`
- [ci: Remove rootly incident creation and rely on alerts alone](https://github.com/hiero-ledger/hiero-consensus-node/pull/21092), `8d6f86cbf96e43a242af6ebc7c59113929b196d4`

**Approved on Sep 22 2025**:

- [ci(fix): Solo version mismatch causing errors in regression panels](https://github.com/hiero-ledger/hiero-consensus-node/pull/21139), `fc63b99e1e397a5cb991efd3ce66ae5d9e79f89f`
- [ci(fix): Add granularity to failure-modes in zxc-compile-application](https://github.com/hiero-ledger/hiero-consensus-node/pull/21141), `a34328d4658cc64210f73d81be957317cf2d2cf6`

**Related issue(s)**:

Implements #21100 
