### PR TITLE
ci(main): Split CITR eXtended Test Suite into component parts 

### DIFF
--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -171,17 +171,73 @@ jobs:
             gh run cancel "${{ github.run_id }}"
           fi
 
-  extended-test-suite:
-    name: Execute eXtended Test Suite
+  xts-timing-sensitive-tests:
+    name: XTS Timing Sensitive Tests
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     needs: fetch-xts-candidate
     if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
     with:
-      custom-job-label: Execute eXtended Test Suite
+      custom-job-label: "XTS Timing Sensitive"
       enable-timing-sensitive-tests: true
+      enable-network-log-capture: true
+      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  xts-time-consuming-tests:
+    name: XTS Time Consuming Tests
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs: fetch-xts-candidate
+    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
+    with:
+      custom-job-label: "XTS Time Consuming"
       enable-time-consuming-tests: true
+      enable-network-log-capture: true
+      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  xts-hammer-tests:
+    name: XTS Hammer Tests
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs: fetch-xts-candidate
+    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
+    with:
+      custom-job-label: "XTS Hammer Tests"
       enable-hammer-tests: true
+      enable-network-log-capture: true
+      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  xts-hapi-time-consuming-tests:
+    name: XTS HAPI Tests (Time Consuming)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs: fetch-xts-candidate
+    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
+    with:
+      custom-job-label: "XTS HAPI Time Consuming"
       enable-hapi-tests-time-consuming: true
+      enable-network-log-capture: true
+      ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  xts-hapi-block-node-comms-tests:
+    name: XTS HAPI Tests (Block Node Communication)
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    needs: fetch-xts-candidate
+    if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-tag-exists == 'true' }}
+    with:
+      custom-job-label: "XTS HAPI Block Node Comms"
       enable-hapi-tests-bn-communication: true
       enable-network-log-capture: true
       ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}
@@ -299,11 +355,23 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - abbreviated-panel
-      - extended-test-suite
       - fetch-xts-candidate
       - hedera-node-jrs-panel
       - sdk-tck-regression-panel
-    if: ${{ needs.abbreviated-panel.result == 'success' || needs.extended-test-suite.result == 'success' || needs.hedera-node-jrs-panel.result == 'success' }}
+      - xts-hammer-tests
+      - xts-hapi-block-node-comms-tests
+      - xts-hapi-time-consuming-tests
+      - xts-time-consuming-tests
+      - xts-timing-sensitive-tests
+    if: ${{ needs.abbreviated-panel.result == 'success' ||
+      needs.extended-test-suite.result == 'success' ||
+      needs.hedera-node-jrs-panel.result == 'success' ||
+      needs.sdk-tck-regression-panel.result == 'success' ||
+      needs.xts-hammer-tests.result == 'success' ||
+      needs.xts-hapi-block-node-comms-tests.result == 'success' ||
+      needs.xts-hapi-time-consuming-tests.result == 'success' ||
+      needs.xts-time-consuming-tests.result == 'success' ||
+      needs.xts-timing-sensitive-tests.result == 'success' }}
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
@@ -367,17 +435,25 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - abbreviated-panel
-      - extended-test-suite
       - fetch-xts-candidate
       - hedera-node-jrs-panel
       - sdk-tck-regression-panel
       - tag-for-promotion
+      - xts-hammer-tests
+      - xts-hapi-block-node-comms-tests
+      - xts-hapi-time-consuming-tests
+      - xts-time-consuming-tests
+      - xts-timing-sensitive-tests
     if: ${{ (needs.abbreviated-panel.result == 'success' &&
-      needs.extended-test-suite.result == 'success' &&
       needs.fetch-xts-candidate.result == 'success' &&
       needs.hedera-node-jrs-panel.result == 'success' &&
       needs.sdk-tck-regression-panel.result == 'success' &&
-      needs.tag-for-promotion.result == 'success') &&
+      needs.tag-for-promotion.result == 'success' &&
+      needs.xts-hammer-tests.result == 'success' &&
+      needs.xts-hapi-block-node-comms-tests.result == 'success' &&
+      needs.xts-hapi-time-consuming-tests.result == 'success' &&
+      needs.xts-time-consuming-tests.result == 'success' &&
+      needs.xts-timing-sensitive-tests == 'success') &&
       !cancelled() }}
     steps:
       - name: Harden Runner
@@ -421,7 +497,23 @@ jobs:
                         },
                         {
                           "type": "plain_text",
-                          "text": "Execute eXtended Test Suite: ${{ needs.extended-test-suite.result }}"
+                          "text": "XTS Timing Sensitive Tests: ${{ needs.xts-timing-sensitive-tests.result }}"
+                        },
+                        {
+                          "type": "plain_text",
+                          "text": "XTS Time Consuming Tests: ${{ needs.xts-time-consuming-tests.result }}"
+                        },
+                        {
+                          "type": "plain_text",
+                          "text": "XTS Hammer Tests: ${{ needs.xts-hammer-tests.result }}"
+                        },
+                        {
+                          "type": "plain_text",
+                          "text": "XTS HAPI Time Consuming Tests: ${{ needs.xts-hapi-time-consuming-tests.result }}"
+                        },
+                        {
+                          "type": "plain_text",
+                          "text": "XTS HAPI Block Node Comms Tests: ${{ needs.xts-hapi-block-node-comms-tests.result }}"
                         },
                         {
                           "type": "plain_text",
@@ -511,17 +603,26 @@ jobs:
     runs-on: hiero-citr-linux-medium
     needs:
       - abbreviated-panel
-      - extended-test-suite
       - fetch-xts-candidate
       - hedera-node-jrs-panel
       - sdk-tck-regression-panel
       - tag-for-promotion
+      - xts-hammer-tests
+      - xts-hapi-block-node-comms-tests
+      - xts-hapi-time-consuming-tests
+      - xts-time-consuming-tests
+      - xts-timing-sensitive-tests
     if: ${{ (needs.fetch-xts-candidate.result != 'success' ||
       needs.abbreviated-panel.result != 'success' ||
       needs.extended-test-suite.result != 'success' ||
       needs.hedera-node-jrs-panel.result != 'success' ||
       needs.sdk-tck-regression-panel.result != 'success' ||
-      needs.tag-for-promotion.result != 'success') &&
+      needs.tag-for-promotion.result != 'success' ||
+      needs.xts-hammer-tests.result != 'success' ||
+      needs.xts-hapi-block-node-comms-tests.result != 'success' ||
+      needs.xts-hapi-time-consuming-tests.result != 'success' ||
+      needs.xts-time-consuming-tests.result != 'success' ||
+      needs.xts-timing-sensitive-tests.result != 'success') &&
       !cancelled() && always() }}
 
     steps:
@@ -581,13 +682,48 @@ jobs:
           fi
           echo "slack-user-id=${SLACK_USER_ID}" >> "${GITHUB_OUTPUT}"
 
+      - name: Determine failure mode
+        id: extended-test-suite-failure
+        if: ${{ needs.xts-timing-sensitive-tests.result != 'success' ||
+          needs.xts-time-consuming-tests.result != 'success' ||
+          needs.xts-hammer-tests.result != 'success' ||
+          needs.xts-hapi-time-consuming-tests.result != 'success' ||
+          needs.xts-hapi-block-node-comms-tests.result != 'success' }}
+        run: |
+          # define a function to check for workflow failure mode
+          has_workflow() {
+            local arr=("$@")
+            for mode in "${arr[@]}"; do
+              [[ "mode" == "workflow" ]] && return 0
+            done
+            return 1
+          }
+
+          # Collect the statuses of all XTS suite jobs
+          xts_suite_statuses=(
+            "${{ needs.xts-timing-sensitive-tests.outputs.mode }}"
+            "${{ needs.xts-time-consuming-tests.outputs.mode }}"
+            "${{ needs.xts-hammer-tests.outputs.mode }}"
+            "${{ needs.xts-hapi-time-consuming-tests.outputs.mode }}"
+            "${{ needs.xts-hapi-block-node-comms-tests.outputs.mode }}"
+          )
+
+          # determine failure mode
+          failure_mode="general"
+          if has_workflow "${xts_suite_statuses[@]}"; then
+            failure_mode="workflow"
+          fi
+
+          # Set the output variable
+          echo "mode=${failure_mode}" >> "${GITHUB_OUTPUT}"
+
       - name: Set Rootly Service Name
         id: set-rootly-service
         run: |
           ROOTLY_SERVICE_NAME="CITR General"
           if [[ "${{ needs.fetch-xts-candidate.result }}" =~ ^(cancelled|failure)$ ]] \
             || [[ "${{ needs.tag-for-promotion.result }}" =~ ^(cancelled|failure)$ ]] \
-            || [[ "${{ needs.extended-test-suite.outputs.failure-mode }}" == "workflow" ]]; then
+            || [[ "${{ steps.extended-test-suite-failure.outputs.mode || 'general' }}" == "workflow" ]]; then
             ROOTLY_SERVICE_NAME="CI/CD Workflows"
           elif [[ "${{ needs.sdk-tck-regression-panel.result }}" =~ ^(cancelled|failure)$ ]]; then
             ROOTLY_SERVICE_NAME="CITR TCK"
@@ -604,7 +740,11 @@ jobs:
             echo "------------------------------------"
             echo "Status of each jobs:"
             echo "- Abbreviated Panel: ${{ needs.abbreviated-panel.result }}"
-            echo "- Extended Test Suite: ${{ needs.extended-test-suite.result }}"
+            echo "- XTS Timing Sensitive Tests: ${{ needs.xts-timing-sensitive-tests.result }}"
+            echo "- XTS Time Consuming Tests: ${{ needs.xts-time-consuming-tests.result }}"
+            echo "- XTS Hammer Tests: ${{ needs.xts-hammer-tests.result }}"
+            echo "- XTS HAPI Time Consuming Tests: ${{ needs.xts-hapi-time-consuming-tests.result }}"
+            echo "- XTS HAPI Block Node Comms Tests: ${{ needs.xts-hapi-block-node-comms-tests.result }}"
             echo "- Hedera Node JRS Panel: ${{ needs.hedera-node-jrs-panel.result }}"
             echo "- SDK TCK Regression Panel: ${{ needs.sdk-tck-regression-panel.result }}"
             echo "- Tag for Promotion: ${{ needs.tag-for-promotion.result }}"
@@ -676,7 +816,23 @@ jobs:
                       },
                       {
                         "type": "plain_text",
-                        "text": "Execute eXtended Test Suite: ${{ needs.extended-test-suite.result }}"
+                        "text": "XTS Timing Sensitive Tests: ${{ needs.xts-timing-sensitive-tests.result }}"
+                      },
+                      {
+                        "type": "plain_text",
+                        "text": "XTS Time Consuming Tests: ${{ needs.xts-time-consuming-tests.result }}"
+                      },
+                      {
+                        "type": "plain_text",
+                        "text": "XTS Hammer Tests: ${{ needs.xts-hammer-tests.result }}"
+                      },
+                      {
+                        "type": "plain_text",
+                        "text": "XTS HAPI Time Consuming Tests: ${{ needs.xts-hapi-time-consuming-tests.result }}"
+                      },
+                      {
+                        "type": "plain_text",
+                        "text": "XTS HAPI Block Node Comms Tests: ${{ needs.xts-hapi-block-node-comms-tests.result }}"
                       },
                       {
                         "type": "plain_text",

--- a/.github/workflows/zxcron-extended-test-suite.yaml
+++ b/.github/workflows/zxcron-extended-test-suite.yaml
@@ -364,7 +364,6 @@ jobs:
       - xts-time-consuming-tests
       - xts-timing-sensitive-tests
     if: ${{ needs.abbreviated-panel.result == 'success' ||
-      needs.extended-test-suite.result == 'success' ||
       needs.hedera-node-jrs-panel.result == 'success' ||
       needs.sdk-tck-regression-panel.result == 'success' ||
       needs.xts-hammer-tests.result == 'success' ||
@@ -614,7 +613,6 @@ jobs:
       - xts-timing-sensitive-tests
     if: ${{ (needs.fetch-xts-candidate.result != 'success' ||
       needs.abbreviated-panel.result != 'success' ||
-      needs.extended-test-suite.result != 'success' ||
       needs.hedera-node-jrs-panel.result != 'success' ||
       needs.sdk-tck-regression-panel.result != 'success' ||
       needs.tag-for-promotion.result != 'success' ||

--- a/.github/workflows/zxf-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/zxf-dry-run-extended-test-suite.yaml
@@ -58,16 +58,68 @@ defaults:
     shell: bash
 
 jobs:
-  extended-test-suite:
-    name: Execute eXtended Test Suite
+  xts-timing-sensitive-tests:
+    name: XTS Timing Sensitive Tests
     if: ${{ inputs.enable-extended-test-suite == true }}
     uses: ./.github/workflows/node-zxc-compile-application-code.yaml
     with:
-      custom-job-label: "Dry-Run: Execute eXtended Test Suite"
+      custom-job-label: "XTS Timing Sensitive"
       enable-timing-sensitive-tests: true
+      enable-network-log-capture: true
+      ref: ${{ inputs.commit_sha }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  xts-time-consuming-tests:
+    name: XTS Time Consuming Tests
+    if: ${{ inputs.enable-extended-test-suite == true }}
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    with:
+      custom-job-label: "XTS Time Consuming"
       enable-time-consuming-tests: true
+      enable-network-log-capture: true
+      ref: ${{ inputs.commit_sha }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  xts-hammer-tests:
+    name: XTS Hammer Tests
+    if: ${{ inputs.enable-extended-test-suite == true }}
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    with:
+      custom-job-label: "XTS Hammer Tests"
       enable-hammer-tests: true
+      enable-network-log-capture: true
+      ref: ${{ inputs.commit_sha }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  xts-hapi-time-consuming-tests:
+    name: XTS HAPI Tests (Time Consuming)
+    if: ${{ inputs.enable-extended-test-suite == true }}
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    with:
+      custom-job-label: "XTS HAPI Time Consuming"
       enable-hapi-tests-time-consuming: true
+      enable-network-log-capture: true
+      ref: ${{ inputs.commit_sha }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      gradle-cache-username: ${{ secrets.GRADLE_CACHE_USERNAME }}
+      gradle-cache-password: ${{ secrets.GRADLE_CACHE_PASSWORD }}
+
+  xts-hapi-block-node-comms-tests:
+    name: XTS HAPI Tests (Block Node Communication)
+    if: ${{ inputs.enable-extended-test-suite == true }}
+    uses: ./.github/workflows/node-zxc-compile-application-code.yaml
+    with:
+      custom-job-label: "XTS HAPI Block Node Comms"
       enable-hapi-tests-bn-communication: true
       enable-network-log-capture: true
       ref: ${{ inputs.commit_sha }}


### PR DESCRIPTION
## Description

This pull request restructures the extended test suite workflows in `.github/workflows/zxcron-extended-test-suite.yaml` and `.github/workflows/zxf-dry-run-extended-test-suite.yaml` by splitting the monolithic "extended test suite" job into five distinct jobs, each targeting a specific type of XTS test. It also updates downstream jobs and status reporting to reflect these changes, and introduces logic to better determine and report failure modes.

**Test suite job restructuring:**

* The previous `extended-test-suite` job is replaced by five specialized jobs: `xts-timing-sensitive-tests`, `xts-time-consuming-tests`, `xts-hammer-tests`, `xts-hapi-time-consuming-tests`, and `xts-hapi-block-node-comms-tests`. Each job runs its corresponding subset of tests and passes relevant secrets and parameters. (`.github/workflows/zxcron-extended-test-suite.yaml`, `.github/workflows/zxf-dry-run-extended-test-suite.yaml`) [[1]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687L174-R240) [[2]](diffhunk://#diff-b58cd895cfd227abeaa0e2ef58894fd6cd09317a50827362dce2f3f6bd29568cL61-R122)

**Downstream job and dependency updates:**

* All jobs that previously depended on `extended-test-suite` now depend on the five new jobs, with updated conditional logic to check the success of each. (`.github/workflows/zxcron-extended-test-suite.yaml`) [[1]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687L302-R373) [[2]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687L370-R455) [[3]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687L514-R623)

**Status reporting improvements:**

* Status messages and Slack notifications now individually report results for each new XTS job instead of the old monolithic job, providing more granular feedback. (`.github/workflows/zxcron-extended-test-suite.yaml`) [[1]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687L424-R515) [[2]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687L607-R745) [[3]](diffhunk://#diff-0200fc6fe4d2e0194aa278446c5ef3a562d270505fee1d169229d3d977705687L679-R833)

**Failure mode detection:**

* Adds a new step to aggregate the outputs of all XTS jobs and determine if a workflow-level failure occurred, setting an output variable that is used for subsequent incident reporting. (`.github/workflows/zxcron-extended-test-suite.yaml`)

These changes make the test suite execution more modular, improve visibility into test results, and enhance incident reporting.

### Related Issue(s)

Fixes #21256 

### Testing
- [x] [XTS Dry Run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18026457002)
- [x] [XTS formal run](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/18028484034)