### PR TITLE
ci: rename release workflows

### DIFF
--- a/.github/workflows/flow-increment-next-main-release.yaml
+++ b/.github/workflows/flow-increment-next-main-release.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "[Main] Increment to Next Release Version"
+name: "[Release] Increment Version File"
 on:
   workflow_dispatch:
     inputs:
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   next-main-release:
-    name: Increment to Next Release Version
+    name: Increment Version File
     runs-on: hiero-network-node-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/flow-trigger-release.yaml
+++ b/.github/workflows/flow-trigger-release.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "[Main] Create New Release"
+name: "[Release] Create New Release"
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
**Description**:

Rename release workflows to use a `[Release]` prefix instead of `[Main]` prefix.

**Related Issue(s)**:

Fixes #21148
