### PR TITLE
refactor: 21269 Move `asAccountString` to `hapi` module

### DIFF
--- a/hapi/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
+++ b/hapi/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
@@ -393,7 +393,12 @@ public class HapiUtils {
                         ipV4Addr.getByte(3) & 0xFF);
     }
 
-    public static String asAccountString(final AccountID accountID) {
+    /**
+     * Converts given AccountID to strin
+     * @param accountID account id to convert
+     * @return string representation
+     */
+    public static String asAccountString(@NonNull final AccountID accountID) {
         return String.format("%d.%d.%d", accountID.shardNum(), accountID.realmNum(), accountID.accountNum());
     }
 }

--- a/hapi/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
+++ b/hapi/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
@@ -392,4 +392,8 @@ public class HapiUtils {
                         ipV4Addr.getByte(2) & 0xFF,
                         ipV4Addr.getByte(3) & 0xFF);
     }
+
+    public static String asAccountString(final AccountID accountID) {
+        return String.format("%d.%d.%d", accountID.shardNum(), accountID.realmNum(), accountID.accountNum());
+    }
 }

--- a/hapi/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
+++ b/hapi/hapi/src/main/java/com/hedera/hapi/util/HapiUtils.java
@@ -394,7 +394,7 @@ public class HapiUtils {
     }
 
     /**
-     * Converts given AccountID to strin
+     * Converts given AccountID to string.
      * @param accountID account id to convert
      * @return string representation
      */

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
@@ -2,7 +2,7 @@
 package com.hedera.node.app.blocks.impl.streaming;
 
 import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
-import static com.swirlds.state.lifecycle.HapiUtils.asAccountString;
+import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.block.stream.Block;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.blocks.impl.streaming;
 
-import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static com.hedera.hapi.util.HapiUtils.asAccountString;
+import static com.swirlds.common.io.utility.FileUtils.getAbsolutePath;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.block.stream.Block;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
@@ -14,7 +14,7 @@ import static com.hedera.node.app.records.impl.producers.formats.v6.SignatureWri
 import static com.hedera.pbj.runtime.ProtoWriterTools.writeLong;
 import static com.hedera.pbj.runtime.ProtoWriterTools.writeMessage;
 import static com.swirlds.common.stream.LinkedObjectStreamUtilities.convertInstantToStringWithPadding;
-import static com.swirlds.state.lifecycle.HapiUtils.asAccountString;
+import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
@@ -7,6 +7,7 @@ import static com.hedera.hapi.streams.schema.RecordStreamFileSchema.HAPI_PROTO_V
 import static com.hedera.hapi.streams.schema.RecordStreamFileSchema.RECORD_STREAM_ITEMS;
 import static com.hedera.hapi.streams.schema.RecordStreamFileSchema.SIDECARS;
 import static com.hedera.hapi.streams.schema.RecordStreamFileSchema.START_OBJECT_RUNNING_HASH;
+import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static com.hedera.node.app.records.impl.producers.BlockRecordFormat.TAG_TYPE_BITS;
 import static com.hedera.node.app.records.impl.producers.BlockRecordFormat.WIRE_TYPE_DELIMITED;
 import static com.hedera.node.app.records.impl.producers.formats.v6.BlockRecordFormatV6.VERSION_6;
@@ -14,7 +15,6 @@ import static com.hedera.node.app.records.impl.producers.formats.v6.SignatureWri
 import static com.hedera.pbj.runtime.ProtoWriterTools.writeLong;
 import static com.hedera.pbj.runtime.ProtoWriterTools.writeMessage;
 import static com.swirlds.common.stream.LinkedObjectStreamUtilities.convertInstantToStringWithPadding;
-import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.base.SemanticVersion;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.workflows.handle.record;
 
+import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static com.hedera.node.app.records.BlockRecordService.EPOCH;
 import static com.hedera.node.app.records.BlockRecordService.NAME;
 import static com.hedera.node.app.records.RecordTestData.BLOCK_NUM;
@@ -16,7 +17,6 @@ import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.RUNNING
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.RUNNING_HASHES_STATE_LABEL;
 import static com.swirlds.platform.state.service.PlatformStateService.PLATFORM_STATE_SERVICE;
 import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.UNINITIALIZED_PLATFORM_STATE;
-import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -16,7 +16,7 @@ import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.RUNNING
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.RUNNING_HASHES_STATE_LABEL;
 import static com.swirlds.platform.state.service.PlatformStateService.PLATFORM_STATE_SERVICE;
 import static com.swirlds.platform.state.service.schemas.V0540PlatformStateSchema.UNINITIALIZED_PLATFORM_STATE;
-import static com.swirlds.state.lifecycle.HapiUtils.asAccountString;
+import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
@@ -7,7 +7,7 @@ import static com.hedera.node.app.records.RecordTestData.SIGNER;
 import static com.hedera.node.app.records.RecordTestData.STARTING_RUNNING_HASH_OBJ;
 import static com.hedera.node.app.records.RecordTestData.TEST_BLOCKS;
 import static com.hedera.node.app.records.RecordTestData.VERSION;
-import static com.swirlds.state.lifecycle.HapiUtils.asAccountString;
+import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordWriterV6Test.java
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.records.impl.producers.formats.v6;
 
+import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static com.hedera.node.app.records.RecordTestData.BLOCK_NUM;
 import static com.hedera.node.app.records.RecordTestData.ENDING_RUNNING_HASH_OBJ;
 import static com.hedera.node.app.records.RecordTestData.SIGNER;
 import static com.hedera.node.app.records.RecordTestData.STARTING_RUNNING_HASH_OBJ;
 import static com.hedera.node.app.records.RecordTestData.TEST_BLOCKS;
 import static com.hedera.node.app.records.RecordTestData.VERSION;
-import static com.hedera.hapi.util.HapiUtils.asAccountString;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/HapiUtils.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/HapiUtils.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.state.lifecycle;
 
-import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.SemanticVersion;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -83,7 +82,4 @@ public final class HapiUtils {
         }
     }
 
-    public static String asAccountString(final AccountID accountID) {
-        return String.format("%d.%d.%d", accountID.shardNum(), accountID.realmNum(), accountID.accountNum());
-    }
 }

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/HapiUtils.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/lifecycle/HapiUtils.java
@@ -81,5 +81,4 @@ public final class HapiUtils {
             out.writeNormalisedString(semVerPart);
         }
     }
-
 }


### PR DESCRIPTION
**Description**:

This PR moves  Move `asAccountString` to `hapi` module (from `com.swirlds.state.lifecycle.HapiUtils` to `com.hedera.hapi.util.HapiUtils`)

**Related issue(s)**:

Fixes #21269 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
