### PR TITLE
chore(cherry-pick): additional CI changes for 0.66 release

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -121,26 +121,211 @@ jobs:
       java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
       java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
       enable-unit-tests: ${{ github.event_name == 'push' || github.event.inputs.enable-unit-tests == 'true' }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+      codacy-project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  mats-hapi-tests-misc:
+    name: MATS - HAPI Tests (Misc)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS HAPI Tests (Misc)"
+      enable-unit-tests: false
       enable-hapi-tests-misc: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
-      enable-hapi-tests-misc-records: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
-      enable-hapi-tests-crypto: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
-      enable-hapi-tests-iss: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
-      enable-hapi-tests-token: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
-      enable-hapi-tests-smart-contract: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
-      enable-hapi-tests-restart: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
-      enable-hapi-tests-nd-reconnect: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
-      enable-otter-tests: ${{ github.event_name == 'push' || github.event.inputs.enable-otter-tests == 'true' }}
-      enable-spotless-check: ${{ github.event_name == 'push' || github.event.inputs.enable-spotless-check == 'true' }}
-      enable-snyk-scan: ${{ github.event_name == 'push' || github.event.inputs.enable-snyk-scan == 'true' }}
       enable-network-log-capture: true
       mats-suffix: MATS
     secrets:
       access-token: ${{ secrets.GITHUB_TOKEN }}
-      snyk-token: ${{ secrets.SNYK_TOKEN }}
-      codacy-project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
       gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
       gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
-      codecov-token: ${{ secrets.CODECOV_TOKEN }}
+
+  mats-hapi-tests-misc-records:
+    name: MATS - HAPI Tests (Misc Records)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS HAPI Tests (Misc Records)"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-hapi-tests-misc-records: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
+      enable-network-log-capture: true
+      mats-suffix: MATS
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  mats-hapi-tests-crypto:
+    name: MATS - HAPI Tests (Crypto)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS HAPI Tests (Crypto)"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-hapi-tests-crypto: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
+      enable-network-log-capture: true
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  mats-hapi-tests-iss:
+    name: MATS - HAPI Tests (ISS)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS HAPI Tests (ISS)"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-hapi-tests-iss: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
+      enable-network-log-capture: true
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  mats-hapi-tests-token:
+    name: MATS - HAPI Tests (Token)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS HAPI Tests (Token)"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-hapi-tests-token: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
+      enable-network-log-capture: true
+      mats-suffix: MATS
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  mats-hapi-tests-smart-contract:
+    name: MATS - HAPI Tests (Smart Contract)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS HAPI Tests (Smart Contract)"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-hapi-tests-smart-contract: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
+      enable-network-log-capture: true
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  mats-hapi-tests-restart:
+    name: MATS - HAPI Tests (Restart)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS HAPI Tests (Restart)"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-hapi-tests-restart: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
+      enable-network-log-capture: true
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  mats-hapi-tests-nd-reconnect:
+    name: MATS - HAPI Tests (Node Death Reconnect)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS HAPI Tests (Node Death Reconnect)"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-hapi-tests-nd-reconnect: ${{ github.event_name == 'push' || github.event.inputs.enable-hapi-tests == 'true' }}
+      enable-network-log-capture: true
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  mats-otter-tests:
+    name: MATS - Otter Tests
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS Otter Tests"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-otter-tests: ${{ github.event_name == 'push' || github.event.inputs.enable-otter-tests == 'true' }}
+      enable-network-log-capture: true
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  mats-spotless-check:
+    name: MATS - Spotless Check
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS Spotless Check"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-spotless-check: ${{ github.event_name == 'push' || github.event.inputs.enable-spotless-check == 'true' }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+      snyk-token: ${{ secrets.SNYK_TOKEN }}
+
+  mats-snyk-scan:
+    name: MATS - Snyk Scan
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs:
+      - dependency-check
+      - spotless
+    with:
+      custom-job-label: "MATS Snyk Scan"
+      java-version: ${{ github.event.inputs.java-version || '21.0.6' }}
+      java-distribution: ${{ github.event.inputs.java-distribution || 'temurin' }}
+      enable-unit-tests: false
+      enable-snyk-scan: ${{ github.event_name == 'push' || github.event.inputs.enable-snyk-scan == 'true' }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+      snyk-token: ${{ secrets.SNYK_TOKEN }}
 
   mats-gradle-determinism:
     name: MATS - Gradle Determinism
@@ -177,10 +362,32 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - mats-unit-tests
+      - mats-hapi-tests-misc
+      - mats-hapi-tests-misc-records
+      - mats-hapi-tests-crypto
+      - mats-hapi-tests-iss
+      - mats-hapi-tests-token
+      - mats-hapi-tests-smart-contract
+      - mats-hapi-tests-restart
+      - mats-hapi-tests-nd-reconnect
+      - mats-otter-tests
+      - mats-spotless-check
+      - mats-snyk-scan
       - mats-gradle-determinism
       - mats-docker-determinism
     if: ${{ (github.event_name == 'push') &&
       needs.mats-unit-tests.result == 'success' &&
+      needs.mats-hapi-tests-misc.result == 'success' &&
+      needs.mats-hapi-tests-misc-records.result == 'success' &&
+      needs.mats-hapi-tests-crypto.result == 'success' &&
+      needs.mats-hapi-tests-iss.result == 'success' &&
+      needs.mats-hapi-tests-token.result == 'success' &&
+      needs.mats-hapi-tests-smart-contract.result == 'success' &&
+      needs.mats-hapi-tests-restart.result == 'success' &&
+      needs.mats-hapi-tests-nd-reconnect.result == 'success' &&
+      needs.mats-otter-tests.result == 'success' &&
+      needs.mats-spotless-check.result == 'success' &&
+      needs.mats-snyk-scan.result == 'success' &&
       needs.mats-gradle-determinism.result == 'success' &&
       needs.mats-docker-determinism.result == 'success' }}
     steps:
@@ -210,6 +417,17 @@ jobs:
       - dependency-check
       - spotless
       - mats-unit-tests
+      - mats-hapi-tests-misc
+      - mats-hapi-tests-misc-records
+      - mats-hapi-tests-crypto
+      - mats-hapi-tests-iss
+      - mats-hapi-tests-token
+      - mats-hapi-tests-smart-contract
+      - mats-hapi-tests-restart
+      - mats-hapi-tests-nd-reconnect
+      - mats-otter-tests
+      - mats-spotless-check
+      - mats-snyk-scan
       - mats-gradle-determinism
       - mats-docker-determinism
       - deploy-ci-trigger
@@ -217,6 +435,17 @@ jobs:
       needs.dependency-check.result != 'success' ||
       needs.spotless.result != 'success' ||
       needs.mats-unit-tests.result != 'success' ||
+      needs.mats-hapi-tests-misc.result != 'success' ||
+      needs.mats-hapi-tests-misc-records.result != 'success' ||
+      needs.mats-hapi-tests-crypto.result != 'success' ||
+      needs.mats-hapi-tests-iss.result != 'success' ||
+      needs.mats-hapi-tests-token.result != 'success' ||
+      needs.mats-hapi-tests-smart-contract.result != 'success' ||
+      needs.mats-hapi-tests-restart.result != 'success' ||
+      needs.mats-hapi-tests-nd-reconnect.result != 'success' ||
+      needs.mats-otter-tests.result != 'success' ||
+      needs.mats-spotless-check.result != 'success' ||
+      needs.mats-snyk-scan.result != 'success' ||
       needs.mats-gradle-determinism.result != 'success' ||
       needs.mats-docker-determinism.result != 'success' ||
       needs.deploy-ci-trigger.result != 'success') &&

--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -1354,7 +1354,7 @@ jobs:
           # use back-ticks for proper substitution in the json report
           freport=`/usr/bin/echo -e "$report" | awk '{print $1" "$2" "$3}' |\
             perl -ne 'if ($. < 6) {$comma=","} else {$comma="";} ($t,$d,$l)=split(/\s+/,$_,3); $p=int(($d-$l)/100); \
-            $excl=""; if ($p<=0) {$excl="\\\u2757";}
+            $excl=""; if ($d <= $l) {$excl="\\\u2757";}
             printf("{\"type\": \"text\",\"text\": \"%-25s %7d     %5d%% %7d %s\\\n\"}%s",$t,$d,$p,$l,$excl,$comma);'`
           freport="{\"type\": \"text\",\"text\": \"Name                          TPS         Above min\n\"},$freport"
 

--- a/.github/workflows/zxcron-promote-build-candidate.yaml
+++ b/.github/workflows/zxcron-promote-build-candidate.yaml
@@ -161,7 +161,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-performance-test-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
+          ref: ${{ needs.promote-build-candidate.outputs.build-candidate-tag }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: "Trigger ZXF: [CITR] Single Day Longevity Test (SDLT)"
@@ -169,7 +169,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-longevity-test-controller.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
+          ref: ${{ needs.promote-build-candidate.outputs.build-candidate-tag }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
 
       - name: "Trigger ZXF: [CITR] Single Day Canonical Test (SDCT)"
@@ -177,7 +177,7 @@ jobs:
         with:
           workflow: .github/workflows/zxf-single-day-canonical-test.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: ${{ github.ref }} # ensure we are always using the workflow definition from the called branch
+          ref: ${{ needs.promote-build-candidate.outputs.build-candidate-tag }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "build-tag": "${{ needs.promote-build-candidate.outputs.build-candidate-tag }}"


### PR DESCRIPTION
**CI-Related Scripts Approved on Sep 25 2025**:

- [ci: Update ref to use the correct tag instead of latest on main](https://github.com/hiero-ledger/hiero-consensus-node/pull/21165), `e199f7bede0e8236478304e6fe41de59f3fa1dfb`
- [ci: update MATS to parallel runs](https://github.com/hiero-ledger/hiero-consensus-node/pull/21159), `1a5b9474e13e802d9b4b86a9dba857e8f6ff4513`


**Performance-Related Scripts Approved on Sep 25 2025**:

- [test: fix of 21164 (to use abs diff value instead of rounded percentage)](https://github.com/hiero-ledger/hiero-consensus-node/pull/21166), `d28b84a2038679e1d1c356d309654f7245adbf98`

**Related issue(s)**:

Fixes #21243 
