### PR TITLE
ci: Update ref to use the correct tag instead of latest on main

### DIFF
--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -161,7 +161,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-performance-test-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
+          ref: ${{ needs.promote-build-candidate.outputs.build-candidate-tag }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: "Trigger ZXF: [CITR] Single Day Longevity Test (SDLT)"
@@ -169,7 +169,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-longevity-test-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
+          ref: ${{ needs.promote-build-candidate.outputs.build-candidate-tag }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: "Trigger ZXF: [CITR] Single Day Canonical Test (SDCT)"
@@ -177,7 +177,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-canonical-test.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
+          ref: ${{ needs.promote-build-candidate.outputs.build-candidate-tag }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "build-tag": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"


### PR DESCRIPTION
## Description

This pull request updates how downstream test workflows are triggered in the `.github/workflows/zxcron-promote-build-candidate.yaml` file. Instead of using the current branch reference, the workflows now use the promoted build candidate tag to ensure consistency across all triggered tests.

Workflow triggering improvements:

* Changed the `ref` parameter for all downstream workflow dispatch steps to use `${{ needs.promote-build-candidate.outputs.build-candidate-tag }}` instead of `${{ github.ref }}`. This ensures that all triggered workflows run against the exact build candidate that was promoted, improving reliability and traceability of test results.

### Related Issue(s)

Closes #21163 
