### PR TITLE
ci(alert): Configure rootly to send alerts to multiple services

### DIFF
--- a/.github/workflows/node-flow-build-application.yaml
+++ b/.github/workflows/node-flow-build-application.yaml
@@ -539,11 +539,14 @@ jobs:
         id: set-rootly-parameters
         run: |
           ROOTLY_SERVICE_NAME="CITR General"
+          ROOTLY_SERVICES="CITR General,CITR General - EU"
           if [[ "${{ needs.deploy-ci-trigger.result }}" =~ ^(cancelled|failure)$ ]] \
             || [[ "${{ needs.mats-unit-tests.outputs.failure-mode }}" == "workflow" ]]; then
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
+            ROOTLY_SERVICES="${ROOTLY_SERVICE_NAME}"
           fi
-          echo "service=${ROOTLY_SERVICE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "service-target=${ROOTLY_SERVICE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "services=${ROOTLY_SERVICES}" >> "${GITHUB_OUTPUT}"
 
       - name: Build Rootly Summary
         id: rootly-summary
@@ -574,8 +577,10 @@ jobs:
           echo "## Rootly Summary:"
           echo "### Title: ${{ steps.rootly-summary.outputs.title }}" >> "${GITHUB_STEP_SUMMARY}"
           echo "${{ steps.rootly-summary.outputs.summary }}" >> "${GITHUB_STEP_SUMMARY}"
-          echo "### Rootly Service" >> "${GITHUB_STEP_SUMMARY}"
-          echo "${{ steps.set-rootly-parameters.outputs.service }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### Rootly Notification Target Service" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${{ steps.set-rootly-parameters.outputs.service-target }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### Rootly Service(s)" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${{ steps.set-rootly-parameters.outputs.services }}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Create Rootly Alert
         id: create-rootly-alert
@@ -586,11 +591,12 @@ jobs:
           summary: "${{ steps.rootly-summary.outputs.title }}"
           details: "${{ steps.rootly-summary.outputs.summary }}"
           notification_target_type: "Service"
-          notification_target: ${{ steps.set-rootly-parameters.outputs.service }}
+          notification_target: ${{ steps.set-rootly-parameters.outputs.service-target }}
           set_as_noise: "true"
           alert_urgency: "High"
           external_id: ${{ github.run_id }}
           external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          services: "${{ steps.set-rootly-parameters.outputs.services }}"
           environments: "CITR"
 
       - name: Build Slack Payload Message

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -585,14 +585,18 @@ jobs:
         id: set-rootly-service
         run: |
           ROOTLY_SERVICE_NAME="CITR General"
+          ROOTLY_SERVICES="CITR General,CITR General - EU"
           if [[ "${{ needs.fetch-xts-candidate.result }}" =~ ^(cancelled|failure)$ ]] \
             || [[ "${{ needs.tag-for-promotion.result }}" =~ ^(cancelled|failure)$ ]] \
             || [[ "${{ needs.extended-test-suite.outputs.failure-mode }}" == "workflow" ]]; then
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
+            ROOTLY_SERVICES="${ROOTLY_SERVICE_NAME}"
           elif [[ "${{ needs.sdk-tck-regression-panel.result }}" =~ ^(cancelled|failure)$ ]]; then
             ROOTLY_SERVICE_NAME="CITR TCK"
+            ROOTLY_SERVICES="${ROOTLY_SERVICE_NAME}"
           fi
-          echo "service=${ROOTLY_SERVICE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "service-target=${ROOTLY_SERVICE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "services=${ROOTLY_SERVICES}" >> "${GITHUB_OUTPUT}"
 
       - name: Build Rootly Summary
         id: rootly-summary
@@ -624,8 +628,10 @@ jobs:
           echo "## Rootly Summary:"
           echo "### Title: ${{ steps.rootly-summary.outputs.title }}" >> "${GITHUB_STEP_SUMMARY}"
           echo "${{ steps.rootly-summary.outputs.summary }}" >> "${GITHUB_STEP_SUMMARY}"
-          echo "### Rootly Service" >> "${GITHUB_STEP_SUMMARY}"
-          echo "${{ steps.set-rootly-service.outputs.service }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### Rootly Notification Target Service" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${{ steps.set-rootly-service.outputs.service-target }}" >> "${GITHUB_STEP_SUMMARY}"
+          echo "### Rootly Services" >> "${GITHUB_STEP_SUMMARY}"
+          echo "${{ steps.set-rootly-service.outputs.services }}" >> "${GITHUB_STEP_SUMMARY}"
 
       - name: Create Rootly Alert
         id: create-rootly-alert
@@ -641,6 +647,7 @@ jobs:
           alert_urgency: "High"
           external_id: ${{ github.run_id }}
           external_url: "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          services: "${{ steps.set-rootly-service.outputs.services }}"
           environments: "CITR"
 
       - name: Build Slack Payload Message


### PR DESCRIPTION
## Description

This pull request updates the Rootly integration in both the `node-flow-build-application.yaml` and `zxcron-extended-test-suite.yaml` GitHub workflow files. The main goal is to support multiple Rootly services for notifications, improve clarity in workflow outputs, and ensure alerts are sent to all relevant services.

**Rootly Integration Improvements:**

* Added support for notifying multiple Rootly services by introducing the `ROOTLY_SERVICES` variable and updating workflow outputs and alert payloads to use this list. [[1]](diffhunk://#diff-1f2aadd308cdf2a372f92e553fda2bfaae9bdc475d477c6a2fa2b181ef346fb0R542-R549) [[2]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687R588-R599) [[3]](diffhunk://#diff-1f2aadd308cdf2a372f92e553fda2bfaae9bdc475d477c6a2fa2b181ef346fb0L589-R599) [[4]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687R650)

**Workflow Output and Summary Enhancements:**

* Changed workflow outputs from a single `service` to `service-target` and `services`, and updated summary sections to display both the notification target and all relevant services for better visibility. [[1]](diffhunk://#diff-1f2aadd308cdf2a372f92e553fda2bfaae9bdc475d477c6a2fa2b181ef346fb0L577-R583) [[2]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687L627-R634)

These changes help ensure that incidents and notifications are correctly routed to all impacted Rootly services and improve the transparency of workflow status reporting.

### Related Issue(s)

Closes #21242 

### Testing