### PR TITLE
fix: Fix some BN communication XTS tests

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
@@ -312,7 +312,6 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
      * notifying the connection manager and calling onComplete on the request pipeline.
      */
     public void handleStreamFailure() {
-        logger.debug("[{}] handleStreamFailure", this);
         closeAndReschedule(THIRTY_SECONDS, true);
     }
 
@@ -321,7 +320,6 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
      * notifying the connection manager without calling onComplete on the request pipeline.
      */
     public void handleStreamFailureWithoutOnComplete() {
-        logger.debug("[{}] handleStreamFailureWithoutOnComplete", this);
         closeAndReschedule(THIRTY_SECONDS, false);
     }
 
@@ -529,12 +527,6 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
                         .latestBlockNumber(highestAckedBlockNumber))
                 .build();
 
-        logger.debug(
-                "[{}] Sending EndStream request with code {} (earliestBlockNumber={}, highestAckedBlockNumber={})",
-                this,
-                code,
-                earliestBlockNumber,
-                highestAckedBlockNumber);
         sendRequest(endStream);
         close(true);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
@@ -281,7 +281,7 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
      */
     private void closeAndReschedule(@Nullable final Duration delay, final boolean callOnComplete) {
         close(callOnComplete);
-        blockNodeConnectionManager.rescheduleConnection(this, delay, null);
+        blockNodeConnectionManager.rescheduleConnection(this, delay, null, true);
     }
 
     /**
@@ -293,7 +293,7 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
     private void endStreamAndReschedule(@NonNull final EndStream.Code code) {
         requireNonNull(code, "code must not be null");
         endTheStreamWith(code);
-        blockNodeConnectionManager.rescheduleConnection(this, BlockNodeConnection.THIRTY_SECONDS, null);
+        blockNodeConnectionManager.rescheduleConnection(this, BlockNodeConnection.THIRTY_SECONDS, null, true);
     }
 
     /**
@@ -304,7 +304,7 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
      */
     private void closeAndRestart(final long blockNumber) {
         close(true);
-        blockNodeConnectionManager.rescheduleConnection(this, null, blockNumber);
+        blockNodeConnectionManager.rescheduleConnection(this, null, blockNumber, false);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnection.java
@@ -527,6 +527,12 @@ public class BlockNodeConnection implements Pipeline<PublishStreamResponse> {
                         .latestBlockNumber(highestAckedBlockNumber))
                 .build();
 
+        logger.debug(
+                "[{}] Sending EndStream request with code {} (earliestBlockNumber={}, highestAckedBlockNumber={})",
+                this,
+                code,
+                earliestBlockNumber,
+                highestAckedBlockNumber);
         sendRequest(endStream);
         close(true);
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManager.java
@@ -357,11 +357,14 @@ public class BlockNodeConnectionManager {
      *
      * @param connection the connection to close and reschedule
      * @param delay the delay before attempting to reconnect
+     * @param blockNumber the block number to use once reconnected
+     * @param selectNewBlockNode whether to select a new block node to connect to while rescheduled
      */
     public void rescheduleConnection(
             @NonNull final BlockNodeConnection connection,
             @Nullable final Duration delay,
-            @Nullable final Long blockNumber) {
+            @Nullable final Long blockNumber,
+            final boolean selectNewBlockNode) {
         if (!isStreamingEnabled.get()) {
             return;
         }
@@ -370,7 +373,7 @@ public class BlockNodeConnectionManager {
         logger.warn("[{}] Closing and rescheduling connection for reconnect attempt", connection);
 
         // Handle cleanup and rescheduling
-        handleConnectionCleanupAndReschedule(connection, delay, blockNumber);
+        handleConnectionCleanupAndReschedule(connection, delay, blockNumber, selectNewBlockNode);
     }
 
     /**
@@ -378,7 +381,10 @@ public class BlockNodeConnectionManager {
      * This centralizes the retry and node selection logic.
      */
     private void handleConnectionCleanupAndReschedule(
-            @NonNull final BlockNodeConnection connection, @Nullable Duration delay, @Nullable final Long blockNumber) {
+            @NonNull final BlockNodeConnection connection,
+            @Nullable Duration delay,
+            @Nullable final Long blockNumber,
+            final boolean selectNewBlockNode) {
         // Remove from connections map and clear active reference
         removeConnectionAndClearActive(connection);
 
@@ -407,7 +413,7 @@ public class BlockNodeConnectionManager {
 
         scheduleConnectionAttempt(connection.getNodeConfig(), Duration.ofMillis(delayMs), blockNumber, false);
 
-        if (!isOnlyOneBlockNodeConfigured()) {
+        if (!isOnlyOneBlockNodeConfigured() && selectNewBlockNode) {
             // Immediately try to find and connect to the next available node
             selectNewBlockNodeForStreaming(false);
         }
@@ -782,7 +788,7 @@ public class BlockNodeConnectionManager {
                     latestBlockNumber);
 
             connection.close(true);
-            rescheduleConnection(connection, THIRTY_SECONDS, null);
+            rescheduleConnection(connection, THIRTY_SECONDS, null, true);
             return true;
         }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionManagerTest.java
@@ -178,7 +178,7 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         final Duration delay = Duration.ofSeconds(1);
         doReturn(nodeConfig).when(connection).getNodeConfig();
 
-        connectionManager.rescheduleConnection(connection, delay, null);
+        connectionManager.rescheduleConnection(connection, delay, null, true);
 
         // Verify task created to reconnect to the failing connection after a delay
         verify(executorService)
@@ -198,10 +198,10 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         final BlockNodeConfig nodeConfig = newBlockNodeConfig(8080, 1);
         doReturn(nodeConfig).when(connection).getNodeConfig();
 
-        connectionManager.rescheduleConnection(connection, Duration.ZERO, null);
-        connectionManager.rescheduleConnection(connection, Duration.ofMillis(10L), null);
-        connectionManager.rescheduleConnection(connection, Duration.ofMillis(20L), null);
-        connectionManager.rescheduleConnection(connection, Duration.ofMillis(30L), null);
+        connectionManager.rescheduleConnection(connection, Duration.ZERO, null, true);
+        connectionManager.rescheduleConnection(connection, Duration.ofMillis(10L), null, true);
+        connectionManager.rescheduleConnection(connection, Duration.ofMillis(20L), null, true);
+        connectionManager.rescheduleConnection(connection, Duration.ofMillis(30L), null, true);
 
         assertThat(retryStates).hasSize(1);
         assertThat(retryStates.get(nodeConfig).getRetryAttempt()).isEqualTo(4);
@@ -223,9 +223,9 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
 
         connectionManager = new BlockNodeConnectionManager(configProvider, bufferService, metrics, executorService);
 
-        connectionManager.rescheduleConnection(connection, Duration.ZERO, null);
+        connectionManager.rescheduleConnection(connection, Duration.ZERO, null, true);
         Thread.sleep(1_000L); // sleep to ensure the backoff timeframe has passed
-        connectionManager.rescheduleConnection(connection, Duration.ZERO, null);
+        connectionManager.rescheduleConnection(connection, Duration.ZERO, null, true);
 
         final Map<BlockNodeConfig, RetryState> retryStates = retryStates();
         assertThat(retryStates).hasSize(1);
@@ -1384,7 +1384,7 @@ class BlockNodeConnectionManagerTest extends BlockNodeCommunicationTestBase {
         isStreamingEnabled.set(false);
         final BlockNodeConnection connection = mock(BlockNodeConnection.class);
 
-        connectionManager.rescheduleConnection(connection, Duration.ZERO, null);
+        connectionManager.rescheduleConnection(connection, Duration.ZERO, null, true);
 
         verifyNoInteractions(connection);
         verifyNoInteractions(bufferService);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeConnectionTest.java
@@ -157,7 +157,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         assertThat(postState).isEqualTo(ConnectionState.CLOSED);
 
         verify(requestPipeline).onComplete();
-        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null);
+        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null, true);
         verify(connectionManager).jumpToBlock(-1L);
         verifyNoMoreInteractions(requestPipeline);
         verifyNoMoreInteractions(connectionManager);
@@ -271,7 +271,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(metrics).recordConnectionClosed();
         verify(requestPipeline).onComplete();
         verify(connectionManager).jumpToBlock(-1L);
-        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null);
+        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null, true);
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
@@ -294,7 +294,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verify(requestPipeline).onComplete();
         verify(connectionManager).jumpToBlock(-1L);
-        verify(connectionManager).rescheduleConnection(connection, null, 11L);
+        verify(connectionManager).rescheduleConnection(connection, null, 11L, false);
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
@@ -313,7 +313,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(requestPipeline).onComplete();
         verify(connectionManager).jumpToBlock(-1L);
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
-        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null);
+        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null, true);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
     }
@@ -333,7 +333,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(connectionManager).currentStreamingBlockNumber();
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verify(connectionManager).jumpToBlock(-1L);
-        verify(connectionManager).rescheduleConnection(connection, null, 11L);
+        verify(connectionManager).rescheduleConnection(connection, null, 11L, false);
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verify(bufferService).getBlockState(11L);
         verifyNoMoreInteractions(metrics);
@@ -357,7 +357,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(bufferService).getBlockState(11L);
         verify(requestPipeline).onNext(createRequest(EndStream.Code.TOO_FAR_BEHIND));
         verify(requestPipeline).onComplete();
-        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null);
+        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null, true);
         verify(connectionManager).jumpToBlock(-1L);
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
@@ -376,7 +376,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(metrics).recordConnectionClosed();
         verify(requestPipeline).onComplete();
         verify(connectionManager).jumpToBlock(-1L);
-        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null);
+        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null, true);
         verify(connectionManager).updateLastVerifiedBlock(connection.getNodeConfig(), 10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
@@ -444,7 +444,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
         verify(metrics).recordConnectionClosed();
         verify(requestPipeline).onComplete();
         verify(connectionManager).jumpToBlock(-1L);
-        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null);
+        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null, true);
         verify(bufferService).getBlockState(10L);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
@@ -637,7 +637,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
 
         verify(connectionManager).jumpToBlock(-1L);
         verify(requestPipeline).onComplete();
-        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null);
+        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null, true);
         verifyNoMoreInteractions(metrics);
         verifyNoMoreInteractions(requestPipeline);
         verifyNoMoreInteractions(connectionManager);
@@ -682,7 +682,7 @@ class BlockNodeConnectionTest extends BlockNodeCommunicationTestBase {
 
         verify(connectionManager).jumpToBlock(-1L);
         verify(requestPipeline).onComplete();
-        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null);
+        verify(connectionManager).rescheduleConnection(connection, Duration.ofSeconds(30), null, true);
         verify(metrics).recordConnectionOnComplete();
         verify(metrics).recordConnectionClosed();
         verifyNoMoreInteractions(metrics);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
@@ -151,7 +151,6 @@ public class BlockNodeSuite {
                         spec -> LockSupport.parkNanos(Duration.ofSeconds(10).toNanos())));
     }
 
-    @Disabled
     @HapiTest
     @HapiBlockNode(
             networkSize = 1,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSuite.java
@@ -151,6 +151,7 @@ public class BlockNodeSuite {
                         spec -> LockSupport.parkNanos(Duration.ofSeconds(10).toNanos())));
     }
 
+    @Disabled
     @HapiTest
     @HapiBlockNode(
             networkSize = 1,
@@ -189,7 +190,6 @@ public class BlockNodeSuite {
                         connectionDropTime::get,
                         Duration.ofMinutes(1),
                         Duration.ofSeconds(45),
-                        "onError invoked",
                         String.format("Selected block node localhost:%s for connection attempt", portNumbers.get(1)),
                         String.format(
                                 "/localhost:%s/PENDING] Connection state transitioned from UNINITIALIZED to PENDING",
@@ -582,13 +582,13 @@ public class BlockNodeSuite {
         return hapiTest(
                 waitUntilNextBlocks(1).withBackgroundTraffic(true),
                 doingContextual(spec -> time.set(Instant.now())),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(5L),
+                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(1L),
                 waitUntilNextBlocks(1).withBackgroundTraffic(true),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(8L),
+                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(2L),
                 waitUntilNextBlocks(1).withBackgroundTraffic(true),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(11L),
+                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(3L),
                 waitUntilNextBlocks(1).withBackgroundTraffic(true),
-                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(14L),
+                blockNode(0).sendEndOfStreamImmediately(Code.BEHIND).withBlockNumber(4L),
                 sourcingContextual(spec -> assertHgcaaLogContainsTimeframe(
                         byNodeId(0),
                         time::get,


### PR DESCRIPTION
**Description**:
This PR fixes two BN communication suite tests part of the XTS tests.

Fixing the behaviour when we want to restart a connection to a particular block node. In this case, we don't want to select a new block node while the reschedule period elapses, but restart the same connection to that block node

**Related issue(s)**:

Fixes #


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
