### PR TITLE
fix: compaction is not properly interrupted upon closing MerkleDbDataSource

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbCompactionCoordinator.java
@@ -143,9 +143,13 @@ class MerkleDbCompactionCoordinator {
      * @param timeoutMillis - maximum timeout to wait for compaction tasks to complete (0 for indefinite wait).
      */
     synchronized void awaitForCurrentCompactionsToComplete(long timeoutMillis) {
+        final long deadline = timeoutMillis > 0 ? System.currentTimeMillis() + timeoutMillis : Long.MAX_VALUE;
         while (!compactorsByName.isEmpty()) {
+            final long remaining = deadline - System.currentTimeMillis();
+            if (remaining <= 0) break;
+
             try {
-                wait(timeoutMillis);
+                wait(remaining);
             } catch (InterruptedException e) {
                 logger.warn(MERKLE_DB.getMarker(), "Interrupted while waiting for compaction tasks to complete", e);
                 Thread.currentThread().interrupt(); // Restore the interrupted status

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCompactor.java
@@ -191,7 +191,9 @@ public class DataFileCompactor {
             return Collections.emptyList();
         }
 
-        interruptFlag = false;
+        if (interruptFlag) {
+            return Collections.emptyList();
+        }
 
         // create a merge time stamp, this timestamp is the newest time of the set of files we are
         // merging


### PR DESCRIPTION
**Description**:
* make sure pending compaction tasks are properly interrupted.
* honor the timeout parameter in `awaitForCurrentCompactionsToComplete(long timeoutMillis)`

**Related issue(s)**:

Fixes #21187

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
