### PR TITLE
feat: 21372: MerkleDb: dirty leaves and dirty leaf paths can be handled in parallel during flushes

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/CloseFlushTest.java
@@ -20,13 +20,13 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Stream;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.core.config.Configurator;
 import org.hiero.base.crypto.Hash;
@@ -146,9 +146,9 @@ public class CloseFlushTest {
                 public void saveRecords(
                         final long firstLeafPath,
                         final long lastLeafPath,
-                        @NonNull final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
-                        @NonNull final Stream<VirtualLeafBytes> leafRecordsToAddOrUpdate,
-                        @NonNull final Stream<VirtualLeafBytes> leafRecordsToDelete,
+                        @NonNull final List<VirtualHashRecord> pathHashRecordsToUpdate,
+                        @NonNull final List<VirtualLeafBytes> leafRecordsToAddOrUpdate,
+                        @NonNull final List<VirtualLeafBytes> leafRecordsToDelete,
                         final boolean isReconnectContext) {
                     try {
                         delegate.saveRecords(

--- a/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-platform-core/src/test/java/com/swirlds/platform/reconnect/VirtualMapReconnectTestBase.java
@@ -30,7 +30,6 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Stream;
 import org.hiero.base.constructable.ClassConstructorPair;
 import org.hiero.base.constructable.ConstructableRegistry;
 import org.hiero.base.constructable.ConstructableRegistryException;
@@ -203,15 +202,13 @@ public abstract class VirtualMapReconnectTestBase {
         public void saveRecords(
                 final long firstLeafPath,
                 final long lastLeafPath,
-                @NonNull final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
-                @NonNull final Stream<VirtualLeafBytes> leafRecordsToAddOrUpdate,
-                @NonNull final Stream<VirtualLeafBytes> leafRecordsToDelete,
+                @NonNull final List<VirtualHashRecord> pathHashRecordsToUpdate,
+                @NonNull final List<VirtualLeafBytes> leafRecordsToAddOrUpdate,
+                @NonNull final List<VirtualLeafBytes> leafRecordsToDelete,
                 final boolean isReconnectContext)
                 throws IOException {
-            final List<VirtualLeafBytes> leaves = leafRecordsToAddOrUpdate.toList();
-
             if (builder.numTimesBroken < builder.numTimesToBreak) {
-                builder.numCalls += leaves.size();
+                builder.numCalls += leafRecordsToAddOrUpdate.size();
                 if (builder.numCalls > builder.numCallsBeforeThrow) {
                     builder.numCalls = 0;
                     builder.numTimesBroken++;
@@ -224,7 +221,7 @@ public abstract class VirtualMapReconnectTestBase {
                     firstLeafPath,
                     lastLeafPath,
                     pathHashRecordsToUpdate,
-                    leaves.stream(),
+                    leafRecordsToAddOrUpdate,
                     leafRecordsToDelete,
                     isReconnectContext);
         }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSource.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualDataSource.java
@@ -7,6 +7,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.stream.Stream;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
@@ -65,11 +66,11 @@ public interface VirtualDataSource {
      * @param lastLeafPath
      *      the tree path for last leaf
      * @param pathHashRecordsToUpdate
-     * 		stream of dirty hash records to update
+     * 		list of dirty hash records to update
      * @param leafRecordsToAddOrUpdate
-     * 		stream of new and updated leaf node bytes
+     * 		list of new and updated leaf node bytes
      * @param leafRecordsToDelete
-     * 		stream of new leaf node bytes to delete, The leaf record's key and path have to be
+     * 		list of new leaf node bytes to delete, The leaf record's key and path have to be
      * 		populated, all other data can be null
      * @throws IOException If there was a problem saving changes to data source
      */
@@ -83,9 +84,9 @@ public interface VirtualDataSource {
         saveRecords(
                 firstLeafPath,
                 lastLeafPath,
-                pathHashRecordsToUpdate,
-                leafRecordsToAddOrUpdate,
-                leafRecordsToDelete,
+                pathHashRecordsToUpdate.toList(),
+                leafRecordsToAddOrUpdate.toList(),
+                leafRecordsToDelete.toList(),
                 false);
     }
 
@@ -110,9 +111,9 @@ public interface VirtualDataSource {
     void saveRecords(
             final long firstLeafPath,
             final long lastLeafPath,
-            @NonNull final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
-            @NonNull final Stream<VirtualLeafBytes> leafRecordsToAddOrUpdate,
-            @NonNull final Stream<VirtualLeafBytes> leafRecordsToDelete,
+            @NonNull final List<VirtualHashRecord> pathHashRecordsToUpdate,
+            @NonNull final List<VirtualLeafBytes> leafRecordsToAddOrUpdate,
+            @NonNull final List<VirtualLeafBytes> leafRecordsToDelete,
             final boolean isReconnectContext)
             throws IOException;
 

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashLeafFlusher.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashLeafFlusher.java
@@ -174,13 +174,7 @@ public class ReconnectHashLeafFlusher {
             // flush it down
             final long start = System.currentTimeMillis();
             try {
-                dataSource.saveRecords(
-                        firstLeafPath,
-                        lastLeafPath,
-                        hashesToFlush.stream(),
-                        leavesToFlush.stream(),
-                        leavesToDelete.stream(),
-                        true);
+                dataSource.saveRecords(firstLeafPath, lastLeafPath, hashesToFlush, leavesToFlush, leavesToDelete, true);
                 final long end = System.currentTimeMillis();
                 statistics.recordFlush(end - start);
                 logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flushed in {} ms", end - start);

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/merkle/RecordAccessorTest.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.stream.Stream;
 import org.hiero.base.crypto.Cryptography;
 import org.hiero.base.crypto.CryptographyProvider;
@@ -307,9 +308,9 @@ public class RecordAccessorTest {
         public void saveRecords(
                 final long firstLeafPath,
                 final long lastLeafPath,
-                @NonNull final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
-                @NonNull final Stream<VirtualLeafBytes> leafRecordsToAddOrUpdate,
-                @NonNull final Stream<VirtualLeafBytes> leafRecordsToDelete,
+                @NonNull final List<VirtualHashRecord> pathHashRecordsToUpdate,
+                @NonNull final List<VirtualLeafBytes> leafRecordsToAddOrUpdate,
+                @NonNull final List<VirtualLeafBytes> leafRecordsToDelete,
                 final boolean isReconnectContext)
                 throws IOException {
             delegate.saveRecords(

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/ReconnectHashListenerTest.java
@@ -144,17 +144,20 @@ class ReconnectHashListenerTest {
         public void saveRecords(
                 final long firstLeafPath,
                 final long lastLeafPath,
-                @NonNull final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
-                @NonNull final Stream<VirtualLeafBytes> leafRecordsToAddOrUpdate,
-                @NonNull final Stream<VirtualLeafBytes> leafRecordsToDelete,
+                @NonNull final List<VirtualHashRecord> pathHashRecordsToUpdate,
+                @NonNull final List<VirtualLeafBytes> leafRecordsToAddOrUpdate,
+                @NonNull final List<VirtualLeafBytes> leafRecordsToDelete,
                 final boolean isReconnectContext)
                 throws IOException {
-            final var ir = pathHashRecordsToUpdate.toList();
-            this.internalRecords.add(ir);
-            final var lr = leafRecordsToAddOrUpdate.toList();
-            this.leafRecords.add(lr);
+            this.internalRecords.add(pathHashRecordsToUpdate);
+            this.leafRecords.add(leafRecordsToAddOrUpdate);
             delegate.saveRecords(
-                    firstLeafPath, lastLeafPath, ir.stream(), lr.stream(), leafRecordsToDelete, isReconnectContext);
+                    firstLeafPath,
+                    lastLeafPath,
+                    pathHashRecordsToUpdate,
+                    leafRecordsToAddOrUpdate,
+                    leafRecordsToDelete,
+                    isReconnectContext);
         }
 
         @Override
@@ -169,9 +172,9 @@ class ReconnectHashListenerTest {
             saveRecords(
                     firstLeafPath,
                     lastLeafPath,
-                    pathHashRecordsToUpdate,
-                    leafRecordsToAddOrUpdate,
-                    leafRecordsToDelete,
+                    pathHashRecordsToUpdate.toList(),
+                    leafRecordsToAddOrUpdate.toList(),
+                    leafRecordsToDelete.toList(),
                     true);
         }
 

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/reconnect/VirtualMapReconnectTestBase.java
@@ -34,8 +34,6 @@ import java.io.PrintStream;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.hiero.base.constructable.ClassConstructorPair;
 import org.hiero.base.constructable.ConstructableRegistry;
 import org.hiero.base.constructable.ConstructableRegistryException;
@@ -238,16 +236,14 @@ public abstract class VirtualMapReconnectTestBase {
         public void saveRecords(
                 long firstLeafPath,
                 long lastLeafPath,
-                @NonNull Stream<VirtualHashRecord> pathHashRecordsToUpdate,
-                @NonNull Stream<VirtualLeafBytes> leafRecordsToAddOrUpdate,
-                @NonNull Stream<VirtualLeafBytes> leafRecordsToDelete,
+                @NonNull List<VirtualHashRecord> pathHashRecordsToUpdate,
+                @NonNull List<VirtualLeafBytes> leafRecordsToAddOrUpdate,
+                @NonNull List<VirtualLeafBytes> leafRecordsToDelete,
                 boolean isReconnectContext)
                 throws IOException {
-            final List<VirtualLeafBytes> leaves = leafRecordsToAddOrUpdate.collect(Collectors.toList());
-
             if (builder.numTimesBroken < builder.numTimesToBreak) {
                 if (builder.numCalls <= builder.numCallsBeforeThrow) {
-                    builder.numCalls += leaves.size();
+                    builder.numCalls += leafRecordsToAddOrUpdate.size();
                     if (builder.numCalls > builder.numCallsBeforeThrow) {
                         builder.numTimesBroken++;
                         delegate.close();
@@ -260,7 +256,7 @@ public abstract class VirtualMapReconnectTestBase {
                     firstLeafPath,
                     lastLeafPath,
                     pathHashRecordsToUpdate,
-                    leaves.stream(),
+                    leafRecordsToAddOrUpdate,
                     leafRecordsToDelete,
                     isReconnectContext);
         }

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/InMemoryDataSource.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/InMemoryDataSource.java
@@ -9,9 +9,9 @@ import com.swirlds.virtualmap.datasource.VirtualLeafBytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Stream;
 import org.hiero.base.crypto.Hash;
 
 /**
@@ -77,9 +77,9 @@ public class InMemoryDataSource implements VirtualDataSource {
     public void saveRecords(
             final long firstLeafPath,
             final long lastLeafPath,
-            @NonNull final Stream<VirtualHashRecord> pathHashRecordsToUpdate,
-            @NonNull final Stream<VirtualLeafBytes> leafRecordsToAddOrUpdate,
-            @NonNull final Stream<VirtualLeafBytes> leafRecordsToDelete,
+            @NonNull final List<VirtualHashRecord> pathHashRecordsToUpdate,
+            @NonNull final List<VirtualLeafBytes> leafRecordsToAddOrUpdate,
+            @NonNull final List<VirtualLeafBytes> leafRecordsToDelete,
             final boolean isReconnectContext)
             throws IOException {
         if (failureOnSave) {
@@ -227,11 +227,10 @@ public class InMemoryDataSource implements VirtualDataSource {
     // =================================================================================================================
     // private methods
 
-    private void saveInternalRecords(final long maxValidPath, final Stream<VirtualHashRecord> pathHashRecords)
+    private void saveInternalRecords(final long maxValidPath, final List<VirtualHashRecord> pathHashRecords)
             throws IOException {
         final var itr = pathHashRecords.iterator();
-        while (itr.hasNext()) {
-            final var rec = itr.next();
+        for (var rec : pathHashRecords) {
             final var path = rec.path();
             final var hash = Objects.requireNonNull(rec.hash(), "The hash of a saved internal record cannot be null");
 
@@ -249,11 +248,10 @@ public class InMemoryDataSource implements VirtualDataSource {
     }
 
     private void saveLeafRecords(
-            final long firstLeafPath, final long lastLeafPath, final Stream<VirtualLeafBytes> leafRecords)
+            final long firstLeafPath, final long lastLeafPath, final List<VirtualLeafBytes> leafRecords)
             throws IOException {
         final var itr = leafRecords.iterator();
-        while (itr.hasNext()) {
-            final var rec = itr.next();
+        for (var rec : leafRecords) {
             final var path = rec.path();
             final var key = Objects.requireNonNull(rec.keyBytes(), "Key cannot be null");
             final var value = rec.valueBytes(); // Not sure if this can be null or not.
@@ -278,11 +276,9 @@ public class InMemoryDataSource implements VirtualDataSource {
         }
     }
 
-    private void deleteLeafRecords(
-            final Stream<VirtualLeafBytes> leafRecordsToDelete, final boolean isReconnectContext) {
+    private void deleteLeafRecords(final List<VirtualLeafBytes> leafRecordsToDelete, final boolean isReconnectContext) {
         final var itr = leafRecordsToDelete.iterator();
-        while (itr.hasNext()) {
-            final var rec = itr.next();
+        for (var rec : leafRecordsToDelete) {
             final long path = rec.path();
             final Bytes key = rec.keyBytes();
             final Long oldPath = keyToPathMap.get(key);


### PR DESCRIPTION
Fix summary: `MerkleDbDataSource.writeLeavesToPathToKeyValue()` method is split into two: to process dirty leaves and to process dirty leaf paths. These two methods are now run in parallel.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21372
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
