### PR TITLE
chore: Update determinism checks for macos-13

### DIFF
--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -217,6 +217,7 @@ jobs:
         os:
           - ubuntu-24.04
           #- ubuntu-22.04
+          - macos-13
           #- macos-12
           #- macos-11
           #- hiero-network-node-linux-medium

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -215,13 +215,14 @@ jobs:
         # not supporting BuildKit and the Buildx plugin.
         # GitHub hosted MacOS and Ubuntu runners are temporarily disabled.
         os:
-          - ubuntu-24.04
+          #- ubuntu-24.04
           #- ubuntu-22.04
           - macos-13
+          - macos-14
           #- macos-12
           #- macos-11
           #- hiero-network-node-linux-medium
-          - hiero-network-node-linux-large
+          #- hiero-network-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -298,11 +299,12 @@ jobs:
           sudo rm -rvf /usr/local/bin/docker* || true
           sudo rm -rvf /usr/local/bin/*lima* || true
 
-      - name: Install Lima (macOS)
+      - name: Install CoLima (macOS)
         if: ${{ runner.os == 'macOS' }}
         run: |
-          VERSION="v0.20.0"
-          curl -fsSL "https://github.com/lima-vm/lima/releases/download/${VERSION}/lima-${VERSION:1}-$(uname -s)-$(uname -m).tar.gz" | sudo tar Cxzvm /usr/local
+          brew install docker 
+          brew install colima
+          colima start 
 
       - name: Determine Home Directory
         id: home

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -304,7 +304,18 @@ jobs:
         run: |
           brew install docker 
           brew install colima
-          colima start 
+          colima start --vm-type=vz --cpu=2 --memory=4 --disk=10
+
+      - name: Show CoLima Logs (macOS)
+        if: ${{ runner.os == 'macOS' && failure() }}
+        run: |
+          echo "::group::Serial Logs"
+          cat ${HOME}/.colima/_lima/colima/serial*.log
+          echo "::endgroup::"
+          
+          echo "::group::Error Logs"
+          cat ${HOME}/.colima/_lima/colima/ha.stderr.log
+          echo "::endgroup::"
 
       - name: Determine Home Directory
         id: home

--- a/.github/workflows/zxc-verify-docker-build-determinism.yaml
+++ b/.github/workflows/zxc-verify-docker-build-determinism.yaml
@@ -215,14 +215,14 @@ jobs:
         # not supporting BuildKit and the Buildx plugin.
         # GitHub hosted MacOS and Ubuntu runners are temporarily disabled.
         os:
-          #- ubuntu-24.04
+          - ubuntu-24.04
           #- ubuntu-22.04
           - macos-13
-          - macos-14
+          #- macos-14
           #- macos-12
           #- macos-11
           #- hiero-network-node-linux-medium
-          #- hiero-network-node-linux-large
+          - hiero-network-node-linux-large
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0


### PR DESCRIPTION
## Description

This pull request updates the GitHub Actions workflow for verifying Docker build determinism, primarily to improve macOS support and troubleshooting. The most important changes include expanding the matrix to test on macOS-13, switching from Lima to CoLima for macOS virtualization, and adding log collection steps to aid debugging.

**macOS support and virtualization:**

* Added `macos-13` to the OS matrix in the workflow, enabling CI runs on this newer macOS version.
* Replaced the Lima installation with CoLima for macOS runners, using Homebrew to install both Docker and CoLima, and starting CoLima with specific VM parameters.

**Troubleshooting and diagnostics:**

* Added a step to collect and display CoLima logs if the workflow fails on macOS, making it easier to diagnose virtualization or Docker issues on CI.

### Related Issue(s)

Fixes #21114
