### PR TITLE
fix: 21185: Loading pre 0.67 snapshots is broken, MerkleDb hash threshold is initialized incorrectly

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -283,7 +283,7 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                             + "] because initial capacity is not set");
                 }
             }
-            if (this.hashesRamToDiskThreshold < 0) {
+            if (this.hashesRamToDiskThreshold <= 0) {
                 if (hashesRamToDiskThreshold >= 0) {
                     this.hashesRamToDiskThreshold = hashesRamToDiskThreshold;
                 } else {


### PR DESCRIPTION
Fix summary: see #21185 comments.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21185
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
