### PR TITLE
ci: Add input `enable-promotion` to XTS workflow

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -337,6 +337,18 @@ jobs:
         run: |
           if [[ -n "${RC_TAG}" ]] && [[ "${TAG_WITH_EPOCH}" == "false" ]]; then
             TAG="xts-pass-${RC_TAG}"
+
+            set +e
+              TAG_COMMIT="$(git rev-list -n 1 "${TAG}")" >/dev/null 2>&1
+              TAG_EXISTS="${?}"
+            set -e
+
+            if [[ "${TAG_EXISTS}" -eq 0 ]]; then
+              echo "Tag ${TAG} already exists. Deleting."
+              git push --delete origin "${TAG}"
+              git tag -d "${TAG}"
+            fi
+
             git tag --annotate "${TAG}" --message "chore: tagging release candidate as XTS passing"
             git push --set-upstream origin "${TAG}"
             echo "### Commit Tagged as XTS-Passing" >>  "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -8,6 +8,10 @@ on:
         description: "Release Candidate Tag:"
         type: string
         default: ""
+      enable-promotion:
+        required: false
+        description: "Tag with epoch timestamp (enables promotion)"
+        default: "false"
   schedule:
     # Runs Extended Test Suite every three hours Monday to Friday
     - cron: "0 */3 * * 1-5"
@@ -328,8 +332,9 @@ jobs:
       - name: Tag for XTS promotion
         env:
           RC_TAG: ${{ inputs.rc-tag || '' }}
+          TAG_WITH_EPOCH: ${{ inputs.enable-promotion || 'false' }}
         run: |
-          if [[ -n "${RC_TAG}" ]]; then
+          if [[ -n "${RC_TAG}" ]] && [[ "${TAG_WITH_EPOCH}" == "false" ]]; then
             TAG="xts-pass-${RC_TAG}"
             git tag --annotate "${TAG}" --message "chore: tagging release candidate as XTS passing"
             git push --set-upstream origin "${TAG}"

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -11,7 +11,8 @@ on:
       enable-promotion:
         required: false
         description: "Tag with epoch timestamp (enables promotion)"
-        default: "false"
+        default: false
+        type: boolean
   schedule:
     # Runs Extended Test Suite every three hours Monday to Friday
     - cron: "0 */3 * * 1-5"


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/zxcron-extended-test-suite.yaml` workflow to add an option for enabling promotion tagging and to adjust the tagging logic accordingly.

Workflow input and logic changes:

* Added a new workflow input `enable-promotion` to control whether promotion tagging with an epoch timestamp is enabled.
* Updated the tagging step to only create a tag if `enable-promotion` is not set to `"true"`, ensuring that promotion tagging is conditional based on the new input.

### Related Issue(s)

Closes #21221 

### Testing

- [x] [Test XTS Workflow Dispatch Trigger with promotion enabled](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/17978752960)
- [x] [Test XTS Workflow Dispatch Trigger with promotion disabled](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/17988422131)