### PR TITLE
feat: Add v0.67 module and enable ops duration throttle; minor tweaks

### DIFF
--- a/hedera-node/configuration/dev/application.properties
+++ b/hedera-node/configuration/dev/application.properties
@@ -25,7 +25,7 @@ grpc.nodeOperatorPortEnabled=true
 # For CI tests we want to override roster weights from override-network.json
 networkAdmin.preserveStateWeightsDuringOverride=false
 contracts.systemContract.hts.addresses=359,364
-contracts.evm.version=v0.66
+contracts.evm.version=v0.67
 #Enforce native lib verification to not halt node on dev env
 contracts.evm.nativeLibVerification.halt.enabled=false
 # Disable TSS for PR checks by default because of the time overhead

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/ContractsConfig.java
@@ -19,8 +19,8 @@ public record ContractsConfig(
                 boolean noncesExternalizationEnabled,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean enforceCreationThrottle,
         @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerTransaction,
-        @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSec,
-        @ConfigProperty(defaultValue = "15000000") @NetworkProperty long maxGasPerSecBackend,
+        @ConfigProperty(defaultValue = "1500000000") @NetworkProperty long maxGasPerSec,
+        @ConfigProperty(defaultValue = "1500000000") @NetworkProperty long maxGasPerSecBackend,
         @ConfigProperty(defaultValue = "500000000") @NetworkProperty long opsDurationThrottleCapacity,
         @ConfigProperty(defaultValue = "500000000") @NetworkProperty long opsDurationThrottleUnitsFreedPerSecond,
         @ConfigProperty(value = "maxKvPairs.aggregate", defaultValue = "500000000") @NetworkProperty
@@ -34,11 +34,11 @@ public record ContractsConfig(
         @ConfigProperty(defaultValue = "CONTRACT_STATE_CHANGE,CONTRACT_BYTECODE,CONTRACT_ACTION") @NetworkProperty
                 Set<SidecarType> sidecars,
         @ConfigProperty(defaultValue = "false") @NetworkProperty boolean sidecarValidationEnabled,
-        @ConfigProperty(value = "throttle.throttleByGas", defaultValue = "true") @NetworkProperty
+        @ConfigProperty(value = "throttle.throttleByGas", defaultValue = "false") @NetworkProperty
                 boolean throttleThrottleByGas,
-        @ConfigProperty(value = "throttle.throttleByOpsDuration", defaultValue = "false") @NetworkProperty
+        @ConfigProperty(value = "throttle.throttleByOpsDuration", defaultValue = "true") @NetworkProperty
                 boolean throttleThrottleByOpsDuration,
-        @ConfigProperty(defaultValue = "20") @NetworkProperty int maxRefundPercentOfGasLimit,
+        @ConfigProperty(defaultValue = "100") @NetworkProperty int maxRefundPercentOfGasLimit,
         @ConfigProperty(value = "precompile.exchangeRateGasCost", defaultValue = "100") @NetworkProperty
                 long precompileExchangeRateGasCost,
         @ConfigProperty(value = "precompile.htsDefaultGasCost", defaultValue = "10000") @NetworkProperty

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/OpsDurationConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/OpsDurationConfig.java
@@ -2,32 +2,17 @@
 package com.hedera.node.config.data;
 
 import com.hedera.node.config.NetworkProperty;
-import com.hedera.node.config.types.LongPair;
 import com.swirlds.config.api.ConfigData;
 import com.swirlds.config.api.ConfigProperty;
 import java.util.List;
 
 @ConfigData("contracts.ops.duration")
 public record OpsDurationConfig(
-        // The duration of the operations in microseconds. The key is the operation number and the value is the
-        // duration. The op codes are broken into sets of 64 values.
         @ConfigProperty(
                         defaultValue =
-                                "1-123,2-105,3-93,4-100,5-116,6-212,7-208,8-290,9-262,10-307,11-106,16-55,17-56,18-77,19-77,20-63,21-35,22-91,23-92,24-92,25-85,26-63,27-136,28-149,29-131,32-693,48-23,49-270,50-23,51-23,52-23,53-69,54-28,55-161,56-29,57-243,58-23,59-271,60-349,61-30,62-106,63-279,64-49")
+                                "0,123,105,93,100,116,212,208,290,262,307,106,0,0,0,0,55,56,77,77,63,35,91,92,92,85,63,136,149,131,0,0,693,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,23,270,23,23,23,69,28,161,29,243,23,271,349,30,106,279,49,23,30,29,23,30,23,32,0,0,0,0,0,0,0,0,20,77,102,78,260,713,143,155,29,30,29,5,0,0,0,0,21,20,20,21,20,20,21,21,21,21,27,21,21,21,21,23,21,21,22,23,22,22,22,22,22,22,23,23,22,22,23,23,17,17,17,17,17,17,17,17,17,18,18,18,18,18,18,18,27,27,28,27,28,28,28,28,28,29,28,29,29,29,29,29,109,677,734,808,959,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,26552,98859,2011,0,1596,11291,0,0,0,0,2091,0,0,0,0,0")
                 @NetworkProperty
-                List<LongPair> opsDurations1_to_64,
-        @ConfigProperty(
-                        defaultValue =
-                                "65-23,66-30,67-29,68-23,69-30,70-23,71-32,80-20,81-77,82-102,83-78,84-260,85-713,86-143,87-155,88-29,89-30,90-29,91-5,96-21,97-20,98-20,99-21,100-20,101-20,102-21,103-21,104-21,105-21,106-27,107-21,108-21,109-21,110-21,111-23,112-21,113-21,114-22,115-23,116-22,117-22,118-22,119-22,120-22,121-22,122-23,123-23,124-22,125-22,126-23,127-23,128-17")
-                @NetworkProperty
-                List<LongPair> opsDurations65_to_128,
-        @ConfigProperty(
-                        defaultValue =
-                                "144-27,129-17,145-27,130-17,146-28,131-17,147-27,132-17,148-28,133-17,149-28,134-17,150-28,135-17,151-28,136-17,152-28,137-18,153-29,138-18,154-28,139-18,155-29,140-18,156-29,141-18,157-29,142-18,158-29,143-18,159-29,160-109,161-677,162-734,163-808,164-959")
-                @NetworkProperty
-                List<LongPair> opsDurations129_to_192,
-        @ConfigProperty(defaultValue = "240-26552,241-98859,242-2011,244-1596,245-11291,250-2091") @NetworkProperty
-                List<LongPair> opsDurations193_to_256,
+                List<Long> opsDurationByOpCode,
         @ConfigProperty(defaultValue = "3332") @NetworkProperty long accountLazyCreationOpsDurationMultiplier,
         @ConfigProperty(defaultValue = "1575") @NetworkProperty long opsGasBasedDurationMultiplier,
         @ConfigProperty(defaultValue = "1575") @NetworkProperty long precompileGasBasedDurationMultiplier,

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/ContractServiceModule.java
@@ -1,25 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.contract.impl;
 
-import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.VERSION_030;
-import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.VERSION_034;
-import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.VERSION_038;
-import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.VERSION_046;
-import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.VERSION_050;
-import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.VERSION_051;
-import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.VERSION_065;
-import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.VERSION_066;
+import static com.hedera.node.app.service.contract.impl.hevm.HederaEvmVersion.*;
 import static org.hyperledger.besu.evm.internal.EvmConfiguration.WorldUpdaterMode.JOURNALED;
 
-import com.hedera.node.app.service.contract.impl.annotations.ServicesV030;
-import com.hedera.node.app.service.contract.impl.annotations.ServicesV034;
-import com.hedera.node.app.service.contract.impl.annotations.ServicesV038;
-import com.hedera.node.app.service.contract.impl.annotations.ServicesV046;
-import com.hedera.node.app.service.contract.impl.annotations.ServicesV050;
-import com.hedera.node.app.service.contract.impl.annotations.ServicesV051;
-import com.hedera.node.app.service.contract.impl.annotations.ServicesV065;
-import com.hedera.node.app.service.contract.impl.annotations.ServicesV066;
-import com.hedera.node.app.service.contract.impl.annotations.ServicesVersionKey;
+import com.hedera.node.app.service.contract.impl.annotations.*;
 import com.hedera.node.app.service.contract.impl.exec.QueryComponent;
 import com.hedera.node.app.service.contract.impl.exec.TransactionComponent;
 import com.hedera.node.app.service.contract.impl.exec.TransactionProcessor;
@@ -33,6 +18,7 @@ import com.hedera.node.app.service.contract.impl.exec.v050.V050Module;
 import com.hedera.node.app.service.contract.impl.exec.v051.V051Module;
 import com.hedera.node.app.service.contract.impl.exec.v065.V065Module;
 import com.hedera.node.app.service.contract.impl.exec.v066.V066Module;
+import com.hedera.node.app.service.contract.impl.exec.v067.V067Module;
 import com.hedera.node.app.service.contract.impl.handlers.ContractCallHandler;
 import com.hedera.node.app.service.contract.impl.handlers.ContractCallLocalHandler;
 import com.hedera.node.app.service.contract.impl.handlers.ContractCreateHandler;
@@ -74,6 +60,7 @@ import org.hyperledger.besu.evm.precompile.PrecompiledContract;
             V051Module.class,
             V065Module.class,
             V066Module.class,
+            V067Module.class,
             ProcessorModule.class
         },
         subcomponents = {TransactionComponent.class, QueryComponent.class})
@@ -210,4 +197,14 @@ public interface ContractServiceModule {
     @Singleton
     @ServicesVersionKey(VERSION_066)
     TransactionProcessor bindV066Processor(@ServicesV066 @NonNull final TransactionProcessor processor);
+
+    /**
+     * @param processor the transaction processor
+     * @return the bound transaction processor for version 0.67
+     */
+    @Binds
+    @IntoMap
+    @Singleton
+    @ServicesVersionKey(VERSION_067)
+    TransactionProcessor bindV067Processor(@ServicesV067 @NonNull final TransactionProcessor processor);
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV066.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV066.java
@@ -12,8 +12,9 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * Qualifies a binding for use with the {@code v0.66} (Cancun/Pectra) Services EVM.  Adds support for the
- * Hedera Account Service system contract.
+ * Qualifies a binding for use with the {@code v0.66} (Cancun/Pectra) Services EVM.
+ * Adds besu native library check and temporarily removes support for the
+ * Hedera EVM class for calculating and alternate ops duration and throttling system (due to release process).
  */
 @Target({METHOD, PARAMETER, TYPE})
 @Retention(RUNTIME)

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV067.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/annotations/ServicesV067.java
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.contract.impl.annotations;
 
-import static java.lang.annotation.ElementType.METHOD;
-import static java.lang.annotation.ElementType.PARAMETER;
-import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.ElementType.*;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 import java.lang.annotation.Documented;
@@ -12,11 +10,12 @@ import java.lang.annotation.Target;
 import javax.inject.Qualifier;
 
 /**
- * Qualifies a binding for use with the {@code v0.65} (Cancun) Services EVM. Adds support for the
+ * Qualifies a binding for use with the {@code v0.67} (Cancun/Pectra) Services EVM.
+ * Re-adds support for the
  * Hedera EVM class for calculating and alternate ops duration and throttling system.
  */
 @Target({METHOD, PARAMETER, TYPE})
 @Retention(RUNTIME)
 @Documented
 @Qualifier
-public @interface ServicesV065 {}
+public @interface ServicesV067 {}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/OpsDurationCounter.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/utils/OpsDurationCounter.java
@@ -9,15 +9,12 @@ import java.util.Objects;
  * throughout the execution of a single EVM transaction.
  */
 public final class OpsDurationCounter {
-
-    private static final OpsDurationCounter DISABLED = new OpsDurationCounter(OpsDurationSchedule.empty());
-
     private final OpsDurationSchedule schedule;
 
     private long opsDurationUnitsConsumed;
 
     public static OpsDurationCounter disabled() {
-        return DISABLED;
+        return new OpsDurationCounter(OpsDurationSchedule.empty());
     }
 
     public static OpsDurationCounter withSchedule(final OpsDurationSchedule schedule) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v066/Version066FeatureFlags.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v066/Version066FeatureFlags.java
@@ -1,12 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.contract.impl.exec.v066;
 
-import static java.util.Objects.requireNonNull;
-
 import com.hedera.node.app.service.contract.impl.exec.v065.Version065FeatureFlags;
-import com.hedera.node.config.data.ContractsConfig;
-import com.swirlds.config.api.Configuration;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
@@ -16,10 +11,5 @@ public class Version066FeatureFlags extends Version065FeatureFlags {
     @Inject
     public Version066FeatureFlags() {
         // Dagger2
-    }
-
-    public boolean isNativeLibVerificationEnabled(@NonNull Configuration config) {
-        requireNonNull(config);
-        return config.getConfigData(ContractsConfig.class).nativeLibVerificationHaltEnabled();
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v067/Version067FeatureFlags.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v067/Version067FeatureFlags.java
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.contract.impl.exec.v067;
+
+import com.hedera.node.app.service.contract.impl.exec.v066.Version066FeatureFlags;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class Version067FeatureFlags extends Version066FeatureFlags {
+
+    @Inject
+    public Version067FeatureFlags() {
+        // Dagger2
+    }
+}

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEVM.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEVM.java
@@ -98,7 +98,6 @@ public class HederaEVM extends EVM {
 
         final OpsDurationCounter opsDurationCounter = FrameUtils.opsDurationCounter(frame);
         final OpsDurationSchedule opsDurationSchedule = opsDurationCounter.schedule();
-        final long[] opsDurationByOpCode = opsDurationSchedule.opsDurationByOpCode();
         final long opsDurationMultiplier = opsDurationSchedule.opsGasBasedDurationMultiplier();
         final long opsDurationDenominator = opsDurationSchedule.multipliersDenominator();
 
@@ -213,9 +212,10 @@ public class HederaEVM extends EVM {
                  ** As the code is in a while loop it is difficult to isolate.  We will need to maintain these changes
                  ** against new versions of the EVM class.
                  */
-                final var opsDurationUnitsCost = opsDurationByOpCode[opcode] == 0
+                final var opCodeCost = opsDurationSchedule.opCodeCost(opcode);
+                final var opsDurationUnitsCost = opCodeCost == 0
                         ? result.getGasCost() * opsDurationMultiplier / opsDurationDenominator
-                        : opsDurationByOpCode[opcode];
+                        : opCodeCost;
                 opsDurationCounter.recordOpsDurationUnitsConsumed(opsDurationUnitsCost);
             }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmVersion.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/hevm/HederaEvmVersion.java
@@ -35,7 +35,11 @@ public enum HederaEvmVersion {
     /**
      * EVM version 0.66
      */
-    VERSION_066("v0.66"); /* Native libs verification */
+    VERSION_066("v0.66"), /* Native libs verification; Disable alternate gas schedule */
+    /**
+     * EVM version 0.67
+     */
+    VERSION_067("v0.67"); /* Re-enable alternate gas schedule */
 
     /**
      * All supported EVM versions
@@ -48,7 +52,8 @@ public enum HederaEvmVersion {
             VERSION_050.key(), VERSION_050,
             VERSION_051.key(), VERSION_051,
             VERSION_065.key(), VERSION_065,
-            VERSION_066.key(), VERSION_066);
+            VERSION_066.key(), VERSION_066,
+            VERSION_067.key(), VERSION_067);
 
     HederaEvmVersion(String key) {
         this.key = key;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/OpsDurationScheduleTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/hevm/OpsDurationScheduleTest.java
@@ -12,9 +12,15 @@ class OpsDurationScheduleTest {
     void testAllDurationsAreLoadedFromConfig() {
         final var opsDurationSchedule = OpsDurationSchedule.fromConfig(DEFAULT_OPS_DURATION_CONFIG);
 
-        assertEquals(123, opsDurationSchedule.opsDurationByOpCode()[1]);
-        assertEquals(105, opsDurationSchedule.opsDurationByOpCode()[2]);
-        assertEquals(2091, opsDurationSchedule.opsDurationByOpCode()[250]);
+        assertEquals(123, opsDurationSchedule.opCodeCost(1));
+        assertEquals(105, opsDurationSchedule.opCodeCost(2));
+        assertEquals(26552, opsDurationSchedule.opCodeCost(240));
+        assertEquals(98859, opsDurationSchedule.opCodeCost(241));
+        assertEquals(2011, opsDurationSchedule.opCodeCost(242));
+        assertEquals(1596, opsDurationSchedule.opCodeCost(244));
+        assertEquals(11291, opsDurationSchedule.opCodeCost(245));
+        assertEquals(2091, opsDurationSchedule.opCodeCost(250));
+
         assertEquals(3332, opsDurationSchedule.accountLazyCreationOpsDurationMultiplier());
         assertEquals(1575, opsDurationSchedule.opsGasBasedDurationMultiplier());
         assertEquals(1575, opsDurationSchedule.precompileGasBasedDurationMultiplier());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumSuite.java
@@ -277,23 +277,23 @@ public class EthereumSuite {
         final long noPayment = 0L;
         final long thirdOfFee = GAS_PRICE / 3;
         final long thirdOfPayment = thirdOfFee * chargedGasLimit;
-        final long thirdOfLimit = thirdOfFee * GAS_LIMIT;
         final long fullAllowance = GAS_PRICE * chargedGasLimit * 5 / 4;
-        final long fullPayment = GAS_PRICE * chargedGasLimit;
         final long ninetyPercentFee = GAS_PRICE * 9 / 10;
+        final boolean charged = true;
+        final boolean notCharged = false;
         return Stream.of(
-                        new Object[] {false, noPayment, noPayment, noPayment},
-                        new Object[] {false, noPayment, thirdOfPayment, noPayment},
-                        new Object[] {true, noPayment, fullAllowance, noPayment},
-                        new Object[] {false, thirdOfFee, noPayment, noPayment},
-                        new Object[] {false, thirdOfFee, thirdOfPayment, noPayment},
-                        new Object[] {true, thirdOfFee, fullAllowance, thirdOfLimit},
-                        new Object[] {true, thirdOfFee, fullAllowance * 9 / 10, thirdOfLimit},
-                        new Object[] {false, ninetyPercentFee, noPayment, noPayment},
-                        new Object[] {true, ninetyPercentFee, thirdOfPayment, fullPayment},
-                        new Object[] {true, GAS_PRICE, noPayment, fullPayment},
-                        new Object[] {true, GAS_PRICE, thirdOfPayment, fullPayment},
-                        new Object[] {true, GAS_PRICE, fullAllowance, fullPayment})
+                        new Object[] {false, noPayment, noPayment, notCharged},
+                        new Object[] {false, noPayment, thirdOfPayment, notCharged},
+                        new Object[] {true, noPayment, fullAllowance, notCharged},
+                        new Object[] {false, thirdOfFee, noPayment, notCharged},
+                        new Object[] {false, thirdOfFee, thirdOfPayment, notCharged},
+                        new Object[] {true, thirdOfFee, fullAllowance, charged},
+                        new Object[] {true, thirdOfFee, fullAllowance * 9 / 10, charged},
+                        new Object[] {false, ninetyPercentFee, noPayment, notCharged},
+                        new Object[] {true, ninetyPercentFee, thirdOfPayment, charged},
+                        new Object[] {true, GAS_PRICE, noPayment, charged},
+                        new Object[] {true, GAS_PRICE, thirdOfPayment, charged},
+                        new Object[] {true, GAS_PRICE, fullAllowance, charged})
                 .map(params ->
                         // [0] - success
                         // [1] - sender gas price
@@ -302,7 +302,7 @@ public class EthereumSuite {
                         // relayer charged amount can easily be calculated via
                         // wholeTransactionFee - senderChargedAmount
                         matrixedPayerRelayerTest(
-                                (boolean) params[0], (long) params[1], (long) params[2], (long) params[3]))
+                                (boolean) params[0], (long) params[1], (long) params[2], (boolean) params[3]))
                 .toList();
     }
 
@@ -367,7 +367,7 @@ public class EthereumSuite {
     }
 
     final Stream<DynamicTest> matrixedPayerRelayerTest(
-            final boolean success, final long senderGasPrice, final long relayerOffered, final long senderCharged) {
+            final boolean success, final long senderGasPrice, final long relayerOffered, final boolean senderCharged) {
         return Stream.of(namedHapiTest(
                 "feePaymentMatrix " + (success ? "Success/" : "Failure/") + senderGasPrice + "/" + relayerOffered,
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -405,14 +405,15 @@ public class EthereumSuite {
 
                     final long wholeTransactionFee =
                             hapiGetTxnRecord.getResponseRecord().getTransactionFee();
+                    final var senderGasCharged = senderCharged ? (gasUsed.get() * GAS_PRICE) : 0;
                     final var subop4 = getAutoCreatedAccountBalance(SECP_256K1_SOURCE_KEY)
-                            .hasTinyBars(
-                                    changeFromSnapshot(senderBalance, success ? (-DEPOSIT_AMOUNT - senderCharged) : 0));
+                            .hasTinyBars(changeFromSnapshot(
+                                    senderBalance, success ? (-DEPOSIT_AMOUNT - senderGasCharged) : 0));
                     // The relayer is not charged with Hapi fee unless the relayed transaction failed
                     final var subop5 = getAccountBalance(RELAYER)
                             .hasTinyBars(changeFromSnapshot(
                                     payerBalance,
-                                    success ? -(wholeTransactionFee - senderCharged) : -wholeTransactionFee));
+                                    success ? -(wholeTransactionFee - senderGasCharged) : -wholeTransactionFee));
                     allRunFor(spec, subop4, subop5);
                 })));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/JumboTransactionsEnabledTest.java
@@ -152,13 +152,13 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
                 // send jumbo payload to jumbo endpoint and assert the used gas
                 jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, jumboPayload)
                         .gasLimit(800000)
-                        .exposingGasTo((s, gasUsed) -> assertEquals(640000, gasUsed)),
+                        .exposingGasTo((s, gasUsed) -> assertEquals(63_742, gasUsed)),
                 jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, halfJumboPayload)
                         .gasLimit(500000)
-                        .exposingGasTo((s, gasUsed) -> assertEquals(400000, gasUsed)),
+                        .exposingGasTo((s, gasUsed) -> assertEquals(43_262, gasUsed)),
                 jumboEthCall(CONTRACT_CALLDATA_SIZE, FUNCTION, thirdJumboPayload)
                         .gasLimit(300000)
-                        .exposingGasTo((s, gasUsed) -> assertEquals(240000, gasUsed)));
+                        .exposingGasTo((s, gasUsed) -> assertEquals(35_070, gasUsed)));
     }
 
     @Nested
@@ -166,15 +166,13 @@ public class JumboTransactionsEnabledTest implements LifecycleTest {
     class JumboEthereumTransactionsPositiveTests {
 
         private final Stream<TestCombinationWithGas> positiveBoundariesTestCases = Stream.of(
-                new TestCombinationWithGas(SIX_KB_SIZE, EthTxData.EthTransactionType.LEGACY_ETHEREUM, 400_000, 320_000),
-                new TestCombinationWithGas(SIX_KB_SIZE, EthTxData.EthTransactionType.EIP2930, 400_000, 320_000),
-                new TestCombinationWithGas(SIX_KB_SIZE, EthTxData.EthTransactionType.EIP1559, 400_000, 320_000),
+                new TestCombinationWithGas(SIX_KB_SIZE, EthTxData.EthTransactionType.LEGACY_ETHEREUM, 400_000, 47_358),
+                new TestCombinationWithGas(SIX_KB_SIZE, EthTxData.EthTransactionType.EIP2930, 400_000, 47_358),
+                new TestCombinationWithGas(SIX_KB_SIZE, EthTxData.EthTransactionType.EIP1559, 400_000, 47_358),
                 new TestCombinationWithGas(
-                        MAX_ALLOWED_SIZE, EthTxData.EthTransactionType.LEGACY_ETHEREUM, 9_000_000, 7_200_000),
-                new TestCombinationWithGas(
-                        MAX_ALLOWED_SIZE, EthTxData.EthTransactionType.EIP2930, 9_000_000, 7_200_000),
-                new TestCombinationWithGas(
-                        MAX_ALLOWED_SIZE, EthTxData.EthTransactionType.EIP1559, 9_000_000, 7_200_000));
+                        MAX_ALLOWED_SIZE, EthTxData.EthTransactionType.LEGACY_ETHEREUM, 9_000_000, 542_986),
+                new TestCombinationWithGas(MAX_ALLOWED_SIZE, EthTxData.EthTransactionType.EIP2930, 9_000_000, 542_986),
+                new TestCombinationWithGas(MAX_ALLOWED_SIZE, EthTxData.EthTransactionType.EIP1559, 9_000_000, 542_986));
 
         @RepeatableHapiTest(RepeatableReason.NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
         @DisplayName("Jumbo Ethereum transactions should pass for valid sizes and expected gas used")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/batch/AtomicEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/batch/AtomicEthereumSuite.java
@@ -75,6 +75,7 @@ import static com.hedera.services.bdd.suites.contract.ethereum.HelloWorldEthereu
 import static com.hedera.services.bdd.suites.contract.hapi.ContractCallSuite.DEPOSIT;
 import static com.hedera.services.bdd.suites.contract.leaky.LeakyContractTestsSuite.RECEIVER;
 import static com.hedera.services.bdd.suites.contract.precompile.CreatePrecompileSuite.TOKEN_NAME;
+import static com.hedera.services.bdd.suites.contract.precompile.token.GasCalculationIntegrityTest.constantGasAssertion;
 import static com.hedera.services.bdd.suites.crypto.AutoCreateUtils.updateSpecFor;
 import static com.hedera.services.bdd.suites.crypto.CryptoCreateSuite.ACCOUNT;
 import static com.hedera.services.bdd.suites.token.TokenAssociationSpecs.MULTI_KEY;
@@ -99,6 +100,7 @@ import com.esaulpaugh.headlong.abi.Address;
 import com.google.common.io.Files;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.contracts.ParsingConstants.FunctionType;
+import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.HapiTest;
@@ -297,24 +299,24 @@ public class AtomicEthereumSuite {
         final long noPayment = 0L;
         final long thirdOfFee = GAS_PRICE / 3;
         final long thirdOfPayment = thirdOfFee * chargedGasLimit;
-        final long thirdOfLimit = thirdOfFee * GAS_LIMIT;
         final long fullAllowance = GAS_PRICE * chargedGasLimit * 5 / 4;
-        final long fullPayment = GAS_PRICE * chargedGasLimit;
         final long ninetyPercentFee = GAS_PRICE * 9 / 10;
+        final boolean charged = true;
+        final boolean notCharged = false;
 
         return Stream.of(
-                        new Object[] {false, noPayment, noPayment, noPayment},
-                        new Object[] {false, noPayment, thirdOfPayment, noPayment},
-                        new Object[] {true, noPayment, fullAllowance, noPayment},
-                        new Object[] {false, thirdOfFee, noPayment, noPayment},
-                        new Object[] {false, thirdOfFee, thirdOfPayment, noPayment},
-                        new Object[] {true, thirdOfFee, fullAllowance, thirdOfLimit},
-                        new Object[] {true, thirdOfFee, fullAllowance * 9 / 10, thirdOfLimit},
-                        new Object[] {false, ninetyPercentFee, noPayment, noPayment},
-                        new Object[] {true, ninetyPercentFee, thirdOfPayment, fullPayment},
-                        new Object[] {true, GAS_PRICE, noPayment, fullPayment},
-                        new Object[] {true, GAS_PRICE, thirdOfPayment, fullPayment},
-                        new Object[] {true, GAS_PRICE, fullAllowance, fullPayment})
+                        new Object[] {false, noPayment, noPayment, notCharged},
+                        new Object[] {false, noPayment, thirdOfPayment, notCharged},
+                        new Object[] {true, noPayment, fullAllowance, notCharged},
+                        new Object[] {false, thirdOfFee, noPayment, notCharged},
+                        new Object[] {false, thirdOfFee, thirdOfPayment, notCharged},
+                        new Object[] {true, thirdOfFee, fullAllowance, charged},
+                        new Object[] {true, thirdOfFee, fullAllowance * 9 / 10, charged},
+                        new Object[] {false, ninetyPercentFee, noPayment, notCharged},
+                        new Object[] {true, ninetyPercentFee, thirdOfPayment, charged},
+                        new Object[] {true, GAS_PRICE, noPayment, charged},
+                        new Object[] {true, GAS_PRICE, thirdOfPayment, charged},
+                        new Object[] {true, GAS_PRICE, fullAllowance, charged})
                 .map(params ->
                         // [0] - success
                         // [1] - sender gas price
@@ -323,7 +325,7 @@ public class AtomicEthereumSuite {
                         // relayer charged amount can easily be calculated via
                         // wholeTransactionFee - senderChargedAmount
                         matrixedPayerRelayerTest(
-                                (boolean) params[0], (long) params[1], (long) params[2], (long) params[3]))
+                                (boolean) params[0], (long) params[1], (long) params[2], (boolean) params[3]))
                 .toList();
     }
 
@@ -389,7 +391,7 @@ public class AtomicEthereumSuite {
     }
 
     final Stream<DynamicTest> matrixedPayerRelayerTest(
-            final boolean success, final long senderGasPrice, final long relayerOffered, final long senderCharged) {
+            final boolean success, final long senderGasPrice, final long relayerOffered, final boolean senderCharged) {
         return Stream.of(namedHapiTest(
                 "feePaymentMatrix " + (success ? "Success/" : "Failure/") + senderGasPrice + "/" + relayerOffered,
                 newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
@@ -409,7 +411,7 @@ public class AtomicEthereumSuite {
                     final var subop2 = balanceSnapshot(payerBalance, RELAYER);
                     final var subop3 = atomicBatch(ethereumCall(
                                             PAY_RECEIVABLE_CONTRACT, "deposit", BigInteger.valueOf(DEPOSIT_AMOUNT))
-                                    .type(EthTransactionType.EIP1559)
+                                    .type(EthTxData.EthTransactionType.EIP1559)
                                     .signingWith(SECP_256K1_SOURCE_KEY)
                                     .payingWith(RELAYER)
                                     .via(PAY_TXN)
@@ -420,6 +422,7 @@ public class AtomicEthereumSuite {
                                     .sending(DEPOSIT_AMOUNT)
                                     .hasKnownStatus(
                                             success ? ResponseCodeEnum.SUCCESS : ResponseCodeEnum.INSUFFICIENT_TX_FEE)
+                                    .exposingGasTo(constantGasAssertion(gasUsed))
                                     .batchKey(BATCH_OPERATOR))
                             .payingWith(BATCH_OPERATOR)
                             .hasKnownStatus(success ? ResponseCodeEnum.SUCCESS : INNER_TRANSACTION_FAILED);
@@ -430,14 +433,15 @@ public class AtomicEthereumSuite {
 
                     final long wholeTransactionFee =
                             hapiGetTxnRecord.getResponseRecord().getTransactionFee();
+                    final var senderGasCharged = senderCharged ? (gasUsed.get() * GAS_PRICE) : 0;
                     final var subop4 = getAutoCreatedAccountBalance(SECP_256K1_SOURCE_KEY)
-                            .hasTinyBars(
-                                    changeFromSnapshot(senderBalance, success ? (-DEPOSIT_AMOUNT - senderCharged) : 0));
+                            .hasTinyBars(changeFromSnapshot(
+                                    senderBalance, success ? (-DEPOSIT_AMOUNT - senderGasCharged) : 0));
                     // The relayer is not charged with Hapi fee unless the relayed transaction failed
                     final var subop5 = getAccountBalance(RELAYER)
                             .hasTinyBars(changeFromSnapshot(
                                     payerBalance,
-                                    success ? -(wholeTransactionFee - senderCharged) : -wholeTransactionFee));
+                                    success ? -(wholeTransactionFee - senderGasCharged) : -wholeTransactionFee));
                     allRunFor(spec, subop4, subop5);
                 })));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/AtomicSmartContractServiceFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/AtomicSmartContractServiceFeesTest.java
@@ -78,7 +78,7 @@ public class AtomicSmartContractServiceFeesTest {
                                 .batchKey(BATCH_OPERATOR))
                         .via(ATOMIC_BATCH)
                         .signedByPayerAnd(BATCH_OPERATOR),
-                validateInnerTxnChargedUsd(creation, ATOMIC_BATCH, 0.73, 5));
+                validateInnerTxnChargedUsd(creation, ATOMIC_BATCH, 0.72, 5));
     }
 
     @HapiTest
@@ -96,7 +96,7 @@ public class AtomicSmartContractServiceFeesTest {
                         .via(ATOMIC_BATCH)
                         .signedByPayerAnd(BATCH_OPERATOR)
                         .payingWith(BATCH_OPERATOR),
-                validateInnerTxnChargedUsd(contract, ATOMIC_BATCH, 0.0068, 1));
+                validateInnerTxnChargedUsd(contract, ATOMIC_BATCH, 0.00184, 1));
     }
 
     @LeakyHapiTest(overrides = "contracts.evm.ethTransaction.zeroHapiFees.enabled")
@@ -124,6 +124,6 @@ public class AtomicSmartContractServiceFeesTest {
                         .signedByPayerAnd(BATCH_OPERATOR)
                         .payingWith(BATCH_OPERATOR),
                 // Estimated base fee for EthereumCall is 0.0001 USD and is paid by the relayer account
-                validateInnerTxnChargedUsd(ethCall, ATOMIC_BATCH, 0.0069, 1));
+                validateInnerTxnChargedUsd(ethCall, ATOMIC_BATCH, 0.00194, 1));
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/SmartContractServiceFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/SmartContractServiceFeesTest.java
@@ -90,8 +90,8 @@ public class SmartContractServiceFeesTest {
         return hapiTest(
                 contract.call("contractCall1Byte", new byte[] {0}).gas(100_000L).via(contractCall),
                 // ContractCall's fee is paid with gas only. Estimated price is based on call data and gas used
-                validateChargedUsdForGasOnly(contractCall, 0.0068, 1),
-                validateChargedUsd(contractCall, 0.0068, 1));
+                validateChargedUsdForGasOnly(contractCall, 0.00184, 1),
+                validateChargedUsd(contractCall, 0.00184, 1));
     }
 
     @LeakyHapiTest(overrides = "contracts.evm.ethTransaction.zeroHapiFees.enabled")
@@ -113,8 +113,8 @@ public class SmartContractServiceFeesTest {
                         .nonce(0)
                         .via(ethCall),
                 // Estimated base fee for EthereumCall is 0.0001 USD and is paid by the relayer account
-                validateChargedUsdWithin(ethCall, 0.0069, 1),
-                validateChargedUsdForGasOnly(ethCall, 0.0068, 1),
+                validateChargedUsdWithin(ethCall, 0.00194, 1),
+                validateChargedUsdForGasOnly(ethCall, 0.00184, 1),
                 validateChargedUsdWithoutGas(ethCall, 0.0001, 1));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/LeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/LeakyContractTestsSuite.java
@@ -1455,8 +1455,8 @@ public class LeakyContractTestsSuite {
                 .payingWith(GENESIS);
     }
 
-    // @Order(39)
-    // @LeakyHapiTest(overrides = "contracts.maxRefundPercentOfGasLimit")
+    @Order(39)
+    @LeakyHapiTest(overrides = "contracts.maxRefundPercentOfGasLimit")
     @DisplayName("Check that gas refund can be changed")
     public Stream<DynamicTest> checkGasRefundChange(
             @Contract(contract = "CallingContract") final SpecContract contract) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
@@ -117,7 +117,7 @@ public class PrngPrecompileSuite {
                             .getTransactionRecord(emptyInputCall)
                             .getContractCallResult()
                             .getGasUsed();
-                    assertEquals(320000, gasUsed);
+                    assertEquals(21_070L, gasUsed);
                 }));
     }
 
@@ -142,7 +142,7 @@ public class PrngPrecompileSuite {
                             .getTransactionRecord(largeInputCall)
                             .getContractCallResult()
                             .getGasUsed();
-                    assertEquals(320000, gasUsed);
+                    assertEquals(26_134L, gasUsed);
                 }));
     }
 
@@ -190,7 +190,7 @@ public class PrngPrecompileSuite {
                             .getTransactionRecord(lessThan4Bytes)
                             .getContractCallResult()
                             .getGasUsed();
-                    assertEquals(320000, gasUsed);
+                    assertEquals(21_118L, gasUsed);
                 }));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
@@ -958,7 +958,7 @@ public class AtomicBatchNegativeTest {
                             .payingWith("batchOperator")
                             .via("batchTxn")
                             .hasKnownStatus(INNER_TRANSACTION_FAILED),
-                    validateChargedUsdForGasOnlyForInnerTxn("ethCall", "batchTxn", 0.015, 5),
+                    validateChargedUsdForGasOnlyForInnerTxn("ethCall", "batchTxn", 0.00183, 5),
                     getAliasedAccountInfo(SECP_256K1_SOURCE_KEY)
                             .has(accountWith().nonce(1L)),
                     getTxnRecord("ethCall")


### PR DESCRIPTION
Enables the ops duration throttle feature in the 0.67 module.

- disables the existing gas throttle (and, even though disabled, bumps its limits by a factor of 100, not sure why we wanted this @lukelee-sl ?)
- enables the new ops duration throttle
- enables 100% gas refund on evm transactions

Includes some tweaks carried over from https://github.com/hiero-ledger/hiero-consensus-node/pull/21076