### PR TITLE
feat: Implement quiescence feature in the event creator

### DIFF
--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/EventCreationStatus.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/EventCreationStatus.java
@@ -29,6 +29,10 @@ public enum EventCreationStatus {
      */
     PLATFORM_STATUS,
     /**
+     * Event creation is paused due to network being quiet
+     */
+    QUIESCENCE,
+    /**
      * Event creation is not permitted because this node is currently overloaded and is not keeping up with the required
      * work load.
      */

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/QuiescenceRule.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/QuiescenceRule.java
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.event.creator.impl.rules;
+
+import static org.hiero.consensus.event.creator.impl.EventCreationStatus.QUIESCENCE;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+import java.util.function.Supplier;
+import org.hiero.consensus.event.creator.impl.EventCreationStatus;
+import org.hiero.consensus.model.quiescence.QuiescenceCommand;
+
+public class QuiescenceRule implements EventCreationRule {
+
+    private final Supplier<QuiescenceCommand> quiescenceCommandSupplier;
+
+    /**
+     * Constructor.
+     *
+     * @param quiescenceCommandSupplier provides the current quiescence status
+     */
+    public QuiescenceRule(@NonNull final Supplier<QuiescenceCommand> quiescenceCommandSupplier) {
+        this.quiescenceCommandSupplier = Objects.requireNonNull(quiescenceCommandSupplier);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isEventCreationPermitted() {
+        final QuiescenceCommand currentStatus = quiescenceCommandSupplier.get();
+
+        return currentStatus != QuiescenceCommand.QUIESCE;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void eventWasCreated() {
+        // no-op
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @NonNull
+    @Override
+    public EventCreationStatus getEventCreationStatus() {
+        return QUIESCENCE;
+    }
+}

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/LatestEventTracker.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/LatestEventTracker.java
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.event.creator.impl.tipset;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.hiero.consensus.model.event.PlatformEvent;
+import org.hiero.consensus.model.hashgraph.EventWindow;
+import org.hiero.consensus.model.node.NodeId;
+
+public class LatestEventTracker {
+
+    private final Map<NodeId, PlatformEvent> latestEvents = new HashMap<>();
+
+    /**
+     * Add a new event. Parents are removed from the set of childless events. Event is ignored if there is another event
+     * from the same creator with a higher nGen. Causes any event by the same creator, if present, to be removed if it
+     * has a lower nGen. This is true even if the event being added is not a direct child (possible if there has been
+     * branching).
+     *
+     * @param event the event to add
+     */
+    public void addEvent(@NonNull final PlatformEvent event) {
+        Objects.requireNonNull(event);
+
+        final PlatformEvent existingEvent = latestEvents.get(event.getCreatorId());
+        if (existingEvent != null) {
+            if (existingEvent.getNGen() >= event.getNGen()) {
+                // Only add a new event if it has the highest ngen of all events observed so far.
+                return;
+            }
+        }
+        latestEvents.put(event.getCreatorId(), event);
+    }
+
+    /**
+     * Remove ancient events.
+     *
+     * @param eventWindow the event window
+     */
+    public void pruneOldEvents(@NonNull final EventWindow eventWindow) {
+        final Set<NodeId> keysToRemove = new HashSet<>();
+        latestEvents.forEach((key, event) -> {
+            if (eventWindow.isAncient(event)) {
+                keysToRemove.add(key);
+            }
+        });
+        latestEvents.keySet().removeAll(keysToRemove);
+    }
+
+    /**
+     * Get random event from any creator except ourselves
+     *
+     * @param selfId our own node id
+     * @return event from other creator or null if nothing is available
+     */
+    public PlatformEvent getRandomNonSelfEvent(@NonNull final NodeId selfId, @NonNull final SecureRandom random) {
+        final List<NodeId> creators = new ArrayList<>(latestEvents.keySet());
+        creators.remove(selfId);
+        if (creators.isEmpty()) {
+            return null;
+        }
+        final int randomIndex = random.nextInt(creators.size());
+        return latestEvents.get(creators.get(randomIndex));
+    }
+}

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTests.java
@@ -13,6 +13,7 @@ import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTe
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils.validateNewEventAndMaybeAdvanceCreatorScore;
 import static org.hiero.consensus.model.hashgraph.ConsensusConstants.ROUND_FIRST;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -38,6 +39,7 @@ import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.quiescence.QuiescenceCommand;
 import org.hiero.consensus.model.test.fixtures.hashgraph.EventWindowBuilder;
 import org.hiero.junit.extensions.ParamName;
 import org.hiero.junit.extensions.ParamSource;
@@ -51,11 +53,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 class TipsetEventCreatorTests {
 
     /**
-     * This test simulates the creation and propagation of events in a small network of simulated nodes (networkSize = 10).
-     * It iterates 100 times, and within each iteration, it cycles through all nodes in the roster in order.
-     * For each node, it potentially advances a simulated clock (if advancingClock is true), generates random transactions, triggers the node to create a new event, distributes this event to other nodes, and then validates the newly created event.
-     * The test asserts that every node is always able to create an event and, if the clock is advancing, that the event's creation time matches the simulated current time.
-     * The ancientMode parameter is used to assign a birthround or a generation at the time the event is being created.
+     * This test simulates the creation and propagation of events in a small network of simulated nodes (networkSize =
+     * 10). It iterates 100 times, and within each iteration, it cycles through all nodes in the roster in order. For
+     * each node, it potentially advances a simulated clock (if advancingClock is true), generates random transactions,
+     * triggers the node to create a new event, distributes this event to other nodes, and then validates the newly
+     * created event. The test asserts that every node is always able to create an event and, if the clock is advancing,
+     * that the event's creation time matches the simulated current time. The ancientMode parameter is used to assign a
+     * birthround or a generation at the time the event is being created.
      *
      * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
      */
@@ -108,20 +112,22 @@ class TipsetEventCreatorTests {
                 }
 
                 validateNewEventAndMaybeAdvanceCreatorScore(
-                        events, event, transactionSupplier.get(), nodes.get(nodeId), false);
+                        events, event, transactionSupplier.get(), nodes.get(nodeId), false, false);
             }
         }
     }
 
     /**
-     * This test simulates the creation and propagation of events in a small network of simulated nodes (networkSize = 10).
-     * It iterates 100 times, and within each iteration, it cycles through all nodes in randomized order.
-     * For each node, it potentially advances a simulated clock (if advancingClock is true), generates random transactions, triggers the node to create a new event, distributes this event to other nodes, and then validates the newly created event.
-     * The test asserts that every node is always able to create an event and, if the clock is advancing, that the event's creation time matches the simulated current time.
-     * The ancientMode parameter is used to assign a birthround or a generation at the time the event is being created.
+     * This test simulates the creation and propagation of events in a small network of simulated nodes (networkSize =
+     * 10). It iterates 100 times, and within each iteration, it cycles through all nodes in randomized order. For each
+     * node, it potentially advances a simulated clock (if advancingClock is true), generates random transactions,
+     * triggers the node to create a new event, distributes this event to other nodes, and then validates the newly
+     * created event. The test asserts that every node is always able to create an event and, if the clock is advancing,
+     * that the event's creation time matches the simulated current time. The ancientMode parameter is used to assign a
+     * birthround or a generation at the time the event is being created.
      *
      * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random         {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -184,7 +190,7 @@ class TipsetEventCreatorTests {
                     assertEquals(event.getTimeCreated(), time.now());
                 }
                 validateNewEventAndMaybeAdvanceCreatorScore(
-                        events, event, transactionSupplier.get(), nodes.get(nodeId), false);
+                        events, event, transactionSupplier.get(), nodes.get(nodeId), false, false);
             }
 
             assertTrue(atLeastOneEventCreated);
@@ -197,7 +203,7 @@ class TipsetEventCreatorTests {
      * but should not fail if we have cleared the vent creator.
      *
      * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random         {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -261,7 +267,7 @@ class TipsetEventCreatorTests {
                         assertEquals(event.getTimeCreated(), time.now());
                     }
                     validateNewEventAndMaybeAdvanceCreatorScore(
-                            events, event, transactionSupplier.get(), nodes.get(nodeId), false);
+                            events, event, transactionSupplier.get(), nodes.get(nodeId), false, false);
                 }
 
                 assertTrue(atLeastOneEventCreated);
@@ -285,7 +291,7 @@ class TipsetEventCreatorTests {
      * unable to create another event without first receiving an event from another node.
      *
      * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random         {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -346,7 +352,7 @@ class TipsetEventCreatorTests {
                         assertEquals(event.getTimeCreated(), time.now());
                     }
                     validateNewEventAndMaybeAdvanceCreatorScore(
-                            events, event, transactionSupplier.get(), nodes.get(nodeId), false);
+                            events, event, transactionSupplier.get(), nodes.get(nodeId), false, false);
 
                     // At best, we can create a genesis event and one event per node in the network.
                     // We are unlikely to create this many, but we definitely shouldn't be able to go beyond this.
@@ -354,6 +360,102 @@ class TipsetEventCreatorTests {
                     count++;
                 }
             }
+        }
+    }
+
+    /**
+     * This test simulates the creation and propagation of events in a small network of simulated nodes (networkSize =
+     * 10). It iterates 100 times, and within each iteration, it cycles through all nodes in randomized order. For each
+     * node, it potentially advances a simulated clock (if advancingClock is true), generates random transactions,
+     * triggers the node to create a new event, distributes this event to other nodes, and then validates the newly
+     * created event. The test asserts that every node is always able to create an event and, if the clock is advancing,
+     * that the event's creation time matches the simulated current time. The ancientMode parameter is used to assign a
+     * birthround or a generation at the time the event is being created. Additionally, if event cannot be created due
+     * to eligible parent constraints, it forces the break quiescence event to be generated, to check that it is
+     * possible in case we need that.
+     *
+     * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
+     * @param random         {@link RandomUtils#getRandomPrintSeed()}
+     */
+    @TestTemplate
+    @ExtendWith(ParameterCombinationExtension.class)
+    @UseParameterSources({
+        @ParamSource(
+                param = "advancingClock",
+                fullyQualifiedClass = "org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreatorTestUtils",
+                method = "booleanValues"),
+        @ParamSource(
+                param = "random",
+                fullyQualifiedClass = "org.hiero.base.utility.test.fixtures.RandomUtils",
+                method = "getRandomPrintSeed")
+    })
+    @DisplayName("Create many events including breaking quiescence")
+    void createManyEventsAndBreakQuiescenceTest(
+            @ParamName("advancingClock") final boolean advancingClock, @ParamName("random") final Random random) {
+
+        final int networkSize = 10;
+
+        final Roster roster =
+                RandomRosterBuilder.create(random).withSize(networkSize).build();
+
+        final FakeTime time = new FakeTime();
+
+        final AtomicReference<List<Bytes>> transactionSupplier = new AtomicReference<>();
+
+        final Map<NodeId, SimulatedNode> nodes = buildSimulatedNodes(random, time, roster, transactionSupplier::get);
+
+        final Map<EventDescriptorWrapper, PlatformEvent> events = new HashMap<>();
+
+        for (int eventIndex = 0; eventIndex < 100; eventIndex++) {
+
+            final List<RosterEntry> addresses = new ArrayList<>(roster.rosterEntries());
+            Collections.shuffle(addresses, random);
+
+            boolean atLeastOneEventCreated = false;
+
+            for (final RosterEntry address : addresses) {
+                if (advancingClock) {
+                    time.tick(Duration.ofMillis(10));
+                }
+
+                transactionSupplier.set(generateRandomTransactions(random));
+
+                final NodeId nodeId = NodeId.of(address.nodeId());
+                final EventCreator eventCreator = nodes.get(nodeId).eventCreator();
+
+                PlatformEvent event = eventCreator.maybeCreateEvent();
+                boolean breakQuiescence = false;
+
+                // It's possible a node may not be able to create an event. But we are guaranteed
+                // to be able to create at least one event per cycle.
+                if (event == null) {
+                    // if we are enough advanced through the hashgraph and failed to create event advancing the score
+                    // let's try to pretend we are breaking quiescence and force creation of event anyway
+                    if (eventIndex > 20) {
+                        eventCreator.quiescenceCommand(QuiescenceCommand.BREAK_QUIESCENCE);
+                        event = eventCreator.maybeCreateEvent();
+                        assertNotNull(event);
+                        assertNotEquals(
+                                event.getSelfParent().creator(),
+                                event.getOtherParents().getFirst().creator());
+                        eventCreator.quiescenceCommand(QuiescenceCommand.DONT_QUIESCE);
+                        breakQuiescence = true;
+                    } else {
+                        continue;
+                    }
+                }
+                atLeastOneEventCreated = true;
+
+                assignNGenAndDistributeEvent(nodes, events, event);
+
+                if (advancingClock) {
+                    assertEquals(event.getTimeCreated(), time.now());
+                }
+                validateNewEventAndMaybeAdvanceCreatorScore(
+                        events, event, transactionSupplier.get(), nodes.get(nodeId), false, breakQuiescence);
+            }
+
+            assertTrue(atLeastOneEventCreated);
         }
     }
 
@@ -448,7 +550,7 @@ class TipsetEventCreatorTests {
                     assertEquals(newEvent.getTimeCreated(), time.now());
                 }
                 validateNewEventAndMaybeAdvanceCreatorScore(
-                        allEvents, newEvent, transactionSupplier.get(), nodes.get(nodeId), false);
+                        allEvents, newEvent, transactionSupplier.get(), nodes.get(nodeId), false, false);
             }
 
             assertTrue(atLeastOneEventCreated);
@@ -467,7 +569,7 @@ class TipsetEventCreatorTests {
      * that they do not get transitive tipset score improvements by using it.
      *
      * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random         {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -576,7 +678,7 @@ class TipsetEventCreatorTests {
                     assertEquals(newEvent.getTimeCreated(), time.now());
                 }
                 validateNewEventAndMaybeAdvanceCreatorScore(
-                        allEvents, newEvent, transactionSupplier.get(), nodes.get(nodeId), true);
+                        allEvents, newEvent, transactionSupplier.get(), nodes.get(nodeId), true, false);
             }
 
             assertTrue(atLeastOneEventCreated);
@@ -590,11 +692,11 @@ class TipsetEventCreatorTests {
     }
 
     /**
-     *  This test evaluates the corner case of 1 node network.
-     *  it should be impossible for a node to be unable to create an event.
+     * This test evaluates the corner case of 1 node network. it should be impossible for a node to be unable to create
+     * an event.
      *
      * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random         {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -654,7 +756,8 @@ class TipsetEventCreatorTests {
      * There was once a bug that could cause event creation to become frozen. This was because we weren't properly
      * including the advancement weight of the self parent when considering the theoretical advancement weight of a new
      * event.
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     *
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -739,7 +842,7 @@ class TipsetEventCreatorTests {
     /**
      * Event from nodes not in the address book should not be used as parents for creating new events.
      *
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -816,7 +919,8 @@ class TipsetEventCreatorTests {
     /**
      * There was once a bug where it was possible to create a self event that was stale at the moment of its creation
      * time. This test verifies that this is no longer possible.
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     *
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -853,8 +957,9 @@ class TipsetEventCreatorTests {
     /**
      * Checks that birth round on events is being set if the setting for using birth round is set.
      * <p>
-     * @param advancingClock  {@link TipsetEventCreatorTestUtils#booleanValues()}
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     *
+     * @param advancingClock {@link TipsetEventCreatorTestUtils#booleanValues()}
+     * @param random         {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -980,7 +1085,7 @@ class TipsetEventCreatorTests {
      * This test verifies that an event recently created by the event creator is not overwritten when it learns of a
      * self event for the first time from the intake pipeline.
      *
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -1024,12 +1129,11 @@ class TipsetEventCreatorTests {
     }
 
     /**
-     * This test verifies that the event creator assigns the propper creationTime in the following scenario:
-     *   - the parent has no transactions
-     *  - current time (wall clock) is after the parent's creation time
-     * We expect the new event creation time to be the current time.
+     * This test verifies that the event creator assigns the propper creationTime in the following scenario: - the
+     * parent has no transactions - current time (wall clock) is after the parent's creation time We expect the new
+     * event creation time to be the current time.
      *
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -1064,12 +1168,11 @@ class TipsetEventCreatorTests {
     }
 
     /**
-     * This test verifies that the event creator assigns the propper creationTime for an event in the following scenario:
-     *  - the parent has transactions
-     *  - current time (wall clock) is after the parent's last transaction time
+     * This test verifies that the event creator assigns the propper creationTime for an event in the following
+     * scenario: - the parent has transactions - current time (wall clock) is after the parent's last transaction time
      * We expect the new event creation time to be the current time.
      *
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -1102,12 +1205,11 @@ class TipsetEventCreatorTests {
     }
 
     /**
-     * This test verifies that the event creator assigns the propper creationTime for an event in the following scenario:
-     * - the parent has transactions
-     * - current time (wall clock) is before the parent's last transaction time
+     * This test verifies that the event creator assigns the propper creationTime for an event in the following
+     * scenario: - the parent has transactions - current time (wall clock) is before the parent's last transaction time
      * We expect the new event creation time to be set to the parent's creation time + number of transactions.
      *
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -1142,12 +1244,11 @@ class TipsetEventCreatorTests {
     }
 
     /**
-     * This test verifies that the event creator assigns the propper creationTime for an event in the following scenarioi:
-     *  - the parent has no transactions
-     *  - current time (wall clock) is the same as the parent's creation time
+     * This test verifies that the event creator assigns the propper creationTime for an event in the following
+     * scenarioi: - the parent has no transactions - current time (wall clock) is the same as the parent's creation time
      * We expect the new event creation time to be set to the parent's creation time + a fixed delta.
      *
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -1177,7 +1278,8 @@ class TipsetEventCreatorTests {
 
     /**
      * This test verifies that the event creator assigns the coin value correctly for a new event.
-     * @param random  {@link RandomUtils#getRandomPrintSeed()}
+     *
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
      */
     @TestTemplate
     @ExtendWith(ParameterCombinationExtension.class)
@@ -1203,5 +1305,37 @@ class TipsetEventCreatorTests {
         assertTrue(
                 event.getEventCore().coin() <= networkSize,
                 "The maximum coin value should be equal to the network size");
+    }
+
+    /**
+     * Let's make sure that we are not creating events when quiescencing
+     *
+     * @param random {@link RandomUtils#getRandomPrintSeed()}
+     */
+    @TestTemplate
+    @ExtendWith(ParameterCombinationExtension.class)
+    @UseParameterSources({
+        @ParamSource(
+                param = "random",
+                fullyQualifiedClass = "org.hiero.base.utility.test.fixtures.RandomUtils",
+                method = "getRandomPrintSeed")
+    })
+    @DisplayName("no events when quiescencing")
+    void quiescenceTest(@ParamName("random") final Random random) {
+
+        // Common test set up. We initialize a network to make it easier to create events.
+        final int networkSize = random.nextInt(1, 100);
+        final Roster roster =
+                RandomRosterBuilder.create(random).withSize(networkSize).build();
+        final EventCreator eventCreator =
+                buildEventCreator(random, new FakeTime(), roster, NodeId.of(0), Collections::emptyList);
+
+        eventCreator.quiescenceCommand(QuiescenceCommand.QUIESCE);
+        var event = eventCreator.maybeCreateEvent(); // the self-parent
+        assertNull(event, "An event should have not been created");
+
+        eventCreator.quiescenceCommand(QuiescenceCommand.DONT_QUIESCE);
+        event = eventCreator.maybeCreateEvent(); // the self-parent
+        assertNotNull(event, "An event should have been created when switched back to active");
     }
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -433,7 +433,7 @@ public class SwirldsPlatform implements Platform {
 
     @Override
     public void quiescenceCommand(@NonNull final QuiescenceCommand quiescenceCommand) {
-        platformCoordinator.setQuiescenceStatus(quiescenceCommand);
+        platformCoordinator.quiescenceCommand(quiescenceCommand);
     }
 
     /**

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/wiring/PlatformCoordinator.java
@@ -362,7 +362,7 @@ public record PlatformCoordinator(@NonNull PlatformComponents components) implem
     /**
      * @see EventCreatorModule#quiescenceCommand(QuiescenceCommand)
      */
-    public void setQuiescenceStatus(@NonNull final QuiescenceCommand quiescenceCommand) {
+    public void quiescenceCommand(@NonNull final QuiescenceCommand quiescenceCommand) {
         components
                 .eventCreationManagerWiring()
                 .getInputWire(EventCreatorModule::quiescenceCommand)


### PR DESCRIPTION
**Description**:
Event creator should not produce event if system is in quiescence mode. It should try its best to create events, even if useful parents are not available if we are breaking quiescence.

Please check https://github.com/hiero-ledger/hiero-improvement-proposals/blob/main/HIP/hip-1238.md for details.

**Related issue(s)**:

Fixes #21111 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
