### PR TITLE
fix: revert validating transaction bodies during throttle check

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/TxnVerbs.java
@@ -456,6 +456,10 @@ public class TxnVerbs {
         return new HapiScheduleCreate<>(scheduled, cryptoCreate("doomed")).functionless();
     }
 
+    public static HapiScheduleCreate<HapiCryptoCreate> scheduleCreateWithoutScheduled(String scheduled) {
+        return new HapiScheduleCreate<>(scheduled, cryptoCreate("doomed")).noScheduled();
+    }
+
     public static HapiScheduleDelete scheduleDelete(String schedule) {
         return new HapiScheduleDelete(schedule);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenMint.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/token/HapiTokenMint.java
@@ -13,6 +13,7 @@ import com.hedera.node.app.hapi.fees.usage.state.UsageAccumulator;
 import com.hedera.node.app.hapi.fees.usage.token.TokenOpsUsage;
 import com.hedera.node.app.hapi.utils.fee.SigValueObj;
 import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.fees.AdapterUtils;
 import com.hedera.services.bdd.spec.keys.KeyRole;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
@@ -40,6 +41,7 @@ public class HapiTokenMint extends HapiTxnOp<HapiTokenMint> {
     private boolean rememberingNothing = false;
     private final List<ByteString> metadata;
     private SubType subType;
+    private boolean setNoToken = false;
 
     private TokenInfo info;
 
@@ -124,7 +126,9 @@ public class HapiTokenMint extends HapiTxnOp<HapiTokenMint> {
         final var tId = TxnUtils.asTokenId(token, spec);
         final TokenMintTransactionBody opBody = spec.txns()
                 .<TokenMintTransactionBody, TokenMintTransactionBody.Builder>body(TokenMintTransactionBody.class, b -> {
-                    b.setToken(tId);
+                    if(!setNoToken){
+                        b.setToken(tId);
+                    }
                     b.setAmount(amount);
                     b.addAllMetadata(metadata);
                 });
@@ -156,5 +160,10 @@ public class HapiTokenMint extends HapiTxnOp<HapiTokenMint> {
         final MoreObjects.ToStringHelper helper =
                 super.toStringHelper().add("token", token).add("amount", amount).add("metadata", metadata);
         return helper;
+    }
+
+    public HapiTokenMint setNoToken() {
+        setNoToken = true;
+        return this;
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/schedule/ScheduleCreateTest.java
@@ -17,6 +17,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreateFunctionless;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleCreateWithoutScheduled;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.scheduleSign;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
 import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromToWithAlias;
@@ -60,6 +61,8 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.IDENTICAL_SCHEDULE_ALREADY_CREATED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ADMIN_KEY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SCHEDULE_ID;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_CUSTOM_FEES_IS_NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MEMO_TOO_LONG;
@@ -69,6 +72,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SOME_SIGNATURE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNRESOLVABLE_REQUIRED_SIGNERS;
 
+import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.spec.HapiSpecSetup;
@@ -475,6 +479,13 @@ public class ScheduleCreateTest {
         return hapiTest(
                 cryptoCreate(SENDER),
                 scheduleCreateFunctionless("unknown").hasPrecheck(BUSY).payingWith(SENDER));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> noScheduledTxnFails() {
+        return hapiTest(
+                cryptoCreate(SENDER),
+                scheduleCreateWithoutScheduled("unknown").hasPrecheck(INVALID_TRANSACTION).payingWith(SENDER));
     }
 
     @LeakyHapiTest(overrides = {"scheduling.whitelist"})

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/TokenAssociationSpecs.java
@@ -152,6 +152,23 @@ public class TokenAssociationSpecs {
     }
 
     @HapiTest
+    final Stream<DynamicTest> handlesMintingTokenWithoutSetting() {
+        return hapiTest(
+                newKeyNamed(MULTI_KEY),
+                cryptoCreate(TOKEN_TREASURY),
+                cryptoCreate("replacementTreasury"),
+                tokenCreate(TBD_TOKEN)
+                        .adminKey(MULTI_KEY)
+                        .tokenType(NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0L)
+                        .treasury(TOKEN_TREASURY)
+                        .supplyKey(MULTI_KEY),
+                mintToken(TBD_TOKEN, List.of(ByteString.copyFromUtf8("1"), ByteString.copyFromUtf8("2")))
+                        .setNoToken()
+                        .hasPrecheck(INVALID_TOKEN_ID));
+    }
+
+    @HapiTest
     final Stream<DynamicTest> handlesUseOfDefaultTokenId() {
         return hapiTest(tokenAssociate(DEFAULT_PAYER, "0.0.0").hasPrecheck(INVALID_TOKEN_ID));
     }


### PR DESCRIPTION
Reverts some part of https://github.com/hiero-ledger/hiero-consensus-node/pull/21108 so we don't respond with different response codes