### PR TITLE
fix: 19574: Virtual map snapshots pause virtual lifecycle thread for too long

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -109,7 +109,7 @@ class MerkleDbBuilderTest {
                 new MerkleDbDataSourceBuilder(CONFIGURATION, initialCapacity, hashesRamToDiskThreshold);
         VirtualDataSource dataSource = null;
         try {
-            dataSource = builder.build("test1", false);
+            dataSource = builder.build("test1", null, false, false);
             assertTrue(dataSource instanceof MerkleDbDataSource);
             MerkleDbDataSource merkleDbDataSource = (MerkleDbDataSource) dataSource;
             assertEquals(initialCapacity, merkleDbDataSource.getInitialCapacity());
@@ -128,7 +128,7 @@ class MerkleDbBuilderTest {
         final MerkleDbDataSourceBuilder builder = new MerkleDbDataSourceBuilder(CONFIGURATION, 1024, 0);
         VirtualDataSource dataSource = null;
         try {
-            dataSource = builder.build("test2", compactionEnabled);
+            dataSource = builder.build("test2", null, compactionEnabled, false);
             assertTrue(dataSource instanceof MerkleDbDataSource);
             MerkleDbDataSource merkleDbDataSource = (MerkleDbDataSource) dataSource;
             assertEquals(compactionEnabled, merkleDbDataSource.isCompactionEnabled());
@@ -143,7 +143,7 @@ class MerkleDbBuilderTest {
         VirtualDataSource dataSource = null;
         try {
             final String label = "testSnapshot";
-            dataSource = builder.build(label, false);
+            dataSource = builder.build(label, null, false, false);
             final Path tmpDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("snapshot", CONFIGURATION);
             builder.snapshot(tmpDir, dataSource);
             assertTrue(Files.isDirectory(tmpDir.resolve("data").resolve(label)));
@@ -160,13 +160,13 @@ class MerkleDbBuilderTest {
         VirtualDataSource dataSource = null;
         try {
             final String label = "testSnapshotRestore";
-            dataSource = builder.build(label, false);
+            dataSource = builder.build(label, null, false, false);
             final Path tmpDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("snapshot", CONFIGURATION);
             builder.snapshot(tmpDir, dataSource);
             assertTrue(Files.isDirectory(tmpDir.resolve("data").resolve(label)));
             VirtualDataSource restored = null;
             try {
-                restored = builder.restore(label, tmpDir, false);
+                restored = builder.build(label, tmpDir, false, false);
                 assertNotNull(restored);
                 assertTrue(restored instanceof MerkleDbDataSource);
                 final MerkleDbDataSource merkleDbRestored = (MerkleDbDataSource) restored;
@@ -310,9 +310,10 @@ class MerkleDbBuilderTest {
     @Test
     void testSnapshotAfterReconnect() throws Exception {
         final MerkleDbDataSourceBuilder dsBuilder = createDefaultBuilder();
-        final VirtualDataSource original = dsBuilder.build("vm", false);
+        final VirtualDataSource original = dsBuilder.build("vm", null, false, false);
         // Simulate reconnect as a learner
-        final VirtualDataSource copy = dsBuilder.copy(original, true, false);
+        final Path snapshotPath = dsBuilder.snapshot(null, original);
+        final VirtualDataSource copy = dsBuilder.build("vm", snapshotPath, true, false);
 
         try {
             final Path snapshotDir = LegacyTemporaryFileBuilder.buildTemporaryDirectory("snapshot", CONFIGURATION);

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
@@ -17,6 +17,7 @@ import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
 import com.swirlds.virtualmap.datasource.VirtualHashRecord;
 import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Random;
@@ -130,7 +131,11 @@ public class CloseFlushTest {
 
         @NonNull
         @Override
-        public VirtualDataSource build(final String label, final boolean withDbCompactionEnabled) {
+        public VirtualDataSource build(
+                final String label,
+                @Nullable final Path sourceDir,
+                final boolean compactionEnabled,
+                final boolean offlineUse) {
             return new VirtualDataSource() {
                 @Override
                 public void close(boolean keepData) throws IOException {

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
@@ -24,6 +24,7 @@ import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import com.swirlds.virtualmap.internal.merkle.ExternalVirtualMapMetadata;
 import com.swirlds.virtualmap.internal.merkle.VirtualRootNode;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Path;
@@ -162,28 +163,21 @@ public abstract class VirtualMapReconnectTestBase {
             numTimesBroken = in.readInt();
         }
 
+        @NonNull
         @Override
-        public BreakableDataSource build(final String label, final boolean withDbCompactionEnabled) {
-            return new BreakableDataSource(this, delegate.build(label, withDbCompactionEnabled));
+        public BreakableDataSource build(
+                final String label,
+                @Nullable final Path sourceDir,
+                final boolean compactionEnabled,
+                final boolean offlineUse) {
+            return new BreakableDataSource(this, delegate.build(label, sourceDir, compactionEnabled, offlineUse));
         }
 
+        @NonNull
         @Override
-        public BreakableDataSource copy(
-                final VirtualDataSource snapshotMe, final boolean compactionEnabled, final boolean offlineUse) {
+        public Path snapshot(@Nullable final Path destination, @NonNull final VirtualDataSource snapshotMe) {
             final var breakableSnapshot = (BreakableDataSource) snapshotMe;
-            return new BreakableDataSource(
-                    this, delegate.copy(breakableSnapshot.delegate, compactionEnabled, offlineUse));
-        }
-
-        @Override
-        public void snapshot(final Path destination, final VirtualDataSource snapshotMe) {
-            final var breakableSnapshot = (BreakableDataSource) snapshotMe;
-            delegate.snapshot(destination, breakableSnapshot.delegate);
-        }
-
-        @Override
-        public BreakableDataSource restore(final String label, final Path from) {
-            return new BreakableDataSource(this, delegate.restore(label, from));
+            return delegate.snapshot(destination, breakableSnapshot.delegate);
         }
 
         public void setNumCallsBeforeThrow(int num) {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -93,6 +93,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hiero.base.ValueReference;
 import org.hiero.base.constructable.ConstructableClass;
 import org.hiero.base.constructable.RuntimeConstructable;
 import org.hiero.base.crypto.Hash;
@@ -447,7 +448,7 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             cache = new VirtualNodeCache(virtualMapConfig);
         }
         if (dataSource == null) {
-            dataSource = dataSourceBuilder.build(metadata.getLabel(), true);
+            dataSource = dataSourceBuilder.build(metadata.getLabel(), null, true, false);
         }
 
         updateShouldBeFlushed();
@@ -1136,58 +1137,37 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
 
     /**
      * {@inheritDoc}
+     *
+     * <p>This method must be called when the lifecycle thread for this virtual map is paused,
+     * or data source flushes are disabled some other way.
      */
     @Override
     public RecordAccessor detach() {
-        if (isDestroyed()) {
-            throw new IllegalStateException("detach is illegal on already destroyed copies");
-        }
-        if (!isImmutable()) {
-            throw new IllegalStateException("detach is only allowed on immutable copies");
-        }
-        if (!isHashed()) {
-            throw new IllegalStateException("copy must be hashed before it is detached");
-        }
-
-        detached.set(true);
-
-        // The pipeline is paused while this runs, so I can go ahead and call snapshot on the data
-        // source, and also snapshot the cache. I will create a new "RecordAccessor" for the detached
-        // record state.
-        final VirtualDataSource dataSourceCopy = dataSourceBuilder.copy(dataSource, false, false);
+        final Path snapshotPath = dataSourceSnapshot();
+        final VirtualDataSource dataSourceCopy = dataSourceBuilder.build(getLabel(), snapshotPath, false, false);
         final VirtualNodeCache cacheSnapshot = cache.snapshot();
         return new RecordAccessor(metadata.copy(), cacheSnapshot, dataSourceCopy);
     }
 
     /**
-     * {@inheritDoc}
+     * Creates a snapshot of this map's data source. This method must be called only when
+     * the lifecycle thread is paused to make sure no data is flushed to the data source
+     * while the copy is prepared. The base path to the snapshot is returned.
      */
-    @Override
-    public void snapshot(@NonNull final Path destination) throws IOException {
-        requireNonNull(destination);
+    private Path dataSourceSnapshot() {
         if (isDestroyed()) {
-            throw new IllegalStateException("snapshot is illegal on already destroyed copies");
+            throw new IllegalStateException("Can't make data source copy: virtual map copy is already destroyed");
         }
         if (!isImmutable()) {
-            throw new IllegalStateException("snapshot is only allowed on immutable copies");
+            throw new IllegalStateException("Can't make data source copy: virtual map copy is mutable");
         }
         if (!isHashed()) {
-            throw new IllegalStateException("copy must be hashed before snapshot");
+            throw new IllegalStateException("Can't make data source copy: virtual map copy isn't hashed");
         }
 
         detached.set(true);
 
-        // The pipeline is paused while this runs, so I can go ahead and call snapshot on the data
-        // source, and also snapshot the cache. I will create a new "RecordAccessor" for the detached
-        // record state.
-        final VirtualDataSource dataSourceCopy = dataSourceBuilder.copy(dataSource, false, true);
-        try {
-            final VirtualNodeCache cacheSnapshot = cache.snapshot();
-            flush(cacheSnapshot, metadata, dataSourceCopy);
-            dataSourceBuilder.snapshot(destination, dataSourceCopy);
-        } finally {
-            dataSourceCopy.close();
-        }
+        return dataSourceBuilder.snapshot(null, dataSource);
     }
 
     /**
@@ -1247,7 +1227,8 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             originalMap.dataSource.stopAndDisableBackgroundCompaction();
 
             // Take a snapshot, and use the snapshot database as my data source
-            this.dataSource = dataSourceBuilder.copy(originalMap.dataSource, true, false);
+            final Path snapshotPath = dataSourceBuilder.snapshot(null, originalMap.dataSource);
+            this.dataSource = dataSourceBuilder.build(originalMap.getLabel(), snapshotPath, true, false);
 
             // The old map's cache is going to become immutable, but that's OK, because the old map
             // will NEVER be updated again.
@@ -1606,10 +1587,30 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             // FUTURE WORK: get rid of the label once we migrate to Virtual Mega Map
             serout.writeNormalisedString(metadata.getLabel());
             serout.writeLong(metadata.getSize());
-            pipeline.pausePipelineAndRun("detach", () -> {
-                snapshot(outputDirectory);
-                return null;
+            final ValueReference<VirtualNodeCache> cacheSnapshot = new ValueReference<>();
+            final Path snapshotPath = pipeline.pausePipelineAndRun("detach", () -> {
+                // Lifecycle thread is paused, no cache flushes/merges, it's safe to take cache snapshot
+                cacheSnapshot.setValue(cache.snapshot());
+                // And make a data source snapshot. The snapshot is not loaded here, though, it is
+                // done below
+                return dataSourceSnapshot();
             });
+            // build(), flush() and snapshot() below are called outside pausePipelineAndRun() to
+            // unpause the lifecycle thread as quickly as possible. If the lifecycle thread is paused
+            // for too long, unhandled copies pile up in the virtual pipeline, which triggers size
+            // backpressure mechanism
+            VirtualDataSource dataSourceCopy = null;
+            try {
+                dataSourceCopy = dataSourceBuilder.build(getLabel(), snapshotPath, false, true);
+                // Then flush the cache snapshot to the data source copy
+                flush(cacheSnapshot.getValue(), metadata, dataSourceCopy);
+                // And finally snapshot the copy to the target dir
+                dataSourceBuilder.snapshot(outputDirectory, dataSourceCopy);
+            } finally {
+                if (dataSourceCopy != null) {
+                    dataSourceCopy.close();
+                }
+            }
             serout.writeSerializable(dataSourceBuilder, true);
             serout.writeLong(cache.getFastCopyVersion());
         }
@@ -1667,7 +1668,7 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
     private void loadFromFileV4(Path inputFile, MerkleDataInputStream stream, VirtualMapMetadata virtualMapMetadata)
             throws IOException {
         dataSourceBuilder = stream.readSerializable();
-        dataSource = dataSourceBuilder.restore(virtualMapMetadata.getLabel(), inputFile.getParent());
+        dataSource = dataSourceBuilder.build(virtualMapMetadata.getLabel(), inputFile.getParent(), true, false);
         cache = new VirtualNodeCache(virtualMapConfig, stream.readLong());
         metadata = virtualMapMetadata;
     }
@@ -1681,7 +1682,7 @@ public final class VirtualMap extends PartialBinaryMerkleInternal
             throw new IllegalStateException("Label of the VirtualRootNode is not equal to the label of the VirtualMap");
         }
         dataSourceBuilder = stream.readSerializable();
-        dataSource = dataSourceBuilder.restore(label, inputFile.getParent());
+        dataSource = dataSourceBuilder.build(label, inputFile.getParent(), true, false);
         metadata = externalState;
         if (virtualRootVersion < VirtualRootNode.ClassVersion.VERSION_3_NO_NODE_CACHE) {
             throw new UnsupportedOperationException("Version " + virtualRootVersion + " is not supported");

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -10,11 +10,8 @@ import com.swirlds.base.function.CheckedSupplier;
 import com.swirlds.common.threading.framework.config.ThreadConfiguration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
-import com.swirlds.virtualmap.internal.RecordAccessor;
 import com.swirlds.virtualmap.internal.merkle.VirtualMapStatistics;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.concurrent.CountDownLatch;
@@ -362,50 +359,6 @@ public class VirtualPipeline {
             scheduleWork();
         }
         return ret;
-    }
-
-    /**
-     * Put a copy into a detached state. A detached copy will split off from the regular chain of caches. This
-     * allows for merges and flushes to continue even if this copy is long-lived.
-     *
-     * <p>This method waits for the current pipeline job to complete, then puts the pipeline on hold, and
-     * calls copy's {@link VirtualRoot#detach()} method on the current thread. It prevents any merging of
-     * flushing while the snapshot is being taken. Then the pipeline is resumed.
-     *
-     * @param copy
-     * 		the copy to detach
-     * @return a reference to the detached state
-     */
-    public RecordAccessor detachCopy(final VirtualRoot copy) {
-        validatePipelineRegistration(copy);
-        final RecordAccessor ret = pausePipelineAndExecute("detach", copy::detach);
-        if (alive) {
-            scheduleWork();
-        }
-        return ret;
-    }
-
-    /**
-     * Takes a snapshot of the given copy to the specified directory.
-     *
-     * <p>This method waits for the current pipeline job to complete, then puts the pipeline on hold, and
-     * calls copy's {@link VirtualRoot#detach()} method on the current thread. It prevents any merging of
-     * flushing while the snapshot is being taken. Then the pipeline is resumed.
-     *
-     * @param copy
-     * 		The copy. Cannot be null. Should be a member of this pipeline, but technically doesn't need to be.
-     * @param targetDirectory
-     * 		the location where detached files are written. If null then default location is used.
-     */
-    public void snapshot(final VirtualRoot copy, final Path targetDirectory) throws IOException {
-        validatePipelineRegistration(copy);
-        pausePipelineAndExecute("snapshot", () -> {
-            copy.snapshot(targetDirectory);
-            return null;
-        });
-        if (alive) {
-            scheduleWork();
-        }
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualRoot.java
@@ -3,9 +3,6 @@ package com.swirlds.virtualmap.internal.pipeline;
 
 import com.swirlds.common.merkle.MerkleNode;
 import com.swirlds.virtualmap.internal.RecordAccessor;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
-import java.nio.file.Path;
 
 /**
  * The root of a merkle tree containing virtual nodes (i.e. nodes that can be flushed to disk).
@@ -91,17 +88,6 @@ public interface VirtualRoot extends MerkleNode {
      * @return a reference to the detached state
      */
     RecordAccessor detach();
-
-    /**
-     * Takes a snapshot of this virtual root into the specified location. The snapshot can be loaded
-     * back to memory using {@link com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder#restore(String, Path)}
-     * method. It will contain the same data as this root, but some data may be moved from memory to
-     * disk or vice versa. After snapshot is taken, it does not consume any runtime resources, CPU or memory.
-     *
-     * @param destination the location where snapshot files will be located
-     * @throws IOException if an I/O error occurs
-     */
-    void snapshot(@NonNull final Path destination) throws IOException;
 
     /**
      * Gets whether this copy is detached.

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -1386,22 +1386,17 @@ class VirtualMapTests extends VirtualTestBase {
     @Test
     @DisplayName("Snapshot Test")
     void snapshotTest() throws IOException {
-        final List<Path> paths = new LinkedList<>();
-        paths.add(Path.of("asdf"));
-        for (final Path destination : paths) {
-            final VirtualMap original = new VirtualMap("test", new InMemoryBuilder(), CONFIGURATION);
-            final VirtualMap copy = original.copy();
+        final VirtualMap original = new VirtualMap("test", new InMemoryBuilder(), CONFIGURATION);
+        final VirtualMap copy = original.copy();
 
-            original.getHash(); // forces copy to become hashed
-            original.getPipeline().pausePipelineAndRun("snapshot", () -> {
-                original.snapshot(destination);
-                return null;
-            });
-            assertTrue(original.isDetached(), "root should be detached");
+        original.getHash(); // forces copy to become hashed
+        final RecordAccessor snapshot = original.getPipeline().pausePipelineAndRun("snapshot", () -> {
+            return original.detach();
+        });
+        assertTrue(original.isDetached(), "root should be detached");
 
-            original.release();
-            copy.release();
-        }
+        original.release();
+        copy.release();
     }
 
     @Test

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorTest.java
@@ -269,7 +269,7 @@ public class RecordAccessorTest {
 
     private static final class BreakableDataSource implements VirtualDataSource {
 
-        private final InMemoryDataSource delegate = new InMemoryBuilder().build("delegate", true);
+        private final InMemoryDataSource delegate = new InMemoryBuilder().build("delegate", null, true, false);
         boolean throwExceptionOnLoadLeafRecordByKey = false;
         boolean throwExceptionOnLoadLeafRecordByPath = false;
         boolean throwExceptionOnLoadHashByPath = false;

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/DummyVirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/DummyVirtualRoot.java
@@ -10,9 +10,7 @@ import com.swirlds.metrics.api.Metrics;
 import com.swirlds.virtualmap.config.VirtualMapConfig;
 import com.swirlds.virtualmap.internal.RecordAccessor;
 import com.swirlds.virtualmap.internal.merkle.VirtualMapStatistics;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.util.concurrent.CountDownLatch;
 import java.util.function.Predicate;
 import org.hiero.base.crypto.Hash;
@@ -387,14 +385,6 @@ class DummyVirtualRoot extends PartialMerkleLeaf implements VirtualRoot, MerkleL
     public RecordAccessor detach() {
         this.detached = true;
         return null;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void snapshot(@NonNull final Path destination) {
-        this.detached = true;
     }
 
     /**

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/NoOpVirtualRoot.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/NoOpVirtualRoot.java
@@ -4,9 +4,7 @@ package com.swirlds.virtualmap.internal.pipeline;
 import com.swirlds.common.merkle.MerkleLeaf;
 import com.swirlds.common.merkle.impl.PartialMerkleLeaf;
 import com.swirlds.virtualmap.internal.RecordAccessor;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.nio.file.Path;
 import org.hiero.base.constructable.ConstructableIgnored;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
@@ -81,9 +79,6 @@ public final class NoOpVirtualRoot extends PartialMerkleLeaf implements VirtualR
     public RecordAccessor detach() {
         return null;
     }
-
-    @Override
-    public void snapshot(@NonNull final Path destination) {}
 
     @Override
     public boolean isDetached() {

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
@@ -66,7 +66,8 @@ class ReconnectHashListenerTest {
     @ValueSource(ints = {1, 2, 10, 100, 1000, 10_000, 100_000, 1_000_000})
     @DisplayName("Flushed data is always done in the right order")
     void flushOrder(int size) {
-        final VirtualDataSourceSpy ds = new VirtualDataSourceSpy(new InMemoryBuilder().build("flushOrder", true));
+        final VirtualDataSourceSpy ds =
+                new VirtualDataSourceSpy(new InMemoryBuilder().build("flushOrder", null, true, false));
 
         final VirtualMapStatistics statistics = mock(VirtualMapStatistics.class);
         final ReconnectHashLeafFlusher flusher =

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
@@ -26,6 +26,7 @@ import com.swirlds.virtualmap.internal.merkle.VirtualRootNode;
 import com.swirlds.virtualmap.test.fixtures.TestKey;
 import com.swirlds.virtualmap.test.fixtures.TestValue;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
@@ -193,28 +194,21 @@ public abstract class VirtualMapReconnectTestBase {
             numTimesBroken = in.readInt();
         }
 
+        @NonNull
         @Override
-        public BreakableDataSource build(final String label, final boolean withDbCompactionEnabled) {
-            return new BreakableDataSource(this, delegate.build(label, withDbCompactionEnabled));
+        public BreakableDataSource build(
+                final String label,
+                @Nullable final Path sourceDir,
+                final boolean compactionEnabled,
+                final boolean offlineUse) {
+            return new BreakableDataSource(this, delegate.build(label, sourceDir, compactionEnabled, offlineUse));
         }
 
+        @NonNull
         @Override
-        public BreakableDataSource copy(
-                final VirtualDataSource snapshotMe, final boolean compactionEnabled, final boolean offlineUse) {
+        public Path snapshot(@Nullable final Path destination, @NonNull final VirtualDataSource snapshotMe) {
             final var breakableSnapshot = (BreakableDataSource) snapshotMe;
-            return new BreakableDataSource(
-                    this, delegate.copy(breakableSnapshot.delegate, compactionEnabled, offlineUse));
-        }
-
-        @Override
-        public void snapshot(final Path destination, final VirtualDataSource snapshotMe) {
-            final var breakableSnapshot = (BreakableDataSource) snapshotMe;
-            delegate.snapshot(destination, breakableSnapshot.delegate);
-        }
-
-        @Override
-        public BreakableDataSource restore(final String label, final Path from) {
-            return new BreakableDataSource(this, delegate.restore(label, from));
+            return delegate.snapshot(destination, breakableSnapshot.delegate);
         }
 
         public void setNumCallsBeforeThrow(int num) {

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/InMemoryBuilder.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/InMemoryBuilder.java
@@ -4,10 +4,12 @@ package com.swirlds.virtualmap.test.fixtures;
 import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import com.swirlds.virtualmap.datasource.VirtualDataSourceBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
 
@@ -18,7 +20,8 @@ public class InMemoryBuilder implements VirtualDataSourceBuilder {
 
     private final Map<String, InMemoryDataSource> databases = new ConcurrentHashMap<>();
 
-    // Path to data source, used in snapshot() and restore()
+    private static final AtomicInteger dbIndex = new AtomicInteger(0);
+
     private static final Map<String, InMemoryDataSource> snapshots = new ConcurrentHashMap<>();
 
     private static final long CLASS_ID = 0x29e653a8c81959b8L;
@@ -48,8 +51,17 @@ public class InMemoryBuilder implements VirtualDataSourceBuilder {
      */
     @NonNull
     @Override
-    public InMemoryDataSource build(final String label, final boolean withDbCompactionEnabled) {
-        return databases.computeIfAbsent(label, (s) -> createDataSource(label));
+    public InMemoryDataSource build(
+            final String label,
+            @Nullable final Path sourceDir,
+            final boolean compactionEnabled,
+            final boolean offlineUse) {
+        if (sourceDir == null) {
+            return databases.computeIfAbsent(label, (s) -> createDataSource(label));
+        } else {
+            assert snapshots.containsKey(sourceDir.toString());
+            return snapshots.get(sourceDir.toString());
+        }
     }
 
     /**
@@ -57,31 +69,15 @@ public class InMemoryBuilder implements VirtualDataSourceBuilder {
      */
     @NonNull
     @Override
-    public InMemoryDataSource copy(
-            final VirtualDataSource snapshotMe, final boolean compactionEnabled, final boolean offlineUse) {
+    public Path snapshot(@Nullable Path destinationDir, @NonNull final VirtualDataSource snapshotMe) {
+        if (destinationDir == null) {
+            // This doesn't have to be a real path, it's only used a key in the databases field
+            destinationDir = Path.of("inmemory_db_" + dbIndex.getAndIncrement());
+        }
         final InMemoryDataSource source = (InMemoryDataSource) snapshotMe;
         final InMemoryDataSource snapshot = new InMemoryDataSource(source);
-        databases.put(createUniqueDataSourceName(source.getName()), snapshot);
-        return snapshot;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void snapshot(final Path to, final VirtualDataSource snapshotMe) {
-        final InMemoryDataSource source = (InMemoryDataSource) snapshotMe;
-        final InMemoryDataSource snapshot = new InMemoryDataSource(source);
-        snapshots.put(to.toString(), snapshot);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @NonNull
-    @Override
-    public VirtualDataSource restore(final String label, final Path from) {
-        return snapshots.get(from.toString());
+        snapshots.put(destinationDir.toString(), snapshot);
+        return destinationDir;
     }
 
     @Override
@@ -99,9 +95,5 @@ public class InMemoryBuilder implements VirtualDataSourceBuilder {
 
     protected InMemoryDataSource createDataSource(final String name) {
         return new InMemoryDataSource(name);
-    }
-
-    private String createUniqueDataSourceName(final String name) {
-        return name + "-" + System.currentTimeMillis();
     }
 }


### PR DESCRIPTION
Fix summary:
* The core of the fix is in `VirtualMap.serialize()` method. Previously a full VM snapshot was taken in this method, while virtual lifecycle thread is paused. Now this process is split into two parts: cache snapshot + ds snapshot (with lifecycle thread paused) and cache flush + final snapshot (with lifecycle thread released)
* `VirtualDataSourceBuilder` interface is cleaned up. It now has just two methods, `build()` and `snapshot()`. `copy()` is removed in favor of `snapshot()` + `build()`, `restore()` can be replaced with `build()` with some minor changes
* Some unused methods are removed from `VirtualPipeline` and `VirtualRoot`

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/19574
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
