### PR TITLE
ci(fix): Fix typo in set rootly service name

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -568,7 +568,7 @@ jobs:
           ROOTLY_SERVICE_NAME="CITR General"
           if [[ "${{ needs.fetch-xts-candidate.result }}" =~ ^(cancelled|failure)$ ]] \
             || [[ "${{ needs.tag-for-promotion.result }}" =~ ^(cancelled|failure)$ ]] \
-            || [[ "${{ needs.extended-test-suite.outputs.failure-mode }}" == "workflow"; then
+            || [[ "${{ needs.extended-test-suite.outputs.failure-mode }}" == "workflow" ]]; then
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
           elif [[ "${{ needs.sdk-tck-regression-panel.result }}" =~ ^(cancelled|failure)$ ]]; then
             ROOTLY_SERVICE_NAME="CITR TCK"


### PR DESCRIPTION
**Description**:

This pull request fixes a minor syntax error in the `.github/workfl#21140 cron-extended-test-suite.yaml` workflow file. The change ensures a conditional statement in the job script is properly closed, which helps prevent workflow failures due to incorrect shell syntax. 

* Corrected a missing closing bracket in the conditional statement for checking the `failure-mode` output, ensuring the script runs as intended. (`.github/workflows/zxcron-extended-test-suite.yaml`)

[Fixes XTS Run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/17924198024/job/50966346898)

**Related issue(s)**:

Fixes #21140
