### PR TITLE
chore: Clean up redundant atomic batch properties in hapi tests

### DIFF
--- a/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/AtomicBatchHandlerTest.java
+++ b/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/AtomicBatchHandlerTest.java
@@ -105,7 +105,6 @@ class AtomicBatchHandlerTest {
     @BeforeEach
     void setUp() {
         final var config = HederaTestConfigBuilder.create()
-                .withValue("atomicBatch.isEnabled", true)
                 .withValue("atomicBatch.maxNumberOfTransactions", 2)
                 .getOrCreateConfig();
         given(handleContext.configuration()).willReturn(config);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicBatchConsensusServiceEndToEndTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicBatchConsensusServiceEndToEndTest.java
@@ -35,22 +35,16 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.transactions.consensus.HapiTopicCreate;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestLifecycle
-public class AtomicBatchConsensusServiceEndToEndTest {
+class AtomicBatchConsensusServiceEndToEndTest {
 
     private static final double BASE_FEE_BATCH_TRANSACTION = 0.001;
     private static final long HBAR_FEE = 1L;
@@ -91,17 +85,12 @@ public class AtomicBatchConsensusServiceEndToEndTest {
     private static final String newAdminKey = "newAdminKey";
     private static final String feeScheduleKey = "feeScheduleKey";
 
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
-
     @Nested
     @DisplayName(
             "Atomic Batch Consensus Service End-to-End Tests - Test Cases with Topic Submit Messages, Topic Updates and Deletes")
     class AtomicBatchConsensusServiceEndToEndTestsWithSubmitMessagesTopicUpdatesAndDeletes {
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToMutableTopicWithSubmitKeyAndUpdateTopicSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToMutableTopicWithSubmitKeyAndUpdateTopicSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -144,7 +133,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessageToMutableTopicWithSubmitKeyAndDeleteTheTopicSuccessInBatch() {
+        Stream<DynamicTest> submitMessageToMutableTopicWithSubmitKeyAndDeleteTheTopicSuccessInBatch() {
 
             // submit message to topic inner transaction
             final var submitMessageBeforeDelete = submitMessageTo(TOPIC_ID)
@@ -177,7 +166,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMultipleMessagesToMutableTopicWithSubmitKeySuccessInBatch() {
+        Stream<DynamicTest> submitMultipleMessagesToMutableTopicWithSubmitKeySuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageFirstTransaction = submitMessageTo(TOPIC_ID)
@@ -215,7 +204,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMultipleMessagesToImmutableTopicWithSubmitKeySuccessInBatch() {
+        Stream<DynamicTest> submitMultipleMessagesToImmutableTopicWithSubmitKeySuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageFirstTransaction = submitMessageTo(TOPIC_ID)
@@ -253,7 +242,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> updateMutableTopicWithSubmitKeySubmitMessageAndDeleteTheTopicSuccessInBatch() {
+        Stream<DynamicTest> updateMutableTopicWithSubmitKeySubmitMessageAndDeleteTheTopicSuccessInBatch() {
 
             // update topic inner transaction
             final var updateTopic = updateTopic(TOPIC_ID)
@@ -294,7 +283,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToDeletedTopicFailsInBatch() {
+        Stream<DynamicTest> submitMessagesToDeletedTopicFailsInBatch() {
 
             // submit message to topic inner transaction
             final var submitMessageBeforeDelete = submitMessageTo(TOPIC_ID)
@@ -338,7 +327,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> updateTopicDeleteTopicAndSubmitMessagesToTheDeletedTopicFailsInBatch() {
+        Stream<DynamicTest> updateTopicDeleteTopicAndSubmitMessagesToTheDeletedTopicFailsInBatch() {
 
             // update topic inner transaction
             final var updateTopic = updateTopic(TOPIC_ID)
@@ -383,7 +372,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessageDeleteTopicAndUpdateTheDeletedTopicFailsInBatch() {
+        Stream<DynamicTest> submitMessageDeleteTopicAndUpdateTheDeletedTopicFailsInBatch() {
 
             // submit message to topic inner transaction
             final var submitMessageBeforeDelete = submitMessageTo(TOPIC_ID)
@@ -427,7 +416,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> updateMutableTopicWithNewAutoRenewAccountAndPeriodAndSubmitMessagesSuccessInBatch() {
+        Stream<DynamicTest> updateMutableTopicWithNewAutoRenewAccountAndPeriodAndSubmitMessagesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -474,7 +463,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 updateMutableTopicWithoutAutoRenewWithAutoRenewAccountAndPeriodAndSubmitMessagesSuccessInBatch() {
 
             // submit message to topic inner transactions
@@ -522,7 +511,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 updateMutableTopicWithoutAutoRenewWithAutoRenewAndSubmitMessagesNotSignedByAutoRenewFailsInBatch() {
 
             // submit message to topic inner transactions
@@ -569,7 +558,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> updateImmutableTopicWithNewAutoRenewAccountAndPeriodAndSubmitMessagesFailsInBatch() {
+        Stream<DynamicTest> updateImmutableTopicWithNewAutoRenewAccountAndPeriodAndSubmitMessagesFailsInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -614,7 +603,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 updateImmutableTopicWithoutAutoRenewWithAutoRenewAccountAndPeriodAndSubmitMessagesFailsInBatch() {
 
             // submit message to topic inner transactions
@@ -661,7 +650,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> deleteImmutableTopicAndSubmitMessageFailsInBatch() {
+        Stream<DynamicTest> deleteImmutableTopicAndSubmitMessageFailsInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -704,7 +693,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
 
         @HapiTest
         @Tag(MATS)
-        public Stream<DynamicTest> updateMutableTopicWithNewAdminKeyAndSubmitMessagesSuccessInBatch() {
+        Stream<DynamicTest> updateMutableTopicWithNewAdminKeyAndSubmitMessagesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -747,8 +736,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest>
-                updateMutableTopicWithNewAdminKeyAndSubmitMessagesNotSignedByOldAdminKeyFailsInBatch() {
+        Stream<DynamicTest> updateMutableTopicWithNewAdminKeyAndSubmitMessagesNotSignedByOldAdminKeyFailsInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -792,8 +780,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest>
-                updateMutableTopicWithNewAdminKeyAndSubmitMessagesNotSignedByNewAdminKeyFailsInBatch() {
+        Stream<DynamicTest> updateMutableTopicWithNewAdminKeyAndSubmitMessagesNotSignedByNewAdminKeyFailsInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -837,7 +824,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> updateMutableTopicWithNewAdminKeyAndUpdateTheTopicSuccessInBatch() {
+        Stream<DynamicTest> updateMutableTopicWithNewAdminKeyAndUpdateTheTopicSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -891,8 +878,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest>
-                updateMutableTopicWithNewAdminKeyAndUpdateTheTopicNotSignedByTheNewAdminKeyFailsInBatch() {
+        Stream<DynamicTest> updateMutableTopicWithNewAdminKeyAndUpdateTheTopicNotSignedByTheNewAdminKeyFailsInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -947,7 +933,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> updateMutableTopicWithNewSubmitKeyAndSubmitMessagesSuccessInBatch() {
+        Stream<DynamicTest> updateMutableTopicWithNewSubmitKeyAndSubmitMessagesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -990,7 +976,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> updateMutableTopicWithNewAdminKeyAndNewSubmitKeyAndSubmitMessagesSuccessInBatch() {
+        Stream<DynamicTest> updateMutableTopicWithNewAdminKeyAndNewSubmitKeyAndSubmitMessagesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -1048,7 +1034,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
     @DisplayName("Atomic Batch Consensus Service End-to-End Tests with Submit Messages to Topics with Custom Fees")
     class AtomicBatchConsensusServiceWithCustomFees {
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToMutableTopicWithHBARCustomFeeAndUpdateTopicSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToMutableTopicWithHBARCustomFeeAndUpdateTopicSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -1094,7 +1080,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToMutableTopicWithHTSCustomFeeAndUpdateTopicSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToMutableTopicWithHTSCustomFeeAndUpdateTopicSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -1143,7 +1129,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToMultipleTopicsWithCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToMultipleTopicsWithCustomFeesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageToFirstTopic = submitMessageTo(TOPIC_ID)
@@ -1179,7 +1165,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 submitMessagesToTopicWithCustomFeesWithInvalidInnerTxnFailInBatchAndNoCustomFeesAreTransferred() {
 
             // submit message to topic inner transactions
@@ -1228,7 +1214,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToTopicWithCustomFeesWithInsufficientPayerBalanceFailsInBatch() {
+        Stream<DynamicTest> submitMessagesToTopicWithCustomFeesWithInsufficientPayerBalanceFailsInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageToFirstTopic = submitMessageTo(TOPIC_ID)
@@ -1265,7 +1251,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToTopicWithMaxCustomFeeLessThanRequiredFeeFailsInBatch() {
+        Stream<DynamicTest> submitMessagesToTopicWithMaxCustomFeeLessThanRequiredFeeFailsInBatch() {
 
             // set custom fees limit
             final var htsFeeLimit = htsLimit(DENOM_TOKEN, 1 / 2);
@@ -1311,7 +1297,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
     class AtomicBatchConsensusServiceWithCustomFeesUpdates {
         @HapiTest
         @Tag(MATS)
-        public Stream<DynamicTest> submitMessagesToMultipleTopicsWithCustomFeesUpdatesSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToMultipleTopicsWithCustomFeesUpdatesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageToFirstTopicBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -1383,7 +1369,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToTopicsWithUpdatedToHTSCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToTopicsWithUpdatedToHTSCustomFeesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageToFirstTopicBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -1437,7 +1423,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToTopicsWithUpdatedToHBARCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToTopicsWithUpdatedToHBARCustomFeesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageToSecondTopicBeforeUpdate = submitMessageTo(TOPIC_ID_SECOND)
@@ -1491,7 +1477,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToTopicsWithRemovedCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToTopicsWithRemovedCustomFeesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageToFirstTopicBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -1541,7 +1527,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToMultipleTopicsWithCustomFeesUpdatesAddAndRemoveFeesSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToMultipleTopicsWithCustomFeesUpdatesAddAndRemoveFeesSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageToFirstTopicBeforeFirstUpdate = submitMessageTo(TOPIC_ID)
@@ -1612,7 +1598,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> topicCustomFeesUpdatesNotSignedByFeeScheduleKeyFailsInBatch() {
+        Stream<DynamicTest> topicCustomFeesUpdatesNotSignedByFeeScheduleKeyFailsInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageToTopicBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -1666,7 +1652,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> topicWithMoreThanTenCustomFeesFailsInBatch() {
+        Stream<DynamicTest> topicWithMoreThanTenCustomFeesFailsInBatch() {
 
             // submit message to topic inner transactions
             final var submitMessageToTopicBeforeUpdate = submitMessageTo(TOPIC_ID)
@@ -1734,7 +1720,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
     @DisplayName("Atomic Batch Consensus Service End-to-End Tests with Custom Fees Exempt List")
     class AtomicBatchConsensusServiceWithCustomFeesExemptList {
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToTopicsWithCustomFeesExemptListSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToTopicsWithCustomFeesExemptListSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitFirstMessageToTopicExempt = submitMessageTo(TOPIC_ID)
@@ -1774,7 +1760,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToTopicsWithCustomFeesExemptAndNonExemptPayersSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToTopicsWithCustomFeesExemptAndNonExemptPayersSuccessInBatch() {
 
             // submit message to topic inner transactions
             final var submitFirstMessageToTopicExempt = submitMessageTo(TOPIC_ID)
@@ -1814,7 +1800,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 submitMessagesToTopicsWithCustomFeesUpdateFeesExemptListAddExemptPayersListSuccessInBatch() {
 
             // submit message to topic inner transactions
@@ -1867,7 +1853,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 submitMessagesToTopicsWithCustomFeesUpdateFeesExemptListRemoveExemptPayersListSuccessInBatch() {
 
             // submit message to topic inner transactions
@@ -1921,7 +1907,7 @@ public class AtomicBatchConsensusServiceEndToEndTest {
         }
 
         @HapiTest
-        public Stream<DynamicTest> submitMessagesToTopicsWithCustomFeesExemptListWithMoreThanTenPayersFailsInBatch() {
+        Stream<DynamicTest> submitMessagesToTopicsWithCustomFeesExemptListWithMoreThanTenPayersFailsInBatch() {
 
             // submit message to topic inner transactions
             final var submitFirstMessageToTopicBeforeUpdateExempt = submitMessageTo(TOPIC_ID)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicBatchConsensusServiceTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicBatchConsensusServiceTest.java
@@ -28,31 +28,20 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hedera.services.bdd.spec.transactions.consensus.HapiTopicUpdate;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestLifecycle
-public class AtomicBatchConsensusServiceTest {
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
+class AtomicBatchConsensusServiceTest {
 
     // Submit Message to Topic with Submit Key tests
 
     @HapiTest
-    public Stream<DynamicTest> topicSubmitMessageWithSubmitKeyValidSignatureSuccessInBatch() {
+    Stream<DynamicTest> topicSubmitMessageWithSubmitKeyValidSignatureSuccessInBatch() {
         final double BASE_FEE_BATCH_TRANSACTION = 0.001;
 
         // Define a threshold submit key that requires two simple keys signatures
@@ -80,7 +69,7 @@ public class AtomicBatchConsensusServiceTest {
     }
 
     @HapiTest
-    public Stream<DynamicTest> topicSubmitMessageWithSubmitKeyInvalidSignatureInBatch() {
+    Stream<DynamicTest> topicSubmitMessageWithSubmitKeyInvalidSignatureInBatch() {
         final double BASE_FEE_BATCH_TRANSACTION = 0.001;
 
         // Define a threshold submit key that requires two simple keys signatures
@@ -108,7 +97,7 @@ public class AtomicBatchConsensusServiceTest {
     }
 
     @HapiTest
-    public Stream<DynamicTest> topicSubmitMessageWithSubmitKeyInvalidAndValidSignatureInBatch() {
+    Stream<DynamicTest> topicSubmitMessageWithSubmitKeyInvalidAndValidSignatureInBatch() {
         final double BASE_FEE_BATCH_TRANSACTION = 0.001;
 
         // Define a threshold submit key that requires two simple keys signatures
@@ -142,7 +131,7 @@ public class AtomicBatchConsensusServiceTest {
     }
 
     @HapiTest
-    public Stream<DynamicTest> topicSubmitMessageWithSubmitKeyValidAndInvalidSignatureInBatch() {
+    Stream<DynamicTest> topicSubmitMessageWithSubmitKeyValidAndInvalidSignatureInBatch() {
         final double BASE_FEE_BATCH_TRANSACTION = 0.001;
 
         // Define a threshold submit key that requires two simple keys signatures
@@ -176,7 +165,7 @@ public class AtomicBatchConsensusServiceTest {
     }
 
     @HapiTest
-    public Stream<DynamicTest> topicSubmitMessageWithSubmitKeyAllInvalidSignaturesInBatch() {
+    Stream<DynamicTest> topicSubmitMessageWithSubmitKeyAllInvalidSignaturesInBatch() {
         final double BASE_FEE_BATCH_TRANSACTION = 0.001;
 
         // Define a threshold submit key that requires two simple keys signatures
@@ -209,7 +198,7 @@ public class AtomicBatchConsensusServiceTest {
     }
 
     @HapiTest
-    public Stream<DynamicTest> topicSubmitMessageToPublicTopicSuccessInBatch() {
+    Stream<DynamicTest> topicSubmitMessageToPublicTopicSuccessInBatch() {
         final double BASE_FEE_BATCH_TRANSACTION = 0.001;
 
         final var submitMessage_innerTxn = submitMessageTo("testTopic")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicSubmitMessageSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicSubmitMessageSuite.java
@@ -34,30 +34,18 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_OVERSIZE;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of SubmitMessageSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicSubmitMessageSuite {
+class AtomicSubmitMessageSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> pureCheckInvalidTopicIdFails() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicTopicCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicTopicCreateSuite.java
@@ -43,32 +43,20 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of TopicCreateSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicTopicCreateSuite {
+class AtomicTopicCreateSuite {
 
     public static final String TEST_TOPIC = "testTopic";
     public static final String TESTMEMO = "testmemo";
     private static final String BATCH_OPERATOR = "batchOperator";
     private static final String ATOMIC_BATCH = "atomicBatch";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> adminKeyIsValidated() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicTopicDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicTopicDeleteSuite.java
@@ -17,29 +17,17 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_TOPIC_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of TopicDeleteSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicTopicDeleteSuite {
+class AtomicTopicDeleteSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
     private static final String ATOMIC_BATCH = "atomicBatch";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     @Tag(MATS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicTopicUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/consensus/AtomicTopicUpdateSuite.java
@@ -33,34 +33,22 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.transactions.util.HapiAtomicBatch;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of TopicUpdateSuite\. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicTopicUpdateSuite {
+class AtomicTopicUpdateSuite {
 
     private static final long validAutoRenewPeriod = 7_000_000L;
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> pureCheckFails() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/batch/AtomicEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/batch/AtomicEthereumSuite.java
@@ -123,7 +123,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -139,7 +138,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)
 @SuppressWarnings("java:S5960")
-public class AtomicEthereumSuite {
+class AtomicEthereumSuite {
     public static final long GAS_LIMIT = 1_000_000;
     public static final String ERC20_CONTRACT = "ERC20Contract";
     public static final String EMIT_SENDER_ORIGIN_CONTRACT = "EmitSenderOrigin";
@@ -162,8 +161,6 @@ public class AtomicEthereumSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/batch/AtomicHelloWorldEthereumSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/batch/AtomicHelloWorldEthereumSuite.java
@@ -84,7 +84,6 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -96,7 +95,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)
-public class AtomicHelloWorldEthereumSuite {
+class AtomicHelloWorldEthereumSuite {
     public static final long depositAmount = 20_000L;
 
     private static final String PAY_RECEIVABLE_CONTRACT = "PayReceivable";
@@ -109,8 +108,6 @@ public class AtomicHelloWorldEthereumSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm38ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm38ValidationSuite.java
@@ -67,7 +67,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @Tag(SMART_CONTRACT)
 @HapiTestLifecycle
-public class AtomicEvm38ValidationSuite {
+class AtomicEvm38ValidationSuite {
 
     private static final String CREATE_TRIVIAL = "CreateTrivial";
     private static final String STATIC_CALL = "staticcall";
@@ -77,13 +77,7 @@ public class AtomicEvm38ValidationSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "contracts.evm.version",
-                "v0.38",
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50"));
+        testLifecycle.overrideInClass(Map.of("contracts.evm.version", "v0.38"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm46ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm46ValidationSuite.java
@@ -73,7 +73,6 @@ import com.hederahashgraph.api.proto.java.ContractID;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
@@ -85,7 +84,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)
-public class AtomicEvm46ValidationSuite {
+class AtomicEvm46ValidationSuite {
 
     private static final long FIRST_NONEXISTENT_CONTRACT_NUM = 4303224382569680425L;
     private static final String NAME = "name";
@@ -121,8 +120,6 @@ public class AtomicEvm46ValidationSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm50ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm50ValidationSuite.java
@@ -19,7 +19,6 @@ import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -29,7 +28,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)
-public class AtomicEvm50ValidationSuite {
+class AtomicEvm50ValidationSuite {
 
     private static final String Module05OpcodesExist_CONTRACT = "Module050OpcodesExist";
     private static final long A_BUNCH_OF_GAS = 500_000L;
@@ -37,8 +36,6 @@ public class AtomicEvm50ValidationSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/AtomicSmartContractServiceFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/fees/AtomicSmartContractServiceFeesTest.java
@@ -30,7 +30,6 @@ import com.hedera.services.bdd.spec.dsl.annotations.Account;
 import com.hedera.services.bdd.spec.dsl.annotations.Contract;
 import com.hedera.services.bdd.spec.dsl.entities.SpecAccount;
 import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -43,7 +42,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @OrderedInIsolation
 @Tag(SMART_CONTRACT)
-public class AtomicSmartContractServiceFeesTest {
+class AtomicSmartContractServiceFeesTest {
 
     private static final String ATOMIC_BATCH = "atomicBatch";
     private static final String BATCH_OPERATOR = "batchOperator";
@@ -60,7 +59,6 @@ public class AtomicSmartContractServiceFeesTest {
     @BeforeAll
     public static void setup(final TestLifecycle lifecycle) {
         lifecycle.doAdhoc(contract.getInfo(), civilian.getInfo(), relayer.getInfo());
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractCallSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractCallSuite.java
@@ -139,7 +139,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)
-public class AtomicContractCallSuite {
+class AtomicContractCallSuite {
 
     public static final String TOKEN = "yahcliToken";
     private static final Logger LOG = LogManager.getLogger(AtomicContractCallSuite.class);
@@ -201,13 +201,7 @@ public class AtomicContractCallSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractCreateSuite.java
@@ -125,7 +125,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 @OrderedInIsolation
 @SuppressWarnings("java:S1192") // "string literal should not be duplicated" - this rule makes test suites worse
-public class AtomicContractCreateSuite {
+class AtomicContractCreateSuite {
 
     public static final String EMPTY_CONSTRUCTOR_CONTRACT = "EmptyConstructor";
     public static final String PARENT_INFO = "parentInfo";
@@ -144,13 +144,7 @@ public class AtomicContractCreateSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractDeleteSuite.java
@@ -64,7 +64,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)
-public class AtomicContractDeleteSuite {
+class AtomicContractDeleteSuite {
 
     private static final String CONTRACT = "Multipurpose";
     private static final String PAYABLE_CONSTRUCTOR = "PayableConstructor";
@@ -75,13 +75,7 @@ public class AtomicContractDeleteSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/batch/AtomicContractUpdateSuite.java
@@ -62,7 +62,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)
-public class AtomicContractUpdateSuite {
+class AtomicContractUpdateSuite {
 
     private static final long ONE_DAY = 60L * 60L * 24L;
     public static final String ADMIN_KEY = "adminKey";
@@ -75,13 +75,7 @@ public class AtomicContractUpdateSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicAliasTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicAliasTest.java
@@ -61,15 +61,8 @@ class AtomicAliasTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false",
-                "cryptoCreateWithAlias.enabled",
-                "false"));
+        testLifecycle.overrideInClass(
+                Map.of("contracts.throttle.throttleByGas", "false", "cryptoCreateWithAlias.enabled", "false"));
         testLifecycle.doAdhoc(
                 newKeyNamed(ALIAS).shape(SECP_256K1_SHAPE),
                 createHollow(1, i -> ALIAS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicCreateWithAliasDisabledTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicCreateWithAliasDisabledTest.java
@@ -64,21 +64,14 @@ import org.junit.jupiter.api.Tag;
  * <a href="https://hips.hedera.com/hip/hip-583">HIP-583, "Expand alias support in CryptoCreate &amp; CryptoTransfer Transactions"</a>.
  */
 @HapiTestLifecycle
-public class AtomicCreateWithAliasDisabledTest {
+class AtomicCreateWithAliasDisabledTest {
 
     private static final String BATCH_OPERATOR = "batchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false",
-                "cryptoCreateWithAlias.enabled",
-                "false"));
+        testLifecycle.overrideInClass(
+                Map.of("contracts.throttle.throttleByGas", "false", "cryptoCreateWithAlias.enabled", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicIsAuthorizedTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/batch/AtomicIsAuthorizedTest.java
@@ -86,7 +86,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 @HapiTestLifecycle
 @SuppressWarnings("java:S1192") // "String literals should not be duplicated" - would impair readability here
-public class AtomicIsAuthorizedTest {
+class AtomicIsAuthorizedTest {
 
     public static final String ACCOUNT = "account";
     public static final String ANOTHER_ACCOUNT = "anotherAccount";
@@ -110,15 +110,8 @@ public class AtomicIsAuthorizedTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false",
-                "cryptoCreateWithAlias.enabled",
-                "false"));
+        testLifecycle.overrideInClass(
+                Map.of("contracts.throttle.throttleByGas", "false", "cryptoCreateWithAlias.enabled", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/batch/AtomicLeakyContractTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/batch/AtomicLeakyContractTestsSuite.java
@@ -157,7 +157,7 @@ import org.junit.jupiter.api.Tag;
 @SuppressWarnings("java:S1192") // "string literal should not be duplicated" - this rule makes test suites worse
 @OrderedInIsolation
 @HapiTestLifecycle
-public class AtomicLeakyContractTestsSuite {
+class AtomicLeakyContractTestsSuite {
     public static final String CREATE_TX = "createTX";
     public static final String CREATE_TX_REC = "createTXRec";
     public static final String FALSE = "false";
@@ -193,15 +193,8 @@ public class AtomicLeakyContractTestsSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false",
-                "cryptoCreateWithAlias.enabled",
-                "false"));
+        testLifecycle.overrideInClass(
+                Map.of("contracts.throttle.throttleByGas", "false", "cryptoCreateWithAlias.enabled", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/batch/AtomicLeakyEthereumTestsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/leaky/batch/AtomicLeakyEthereumTestsSuite.java
@@ -44,21 +44,14 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 @SuppressWarnings("java:S5960")
 @HapiTestLifecycle
-public class AtomicLeakyEthereumTestsSuite {
+class AtomicLeakyEthereumTestsSuite {
     private static final String PAY_RECEIVABLE_CONTRACT = "PayReceivable";
     private static final String BATCH_OPERATOR = "batchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false",
-                "cryptoCreateWithAlias.enabled",
-                "false"));
+        testLifecycle.overrideInClass(
+                Map.of("contracts.throttle.throttleByGas", "false", "cryptoCreateWithAlias.enabled", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/AtomicOpCodesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/AtomicOpCodesSuite.java
@@ -66,7 +66,7 @@ import org.junit.jupiter.api.Tag;
 
 // Wrapping the most important tests from this package with an atomic batch
 @HapiTestLifecycle
-public class AtomicOpCodesSuite {
+class AtomicOpCodesSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
     private static final String CREATE_CONTRACT = "FactoryContract";
@@ -91,8 +91,6 @@ public class AtomicOpCodesSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
         testLifecycle.overrideInClass(Map.of("contracts.evm.version", "v0.50"));
         testLifecycle.doAdhoc(
@@ -358,7 +356,7 @@ public class AtomicOpCodesSuite {
     static SpecContract gasPriceContract;
 
     @HapiTest
-    public Stream<DynamicTest> getGasPrice() {
+    Stream<DynamicTest> getGasPrice() {
         return hapiTest(gasPriceContract
                 .call("getTxGasPrice")
                 .wrappedInBatchOperation(BATCH_OPERATOR)
@@ -369,7 +367,7 @@ public class AtomicOpCodesSuite {
     }
 
     @HapiTest
-    public Stream<DynamicTest> getLastGasPrice() {
+    Stream<DynamicTest> getLastGasPrice() {
         return hapiTest(
                 gasPriceContract
                         .call("getLastTxGasPrice")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/batch/AtomicLogsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/batch/AtomicLogsSuite.java
@@ -34,7 +34,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(SMART_CONTRACT)
-public class AtomicLogsSuite {
+class AtomicLogsSuite {
 
     private static final long GAS_TO_OFFER = 25_000L;
 
@@ -43,13 +43,7 @@ public class AtomicLogsSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/batch/AtomicRecordsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/batch/AtomicRecordsSuite.java
@@ -66,7 +66,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 @HapiTestLifecycle
 @DisplayName("Records Suite")
-public class AtomicRecordsSuite {
+class AtomicRecordsSuite {
 
     public static final String LOG_NOW = "logNow";
     public static final String AUTO_ACCOUNT = "autoAccount";
@@ -74,13 +74,7 @@ public class AtomicRecordsSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/validation/batch/AtomicEvmValidationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/validation/batch/AtomicEvmValidationTest.java
@@ -42,19 +42,13 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 @DisplayName("evmValidation")
 @HapiTestLifecycle
-public class AtomicEvmValidationTest {
+class AtomicEvmValidationTest {
 
     private static final String BATCH_OPERATOR = "batchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "atomicBatch.maxNumberOfTransactions",
-                "50",
-                "contracts.throttle.throttleByGas",
-                "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 
@@ -68,7 +62,7 @@ public class AtomicEvmValidationTest {
         @HapiTest
         @DisplayName("succeeds on non-existent contract")
         @Tag(MATS)
-        public Stream<DynamicTest> canCallBalanceOperationNonExtantContract() {
+        Stream<DynamicTest> canCallBalanceOperationNonExtantContract() {
             final var INVALID_ADDRESS = "0x0000000000000000000000000000000000123456";
             return hapiTest(balanceChecker46Version
                     .call("balanceOf", asHeadlongAddress(INVALID_ADDRESS))
@@ -94,21 +88,21 @@ public class AtomicEvmValidationTest {
 
             @HapiTest
             @DisplayName("when transferring value to long zero address 00000000000000000000000000000000001117d0 ")
-            public Stream<DynamicTest> lazyCreateToLongZeroFails() {
+            Stream<DynamicTest> lazyCreateToLongZeroFails() {
                 final Function<HapiSpec, String> longZeroAddress = (spec) -> toAddressString("1117d0");
                 return callContractWithValue(longZeroAddress, CONTRACT_REVERT_EXECUTED);
             }
 
             @HapiTest
             @DisplayName("when transferring value to long zero burn address 000000000000000000000000000000000000dEaD ")
-            public Stream<DynamicTest> lazyCreateToLongZeroBurnAddressFails() {
+            Stream<DynamicTest> lazyCreateToLongZeroBurnAddressFails() {
                 final Function<HapiSpec, String> longZeroBurnAddress = (spec) -> toAddressString("dEaD");
                 return callContractWithValue(longZeroBurnAddress, CONTRACT_REVERT_EXECUTED);
             }
 
             @HapiTest
             @DisplayName("when transferring value to all zero address 0000000000000000000000000000000000000000 ")
-            public Stream<DynamicTest> lazyCreateToAllZeroFails() {
+            Stream<DynamicTest> lazyCreateToAllZeroFails() {
                 final var ALL_ZERO_ADDRESS = "0000000000000000000000000000000000000000";
                 return callContractWithValue(ALL_ZERO_ADDRESS, INVALID_CONTRACT_ID);
             }
@@ -120,14 +114,14 @@ public class AtomicEvmValidationTest {
 
             @HapiTest
             @DisplayName("when transferring value to evm address 0000000100000000000000020000000000000003")
-            public Stream<DynamicTest> lazyCreateToEvmAddressSucceeds() {
+            Stream<DynamicTest> lazyCreateToEvmAddressSucceeds() {
                 final var EVM_ADDRESS = "0000000100000000000000020000000000000003";
                 return callContractWithValue(EVM_ADDRESS, ResponseCodeEnum.SUCCESS);
             }
 
             @HapiTest
             @DisplayName("when transferring value to realistic evm address 388C818CA8B9251b393131C08a736A67ccB19297")
-            public Stream<DynamicTest> lazyCreateToRealisticEvmAddressSucceeds() {
+            Stream<DynamicTest> lazyCreateToRealisticEvmAddressSucceeds() {
                 final var REALISTIC_EVM_ADDRESS = "388C818CA8B9251b393131C08a736A67ccB19297";
                 return callContractWithValue(REALISTIC_EVM_ADDRESS, ResponseCodeEnum.SUCCESS);
             }
@@ -169,7 +163,7 @@ public class AtomicEvmValidationTest {
 
         @HapiTest
         @DisplayName("should fail to deploy")
-        public Stream<DynamicTest> canCallBalanceOperationNonExtantContract() {
+        Stream<DynamicTest> canCallBalanceOperationNonExtantContract() {
             return hapiTest(
                     uploadInitCode(emptyContract),
                     atomicBatch(contractCreate(emptyContract)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AtomicBatchAutoAccountCreationBasicTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AtomicBatchAutoAccountCreationBasicTests.java
@@ -38,8 +38,6 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import com.google.protobuf.ByteString;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
@@ -47,21 +45,17 @@ import com.hedera.services.bdd.spec.transactions.token.HapiTokenCreate;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenMint;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.bouncycastle.util.encoders.Hex;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestLifecycle
-public class AtomicBatchAutoAccountCreationBasicTests {
+class AtomicBatchAutoAccountCreationBasicTests {
 
     private static final double BASE_FEE_BATCH_TRANSACTION = 0.001;
     private static final String FT_FOR_AUTO_ACCOUNT = "ftForAutoAccount";
@@ -79,14 +73,9 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     private static final String nftSupplyKey = "nftSupplyKey";
     private static final String adminKey = "adminKey";
 
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
-
     @HapiTest
     @DisplayName("Auto Create ED25519 Account with FT Transfer success in Atomic Batch")
-    public Stream<DynamicTest> autoCreateED25519AccountWithFT_TransferSuccessInBatch() {
+    Stream<DynamicTest> autoCreateED25519AccountWithFT_TransferSuccessInBatch() {
 
         // create transfer to alias inner transaction
         final var tokenTransferToAlias = cryptoTransfer(
@@ -149,7 +138,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     @HapiTest
     @DisplayName("Auto Create ECDSA Account with FT Transfer success in Atomic Batch")
     @Tag(MATS)
-    public Stream<DynamicTest> autoCreateECDSA_AccountWithFT_TransferSuccessInBatch() {
+    Stream<DynamicTest> autoCreateECDSA_AccountWithFT_TransferSuccessInBatch() {
 
         // create transfer to alias inner transaction
         final var tokenTransferToAlias = cryptoTransfer(
@@ -211,7 +200,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     @HapiTest
     @DisplayName("Auto Account Create with Public Key ED25519 and ECDSA and HBAR Transfer success in "
             + "Atomic Batch - Parametrized")
-    public Stream<DynamicTest> autoCreateAccountWithHBAR_TransferSuccessInBatch_Parametrized() {
+    Stream<DynamicTest> autoCreateAccountWithHBAR_TransferSuccessInBatch_Parametrized() {
         record AliasTestCase(String displayName, String aliasKeyName, String aliasType) {}
 
         final List<AliasTestCase> aliasTypes = List.of(
@@ -259,7 +248,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     @HapiTest
     @DisplayName("Auto Account Create with Public Key ED25519 and ECDSA and FT Transfer success in "
             + "Atomic Batch - Parametrized")
-    public Stream<DynamicTest> autoCreateAccountWithFT_TransferSuccessInBatch_Parametrized() {
+    Stream<DynamicTest> autoCreateAccountWithFT_TransferSuccessInBatch_Parametrized() {
         record AliasTestCase(String displayName, String aliasKeyName, String aliasType) {}
 
         final List<AliasTestCase> aliasTypes = List.of(
@@ -327,7 +316,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     @HapiTest
     @DisplayName("Auto Account Create with Public Key ED25519 and ECDSA and NFT Transfer success in "
             + "Atomic Batch - Parametrized")
-    public Stream<DynamicTest> autoCreateAccountWithNFT_TransferSuccessInBatch_Parametrized() {
+    Stream<DynamicTest> autoCreateAccountWithNFT_TransferSuccessInBatch_Parametrized() {
         record AliasTestCase(String displayName, String aliasKeyName, String aliasType) {}
 
         final List<AliasTestCase> aliasTypes = List.of(
@@ -399,7 +388,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     @HapiTest
     @DisplayName("Auto Account Create with Public Key ED25519 and ECDSA and HBAR, FT and NFT Transfers success in "
             + "Atomic Batch - Parametrized")
-    public Stream<DynamicTest> autoCreateAccountWithHBAR_FT_NFT_TransferSuccessInBatch_Parametrized() {
+    Stream<DynamicTest> autoCreateAccountWithHBAR_FT_NFT_TransferSuccessInBatch_Parametrized() {
         record AliasTestCase(String displayName, String aliasKeyName, String aliasType) {}
 
         final List<AliasTestCase> aliasTypes = List.of(
@@ -476,7 +465,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create Hollow Account with HBAR Transfer success in Atomic Batch")
-    public Stream<DynamicTest> autoCreateHollowAccountWithHBAR_TransferSuccessInBatch() {
+    Stream<DynamicTest> autoCreateHollowAccountWithHBAR_TransferSuccessInBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -543,7 +532,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create Hollow Account with FT Transfer success in Atomic Batch")
-    public Stream<DynamicTest> autoCreateHollowAccountWithFT_TransferSuccessInBatch() {
+    Stream<DynamicTest> autoCreateHollowAccountWithFT_TransferSuccessInBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -611,7 +600,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     @HapiTest
     @DisplayName("Auto Create Hollow Account with NFT Transfer success in Atomic Batch")
     @Tag(MATS)
-    public Stream<DynamicTest> autoCreateHollowAccountWithNFT_TransferSuccessInBatch() {
+    Stream<DynamicTest> autoCreateHollowAccountWithNFT_TransferSuccessInBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -678,7 +667,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create Hollow Account with HBAR, FT And NFT Transfers success in Atomic Batch")
-    public Stream<DynamicTest> autoCreateHollowAccountWithHBAR_FT_NFT_TransferSuccessInBatch() {
+    Stream<DynamicTest> autoCreateHollowAccountWithHBAR_FT_NFT_TransferSuccessInBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -745,7 +734,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create All Types - Public Key and Hollow Accounts with HBAR Transfer success in Atomic Batch")
-    public Stream<DynamicTest> autoCreatePublicKeyAndHollowAccountWithHBAR_TransferSuccessInBatch() {
+    Stream<DynamicTest> autoCreatePublicKeyAndHollowAccountWithHBAR_TransferSuccessInBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -850,7 +839,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create All Types - Public Key and Hollow Accounts with FT Transfer success in Atomic Batch")
-    public Stream<DynamicTest> autoCreatePublicKeyAndHollowAccountWithFT_TransferSuccessInBatch() {
+    Stream<DynamicTest> autoCreatePublicKeyAndHollowAccountWithFT_TransferSuccessInBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -965,7 +954,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create All Types - Public Key and Hollow Accounts with NFT Transfer success in Atomic Batch")
-    public Stream<DynamicTest> autoCreatePublicKeyAndHollowAccountWithNFT_TransferSuccessInBatch() {
+    Stream<DynamicTest> autoCreatePublicKeyAndHollowAccountWithNFT_TransferSuccessInBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -1084,7 +1073,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create Hollow Account and Transfer to the same ECDSA Public Key success in Atomic Batch")
-    public Stream<DynamicTest> autoCreateHollowAccountAndTransferToSameECDSA_InBatch() {
+    Stream<DynamicTest> autoCreateHollowAccountAndTransferToSameECDSA_InBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -1169,7 +1158,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     @HapiTest
     @DisplayName("Auto Create Account from Public Key and Transfer to evm alias derived from the same ECDSA Public Key "
             + "success in Atomic Batch")
-    public Stream<DynamicTest> autoCreatePublicKeyAccountAndTransferToEvmAliasFromTheSameECDSA_InBatch() {
+    Stream<DynamicTest> autoCreatePublicKeyAccountAndTransferToEvmAliasFromTheSameECDSA_InBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -1253,7 +1242,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create Account from Transfer to Invalid evm alias fails in Batch ")
-    public Stream<DynamicTest> autoCreateAccountFromTransferToInvalidEvmAliasFailsInBatch_Parametrized() {
+    Stream<DynamicTest> autoCreateAccountFromTransferToInvalidEvmAliasFailsInBatch_Parametrized() {
 
         record InvalidAliasCase(String description, byte[] invalidAliasBytes) {}
 
@@ -1318,7 +1307,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create Account from Transfer to Invalid ECDSA and ED25519 public keys fails in Batch ")
-    public Stream<DynamicTest> autoCreateAccountFromTransferToInvalidPublicKeysFailsInBatch_Parametrized() {
+    Stream<DynamicTest> autoCreateAccountFromTransferToInvalidPublicKeysFailsInBatch_Parametrized() {
 
         record InvalidKeyCase(String description, byte[] invalidKeyBytes) {}
 
@@ -1386,7 +1375,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     // transfer with 0 HBAR amount
     @HapiTest
     @DisplayName("Auto Create ECDSA Public Key Account with 0 Transfer fails in Atomic Batch")
-    public Stream<DynamicTest> autoCreateECDSAKeyAccountWithZeroTransferFailsInBatch() {
+    Stream<DynamicTest> autoCreateECDSAKeyAccountWithZeroTransferFailsInBatch() {
 
         // create transfer to ECDSA alias inner transaction
         final var tokenTransferTo_ECDSA_Alias = cryptoTransfer(
@@ -1425,7 +1414,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create ED25519 Public Key Account with 0 Transfer fails in Atomic Batch")
-    public Stream<DynamicTest> autoCreateED25519KeyAccountWithZeroTransferFailsInBatch() {
+    Stream<DynamicTest> autoCreateED25519KeyAccountWithZeroTransferFailsInBatch() {
 
         // create transfer to ED25519 alias inner transaction
         final var tokenTransferTo_ED25519_Alias = cryptoTransfer(movingHbar(0L).between(OWNER, VALID_ALIAS_ED25519))
@@ -1463,7 +1452,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create Hollow Account with 0 Transfer fails in Atomic Batch")
-    public Stream<DynamicTest> autoCreateHollowAccountWithZeroTransferFailsInBatch() {
+    Stream<DynamicTest> autoCreateHollowAccountWithZeroTransferFailsInBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -1536,7 +1525,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     // Insufficient funds for transfer
     @HapiTest
     @DisplayName("Auto Create ECDSA Public Key Account with Sender with Insufficient funds fails in Atomic Batch")
-    public Stream<DynamicTest> autoCreateECDSAKeyAccountWithInsufficientFundsSenderFailsInBatch() {
+    Stream<DynamicTest> autoCreateECDSAKeyAccountWithInsufficientFundsSenderFailsInBatch() {
 
         // create transfer to ECDSA alias inner transaction
         final var tokenTransferTo_ECDSA_Alias = cryptoTransfer(
@@ -1572,7 +1561,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create ED25519 Public Key Account with Sender with Insufficient funds fails in Atomic Batch")
-    public Stream<DynamicTest> autoCreateED25519KeyAccountWithInsufficientFundsSenderFailsInBatch() {
+    Stream<DynamicTest> autoCreateED25519KeyAccountWithInsufficientFundsSenderFailsInBatch() {
 
         // create transfer to ED25519 alias inner transaction
         final var tokenTransferTo_ED25519_Alias = cryptoTransfer(
@@ -1608,7 +1597,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
 
     @HapiTest
     @DisplayName("Auto Create Hollow Account with Sender with Insufficient funds fails in Atomic Batch")
-    public Stream<DynamicTest> autoCreateHollowAccountWithInsufficientFundsSenderFailsInBatch() {
+    Stream<DynamicTest> autoCreateHollowAccountWithInsufficientFundsSenderFailsInBatch() {
 
         final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -1669,7 +1658,7 @@ public class AtomicBatchAutoAccountCreationBasicTests {
     // valid length alias that is not recoverable from a public key
     @HapiTest
     @DisplayName("Auto Create Account with Unrecoverable Valid Alias fails in Atomic Batch")
-    public Stream<DynamicTest> autoCreateAccountWithUnrecoverableValidAliasFailsInBatch() {
+    Stream<DynamicTest> autoCreateAccountWithUnrecoverableValidAliasFailsInBatch() {
 
         final var aliasBytes = ByteString.copyFrom(new byte[20]); // valid length but not recoverable
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AtomicBatchAutoAccountCreationEndToEndTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/AtomicBatchAutoAccountCreationEndToEndTests.java
@@ -45,8 +45,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import com.google.protobuf.ByteString;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.keys.KeyShape;
@@ -58,21 +56,17 @@ import com.hederahashgraph.api.proto.java.Key;
 import com.hederahashgraph.api.proto.java.KeyList;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.ThresholdKey;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestLifecycle
-public class AtomicBatchAutoAccountCreationEndToEndTests {
+class AtomicBatchAutoAccountCreationEndToEndTests {
 
     private static final double BASE_FEE_BATCH_TRANSACTION = 0.001;
     private static final String FT_FOR_AUTO_ACCOUNT = "ftForAutoAccount";
@@ -100,18 +94,13 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
     private static final String nftSupplyKey = "nftSupplyKey";
     private static final String adminKey = "adminKey";
 
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
-
     @Nested
     @DisplayName("Atomic Batch Auto Account Creation End-to-End Tests - Multiple Accounts and Transfers Test Cases ")
     class AtomicBatchAutoAccountCreationMultipleAccountsAndTransfersTests {
         @HapiTest
         @DisplayName(
                 "Auto Create Multiple Public Key and EVM Alias Accounts with Token Transfers success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateMultipleAccountsWithTokenTransfersSuccessInBatch() {
+        Stream<DynamicTest> autoCreateMultipleAccountsWithTokenTransfersSuccessInBatch() {
 
             final AtomicReference<ByteString> evmAliasFirst = new AtomicReference<>();
             final AtomicReference<ByteString> evmAliasSecond = new AtomicReference<>();
@@ -295,7 +284,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName(
                 "Auto Create Multiple EVM Alias Hollow Accounts with Multiple NFT Transfers success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateMultipleEVMAliasHollowAccountsWithMultipleNFTTransfersSuccessInBatch() {
+        Stream<DynamicTest> autoCreateMultipleEVMAliasHollowAccountsWithMultipleNFTTransfersSuccessInBatch() {
 
             final AtomicReference<ByteString> evmAliasFirst = new AtomicReference<>();
             final AtomicReference<ByteString> evmAliasSecond = new AtomicReference<>();
@@ -474,7 +463,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @DisplayName(
                 "Auto Create Accounts with Multiple Transfers to valid Public Keys and evm alias with failing Transfer - "
                         + "Fails in Atomic Batch and no accounts are created")
-        public Stream<DynamicTest> autoCreateECDSAAccountWithFailingTokenTransferFailsInBatch() {
+        Stream<DynamicTest> autoCreateECDSAAccountWithFailingTokenTransferFailsInBatch() {
 
             final AtomicReference<ByteString> evmAliasFirst = new AtomicReference<>();
             final AtomicReference<ByteString> evmAliasSecond = new AtomicReference<>();
@@ -617,7 +606,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
 
         @HapiTest
         @DisplayName("Auto Create Hollow Account in one Batch and Finalize it in Another Atomic Batch")
-        public Stream<DynamicTest> autoCreateHollowAccountInOneBatchAndFinalizeInAnotherBatch() {
+        Stream<DynamicTest> autoCreateHollowAccountInOneBatchAndFinalizeInAnotherBatch() {
 
             final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -726,7 +715,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName("Auto Create Hollow Account in one Batch, Finalize it and Token Transfer in Another Atomic Batch")
         @Tag(MATS)
-        public Stream<DynamicTest> autoCreateHollowAccountInOneBatchFinalizeAndTokenTransferInAnotherBatch() {
+        Stream<DynamicTest> autoCreateHollowAccountInOneBatchFinalizeAndTokenTransferInAnotherBatch() {
 
             final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -847,7 +836,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
 
         @HapiTest
         @DisplayName("Auto Create Hollow Account in one Batch, Finalize it Outside Atomic Batch")
-        public Stream<DynamicTest> autoCreateHollowAccountInOneBatchFinalizeOutsideBatch() {
+        Stream<DynamicTest> autoCreateHollowAccountInOneBatchFinalizeOutsideBatch() {
 
             final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -961,7 +950,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName(
                 "Auto Create Hollow Account in one Batch and Finalize it in another Batch Inner Transaction Fails in Atomic Batch")
-        public Stream<DynamicTest> autoCreateHollowAccountAndFinalizeInInnerTxnFailsInBatch() {
+        Stream<DynamicTest> autoCreateHollowAccountAndFinalizeInInnerTxnFailsInBatch() {
 
             final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -1078,7 +1067,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName(
                 "Mint Token and Transfer it to Public key and evm alias auto-creating accounts success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountsWithTokenMintAndTransfersSuccessInBatch() {
+        Stream<DynamicTest> autoCreateAccountsWithTokenMintAndTransfersSuccessInBatch() {
 
             final AtomicReference<ByteString> evmAliasFirst = new AtomicReference<>();
 
@@ -1201,8 +1190,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName("Mint Token, Transfer to Public key alias and Transfer from the auto-created account to new alias"
                 + " success in Atomic Batch")
-        public Stream<DynamicTest>
-                autoCreateAccountWithTokenMintAndTransferAndNewTransferToPublicKeyAliasSuccessInBatch() {
+        Stream<DynamicTest> autoCreateAccountWithTokenMintAndTransferAndNewTransferToPublicKeyAliasSuccessInBatch() {
 
             // create NFT transfers to ED25519 and ECDSA aliases in a batch
             final var tokenTransferFT_To_ED25519 = cryptoTransfer(
@@ -1314,7 +1302,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName("Mint Token, Transfer to Public key alias and transfer from the auto-created account to evm alias"
                 + "creating hollow account success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountWithTokenMintAndTransferAndNewTransferToEvmAliasSuccessInBatch() {
+        Stream<DynamicTest> autoCreateAccountWithTokenMintAndTransferAndNewTransferToEvmAliasSuccessInBatch() {
 
             final AtomicReference<ByteString> evmAliasFirst = new AtomicReference<>();
 
@@ -1431,7 +1419,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @DisplayName(
                 "Auto Create Account in one batch, edit Account Key and transfer from the edited account in second "
                         + "batch success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditAccountKeyAndTransferFromEditedAccountSuccessInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAccountKeyAndTransferFromEditedAccountSuccessInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -1538,7 +1526,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @DisplayName(
                 "Auto Create Account in one batch, edit Account Key with the same key and transfer in second batch "
                         + "success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditAccountKeyWithSameKeyAndTransferSuccessInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAccountKeyWithSameKeyAndTransferSuccessInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -1645,7 +1633,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @DisplayName(
                 "Auto Create Account in one batch, increase Auto-Association limit and Auto-Associate the edited account in second "
                         + "batch success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditAutoAssociationLimitAndAssociateEditedAccountSuccessInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAutoAssociationLimitAndAssociateEditedAccountSuccessInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -1744,7 +1732,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @DisplayName(
                 "Auto Create Account in one batch, edit both Account Key and Auto-Association limit in second batch "
                         + "success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditBothAccountKeyAndAutoAssociationLimitSuccessInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditBothAccountKeyAndAutoAssociationLimitSuccessInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -1850,7 +1838,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
 
         @HapiTest
         @DisplayName("Auto Create Hollow Account in one batch and edit its key in second batch success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateHollowAccountEditKeySuccessInBatch() {
+        Stream<DynamicTest> autoCreateHollowAccountEditKeySuccessInBatch() {
 
             final AtomicReference<ByteString> evmAlias = new AtomicReference<>();
 
@@ -1979,8 +1967,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @DisplayName(
                 "Auto Create Account in one batch, edit Account Key with Threshold Key and Transfer from the edited account in second "
                         + "batch success in Atomic Batch")
-        public Stream<DynamicTest>
-                autoCreateAccountEditAccountKeyWithThresholdAndTransferFromEditedAccountSuccessInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAccountKeyWithThresholdAndTransferFromEditedAccountSuccessInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -2095,7 +2082,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName("Auto Create Account in one batch, edit Account Key with new Key and edit again with the Old Key "
                 + "success in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditAccountKeyWithNewAndEditAgainWithOldKeysSuccessInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAccountKeyWithNewAndEditAgainWithOldKeysSuccessInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -2214,8 +2201,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName(
                 "Auto Create Account in one batch and edit Auto-Association limit to 0 in second batch fails in Atomic Batch")
-        public Stream<DynamicTest>
-                autoCreateAccountEditAutoAssociationLimitToZeroAndAssociateEditedAccountFailsInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAutoAssociationLimitToZeroAndAssociateEditedAccountFailsInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -2300,7 +2286,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @DisplayName(
                 "Auto Create Account in one batch, edit Auto-Association limit to 1 and Associate exceeding the edited limit "
                         + "in second batch fails in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditAutoAssociationLimitAndExceedAssociationNumberFailsInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAutoAssociationLimitAndExceedAssociationNumberFailsInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -2400,8 +2386,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @DisplayName(
                 "Auto Create Account in one batch, edit Account Key and sign transfer from the edited account in second "
                         + "batch with old key fails in Atomic Batch")
-        public Stream<DynamicTest>
-                autoCreateAccountEditAccountKeyAndSignTransferFromEditedAccountWithOldKeyFailsInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAccountKeyAndSignTransferFromEditedAccountWithOldKeyFailsInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -2509,7 +2494,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @DisplayName(
                 "Auto Create Account in one batch, edit Account Key and do not sign the edit with the new key in second "
                         + "batch fails in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditAccountKeyAndDoNotSignEditTxnWithNewKeyFailsInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAccountKeyAndDoNotSignEditTxnWithNewKeyFailsInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -2588,7 +2573,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
 
         @HapiTest
         @DisplayName("Auto Create Account in one batch, edit Account Key with Invalid Key fails in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditAccountKeyWithInvalidKeyFailsInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAccountKeyWithInvalidKeyFailsInBatch() {
 
             final Key invalidKey =
                     Key.newBuilder().setKeyList(KeyList.newBuilder()).build();
@@ -2672,7 +2657,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName(
                 "Auto Create Account in one batch, edit Account Key with Invalid Threshold Key fails in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditAccountKeyWithInvalidThresholdKeyFailsInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAccountKeyWithInvalidThresholdKeyFailsInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(
@@ -2778,7 +2763,7 @@ public class AtomicBatchAutoAccountCreationEndToEndTests {
         @HapiTest
         @DisplayName("Auto Create Account in one batch, edit Account Key with Valid Threshold Key and sign with Old Key"
                 + " fails in Atomic Batch")
-        public Stream<DynamicTest> autoCreateAccountEditAccountKeyWithThresholdKeyAndSignWithOldFailsInBatch() {
+        Stream<DynamicTest> autoCreateAccountEditAccountKeyWithThresholdKeyAndSignWithOldFailsInBatch() {
 
             // create FT transfer to ED25519 alias in a batch
             final var tokenTransferNFT_To_ED25519 = cryptoTransfer(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/batch/AtomicAutoAccountCreationUnlimitedAssociationsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/batch/AtomicAutoAccountCreationUnlimitedAssociationsSuite.java
@@ -75,7 +75,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @Tag(CRYPTO)
 @HapiTestLifecycle
-public class AtomicAutoAccountCreationUnlimitedAssociationsSuite {
+class AtomicAutoAccountCreationUnlimitedAssociationsSuite {
 
     public static final String TRUE = "true";
     public static final String FALSE = "false";
@@ -99,8 +99,6 @@ public class AtomicAutoAccountCreationUnlimitedAssociationsSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/batch/AtomicAutoAccountUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/batch/AtomicAutoAccountUpdateSuite.java
@@ -30,7 +30,6 @@ import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -47,7 +46,7 @@ import org.junit.jupiter.api.Tag;
  */
 @Tag(CRYPTO)
 @HapiTestLifecycle
-public class AtomicAutoAccountUpdateSuite {
+class AtomicAutoAccountUpdateSuite {
 
     public static final long INITIAL_BALANCE = 1000L;
 
@@ -60,8 +59,6 @@ public class AtomicAutoAccountUpdateSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicConsensusServiceFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicConsensusServiceFeesSuite.java
@@ -19,22 +19,16 @@ import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of ConsensusServiceFeesSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm the fees are the same
-@HapiTestLifecycle
-public class AtomicConsensusServiceFeesSuite {
+class AtomicConsensusServiceFeesSuite {
 
     private static final double BASE_FEE_TOPIC_CREATE = 0.01;
     private static final double BASE_FEE_TOPIC_CREATE_WITH_CUSTOM_FEE = 2.00;
@@ -47,12 +41,6 @@ public class AtomicConsensusServiceFeesSuite {
 
     private static final String PAYER = "payer";
     private static final String TOPIC_NAME = "testTopic";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     private HapiSpecOperation[] topicCreateSetup() {
         return new HapiSpecOperation[] {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicCryptoServiceFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicCryptoServiceFeesSuite.java
@@ -56,7 +56,7 @@ import org.junit.jupiter.api.Tag;
 // This test cases are direct copies of CryptoServiceFeesSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm the fees are the same
 @HapiTestLifecycle
-public class AtomicCryptoServiceFeesSuite {
+class AtomicCryptoServiceFeesSuite {
 
     private static final double BASE_FEE_CRYPTO_CREATE = 0.05;
     private static final double BASE_FEE_CRYPTO_DELETE = 0.005;
@@ -82,8 +82,6 @@ public class AtomicCryptoServiceFeesSuite {
         testLifecycle.doAdhoc(
                 cryptoCreate(FEES_ACCOUNT).balance(5 * ONE_HUNDRED_HBARS),
                 cryptoCreate(CIVILIAN).balance(5 * ONE_HUNDRED_HBARS).key(FEES_ACCOUNT));
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicFileServiceFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicFileServiceFeesSuite.java
@@ -16,22 +16,16 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.THREE_MONTHS_IN_SECONDS;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of FileServiceFeesSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm the fees are the same
-@HapiTestLifecycle
-public class AtomicFileServiceFeesSuite {
+class AtomicFileServiceFeesSuite {
 
     private static final String MEMO = "Really quite something!";
     private static final String CIVILIAN = "civilian";
@@ -42,12 +36,6 @@ public class AtomicFileServiceFeesSuite {
     private static final double BASE_FEE_FILE_APPEND = 0.05;
     private static final String BATCH_OPERATOR = "batchOperator";
     private static final String ATOMIC_BATCH = "atomicBatch";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     @DisplayName("USD base fee as expected for file create transaction")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicMiscellaneousFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicMiscellaneousFeesSuite.java
@@ -14,21 +14,16 @@ import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of MiscellaneousFeesSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm the fees are the same
-@HapiTestLifecycle
 @Tag(MATS)
-public class AtomicMiscellaneousFeesSuite {
+class AtomicMiscellaneousFeesSuite {
 
     private static final String PRNG_IS_ENABLED = "utilPrng.isEnabled";
     private static final String BOB = "bob";
@@ -36,12 +31,6 @@ public class AtomicMiscellaneousFeesSuite {
     private static final double EXPECTED_FEE_PRNG_RANGE_TRX = 0.0010010316;
     private static final String BATCH_OPERATOR = "batchOperator";
     private static final String ATOMIC_BATCH = "atomicBatch";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     @DisplayName("USD base fee as expected for Prng transaction")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicTokenServiceFeesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/fees/AtomicTokenServiceFeesSuite.java
@@ -54,20 +54,16 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenClaimAirdrop;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
@@ -76,8 +72,7 @@ import org.junit.jupiter.api.Tag;
 // This test cases are direct copies of TokenServiceFeesSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm the fees are the same
 @Tag(TOKEN)
-@HapiTestLifecycle
-public class AtomicTokenServiceFeesSuite {
+class AtomicTokenServiceFeesSuite {
 
     private static final double ALLOWED_DIFFERENCE_PERCENTAGE = 0.01;
     private static final double ALLOWED_DIFFERENCE = 5;
@@ -128,12 +123,6 @@ public class AtomicTokenServiceFeesSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
     private static final String ATOMIC_BATCH = "atomicBatch";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     @Tag(MATS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicExchangeRateControlSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicExchangeRateControlSuite.java
@@ -22,30 +22,18 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACT
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.OrderedInIsolation;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.transactions.file.HapiFileUpdate;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of ExchangeRateControlSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
 @OrderedInIsolation
-public class AtomicExchangeRateControlSuite {
+class AtomicExchangeRateControlSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     final HapiFileUpdate resetRatesOp = fileUpdate(EXCHANGE_RATES)
             .payingWith(EXCHANGE_RATE_CONTROL)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileAppendSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileAppendSuite.java
@@ -12,28 +12,16 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.MAX_FILE_SIZE_EXCEEDED;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 
 // This test cases are direct copies of FileAppendSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicFileAppendSuite {
+class AtomicFileAppendSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> appendIdVariantsTreatedAsExpected() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileCreateSuite.java
@@ -30,8 +30,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNAT
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.ControlForKey;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
@@ -40,26 +38,16 @@ import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.Transaction;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Path;
 import java.time.Instant;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 
 // This test cases are direct copies of FileAppendSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicFileCreateSuite {
+class AtomicFileCreateSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> exchangeRateControlAccountIsntCharged() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileDeleteSuite.java
@@ -20,30 +20,18 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of FileDeleteSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicFileDeleteSuite {
+class AtomicFileDeleteSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> canDeleteWithAnyOneOfTopLevelKeyList() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileUpdateSuite.java
@@ -35,32 +35,21 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 import static java.lang.Long.parseLong;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.SigControl;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of FileUpdateSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
 @SuppressWarnings("java:S1192")
-public class AtomicFileUpdateSuite {
+class AtomicFileUpdateSuite {
 
     private static final String CREATE_TXN = "create";
     public static final String CIVILIAN = "civilian";
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @LeakyHapiTest(requirement = PERMISSION_OVERRIDES)
     @Tag(MATS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicPermissionSemanticsSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicPermissionSemanticsSpec.java
@@ -31,36 +31,24 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.ControlForKey;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
 import com.hedera.services.bdd.spec.keys.KeyShape;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of PermissionSemanticsSpec. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicPermissionSemanticsSpec {
+class AtomicPermissionSemanticsSpec {
 
     public static final String NEVER_TO_BE_USED = "neverToBeUsed";
     public static final String CIVILIAN = "civilian";
     public static final String ETERNAL = "eternal";
     public static final String WACL = "wacl";
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> addressBookAdminExemptFromFeesGivenAuthorizedOps() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicProtectedFilesUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicProtectedFilesUpdateSuite.java
@@ -32,9 +32,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.InvalidProtocolBufferException;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.OrderedInIsolation;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.queries.file.HapiGetFileContents;
 import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
@@ -42,7 +40,6 @@ import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hedera.services.bdd.suites.utils.sysfiles.AddressBookPojo;
 import com.hederahashgraph.api.proto.java.NodeAddress;
 import com.hederahashgraph.api.proto.java.NodeAddressBook;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Map;
 import java.util.SplittableRandom;
 import java.util.function.UnaryOperator;
@@ -52,15 +49,13 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.utility.CommonUtils;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of ProtectedFilesUpdateSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
 @OrderedInIsolation
-public class AtomicProtectedFilesUpdateSuite {
+class AtomicProtectedFilesUpdateSuite {
 
     private static final String IGNORE = "ignore";
     private static final String TARGET_MEMO = "0.0.5";
@@ -72,12 +67,6 @@ public class AtomicProtectedFilesUpdateSuite {
 
     // The number of chars that separate a property and its value
     private static final int PROPERTY_VALUE_SPACE_LENGTH = 2;
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> account2CanUpdateApplicationProperties() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicSysDelSysUndelSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicSysDelSysUndelSpec.java
@@ -26,31 +26,19 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of SysDelSysUndelSpec. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicSysDelSysUndelSpec {
+class AtomicSysDelSysUndelSpec {
 
     byte[] ORIG_FILE = "SOMETHING".getBytes();
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     @Tag(MATS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicUpdateFailuresSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicUpdateFailuresSpec.java
@@ -28,35 +28,23 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.queries.QueryVerbs;
 import com.hedera.services.bdd.spec.utilops.CustomSpecAssert;
 import com.hedera.services.bdd.spec.utilops.UtilVerbs;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of UpdateFailuresSpec. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicUpdateFailuresSpec {
+class AtomicUpdateFailuresSpec {
 
     private static final long A_LOT = 1_234_567_890L;
     private static final String CIVILIAN = "civilian";
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> confusedUpdateCantExtendExpiry() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicAutoAccountCreationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicAutoAccountCreationSuite.java
@@ -106,7 +106,6 @@ import com.hederahashgraph.api.proto.java.TokenType;
 import com.hederahashgraph.api.proto.java.TransferList;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -119,12 +118,10 @@ import org.junit.jupiter.api.Tag;
 // The difference here is that we are wrapping the operations in an atomic batch to confirm the behavior is the same
 @Tag(CRYPTO)
 @HapiTestLifecycle
-public class AtomicAutoAccountCreationSuite {
+class AtomicAutoAccountCreationSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate("batchOperator").balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchCustomFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchCustomFeesTest.java
@@ -32,20 +32,14 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSO
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.SpecOperation;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestLifecycle
-public class AtomicBatchCustomFeesTest {
+class AtomicBatchCustomFeesTest {
     private static final String FT_WITH_FIXED_HBAR_FEE = "FT_WithFixedHbarFee";
     private static final String SENDER = "alice";
     private static final String RECEIVER = "bob";
@@ -54,16 +48,10 @@ public class AtomicBatchCustomFeesTest {
     private static final String FEE_COLLECTOR = "customFeeCollector";
     private static final String BATCH_OPERATOR = "batchOperator";
 
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
-
     @HapiTest
     @DisplayName("FT transfer with custom fee rollback")
     @Tag(MATS)
-    public Stream<DynamicTest> fungibleTokenTransferCustomFeeRollback() {
+    Stream<DynamicTest> fungibleTokenTransferCustomFeeRollback() {
         final var successfulTransfer = cryptoTransfer(
                         moving(1, FT_WITH_FIXED_HBAR_FEE).between(SENDER, RECEIVER))
                 .fee(ONE_HBAR)
@@ -95,7 +83,7 @@ public class AtomicBatchCustomFeesTest {
 
     @HapiTest
     @DisplayName("NFT transfer with custom fee rollback")
-    public Stream<DynamicTest> nftTransferCustomFeeRollback() {
+    Stream<DynamicTest> nftTransferCustomFeeRollback() {
         final var successfulTransfer = cryptoTransfer(
                         movingUnique("NFT", 1L).between(SENDER, RECEIVER),
                         moving(100, "feeDenom").between(TREASURY, SENDER))
@@ -137,7 +125,7 @@ public class AtomicBatchCustomFeesTest {
 
     @HapiTest
     @DisplayName("Submit message to topic with custom fee rollback")
-    public Stream<DynamicTest> submitMessageToTopicWithCustomFeesGetsReverted() {
+    Stream<DynamicTest> submitMessageToTopicWithCustomFeesGetsReverted() {
         final var successfulSubmit = submitMessageTo("topic")
                 .maxCustomFee(maxCustomFee(SENDER, hbarLimit(2)))
                 .payingWith(SENDER)
@@ -163,7 +151,7 @@ public class AtomicBatchCustomFeesTest {
 
     @HapiTest
     @DisplayName("Airdrop with custom fees rollback")
-    public Stream<DynamicTest> airdropWithCustomFeesGetsReverted() {
+    Stream<DynamicTest> airdropWithCustomFeesGetsReverted() {
         final var successfulAirdrop = tokenAirdrop(
                         moving(1, FT_WITH_FIXED_HBAR_FEE).between(SENDER, RECEIVER))
                 .payingWith(SENDER)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchEndToEndConsensusAndTokenServiceTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchEndToEndConsensusAndTokenServiceTests.java
@@ -43,27 +43,21 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.transactions.consensus.HapiTopicCreate;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenCreate;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenMint;
 import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hederahashgraph.api.proto.java.TopicID;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestLifecycle
-public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
+class AtomicBatchEndToEndConsensusAndTokenServiceTests {
     private static final double BASE_FEE_BATCH_TRANSACTION = 0.001;
     private static final long HBAR_FEE = 1L;
     private static final String FT_FOR_END_TO_END = "ftForEndToEnd";
@@ -97,11 +91,6 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
     private static final String irrelevantKey2 = "irrelevantKey2";
     private static final String irrelevantKey3 = "irrelevantKey3";
 
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
-
     @Nested
     @DisplayName(
             "Atomic Batch End-to-End Test Cases for Consensus and Token Service with Token Operations and Topic Message Submissions")
@@ -110,8 +99,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Token Transfer From Treasury to Receiver and Submit Message to Topic with the Transfer Details Success "
                         + "in Atomic Batch")
-        public Stream<DynamicTest>
-                tokenTransferFromTreasuryAndSubmitMessageToTopicWithTheTransferDetailsSuccessInBatch() {
+        Stream<DynamicTest> tokenTransferFromTreasuryAndSubmitMessageToTopicWithTheTransferDetailsSuccessInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToAssociatedAccount = cryptoTransfer(
@@ -155,7 +143,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @HapiTest
         @DisplayName("Token Transfer From Account to Receiver and Submit Message to Topic with the Transfer "
                 + "Details Success in Atomic Batch")
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 tokenTransferFromAccountToReceiverAndSubmitMessageToTopicWithTheTransferDetailsSuccessInBatch() {
 
             // token transfers inner transactions
@@ -210,7 +198,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Mint NFT with Metadata and Submit Message to Topic with the NFT Metadata Success in Atomic Batch")
-        public Stream<DynamicTest> mintNFTWithMetadataAndSubmitMessageToTopicWithTheNFTMetadataSuccessInBatch() {
+        Stream<DynamicTest> mintNFTWithMetadataAndSubmitMessageToTopicWithTheNFTMetadataSuccessInBatch() {
 
             final var nftMetadata = "ipfs://test-nft-uri-1";
             final var metadataBytes = nftMetadata.getBytes();
@@ -253,7 +241,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Submit Messages to Topic for FT and NFT and Create and Mint the Tokens Success in Atomic Batch")
-        public Stream<DynamicTest> submitMessageToTopicForFT_And_NFTCreateAndMintTokensSuccessInBatch() {
+        Stream<DynamicTest> submitMessageToTopicForFT_And_NFTCreateAndMintTokensSuccessInBatch() {
 
             final var nftMetadata = "ipfs://test-nft-uri-1";
             final var metadataBytes = nftMetadata.getBytes();
@@ -318,7 +306,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Token Associate and Submit Message to Topic with the Association Details Success in Atomic Batch")
-        public Stream<DynamicTest> tokenAssociateAndSubmitMessageToTopicWithTheAssociationDetailsSuccessInBatch() {
+        Stream<DynamicTest> tokenAssociateAndSubmitMessageToTopicWithTheAssociationDetailsSuccessInBatch() {
 
             // token associate inner transaction
             final var tokensAssociateToAccount = tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_FOR_END_TO_END)
@@ -359,7 +347,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Grant KYC to Account and Submit Message to Topic with the Transfer Details Success in Atomic Batch")
-        public Stream<DynamicTest> grantKYCToAccountAndSubmitMessageToTopicWithTheKYCDetailsSuccessInBatch() {
+        Stream<DynamicTest> grantKYCToAccountAndSubmitMessageToTopicWithTheKYCDetailsSuccessInBatch() {
 
             // grant KYC inner transaction
             final var grantKYCToAccount = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)
@@ -402,8 +390,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Associate Token, Grant KYC to Account and Submit Message to Topic with the Transfer Details Success in Atomic Batch")
-        public Stream<DynamicTest>
-                associateTokenGrantKYCToAccountAndSubmitMessageToTopicWithTheKYCDetailsSuccessInBatch() {
+        Stream<DynamicTest> associateTokenGrantKYCToAccountAndSubmitMessageToTopicWithTheKYCDetailsSuccessInBatch() {
 
             // associate token inner transaction
             final var associateTokenToAccount = tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_FOR_TOKEN_KYC)
@@ -452,8 +439,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Submit Message to Topic, Token Transfer From Treasury to Receiver, Submit New Message to Topic with the Transfer Details"
                         + "and delete the topic Success in Atomic Batch")
-        public Stream<DynamicTest>
-                submitMessageToTopicTokenTransferSubmitSecondMessageAndDeleteTheTopicSuccessInBatch() {
+        Stream<DynamicTest> submitMessageToTopicTokenTransferSubmitSecondMessageAndDeleteTheTopicSuccessInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToAssociatedAccount = cryptoTransfer(
@@ -516,7 +502,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Token Transfer and Submit Message to Topic created without Submit Key Success in Atomic Batch")
-        public Stream<DynamicTest> tokenTransferAndSubmitMessageToTopicCreatedWithoutSubmitKeySuccessInBatch() {
+        Stream<DynamicTest> tokenTransferAndSubmitMessageToTopicCreatedWithoutSubmitKeySuccessInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToAssociatedAccount = cryptoTransfer(
@@ -561,8 +547,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Submit Messages to Multiple Topics with Custom Fees and Transfer the collected fees from the Collector "
                         + "Account Success in Atomic Batch")
-        public Stream<DynamicTest>
-                submitMessagesToMultipleTopicsWithCustomFeesAndTransferTheCollectedFeesSuccessInBatch() {
+        Stream<DynamicTest> submitMessagesToMultipleTopicsWithCustomFeesAndTransferTheCollectedFeesSuccessInBatch() {
 
             // submit message to topics inner transactions
             final var submitMessageToFirstTopic = submitMessageTo(TEST_TOPIC)
@@ -628,8 +613,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Token Transfer From Treasury to Receiver and Submit Message to Topic with Insufficient Payer Balance "
                         + "Fails in Atomic Batch")
-        public Stream<DynamicTest>
-                tokenTransferFromTreasuryAndSubmitMessageToTopicWithInsufficientPayerBalanceFailsInBatch() {
+        Stream<DynamicTest> tokenTransferFromTreasuryAndSubmitMessageToTopicWithInsufficientPayerBalanceFailsInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToAssociatedAccount = cryptoTransfer(
@@ -672,8 +656,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Token Transfer From Treasury to Not Associated Receiver and Submit Message to Topic Fails in Atomic Batch")
-        public Stream<DynamicTest>
-                tokenTransferFromTreasuryToNotAssociatedReceiverAndSubmitMessageToTopicFailsInBatch() {
+        Stream<DynamicTest> tokenTransferFromTreasuryToNotAssociatedReceiverAndSubmitMessageToTopicFailsInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToNotAssociatedAccount = cryptoTransfer(
@@ -717,7 +700,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Token Transfer From Treasury to Associated Receiver and Submit Message to Topic Not Signed by Payer "
                         + "Fails in Atomic Batch")
-        public Stream<DynamicTest> tokenTransferFromTreasuryToAssociatedReceiverNotSignedByPayerFailsInBatch() {
+        Stream<DynamicTest> tokenTransferFromTreasuryToAssociatedReceiverNotSignedByPayerFailsInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToAssociatedAccount = cryptoTransfer(
@@ -762,7 +745,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Token Transfer From Treasury to Associated Receiver and Submit Message to Topic Not Signed by Submit Key "
                         + "Fails in Atomic Batch")
-        public Stream<DynamicTest> tokenTransferFromTreasuryToAssociatedReceiverNotSignedBySubmitKeyFailsInBatch() {
+        Stream<DynamicTest> tokenTransferFromTreasuryToAssociatedReceiverNotSignedBySubmitKeyFailsInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToAssociatedAccount = cryptoTransfer(
@@ -806,7 +789,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Mint NFT and Submit Too Long Message to Topic Fails in Atomic Batch")
-        public Stream<DynamicTest> mintNFTAndSubmitTooLongMessageToTopicFailsInBatch() {
+        Stream<DynamicTest> mintNFTAndSubmitTooLongMessageToTopicFailsInBatch() {
 
             final var tooLongMessageContent = "a".repeat(2000);
 
@@ -847,7 +830,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Mint NFT and Submit Empty Message to Topic Fails in Atomic Batch")
-        public Stream<DynamicTest> mintNFTAndSubmitEmptyMessageToTopicFailsInBatch() {
+        Stream<DynamicTest> mintNFTAndSubmitEmptyMessageToTopicFailsInBatch() {
 
             // mint NFT inner transaction
             final var mintNftInnerTxn = mintNFT(NFT_FOR_END_TO_END, 0, 10)
@@ -886,7 +869,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Token Transfer to Associated Receiver and Submit Message to Topic signed with Multiple Irrelevant Keys "
                         + "Fails in Atomic Batch")
-        public Stream<DynamicTest> tokenTransferAndSendMessageToTopicSignedByMultipleIrrelevantKeysFailsInBatch() {
+        Stream<DynamicTest> tokenTransferAndSendMessageToTopicSignedByMultipleIrrelevantKeysFailsInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToAssociatedAccount = cryptoTransfer(
@@ -928,7 +911,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Token Transfer and Submit Message to Invalid Topic ID Fails in Atomic Batch")
-        public Stream<DynamicTest> tokenTransferAndSendMessageToInvalidTopicIdFailsInBatch() {
+        Stream<DynamicTest> tokenTransferAndSendMessageToInvalidTopicIdFailsInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToAssociatedAccount = cryptoTransfer(
@@ -972,7 +955,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Delete Topic and Submit Message to the Deleted Topic Fails in Atomic Batch")
-        public Stream<DynamicTest> deleteTopicAndSubmitMessageToTheDeletedTopicFailsInBatch() {
+        Stream<DynamicTest> deleteTopicAndSubmitMessageToTheDeletedTopicFailsInBatch() {
 
             // delete topic inner transaction
             final var deleteTopic = deleteTopic(TEST_TOPIC)
@@ -1012,7 +995,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Token Transfer and Submit Message to Topic with Wrong Submit Key Fails in Atomic Batch")
-        public Stream<DynamicTest> tokenTransferAndSubmitMessageWithWrongSubmitKeyFailsInBatch() {
+        Stream<DynamicTest> tokenTransferAndSubmitMessageWithWrongSubmitKeyFailsInBatch() {
 
             // token transfer inner transaction
             final var transferTokensToAssociatedAccount = cryptoTransfer(
@@ -1057,7 +1040,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Submit Invalid Messages to Multiple Topics with Custom Fees and Transfer the collected fees from the Collector "
                         + "Account Fails in Atomic Batch")
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 submitInvalidMessagesToMultipleTopicsWithCustomFeesAndTransferTheCollectedFeesFailsInBatch() {
 
             // submit invalid messages to topics inner transactions
@@ -1126,7 +1109,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Update Token Admin Key and Submit Message to Topic with the Updated Token Details Success in Atomic Batch")
-        public Stream<DynamicTest> updateTokenAdminKeyAndSubmitMessageToTopicSuccessInBatch() {
+        Stream<DynamicTest> updateTokenAdminKeyAndSubmitMessageToTopicSuccessInBatch() {
 
             // token update inner transaction
             final var updateToken = tokenUpdate(FT_FOR_END_TO_END)
@@ -1169,8 +1152,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Update Token Treasury, Token Transfer from new Treasury and Submit Message to Topic with the Update Details"
                         + " Success in Atomic Batch")
-        public Stream<DynamicTest>
-                updateTokenTreasuryTokenTransferFromNewTreasuryAndSubmitMessageToTopicSuccessInBatch() {
+        Stream<DynamicTest> updateTokenTreasuryTokenTransferFromNewTreasuryAndSubmitMessageToTopicSuccessInBatch() {
 
             // token update inner transaction
             final var updateToken = tokenUpdate(FT_FOR_END_TO_END)
@@ -1225,7 +1207,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
                 "Update Topic Submit Key, Token Transfer and Submit Message to the Updated Topic with the Transfer Details"
                         + " Success in Atomic Batch")
         @Tag(MATS)
-        public Stream<DynamicTest> updateTopicTokenTransferAndSubmitMessageToTopicSuccessInBatch() {
+        Stream<DynamicTest> updateTopicTokenTransferAndSubmitMessageToTopicSuccessInBatch() {
 
             // topic update inner transaction
             final var updateTopic = updateTopic(TEST_TOPIC)
@@ -1279,7 +1261,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Update Token Treasury, Update Topic, Token Transfer from new Treasury and Submit Message to Topic with the Update Details"
                         + " Success in Atomic Batch")
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 updateTokenTreasuryUpdateTokenTransferTokenFromNewTreasuryAndSubmitMessageToTopicSuccessInBatch() {
 
             // token update inner transaction
@@ -1343,7 +1325,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Update Token Treasury, Token Transfer from new Treasury, Update Topic and Submit Message to Topic with the Update Details"
                         + " Success in Atomic Batch")
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 updateTokenTreasuryTransferTokenFromNewTreasuryUpdateTokenAndSubmitMessageToTopicSuccessInBatch() {
 
             // token update inner transaction
@@ -1407,7 +1389,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Update Topic Admin Key, Update Topic Submit Key, Token Transfer and Submit Message to Topic with the "
                         + "Transfer Details Success in Atomic Batch")
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 updateTopicAdminKeyUpdateTopicSubmitKeyTransferTokenAndSubmitMessageToTopicSuccessInBatch() {
 
             // topic update inner transactions
@@ -1476,8 +1458,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Update Topic Submit Key, Token Transfer and Submit Message to the Updated Topic Signed by the old "
                         + "Submit Key Fails in Atomic Batch")
-        public Stream<DynamicTest>
-                updateTopicSubmitKeyTokenTransferAndSubmitMessageToTopicSignedByOldSubmitKeyFailsInBatch() {
+        Stream<DynamicTest> updateTopicSubmitKeyTokenTransferAndSubmitMessageToTopicSignedByOldSubmitKeyFailsInBatch() {
 
             // topic update inner transaction
             final var updateTopic = updateTopic(TEST_TOPIC)
@@ -1532,7 +1513,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Update Topic Admin Key, Update Topic Submit Key not signed with New Admin Key, Token Transfer and Submit Message to Topic "
                         + "Fails in Atomic Batch")
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 updateTopicAdminKeyUpdateTopicSubmitKeySignedWithOldAdminKeyTransferTokenAndSubmitMessageToTopicFailsInBatch() {
 
             // topic update inner transactions
@@ -1602,7 +1583,7 @@ public class AtomicBatchEndToEndConsensusAndTokenServiceTests {
         @DisplayName(
                 "Update Topic Admin Key not Signed By New Admin Key, Update Topic Submit Key, Token Transfer and Submit Message to Topic "
                         + "Fails in Atomic Batch")
-        public Stream<DynamicTest>
+        Stream<DynamicTest>
                 updateTopicAdminKeySignedWithOldAdminKeyOnlyUpdateTopicSubmitKeyTransferTokenAndSubmitMessageToTopicFailsInBatch() {
 
             // topic update inner transactions

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchEndToEndCryptoAndTokenServiceTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchEndToEndCryptoAndTokenServiceTests.java
@@ -37,24 +37,18 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenCreate;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenMint;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestLifecycle
-public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
+class AtomicBatchEndToEndCryptoAndTokenServiceTests {
     private static final double BASE_FEE_BATCH_TRANSACTION = 0.001;
     private static final String FT_FOR_END_TO_END = "ftForEndToEnd";
     private static final String NFT_FOR_END_TO_END = "nftForEndToEnd";
@@ -71,11 +65,6 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
     private static final String newAdminKey = "newAdminKey";
     private static final String supplyKey = "supplyKey";
 
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
-
     @Nested
     @DisplayName("Token and Crypto Service operations in Atomic Batch")
     class TokenAndCryptoServiceOperationsInAtomicBatch {
@@ -83,7 +72,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
         // Token Treasury Management test cases
         @HapiTest
         @DisplayName("Transfer all Token Supply and Delete Token and Treasury Accounts Successfully in Atomic Batch")
-        public Stream<DynamicTest> transferAllTokenSupplyAndDeleteTokenAndTreasuryAccountSuccessInAtomicBatch() {
+        Stream<DynamicTest> transferAllTokenSupplyAndDeleteTokenAndTreasuryAccountSuccessInAtomicBatch() {
 
             // delete token inner transaction
             final var deleteToken = tokenDelete(FT_FOR_END_TO_END)
@@ -134,7 +123,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Delete One Token and Transfer Second Token from Treasury Account Successfully in Atomic Batch")
-        public Stream<DynamicTest> deleteTokenAndTransferOtherTokenFromTreasuryAccountSuccessInAtomicBatch() {
+        Stream<DynamicTest> deleteTokenAndTransferOtherTokenFromTreasuryAccountSuccessInAtomicBatch() {
 
             // delete token inner transaction
             final var deleteToken = tokenDelete(FT_FOR_END_TO_END)
@@ -176,7 +165,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Token Transfer from Treasury Account after Token is Deleted Fails in Atomic Batch")
-        public Stream<DynamicTest> tokenTransferAfterTokenDeletedFromTreasuryAccountFailsInAtomicBatch() {
+        Stream<DynamicTest> tokenTransferAfterTokenDeletedFromTreasuryAccountFailsInAtomicBatch() {
 
             // delete token inner transaction
             final var deleteToken = tokenDelete(FT_FOR_END_TO_END)
@@ -215,7 +204,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Token Transfer from Treasury Account with Insufficient Token Balance Fails in Atomic Batch")
-        public Stream<DynamicTest> tokenTransferFromTreasuryAccountWithInsufficientBalanceFailsInAtomicBatch() {
+        Stream<DynamicTest> tokenTransferFromTreasuryAccountWithInsufficientBalanceFailsInAtomicBatch() {
 
             // transfer token from treasury to receiver associated account
             final var transferTokenFromTreasuryWithBalance = cryptoTransfer(
@@ -253,7 +242,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Token Transfer from Treasury Account with Zero Token Balance Fails in Atomic Batch")
-        public Stream<DynamicTest> tokenTransferFromTreasuryAccountWithZeroBalanceFailsInAtomicBatch() {
+        Stream<DynamicTest> tokenTransferFromTreasuryAccountWithZeroBalanceFailsInAtomicBatch() {
 
             // transfer token from treasury to receiver associated account
             final var transferTokenFromTreasuryWithBalance = cryptoTransfer(
@@ -291,7 +280,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Update Token Treasury Account and Token Transfer from new Treasury Success in Atomic Batch")
-        public Stream<DynamicTest> updateTokenTreasuryAndTokenTransferSuccessInAtomicBatch() {
+        Stream<DynamicTest> updateTokenTreasuryAndTokenTransferSuccessInAtomicBatch() {
 
             // update token inner transaction
             final var updateTokenTreasury = tokenUpdate(FT_FOR_END_TO_END)
@@ -335,7 +324,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Update Token Treasury with Account without Free Auto-association Slots and Token Transfer from new Treasury Fails in Atomic Batch")
-        public Stream<DynamicTest> updateTokenTreasuryWithoutFreeAutoAssociationsAndTokenTransferFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenTreasuryWithoutFreeAutoAssociationsAndTokenTransferFailsInAtomicBatch() {
 
             // update token inner transaction
             final var updateTokenTreasury = tokenUpdate(FT_FOR_END_TO_END)
@@ -386,7 +375,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Update Token Treasury with Account with Zero Auto-association Slots and Token Transfer from new Treasury Fails in Atomic Batch")
-        public Stream<DynamicTest> updateTokenTreasuryWithZeroFreeAutoAssociationsAndTokenTransferFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenTreasuryWithZeroFreeAutoAssociationsAndTokenTransferFailsInAtomicBatch() {
 
             // update token inner transaction
             final var updateTokenTreasury = tokenUpdate(FT_FOR_END_TO_END)
@@ -430,8 +419,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Update Token Treasury Account and Token Transfer from new Treasury with Update Signed by the old Treasury Fails in Atomic Batch")
-        public Stream<DynamicTest>
-                updateTokenTreasuryAndTokenTransferWithUpdateSignedByOldTreasuryFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenTreasuryAndTokenTransferWithUpdateSignedByOldTreasuryFailsInAtomicBatch() {
 
             // update token inner transaction
             final var updateTokenTreasury = tokenUpdate(FT_FOR_END_TO_END)
@@ -474,8 +462,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Update Token Treasury Account and Token Transfer from new Treasury with Transfer Signed by the old Treasury Fails in Atomic Batch")
-        public Stream<DynamicTest>
-                updateTokenTreasuryAndTokenTransferWithTransferSignedByOldTreasuryFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenTreasuryAndTokenTransferWithTransferSignedByOldTreasuryFailsInAtomicBatch() {
 
             // update token inner transaction
             final var updateTokenTreasury = tokenUpdate(FT_FOR_END_TO_END)
@@ -519,7 +506,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Update Token Treasury Account and Token Transfer from old Treasury Fails in Atomic Batch")
-        public Stream<DynamicTest> updateTokenTreasuryAndTokenTransferFromOldTreasuryFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenTreasuryAndTokenTransferFromOldTreasuryFailsInAtomicBatch() {
 
             // update token inner transaction
             final var updateTokenTreasury = tokenUpdate(FT_FOR_END_TO_END)
@@ -564,8 +551,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Update Token Treasury Account and Token Transfer from new Treasury with Update Not Signed by the Admin Key Fails in Atomic Batch")
-        public Stream<DynamicTest>
-                updateTokenTreasuryAndTokenTransferWithUpdateNotSignedByAdminKeyFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenTreasuryAndTokenTransferWithUpdateNotSignedByAdminKeyFailsInAtomicBatch() {
 
             // update token inner transaction
             final var updateTokenTreasury = tokenUpdate(FT_FOR_END_TO_END)
@@ -610,8 +596,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Update Token Treasury Account and Token Transfer from new Treasury with Update Not Signed by the New Treasury Key Fails in Atomic Batch")
-        public Stream<DynamicTest>
-                updateTokenTreasuryAndTokenTransferWithUpdateNotSignedByNewTreasuryKeyFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenTreasuryAndTokenTransferWithUpdateNotSignedByNewTreasuryKeyFailsInAtomicBatch() {
 
             // update token inner transaction
             final var updateTokenTreasury = tokenUpdate(FT_FOR_END_TO_END)
@@ -654,7 +639,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
         @HapiTest
         @DisplayName("Update Token Admin Key And Update Treasury Account Success in Atomic Batch")
         @Tag(MATS)
-        public Stream<DynamicTest> updateTokenAdminKeyAndTreasuryAccountSuccessInAtomicBatch() {
+        Stream<DynamicTest> updateTokenAdminKeyAndTreasuryAccountSuccessInAtomicBatch() {
 
             // update token inner transactions
             final var updateTokenAdminKey = tokenUpdate(FT_FOR_END_TO_END)
@@ -695,7 +680,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Update Token Admin Key And Update Treasury Account Signed by Old Admin Key Fails in Atomic Batch")
-        public Stream<DynamicTest> updateTokenAdminKeyAndTreasuryAccountSignedByOldAdminKeyFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenAdminKeyAndTreasuryAccountSignedByOldAdminKeyFailsInAtomicBatch() {
 
             // update token inner transactions
             final var updateTokenAdminKey = tokenUpdate(FT_FOR_END_TO_END)
@@ -737,7 +722,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
 
         @HapiTest
         @DisplayName("Update Token Admin Key And Update Treasury Account Signed by Old Treasury Fails in Atomic Batch")
-        public Stream<DynamicTest> updateTokenAdminKeyAndTreasuryAccountSignedByOldTreasuryFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenAdminKeyAndTreasuryAccountSignedByOldTreasuryFailsInAtomicBatch() {
 
             // update token inner transactions
             final var updateTokenAdminKey = tokenUpdate(FT_FOR_END_TO_END)
@@ -780,8 +765,7 @@ public class AtomicBatchEndToEndCryptoAndTokenServiceTests {
         @HapiTest
         @DisplayName(
                 "Update Token Admin Key And Update Treasury Account Signed by Old Admin Key and Old Treasury Fails in Atomic Batch")
-        public Stream<DynamicTest>
-                updateTokenAdminKeyAndTreasuryAccountSignedByOldAdminAndTreasuryFailsInAtomicBatch() {
+        Stream<DynamicTest> updateTokenAdminKeyAndTreasuryAccountSignedByOldAdminAndTreasuryFailsInAtomicBatch() {
 
             // update token inner transactions
             final var updateTokenAdminKey = tokenUpdate(FT_FOR_END_TO_END)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchIntegrationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchIntegrationTest.java
@@ -30,33 +30,21 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.TargetEmbeddedMode;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hederahashgraph.api.proto.java.TokenType;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(INTEGRATION)
 @TargetEmbeddedMode(CONCURRENT)
-@HapiTestLifecycle
-public class AtomicBatchIntegrationTest {
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
+class AtomicBatchIntegrationTest {
 
     @HapiTest
     @DisplayName("Validate burn precompile gas used for inner transaction")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchInvalidSignaturesTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchInvalidSignaturesTests.java
@@ -51,7 +51,6 @@ import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.OptionalLong;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -61,15 +60,13 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
-public class AtomicBatchInvalidSignaturesTests {
+class AtomicBatchInvalidSignaturesTests {
 
     private static final String TOKEN_TREASURY = "treasury";
     private static final String DEFAULT_BATCH_OPERATOR = "DEFAULT_BATCH_OPERATOR";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 
@@ -79,7 +76,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
         @HapiTest
         @DisplayName("Batch with token creation, contract creation, and association - missing admin key")
-        public Stream<DynamicTest> fullBatchTokenContractAssociationWithoutAdminKey() {
+        Stream<DynamicTest> fullBatchTokenContractAssociationWithoutAdminKey() {
             final var batchOperator = "batchOperator";
             final var misc = "someToken";
             final var contract = "CalldataSize";
@@ -107,7 +104,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
         @HapiTest
         @DisplayName("Batch with multiple contract associations - mixed admin key scenarios")
-        public Stream<DynamicTest> mixedContractAssociationScenarios() {
+        Stream<DynamicTest> mixedContractAssociationScenarios() {
             final var batchOperator = "batchOperator";
             final var token1 = "token1";
             final var token2 = "token2";
@@ -158,7 +155,7 @@ public class AtomicBatchInvalidSignaturesTests {
         @HapiTest
         @DisplayName("Batch with multiple contracts and complex association patterns")
         @Tag(MATS)
-        public Stream<DynamicTest> complexContractAssociationPatterns() {
+        Stream<DynamicTest> complexContractAssociationPatterns() {
             final var batchOperator = "batchOperator";
             final var adminKey1 = "adminKey1";
             final var adminKey2 = "adminKey2";
@@ -225,7 +222,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
         @HapiTest
         @DisplayName("Batch with contract deletion and association attempt")
-        public Stream<DynamicTest> contractDeletionAndAssociationAttempt() {
+        Stream<DynamicTest> contractDeletionAndAssociationAttempt() {
             final var batchOperator = "batchOperator";
             final var adminKey = "adminKey";
             final var misc = "someToken";
@@ -269,7 +266,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
     @HapiTest
     @DisplayName("Batch with deleted token association to contract")
-    public Stream<DynamicTest> deletedTokenAssociationWithContract() {
+    Stream<DynamicTest> deletedTokenAssociationWithContract() {
         final var batchOperator = "batchOperator";
         final var adminKey = "adminKey";
         final var tokenAdminKey = "tokenAdminKey";
@@ -315,7 +312,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
         @HapiTest
         @DisplayName("Batch with invalid token create transactions")
-        public Stream<DynamicTest> batchWithInvalidTokenCreateTransactions() {
+        Stream<DynamicTest> batchWithInvalidTokenCreateTransactions() {
             final var batchOperator = "batchOperator";
             final var alice = "ALICE";
             final var aliceKey1 = "aliceKey1";
@@ -366,7 +363,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
         @HapiTest
         @DisplayName("Batch with missing treasury signature failure")
-        public Stream<DynamicTest> batchWithMissingTreasurySignature() {
+        Stream<DynamicTest> batchWithMissingTreasurySignature() {
             final var batchOperator = "batchOperator";
             final var tokenName = "PRIMARY";
             final var tokenCreateTxnId = "tokenCreateTxnId";
@@ -402,7 +399,7 @@ public class AtomicBatchInvalidSignaturesTests {
         @HapiTest
         @DisplayName("Batch with fee collector signing requirements")
         @Tag(MATS)
-        public Stream<DynamicTest> batchFeeCollectorSigningRequirements() {
+        Stream<DynamicTest> batchFeeCollectorSigningRequirements() {
             final var batchOperator = "batchOperator";
             final var customFeesKey = "customFeesKey";
             final var htsCollector = "htsCollector";
@@ -452,7 +449,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
         @HapiTest
         @DisplayName("Batch with token wipe failure cases")
-        public Stream<DynamicTest> batchWithTokenWipeFailures() {
+        Stream<DynamicTest> batchWithTokenWipeFailures() {
             final var batchOperator = "batchOperator";
             final var unwipeableToken = "without";
             final var wipeableToken = "with";
@@ -503,7 +500,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
         @HapiTest
         @DisplayName("Batch with KYC management failure cases")
-        public Stream<DynamicTest> batchWithKycManagementFailures() {
+        Stream<DynamicTest> batchWithKycManagementFailures() {
             final var batchOperator = "batchOperator";
             final var withoutKycKey = "withoutKycKey";
             final var withKycKey = "withKycKey";
@@ -544,7 +541,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
         @HapiTest
         @DisplayName("Batch fails when NFT metadata update lacks required signatures")
-        public Stream<DynamicTest> batchFailsWithoutMetadataKeySignature() {
+        Stream<DynamicTest> batchFailsWithoutMetadataKeySignature() {
             final var batchOperator = "batchOperator";
             final var nftToken = "nftToken";
             final var updateTxnId = "updateTxnId";
@@ -588,7 +585,7 @@ public class AtomicBatchInvalidSignaturesTests {
 
         @HapiTest
         @DisplayName("Batch with auto renew account update signature requirements")
-        public Stream<DynamicTest> batchWithAutoRenewAccountSignatureRequirement() {
+        Stream<DynamicTest> batchWithAutoRenewAccountSignatureRequirement() {
             final var batchOperator = "batchOperator";
             final var tokenName = "autoRenewToken";
             final var secondPeriod = THREE_MONTHS_IN_SECONDS + 1234;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchKeyReqTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchKeyReqTest.java
@@ -24,29 +24,17 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACT
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestLifecycle
-public class AtomicBatchKeyReqTest {
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
+class AtomicBatchKeyReqTest {
 
     @HapiTest
     @DisplayName("Account update requires account key signature")
-    public Stream<DynamicTest> accountUpdateRequiresKeySig() {
+    Stream<DynamicTest> accountUpdateRequiresKeySig() {
         return hapiTest(
                 newKeyNamed("accountKey"),
                 cryptoCreate("batchOperator"),
@@ -75,7 +63,7 @@ public class AtomicBatchKeyReqTest {
 
         @HapiTest
         @DisplayName("Token update requires admin key")
-        public Stream<DynamicTest> tokenUpdateReqAdminKey() {
+        Stream<DynamicTest> tokenUpdateReqAdminKey() {
             return hapiTest(
                     newKeyNamed("adminKey"),
                     cryptoCreate("batchOperator"),
@@ -100,7 +88,7 @@ public class AtomicBatchKeyReqTest {
 
         @HapiTest
         @DisplayName("Custom fee update requires fee schedule key")
-        public Stream<DynamicTest> customFeeUpdateReqFeeScheduleKey() {
+        Stream<DynamicTest> customFeeUpdateReqFeeScheduleKey() {
             return hapiTest(
                     newKeyNamed("feeScheduleKey"),
                     cryptoCreate("collector"),
@@ -126,7 +114,7 @@ public class AtomicBatchKeyReqTest {
 
         @HapiTest
         @DisplayName("Metadata update requires metadata key")
-        public Stream<DynamicTest> metadataUpdateRequiresKeySig() {
+        Stream<DynamicTest> metadataUpdateRequiresKeySig() {
             return hapiTest(
                     newKeyNamed("metadataKey"),
                     cryptoCreate("batchOperator"),
@@ -151,7 +139,7 @@ public class AtomicBatchKeyReqTest {
 
         @HapiTest
         @DisplayName("Freeze requires freeze key")
-        public Stream<DynamicTest> freezeRequiresFreezeKey() {
+        Stream<DynamicTest> freezeRequiresFreezeKey() {
             return hapiTest(
                     newKeyNamed("freezeKey"),
                     cryptoCreate("toBeFrozen"),
@@ -176,7 +164,7 @@ public class AtomicBatchKeyReqTest {
 
         @HapiTest
         @DisplayName("Token pause requires pause key")
-        public Stream<DynamicTest> pauseRequiresPauseKey() {
+        Stream<DynamicTest> pauseRequiresPauseKey() {
             return hapiTest(
                     newKeyNamed("pauseKey"),
                     cryptoCreate("batchOperator"),
@@ -200,7 +188,7 @@ public class AtomicBatchKeyReqTest {
         @HapiTest
         @DisplayName("Token wipe requires wipe key")
         @Tag(MATS)
-        public Stream<DynamicTest> wipeRequiresWipeKey() {
+        Stream<DynamicTest> wipeRequiresWipeKey() {
             return hapiTest(
                     newKeyNamed("wipeKey"),
                     cryptoCreate("batchOperator"),
@@ -226,7 +214,7 @@ public class AtomicBatchKeyReqTest {
 
         @HapiTest
         @DisplayName("KYC requires kyc key")
-        public Stream<DynamicTest> kycRequiresKycKey() {
+        Stream<DynamicTest> kycRequiresKycKey() {
             return hapiTest(
                     newKeyNamed("kycKey"),
                     cryptoCreate("batchOperator"),
@@ -251,7 +239,7 @@ public class AtomicBatchKeyReqTest {
 
         @HapiTest
         @DisplayName("Token mint requires supply key")
-        public Stream<DynamicTest> mintRequiresSupplyKey() {
+        Stream<DynamicTest> mintRequiresSupplyKey() {
             return hapiTest(
                     newKeyNamed("supplyKey"),
                     cryptoCreate("batchOperator"),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchMiscSignatureTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchMiscSignatureTest.java
@@ -29,27 +29,16 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_PAYER_
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_SIGNATURE;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 
-@HapiTestLifecycle
-public class AtomicBatchMiscSignatureTest {
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
+class AtomicBatchMiscSignatureTest {
 
     @Nested
     @DisplayName("Airdrop Tests")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchOverwriteSameStateKeyTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchOverwriteSameStateKeyTest.java
@@ -42,16 +42,11 @@ import static java.lang.String.valueOf;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -66,18 +61,12 @@ import org.junit.jupiter.api.Tag;
  * effects using trace data, allowing accurate record generation even when
  * state is overwritten within the same batch.
  */
-@HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicBatchOverwriteSameStateKeyTest {
+class AtomicBatchOverwriteSameStateKeyTest {
 
     private static final String OPERATOR = "operator";
     private static final String ADMIN_KEY = "adminKey";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     /**
      * Mint, Burn and Delete NFT token
@@ -85,7 +74,7 @@ public class AtomicBatchOverwriteSameStateKeyTest {
      */
     @HapiTest
     @DisplayName("Mint, Burn and Delete NFT token")
-    public Stream<DynamicTest> mintBurnAndDeleteNftWithoutCustomFeesSuccessInBatch() {
+    Stream<DynamicTest> mintBurnAndDeleteNftWithoutCustomFeesSuccessInBatch() {
         final String nft = "nft";
         final String adminKey = ADMIN_KEY;
         final String nftSupplyKey = "nftSupplyKey";
@@ -135,7 +124,7 @@ public class AtomicBatchOverwriteSameStateKeyTest {
      */
     @HapiTest
     @DisplayName("Multiple crypto updates on same state key")
-    public Stream<DynamicTest> multipleCryptoUpdatesOnSameStateInBatch() {
+    Stream<DynamicTest> multipleCryptoUpdatesOnSameStateInBatch() {
         final var key = "key";
         final var newKey = "newKey1";
         final var newKey2 = "newKey2";
@@ -180,7 +169,7 @@ public class AtomicBatchOverwriteSameStateKeyTest {
      */
     @HapiTest
     @DisplayName("Multiple token updates on same state key in batch")
-    public Stream<DynamicTest> multipleTokenUpdatesOnSameStateInBatch() {
+    Stream<DynamicTest> multipleTokenUpdatesOnSameStateInBatch() {
         final var token = "test";
         final var treasury = "treasury";
         final var treasury1 = "treasury1";
@@ -224,7 +213,7 @@ public class AtomicBatchOverwriteSameStateKeyTest {
 
     @HapiTest
     @DisplayName("Update Token Admin Key And Update Treasury Account Success in Atomic Batch")
-    public Stream<DynamicTest> updateTokenAdminKeyAndTreasuryAccountSuccessInAtomicBatch() {
+    Stream<DynamicTest> updateTokenAdminKeyAndTreasuryAccountSuccessInAtomicBatch() {
         final var token = "test";
         final var adminKey = "adminKey";
         final var newAdminKey = "newAdminKey";
@@ -277,7 +266,7 @@ public class AtomicBatchOverwriteSameStateKeyTest {
      */
     @HapiTest
     @DisplayName("Submit to topic twice in batch")
-    public Stream<DynamicTest> submitToTopicTwiceInBatch() {
+    Stream<DynamicTest> submitToTopicTwiceInBatch() {
         final var topic = "topic";
         final var submitKey = "submitKey";
         final var batchOperator = "batchOperator";
@@ -307,7 +296,7 @@ public class AtomicBatchOverwriteSameStateKeyTest {
      */
     @HapiTest
     @DisplayName("Multiple mint precompile calls")
-    public Stream<DynamicTest> multipleMintPrecompileCalls() {
+    Stream<DynamicTest> multipleMintPrecompileCalls() {
         final var nft = "nft";
         final var gasToOffer = 2_000_000L;
         final var mintContract = "MintContract";
@@ -361,7 +350,7 @@ public class AtomicBatchOverwriteSameStateKeyTest {
      */
     @HapiTest
     @DisplayName("Multiple wipe token")
-    public Stream<DynamicTest> multipleWipeToken() {
+    Stream<DynamicTest> multipleWipeToken() {
         final String nft = "nft";
         final String adminKey = ADMIN_KEY;
         final String treasury = "treasury";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchRepeatableTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchRepeatableTest.java
@@ -46,17 +46,11 @@ import org.junit.jupiter.api.Tag;
 @Tag(INTEGRATION)
 @HapiTestLifecycle
 @TargetEmbeddedMode(REPEATABLE)
-public class AtomicBatchRepeatableTest {
+class AtomicBatchRepeatableTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled",
-                "true",
-                "scheduling.maxExpirySecsToCheckPerUserTxn",
-                "" + Integer.MAX_VALUE,
-                "atomicBatch.maxNumberOfTransactions",
-                "50"));
+        testLifecycle.overrideInClass(Map.of("scheduling.maxExpirySecsToCheckPerUserTxn", "" + Integer.MAX_VALUE));
     }
 
     @LeakyRepeatableHapiTest({NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION})

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicExchangeRateControlSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicExchangeRateControlSuite.java
@@ -22,28 +22,16 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACT
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.OrderedInIsolation;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.transactions.file.HapiFileUpdate;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 
 // This test cases are direct copies of ExchangeRateControlSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
-@OrderedInIsolation
-public class AtomicExchangeRateControlSuite {
+class AtomicExchangeRateControlSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     final HapiFileUpdate resetRatesOp = fileUpdate(EXCHANGE_RATES)
             .payingWith(EXCHANGE_RATE_CONTROL)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicFileCreateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicFileCreateSuite.java
@@ -16,27 +16,15 @@ import static com.hedera.services.bdd.suites.HapiSuite.EXCHANGE_RATE_CONTROL;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 
 // This test cases are direct copies of FileAppendSuite. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
-public class AtomicFileCreateSuite {
+class AtomicFileCreateSuite {
 
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> exchangeRateControlAccountIsntCharged() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/allowance/AtomicBatchApproveAllowanceTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/allowance/AtomicBatchApproveAllowanceTest.java
@@ -100,7 +100,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -113,7 +112,7 @@ import org.junit.jupiter.api.Tag;
  */
 @Tag(CRYPTO)
 @HapiTestLifecycle
-public class AtomicBatchApproveAllowanceTest {
+class AtomicBatchApproveAllowanceTest {
     private static final String OWNER = "owner";
     private static final String SPENDER = "spender";
     private static final String RECEIVER = "receiver";
@@ -138,8 +137,6 @@ public class AtomicBatchApproveAllowanceTest {
 
     @BeforeAll
     public static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 
@@ -149,7 +146,7 @@ public class AtomicBatchApproveAllowanceTest {
      */
     @HapiTest
     @Tag(MATS)
-    public final Stream<DynamicTest> transferErc20TokenFromContractWithApproval() {
+    final Stream<DynamicTest> transferErc20TokenFromContractWithApproval() {
         final var transferFromOtherContractWithSignaturesTxn = "transferFromOtherContractWithSignaturesTxn";
         final var nestedContract = "NestedERC20Contract";
         final var tokenAddress = new AtomicReference<Address>();
@@ -267,7 +264,7 @@ public class AtomicBatchApproveAllowanceTest {
      */
     @HapiTest
     @Tag(MATS)
-    public final Stream<DynamicTest> cannotPayForAnyTransactionWithContractAccount() {
+    final Stream<DynamicTest> cannotPayForAnyTransactionWithContractAccount() {
         final var cryptoAdminKey = "cryptoAdminKey";
         final var contract = "PayableConstructor";
         return hapiTest(
@@ -286,7 +283,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> transferringMissingNftViaApprovalFailsWithInvalidNftId() {
+    final Stream<DynamicTest> transferringMissingNftViaApprovalFailsWithInvalidNftId() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -333,7 +330,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> deleteAllowanceFromDeletedSpender() {
+    final Stream<DynamicTest> deleteAllowanceFromDeletedSpender() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -419,7 +416,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> duplicateKeysAndSerialsInSameTxnDoesntThrow() {
+    final Stream<DynamicTest> duplicateKeysAndSerialsInSameTxnDoesntThrow() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -491,7 +488,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> approveForAllSpenderCanDelegateOnNft() {
+    final Stream<DynamicTest> approveForAllSpenderCanDelegateOnNft() {
         final String delegatingSpender = "delegatingSpender";
         final String newSpender = "newSpender";
         return hapiTest(
@@ -555,7 +552,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> grantFungibleAllowancesWithTreasuryOwner() {
+    final Stream<DynamicTest> grantFungibleAllowancesWithTreasuryOwner() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(TOKEN_TREASURY),
@@ -592,7 +589,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> grantNftAllowancesWithTreasuryOwner() {
+    final Stream<DynamicTest> grantNftAllowancesWithTreasuryOwner() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(TOKEN_TREASURY),
@@ -636,7 +633,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> invalidOwnerFails() {
+    final Stream<DynamicTest> invalidOwnerFails() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -702,7 +699,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> invalidSpenderFails() {
+    final Stream<DynamicTest> invalidSpenderFails() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -760,7 +757,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> noOwnerDefaultsToPayer() {
+    final Stream<DynamicTest> noOwnerDefaultsToPayer() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(PAYER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -817,7 +814,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> multipleOwners() {
+    final Stream<DynamicTest> multipleOwners() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -914,7 +911,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> serialsInAscendingOrder() {
+    final Stream<DynamicTest> serialsInAscendingOrder() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -961,7 +958,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> succeedsWhenTokenPausedFrozenKycRevoked() {
+    final Stream<DynamicTest> succeedsWhenTokenPausedFrozenKycRevoked() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 newKeyNamed(ADMIN_KEY),
@@ -1052,7 +1049,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> tokenExceedsMaxSupplyFails() {
+    final Stream<DynamicTest> tokenExceedsMaxSupplyFails() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1081,7 +1078,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> validatesSerialNums() {
+    final Stream<DynamicTest> validatesSerialNums() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1132,7 +1129,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> invalidTokenTypeFails() {
+    final Stream<DynamicTest> invalidTokenTypeFails() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1182,7 +1179,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> emptyAllowancesRejected() {
+    final Stream<DynamicTest> emptyAllowancesRejected() {
         return hapiTest(
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
                 atomicBatchDefaultOperator(cryptoApproveAllowance()
@@ -1196,7 +1193,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> tokenNotAssociatedToAccountFails() {
+    final Stream<DynamicTest> tokenNotAssociatedToAccountFails() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1249,7 +1246,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> negativeAmountFailsForFungible() {
+    final Stream<DynamicTest> negativeAmountFailsForFungible() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1307,7 +1304,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> chargedUsdScalesWithAllowances() {
+    final Stream<DynamicTest> chargedUsdScalesWithAllowances() {
         final var batchTxn = "batchTxn";
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
@@ -1347,7 +1344,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> happyPathWorks() {
+    final Stream<DynamicTest> happyPathWorks() {
         final var batchTxn = "batchTxn";
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
@@ -1413,7 +1410,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> duplicateEntriesGetsReplacedWithDifferentTxn() {
+    final Stream<DynamicTest> duplicateEntriesGetsReplacedWithDifferentTxn() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1483,7 +1480,7 @@ public class AtomicBatchApproveAllowanceTest {
      */
     @HapiTest
     @Tag(MATS)
-    public final Stream<DynamicTest> cannotHaveMultipleAllowedSpendersForTheSameNftSerial() {
+    final Stream<DynamicTest> cannotHaveMultipleAllowedSpendersForTheSameNftSerial() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1573,7 +1570,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> approveForAllDoesNotSetExplicitNftSpender() {
+    final Stream<DynamicTest> approveForAllDoesNotSetExplicitNftSpender() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1613,7 +1610,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> approveNegativeCases() {
+    final Stream<DynamicTest> approveNegativeCases() {
         final var tryApprovingTheSender = "tryApprovingTheSender";
         final var tryApprovingAboveBalance = "tryApprovingAboveBalance";
         final var tryApprovingNftToOwner = "tryApprovingNFTToOwner";
@@ -1690,7 +1687,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> approveAllowanceForDeletedToken() {
+    final Stream<DynamicTest> approveAllowanceForDeletedToken() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1734,7 +1731,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> approveAllowanceToOwner() {
+    final Stream<DynamicTest> approveAllowanceToOwner() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),
@@ -1768,7 +1765,7 @@ public class AtomicBatchApproveAllowanceTest {
      * @return hapi test
      */
     @HapiTest
-    public final Stream<DynamicTest> delegateAllowanceFromDeletedSpender() {
+    final Stream<DynamicTest> delegateAllowanceFromDeletedSpender() {
         return hapiTest(
                 newKeyNamed(SUPPLY_KEY),
                 cryptoCreate(OWNER).balance(ONE_HUNDRED_HBARS).maxAutomaticTokenAssociations(10),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/AtomicBatchContractKeysHtsTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/AtomicBatchContractKeysHtsTest.java
@@ -76,7 +76,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -90,7 +89,7 @@ import org.junit.jupiter.api.Tag;
  * and dissociating tokens using contract and delegate keys.
  */
 @HapiTestLifecycle
-public class AtomicBatchContractKeysHtsTest {
+class AtomicBatchContractKeysHtsTest {
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
     private static final long GAS_TO_OFFER = 1_500_000L;
 
@@ -143,8 +142,6 @@ public class AtomicBatchContractKeysHtsTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(
                 cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS),
                 uploadInitCode(
@@ -164,7 +161,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> burnWithKeyAsPartOf1OfXThreshold() {
+    final Stream<DynamicTest> burnWithKeyAsPartOf1OfXThreshold() {
         final var delegateContractKeyShape = KeyShape.threshOf(1, SIMPLE, DELEGATE_CONTRACT);
         final var contractKeyShape = KeyShape.threshOf(1, SIMPLE, KeyShape.CONTRACT);
         final var tokenAddress = new AtomicReference<Address>();
@@ -217,7 +214,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> delegateCallForBurnWithContractKey() {
+    final Stream<DynamicTest> delegateCallForBurnWithContractKey() {
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
                 tokenCreate(VANILLA_TOKEN)
@@ -259,7 +256,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> delegateCallForMintWithContractKey() {
+    final Stream<DynamicTest> delegateCallForMintWithContractKey() {
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
                 tokenCreate(VANILLA_TOKEN)
@@ -299,7 +296,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> staticCallForDissociatePrecompileFails() {
+    final Stream<DynamicTest> staticCallForDissociatePrecompileFails() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -325,7 +322,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> staticCallForTransferWithContractKey() {
+    final Stream<DynamicTest> staticCallForTransferWithContractKey() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         final AtomicReference<Address> receiverAddress = new AtomicReference<>();
@@ -365,7 +362,7 @@ public class AtomicBatchContractKeysHtsTest {
 
     @HapiTest
     @Tag(MATS)
-    public final Stream<DynamicTest> staticCallForBurnWithContractKey() {
+    final Stream<DynamicTest> staticCallForBurnWithContractKey() {
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
                 tokenCreate(VANILLA_TOKEN)
@@ -398,7 +395,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> staticCallForMintWithContractKey() {
+    final Stream<DynamicTest> staticCallForMintWithContractKey() {
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
                 tokenCreate(VANILLA_TOKEN)
@@ -428,7 +425,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> staticCallForTransferWithDelegateContractKey() {
+    final Stream<DynamicTest> staticCallForTransferWithDelegateContractKey() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         final AtomicReference<Address> receiverAddress = new AtomicReference<>();
@@ -467,7 +464,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> staticCallForBurnWithDelegateContractKey() {
+    final Stream<DynamicTest> staticCallForBurnWithDelegateContractKey() {
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
                 tokenCreate(VANILLA_TOKEN)
@@ -500,7 +497,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> staticCallForMintWithDelegateContractKey() {
+    final Stream<DynamicTest> staticCallForMintWithDelegateContractKey() {
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
                 tokenCreate(VANILLA_TOKEN)
@@ -530,7 +527,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> staticCallForAssociatePrecompileFails() {
+    final Stream<DynamicTest> staticCallForAssociatePrecompileFails() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -556,7 +553,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> callForMintWithContractKey() {
+    final Stream<DynamicTest> callForMintWithContractKey() {
         final var firstMintTxn = "firstMintTxn";
         final var amount = 10L;
         final AtomicReference<Address> fungibleAddress = new AtomicReference<>();
@@ -599,7 +596,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> callForMintWithDelegateContractKey() {
+    final Stream<DynamicTest> callForMintWithDelegateContractKey() {
         final var firstMintTxn = "firstMintTxn";
         final var amount = 10L;
         final AtomicReference<Address> fungibleAddress = new AtomicReference<>();
@@ -643,7 +640,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> callForTransferWithContractKey() {
+    final Stream<DynamicTest> callForTransferWithContractKey() {
         final AtomicReference<Address> nftAddress = new AtomicReference<>();
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> receiverAddress = new AtomicReference<>();
@@ -693,7 +690,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> callForTransferWithDelegateContractKey() {
+    final Stream<DynamicTest> callForTransferWithDelegateContractKey() {
         final AtomicReference<Address> nftAddress = new AtomicReference<>();
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> receiverAddress = new AtomicReference<>();
@@ -746,7 +743,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> callForAssociateWithDelegateContractKey() {
+    final Stream<DynamicTest> callForAssociateWithDelegateContractKey() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -779,7 +776,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> callForAssociateWithContractKey() {
+    final Stream<DynamicTest> callForAssociateWithContractKey() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -811,7 +808,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> callForDissociateWithDelegateContractKey() {
+    final Stream<DynamicTest> callForDissociateWithDelegateContractKey() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenAddress = new AtomicReference<>();
         final var totalSupply = 1_000;
@@ -869,7 +866,7 @@ public class AtomicBatchContractKeysHtsTest {
 
     @HapiTest
     @Tag(MATS)
-    public final Stream<DynamicTest> callForDissociateWithContractKey() {
+    final Stream<DynamicTest> callForDissociateWithContractKey() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenAddress = new AtomicReference<>();
         final var totalSupply = 1_000;
@@ -926,7 +923,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> callForBurnWithDelegateContractKey() {
+    final Stream<DynamicTest> callForBurnWithDelegateContractKey() {
         final AtomicReference<Address> tokenAddress = new AtomicReference<>();
         return hapiTest(
                 tokenCreate(TOKEN_USAGE)
@@ -959,7 +956,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> delegateCallForAssociatePrecompileSignedWithDelegateContractKeyWorks() {
+    final Stream<DynamicTest> delegateCallForAssociatePrecompileSignedWithDelegateContractKeyWorks() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -994,7 +991,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> delegateCallForDissociatePrecompileSignedWithDelegateContractKeyWorks() {
+    final Stream<DynamicTest> delegateCallForDissociatePrecompileSignedWithDelegateContractKeyWorks() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
 
@@ -1031,7 +1028,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForNonFungibleWithKyc() {
+    final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForNonFungibleWithKyc() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> kycTokenAddress = new AtomicReference<>();
 
@@ -1103,7 +1100,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForFungibleVanilla() {
+    final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForFungibleVanilla() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> treasuryAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenAddress = new AtomicReference<>();
@@ -1196,7 +1193,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForFungibleFrozen() {
+    final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForFungibleFrozen() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> frozenTokenAddress = new AtomicReference<>();
 
@@ -1252,7 +1249,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForFungibleWithKyc() {
+    final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForFungibleWithKyc() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> kycTokenAddress = new AtomicReference<>();
 
@@ -1306,7 +1303,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForNonFungibleVanilla() {
+    final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForNonFungibleVanilla() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> treasuryAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenAddress = new AtomicReference<>();
@@ -1401,7 +1398,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForNonFungibleFrozen() {
+    final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForNonFungibleFrozen() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> frozenTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -1458,7 +1455,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForNonFungibleWithKyc() {
+    final Stream<DynamicTest> dissociatePrecompileWithDelegateContractKeyForNonFungibleWithKyc() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> kycTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -1513,7 +1510,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForNonFungibleFrozen() {
+    final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForNonFungibleFrozen() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> frozenTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -1585,7 +1582,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForNonFungibleVanilla() {
+    final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForNonFungibleVanilla() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -1655,7 +1652,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForFungibleWithKyc() {
+    final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForFungibleWithKyc() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> kycTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -1724,7 +1721,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForFungibleFrozen() {
+    final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForFungibleFrozen() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> frozenTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -1795,7 +1792,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForFungibleVanilla() {
+    final Stream<DynamicTest> associatePrecompileWithDelegateContractKeyForFungibleVanilla() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -1863,7 +1860,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> delegateCallForAssociatePrecompileSignedWithContractKeyFails() {
+    final Stream<DynamicTest> delegateCallForAssociatePrecompileSignedWithContractKeyFails() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -1898,7 +1895,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> delegateCallForDissociatePrecompileSignedWithContractKeyFails() {
+    final Stream<DynamicTest> delegateCallForDissociatePrecompileSignedWithContractKeyFails() {
         final AtomicReference<Address> accountAddress = new AtomicReference<>();
         final AtomicReference<Address> vanillaTokenTokenAddress = new AtomicReference<>();
         return hapiTest(
@@ -1934,7 +1931,7 @@ public class AtomicBatchContractKeysHtsTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> callForBurnWithContractKey() {
+    final Stream<DynamicTest> callForBurnWithContractKey() {
         final AtomicReference<Address> tokenAddress = new AtomicReference<>();
         return hapiTest(
                 tokenCreate(TOKEN_USAGE)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/AtomicBatchContractSignatureValidationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/AtomicBatchContractSignatureValidationTest.java
@@ -57,7 +57,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -67,7 +66,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
-public class AtomicBatchContractSignatureValidationTest {
+class AtomicBatchContractSignatureValidationTest {
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
     private static final String RECEIVER_SIG_REQUIRED = "receiverSigRequired";
     private static final String AUTO_RENEW_ACCOUNT = "autoRenewAccount";
@@ -89,8 +88,6 @@ public class AtomicBatchContractSignatureValidationTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
         testLifecycle.doAdhoc(
                 cryptoCreate(RECEIVER_SIG_REQUIRED).receiverSigRequired(true).exposingCreatedIdTo(receiverId::set));
@@ -100,7 +97,7 @@ public class AtomicBatchContractSignatureValidationTest {
     @HapiTest
     @DisplayName("Validate internal call with value to account requiring receiver signature")
     @Tag(MATS)
-    public final Stream<DynamicTest> internalCallWithValueToAccountWithReceiverSigRequired() {
+    final Stream<DynamicTest> internalCallWithValueToAccountWithReceiverSigRequired() {
         return hapiTest(
                 uploadInitCode(INTERNAL_CALLER_CONTRACT),
                 contractCreate(INTERNAL_CALLER_CONTRACT).balance(ONE_HBAR),
@@ -118,7 +115,7 @@ public class AtomicBatchContractSignatureValidationTest {
 
     @HapiTest
     @DisplayName("Validate transfer to account requiring receiver signature")
-    public final Stream<DynamicTest> transferToAccountWithReceiverSigRequired() {
+    final Stream<DynamicTest> transferToAccountWithReceiverSigRequired() {
         return hapiTest(
                 recordStreamMustIncludeNoFailuresFrom(sidecarIdValidator()),
                 getAccountInfo(RECEIVER_SIG_REQUIRED).savingSnapshot("accInfo"),
@@ -144,7 +141,7 @@ public class AtomicBatchContractSignatureValidationTest {
 
     @HapiTest
     @DisplayName("Validate contract creation fails if missing required signatures")
-    public final Stream<DynamicTest> createFailsIfMissingSigs() {
+    final Stream<DynamicTest> createFailsIfMissingSigs() {
         final var shape = listOf(SIMPLE, threshOf(2, 3), threshOf(1, 3));
         final var validSig = shape.signedWith(sigs(ON, sigs(ON, ON, OFF), sigs(OFF, OFF, ON)));
         final var invalidSig = shape.signedWith(sigs(OFF, sigs(ON, ON, OFF), sigs(OFF, OFF, ON)));
@@ -165,7 +162,7 @@ public class AtomicBatchContractSignatureValidationTest {
 
     @HapiTest
     @DisplayName("Validate contract creation with auto-renew account requiring signatures")
-    public final Stream<DynamicTest> contractWithAutoRenewNeedSignatures() {
+    final Stream<DynamicTest> contractWithAutoRenewNeedSignatures() {
         return hapiTest(
                 newKeyNamed(ADMIN_KEY),
                 uploadInitCode(CONTRACT),
@@ -186,7 +183,7 @@ public class AtomicBatchContractSignatureValidationTest {
 
     @HapiTest
     @DisplayName("Validate updating auto-renew account with proper signatures")
-    public final Stream<DynamicTest> updateAutoRenewAccountWorks() {
+    final Stream<DynamicTest> updateAutoRenewAccountWorks() {
         final var newAccount = "newAccount";
         return hapiTest(
                 newKeyNamed(ADMIN_KEY),
@@ -209,7 +206,7 @@ public class AtomicBatchContractSignatureValidationTest {
 
     @HapiTest
     @DisplayName("Validate updating max automatic associations requires proper key")
-    public final Stream<DynamicTest> updateMaxAutomaticAssociationsAndRequireKey() {
+    final Stream<DynamicTest> updateMaxAutomaticAssociationsAndRequireKey() {
         return hapiTest(
                 newKeyNamed(ADMIN_KEY),
                 uploadInitCode(CONTRACT),
@@ -229,7 +226,7 @@ public class AtomicBatchContractSignatureValidationTest {
 
     @HapiTest
     @DisplayName("Validate contract update fails for all fields except expiry when using the wrong key")
-    public final Stream<DynamicTest> cannotUpdateContractExceptExpiryWithWrongKey() {
+    final Stream<DynamicTest> cannotUpdateContractExceptExpiryWithWrongKey() {
         final var someValidExpiry = new AtomicLong(Instant.now().getEpochSecond() + THREE_MONTHS_IN_SECONDS + 1234L);
         return hapiTest(
                 newKeyNamed(ADMIN_KEY),
@@ -310,7 +307,7 @@ public class AtomicBatchContractSignatureValidationTest {
 
     @HapiTest
     @DisplayName("Validate contract deletion fails without proper signature")
-    public final Stream<DynamicTest> deleteWithoutProperSig() {
+    final Stream<DynamicTest> deleteWithoutProperSig() {
         return hapiTest(
                 uploadInitCode(CONTRACT),
                 contractCreate(CONTRACT),
@@ -323,7 +320,7 @@ public class AtomicBatchContractSignatureValidationTest {
 
     @HapiTest
     @DisplayName("Validate self-destruct fails when beneficiary requires receiver signature without proper signature")
-    public final Stream<DynamicTest> selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn() {
+    final Stream<DynamicTest> selfDestructFailsWhenBeneficiaryHasReceiverSigRequiredAndHasNotSignedTheTxn() {
         return hapiTest(
                 uploadInitCode(SELF_DESTRUCT_CALLABLE_CONTRACT),
                 contractCreate(SELF_DESTRUCT_CALLABLE_CONTRACT).balance(ONE_HBAR),
@@ -342,7 +339,7 @@ public class AtomicBatchContractSignatureValidationTest {
     @DisplayName("Validate contract update and delete")
     // This test is inspired by the "Friday the 13th" contract update and delete scenario
     // see com.hedera.services.bdd.suites.contract.hapi.ContractUpdateSuite.fridayThe13thSpec
-    public final Stream<DynamicTest> fridayThe13thSpec() {
+    final Stream<DynamicTest> fridayThe13thSpec() {
         final var contract = "SimpleStorage";
         final var suffix = "Clone";
         final var newExpiry = Instant.now().getEpochSecond() + DEFAULT_PROPS.defaultExpirationSecs() + 200;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/AtomicBatchEthereumCallKeysTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/AtomicBatchEthereumCallKeysTest.java
@@ -61,7 +61,6 @@ import com.hederahashgraph.api.proto.java.TokenType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -70,18 +69,16 @@ import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
 @Tag(MATS)
-public class AtomicBatchEthereumCallKeysTest {
+class AtomicBatchEthereumCallKeysTest {
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 
     @HapiTest
-    public final Stream<DynamicTest> canCreateTokenWithCryptoAdminKeyOnlyIfHasTopLevelSig() {
+    final Stream<DynamicTest> canCreateTokenWithCryptoAdminKeyOnlyIfHasTopLevelSig() {
         final var cryptoKey = "cryptoKey";
         final var thresholdKey = "thresholdKey";
         final String contract = "TestTokenCreateContract";
@@ -164,7 +161,7 @@ public class AtomicBatchEthereumCallKeysTest {
     }
 
     @HapiTest
-    public final Stream<DynamicTest> precompileCallFailsWhenSignatureMissingFromBothEthereumAndHederaTxn() {
+    final Stream<DynamicTest> precompileCallFailsWhenSignatureMissingFromBothEthereumAndHederaTxn() {
         final AtomicReference<TokenID> fungible = new AtomicReference<>();
         final String fungibleToken = "token";
         final String mintTxn = "mintTxn";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/V2SecurityModel/AtomicBatchAssociatePrecompileV2SecurityModelTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/V2SecurityModel/AtomicBatchAssociatePrecompileV2SecurityModelTest.java
@@ -67,7 +67,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
-public class AtomicBatchAssociatePrecompileV2SecurityModelTest {
+class AtomicBatchAssociatePrecompileV2SecurityModelTest {
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
 
     private static final long GAS_TO_OFFER = 6_000_000L;
@@ -90,10 +90,7 @@ public class AtomicBatchAssociatePrecompileV2SecurityModelTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
-                "contracts.throttle.throttleByGas", "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(
                 cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS),
                 // create contracts

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/V2SecurityModel/AtomicBatchContractBurnHTSV2SecurityModelTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/V2SecurityModel/AtomicBatchContractBurnHTSV2SecurityModelTest.java
@@ -81,7 +81,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
-public class AtomicBatchContractBurnHTSV2SecurityModelTest {
+class AtomicBatchContractBurnHTSV2SecurityModelTest {
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
 
     private static final long GAS_TO_OFFER = 2_000_000L;
@@ -133,10 +133,7 @@ public class AtomicBatchContractBurnHTSV2SecurityModelTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
-                "contracts.throttle.throttleByGas", "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(
                 uploadInitCode(MIXED_BURN_TOKEN),
                 uploadInitCode(MINT_CONTRACT),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/V2SecurityModel/AtomicBatchContractMintHTSV2SecurityModelTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/V2SecurityModel/AtomicBatchContractMintHTSV2SecurityModelTest.java
@@ -58,7 +58,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
-public class AtomicBatchContractMintHTSV2SecurityModelTest {
+class AtomicBatchContractMintHTSV2SecurityModelTest {
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
 
     private static final long GAS_TO_OFFER = 2_000_000L;
@@ -113,10 +113,7 @@ public class AtomicBatchContractMintHTSV2SecurityModelTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
-                "contracts.throttle.throttleByGas", "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         testLifecycle.doAdhoc(
                 uploadInitCode(
                         HTS_CALLS,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchAddress167Test.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchAddress167Test.java
@@ -42,7 +42,7 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 
 @HapiTestLifecycle
-public class AtomicBatchAddress167Test {
+class AtomicBatchAddress167Test {
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
     private static final String ACCOUNT = "account";
     private static final String TOKEN_AND_TYPE_CHECK_CONTRACT = "TokenAndTypeCheck";
@@ -52,11 +52,7 @@ public class AtomicBatchAddress167Test {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        // enable atomic batch
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
-                "contracts.throttle.throttleByGas", "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         // create default batch operator
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchAddress16cTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchAddress16cTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
-public class AtomicBatchAddress16cTest {
+class AtomicBatchAddress16cTest {
 
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
 
@@ -40,8 +40,6 @@ public class AtomicBatchAddress16cTest {
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         // enable atomic batch
         testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
                 "contracts.throttle.throttleByGas", "false",
                 "contracts.systemContract.hts.addresses", "359,364"));
         // create default batch operator
@@ -53,7 +51,7 @@ public class AtomicBatchAddress16cTest {
      */
     @HapiTest
     @DisplayName("when using atomic getTokenKey should return metadata key")
-    public Stream<DynamicTest> atomicSucceedToGetTokenKey(
+    Stream<DynamicTest> atomicSucceedToGetTokenKey(
             @Contract(contract = "NumericContract16c", creationGas = 1_000_000L, variant = VARIANT_16C)
                     final SpecContract numericContract,
             @NonFungibleToken(
@@ -72,7 +70,7 @@ public class AtomicBatchAddress16cTest {
      */
     @HapiTest
     @Tag(MATS)
-    public Stream<DynamicTest> atomicTestUpdateMetadata(
+    Stream<DynamicTest> atomicTestUpdateMetadata(
             @Contract(contract = "CreateTokenVersioned", creationGas = 5_000_000L, variant = VARIANT_16C)
                     final SpecContract contractTarget,
             @FungibleToken(name = "fungibleToken", initialSupply = 1_000L, maxSupply = 1_200L)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchPrecompileSCTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchPrecompileSCTest.java
@@ -59,7 +59,7 @@ import org.junit.jupiter.api.Tag;
 
 @Tag(SMART_CONTRACT)
 @HapiTestLifecycle
-public class AtomicBatchPrecompileSCTest {
+class AtomicBatchPrecompileSCTest {
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
     public static final BigInteger MAX_LONG_PLUS_1_BIG_INT =
             new BigInteger(1, Bytes.fromHex("010000000000000000").toByteArray());
@@ -67,10 +67,7 @@ public class AtomicBatchPrecompileSCTest {
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         // enable atomic batch
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
-                "contracts.throttle.throttleByGas", "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         // create default batch operator
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
@@ -80,7 +77,7 @@ public class AtomicBatchPrecompileSCTest {
      */
     @HapiTest
     @DisplayName("Atomic FT redirect proxy approve(address,uint256)")
-    public Stream<DynamicTest> atomicFailToApproveViaProxyFungibleToken(
+    Stream<DynamicTest> atomicFailToApproveViaProxyFungibleToken(
             @Contract(contract = "NumericContract", creationGas = 8_000_000L) final SpecContract numericContract,
             @FungibleToken(
                             name = "NumericValidationTestFT",
@@ -119,7 +116,7 @@ public class AtomicBatchPrecompileSCTest {
     @HapiTest
     @DisplayName("atomic use updateMetadataForNFTs to correctly update metadata for 1 NFT")
     @Tag(MATS)
-    public Stream<DynamicTest> atomicUsingUpdateMetadataForNFTsWorksForSingleNFT(
+    Stream<DynamicTest> atomicUsingUpdateMetadataForNFTsWorksForSingleNFT(
             @NonFungibleToken(
                             numPreMints = 10,
                             keys = {SUPPLY_KEY, PAUSE_KEY, ADMIN_KEY, METADATA_KEY})
@@ -144,7 +141,7 @@ public class AtomicBatchPrecompileSCTest {
      */
     @HapiTest
     @DisplayName("cannot transfer value to HTS")
-    public Stream<DynamicTest> atomicCannotTransferValueToHts(
+    Stream<DynamicTest> atomicCannotTransferValueToHts(
             @Contract(contract = "InternalCall", creationGas = 1_000_000L) final SpecContract internalCall,
             @FungibleToken(name = "fungibleToken") final SpecFungibleToken fungibleToken) {
         return hapiTest(internalCall
@@ -156,7 +153,7 @@ public class AtomicBatchPrecompileSCTest {
 
     @HapiTest
     @DisplayName("atomic get token type")
-    public Stream<DynamicTest> atomicCannotUpdateMissingToken(
+    Stream<DynamicTest> atomicCannotUpdateMissingToken(
             @Contract(contract = "TokenAndTypeCheck", creationGas = 4_000_000L, variant = VARIANT_16C)
                     final SpecContract tokenTypeCheckContract,
             @FungibleToken(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchPrecompileTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchPrecompileTest.java
@@ -191,7 +191,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
-public class AtomicBatchPrecompileTest {
+class AtomicBatchPrecompileTest {
     private static final String DEFAULT_BATCH_OPERATOR = "batchOperator";
     private static final String APPROVE_SIGNATURE = "Approval(address,address,uint256)";
     private static final Tuple[] EMPTY_TUPLE_ARRAY = new Tuple[] {};
@@ -294,10 +294,7 @@ public class AtomicBatchPrecompileTest {
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         // enable atomic batch
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
-                "contracts.throttle.throttleByGas", "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         // create default batch operator
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
         // upload contracts init code
@@ -2030,7 +2027,7 @@ public class AtomicBatchPrecompileTest {
 
         @HapiTest
         @DisplayName("returns true for EOA msg.sender exactly when associated")
-        public Stream<DynamicTest> atomicReturnsTrueIffEoaMsgSenderIsAssociated() {
+        Stream<DynamicTest> atomicReturnsTrueIffEoaMsgSenderIsAssociated() {
             return hapiTest(
                     assertAtomicEoaGetsResultForBothTokens(false),
                     senderAccount.associateTokens(fungibleToken2, nonFungibleToken2),
@@ -2633,7 +2630,7 @@ public class AtomicBatchPrecompileTest {
 
         @HapiTest
         @DisplayName("fungible token with fixed ℏ fee")
-        public Stream<DynamicTest> atomicUpdateFungibleTokenWithHbarFixedFee() {
+        Stream<DynamicTest> atomicUpdateFungibleTokenWithHbarFixedFee() {
 
             return hapiTest(
                     fungibleToken

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchScheduleTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchScheduleTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
-public class AtomicBatchScheduleTest {
+class AtomicBatchScheduleTest {
 
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
 
@@ -45,11 +45,7 @@ public class AtomicBatchScheduleTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        // enable atomic batch
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
-                "contracts.throttle.throttleByGas", "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         // create default batch operator
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
@@ -59,7 +55,7 @@ public class AtomicBatchScheduleTest {
      */
     @HapiTest
     @DisplayName("Atomic cannot get scheduled info for non-existent fungible create schedule")
-    public Stream<DynamicTest> atomicCannotGetScheduledInfoForNonExistentFungibleCreateSchedule(
+    Stream<DynamicTest> atomicCannotGetScheduledInfoForNonExistentFungibleCreateSchedule(
             @NonNull @Contract(contract = "GetScheduleInfo", creationGas = 5_000_000) final SpecContract contract) {
         return hapiTest(withOpContext((spec, log) -> {
             final var callOp = contract.call(
@@ -78,7 +74,7 @@ public class AtomicBatchScheduleTest {
     @HapiTest
     @DisplayName("Atomic can successfully schedule a create fungible token operation")
     @Tag(MATS)
-    public Stream<DynamicTest> atomicScheduledCreateToken(
+    Stream<DynamicTest> atomicScheduledCreateToken(
             @NonNull @Contract(contract = "HIP756Contract", creationGas = 4_000_000L, isImmutable = true)
                     final SpecContract contract,
             @NonNull @Account final SpecAccount treasury,

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchTokenAirdropTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchTokenAirdropTest.java
@@ -46,17 +46,13 @@ import org.junit.jupiter.api.Order;
 
 @OrderedInIsolation
 @HapiTestLifecycle
-public class AtomicBatchTokenAirdropTest {
+class AtomicBatchTokenAirdropTest {
 
     private static final String DEFAULT_BATCH_OPERATOR = "batchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        // enable atomic batch
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
-                "contracts.throttle.throttleByGas", "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         // create default batch operator
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
@@ -70,7 +66,7 @@ public class AtomicBatchTokenAirdropTest {
     @Order(1)
     @HapiTest
     @DisplayName("Atomic Contract Airdrops a token to a receiver who is associated to the token")
-    public Stream<DynamicTest> atomicAirdropTokenToAccount(
+    Stream<DynamicTest> atomicAirdropTokenToAccount(
             @NonNull @Account(maxAutoAssociations = 10, tinybarBalance = 100L) final SpecAccount receiver,
             @NonNull @Contract(contract = "EmptyOne", creationGas = 10_000_000L) final SpecContract sender,
             @NonNull @FungibleToken(initialSupply = 1_000_000L) final SpecFungibleToken token) {
@@ -99,7 +95,7 @@ public class AtomicBatchTokenAirdropTest {
     @Order(2)
     @HapiTest
     @DisplayName("Atomic Airdrop token")
-    public Stream<DynamicTest> atomicAirdropToken(
+    Stream<DynamicTest> atomicAirdropToken(
             @NonNull @Account(maxAutoAssociations = 10, tinybarBalance = 10_000L * ONE_MILLION_HBARS)
                     final SpecAccount sender,
             @NonNull @Account(maxAutoAssociations = -1) final SpecAccount receiver,
@@ -122,7 +118,7 @@ public class AtomicBatchTokenAirdropTest {
     @Order(3)
     @HapiTest
     @DisplayName("Can atomic airdrop fungible token to a contract that is already associated to it")
-    public Stream<DynamicTest> atomicAirdropToContract(
+    Stream<DynamicTest> atomicAirdropToContract(
             @NonNull @Account(maxAutoAssociations = 10, tinybarBalance = 10_000L * ONE_MILLION_HBARS)
                     final SpecAccount sender,
             @NonNull @Contract(contract = "AssociateContract", isImmutable = true, creationGas = 3_000_000)
@@ -146,7 +142,7 @@ public class AtomicBatchTokenAirdropTest {
      */
     @Order(4)
     @HapiTest
-    public Stream<DynamicTest> atomicHrcSetUnlimitedAutoAssociations() {
+    Stream<DynamicTest> atomicHrcSetUnlimitedAutoAssociations() {
         final AtomicReference<AccountID> accountNum = new AtomicReference<>();
         return hapiTest(
                 cryptoCreate("account")
@@ -184,7 +180,7 @@ public class AtomicBatchTokenAirdropTest {
     @Order(5)
     @HapiTest
     @DisplayName("Can cancel atomic airdrop of fungible token")
-    public Stream<DynamicTest> canCancelAtomicAirdropOfFungibleToken(
+    Stream<DynamicTest> canCancelAtomicAirdropOfFungibleToken(
             @NonNull @FungibleToken(initialSupply = 1_000L) final SpecFungibleToken token,
             @NonNull @Account(tinybarBalance = 10_000L * ONE_MILLION_HBARS) final SpecAccount sender,
             @NonNull @Account(maxAutoAssociations = 0) final SpecAccount receiver) {
@@ -205,7 +201,7 @@ public class AtomicBatchTokenAirdropTest {
     @Order(6)
     @HapiTest
     @DisplayName("Can claim atomic airdrop of fungible token")
-    public Stream<DynamicTest> canClaimAtomicAirdropOfFungibleToken(
+    Stream<DynamicTest> canClaimAtomicAirdropOfFungibleToken(
             @NonNull @FungibleToken(initialSupply = 1_000L) final SpecFungibleToken token,
             @NonNull @Account(tinybarBalance = ONE_HBAR) final SpecAccount sender,
             @NonNull @Account(tinybarBalance = ONE_HBAR) final SpecAccount receiver) {
@@ -228,7 +224,7 @@ public class AtomicBatchTokenAirdropTest {
     @Order(7)
     @HapiTest
     @DisplayName("Atomic HRC rejectTokenFT works")
-    public Stream<DynamicTest> atomicHrcFungibleWorks(
+    Stream<DynamicTest> atomicHrcFungibleWorks(
             @NonNull @FungibleToken(initialSupply = 1000) SpecFungibleToken token,
             @NonNull @Account(tinybarBalance = ONE_HBAR) final SpecAccount sender) {
         return hapiTest(
@@ -249,7 +245,7 @@ public class AtomicBatchTokenAirdropTest {
     @Order(8)
     @HapiTest
     @DisplayName("Atomic Can cancel 1 fungible airdrop")
-    public Stream<DynamicTest> atomicCancelAirdrop(
+    Stream<DynamicTest> atomicCancelAirdrop(
             @NonNull @Contract(contract = "CancelAirdrop", creationGas = 2_000_000L) final SpecContract cancelAirdrop,
             @NonNull @FungibleToken(initialSupply = 1_000L) final SpecFungibleToken token,
             @NonNull @Account(tinybarBalance = ONE_HBAR) final SpecAccount sender,
@@ -280,7 +276,7 @@ public class AtomicBatchTokenAirdropTest {
     @Order(9)
     @HapiTest
     @DisplayName("Atomic can claim 1 fungible airdrop")
-    public Stream<DynamicTest> atomicClaimAirdrop(
+    Stream<DynamicTest> atomicClaimAirdrop(
             @NonNull @Contract(contract = "ClaimAirdrop", creationGas = 2_000_000L) final SpecContract claimAirdrop,
             @NonNull @FungibleToken(initialSupply = 1_000L) final SpecFungibleToken token,
             @NonNull @Account(tinybarBalance = ONE_HBAR) final SpecAccount sender,
@@ -314,7 +310,7 @@ public class AtomicBatchTokenAirdropTest {
     @Order(10)
     @HapiTest
     @DisplayName("Atomic reject fungible token")
-    public Stream<DynamicTest> atomicTokenRejectSystemContractTest(
+    Stream<DynamicTest> atomicTokenRejectSystemContractTest(
             @NonNull @Contract(contract = "TokenReject", creationGas = 1_000_000L) final SpecContract tokenReject,
             @NonNull @FungibleToken(initialSupply = 1000) final SpecFungibleToken token,
             @NonNull @Account(tinybarBalance = ONE_HBAR) final SpecAccount sender) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchTokenTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/contracts/precompile/AtomicBatchTokenTest.java
@@ -36,16 +36,13 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @HapiTestLifecycle
-public class AtomicBatchTokenTest {
+class AtomicBatchTokenTest {
     private static final String DEFAULT_BATCH_OPERATOR = "defaultBatchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
         // enable atomic batch
-        testLifecycle.overrideInClass(Map.of(
-                "atomicBatch.isEnabled", "true",
-                "atomicBatch.maxNumberOfTransactions", "50",
-                "contracts.throttle.throttleByGas", "false"));
+        testLifecycle.overrideInClass(Map.of("contracts.throttle.throttleByGas", "false"));
         // create default batch operator
         testLifecycle.doAdhoc(cryptoCreate(DEFAULT_BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
@@ -55,7 +52,7 @@ public class AtomicBatchTokenTest {
      */
     @HapiTest
     @DisplayName("atomic cannot get a nonsense key type")
-    public Stream<DynamicTest> atomicCannotGetNonsenseKeyType(
+    Stream<DynamicTest> atomicCannotGetNonsenseKeyType(
             @Contract(contract = "UpdateTokenInfoContract", creationGas = 4_000_000L)
                     final SpecContract getTokenKeyContract,
             @NonFungibleToken(
@@ -81,7 +78,7 @@ public class AtomicBatchTokenTest {
     @HapiTest
     @DisplayName("atomic transferring owner's tokens using transferToken function without explicit allowance")
     @Tag(MATS)
-    public Stream<DynamicTest> atomicTransferUsingTransferToken(
+    Stream<DynamicTest> atomicTransferUsingTransferToken(
             @Contract(contract = "TokenTransferContract", creationGas = 10_000_000L)
                     final SpecContract tokenTransferContract,
             @Contract(contract = "NestedHTSTransferrer", creationGas = 10_000_000L)
@@ -106,7 +103,7 @@ public class AtomicBatchTokenTest {
      */
     @HapiTest
     @DisplayName("atomic can update the name")
-    public Stream<DynamicTest> atomicCanUpdateName(
+    Stream<DynamicTest> atomicCanUpdateName(
             @Contract(contract = "TokenInfoSingularUpdate", creationGas = 4_000_000L)
                     final SpecContract updateTokenPropertyContract,
             @NonFungibleToken(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeCreateTest.java
@@ -66,7 +66,6 @@ import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.Spliterators;
 import java.util.stream.Collectors;
@@ -81,7 +80,7 @@ import org.junit.jupiter.api.Tag;
 // This test cases are direct copies of NodeCreateTest. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
-public class AtomicNodeCreateTest {
+class AtomicNodeCreateTest {
 
     public static final String ED_25519_KEY = "ed25519Alias";
     public static List<ServiceEndpoint> GOSSIP_ENDPOINTS_FQDNS = Arrays.asList(
@@ -101,8 +100,6 @@ public class AtomicNodeCreateTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
 
         gossipCertificates = generateX509Certificates(2);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeDeleteTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeDeleteTest.java
@@ -43,7 +43,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -53,7 +52,7 @@ import org.junit.jupiter.api.Tag;
 // This test cases are direct copies of NodeDeleteTest. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
-public class AtomicNodeDeleteTest {
+class AtomicNodeDeleteTest {
 
     private static List<X509Certificate> gossipCertificates;
 
@@ -61,8 +60,6 @@ public class AtomicNodeDeleteTest {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
 
         gossipCertificates = generateX509Certificates(1);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeUpdateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip869/batch/AtomicNodeUpdateTest.java
@@ -63,7 +63,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -72,15 +71,13 @@ import org.junit.jupiter.api.Tag;
 
 @DisplayName("updateNode")
 @HapiTestLifecycle
-public class AtomicNodeUpdateTest {
+class AtomicNodeUpdateTest {
 
     private static List<X509Certificate> gossipCertificates;
     private static final String BATCH_OPERATOR = "batchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
 
         gossipCertificates = generateX509Certificates(2);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeCreateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeCreateTest.java
@@ -46,7 +46,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.keys.KeyShape;
@@ -59,7 +58,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -68,17 +66,10 @@ import org.junit.jupiter.api.Nested;
 
 // This test cases are direct copies of TopicCustomFeeCreateTest. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm the fees are the same
-@HapiTestLifecycle
 @DisplayName("Topic custom fees")
-public class AtomicTopicCustomFeeCreateTest extends TopicCustomFeeBase {
+class AtomicTopicCustomFeeCreateTest extends TopicCustomFeeBase {
 
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @Nested
     @DisplayName("Positive scenarios")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeGetTopicInfoTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeGetTopicInfoTest.java
@@ -21,7 +21,6 @@ import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -31,14 +30,13 @@ import org.junit.jupiter.api.DynamicTest;
 // we are wrapping the operations in an atomic batch to confirm the fees are the same
 @HapiTestLifecycle
 @DisplayName("Topic get info")
-public class AtomicTopicCustomFeeGetTopicInfoTest extends TopicCustomFeeBase {
+class AtomicTopicCustomFeeGetTopicInfoTest extends TopicCustomFeeBase {
 
     private static final String BATCH_OPERATOR = "batchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle lifecycle) {
         lifecycle.doAdhoc(setupBaseKeys());
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeSubmitMessageTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeSubmitMessageTest.java
@@ -74,7 +74,6 @@ import com.hederahashgraph.api.proto.java.TokenType;
 import com.hederahashgraph.api.proto.java.TransactionRecord;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
@@ -86,15 +85,9 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm the fees are the same
 @HapiTestLifecycle
 @DisplayName("Submit message")
-public class AtomicTopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
+class AtomicTopicCustomFeeSubmitMessageTest extends TopicCustomFeeBase {
 
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @Nested
     @DisplayName("Positive scenarios")

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeUpdateTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip991/AtomicTopicCustomFeeUpdateTest.java
@@ -52,7 +52,6 @@ import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.hiero.base.utility.CommonUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -65,7 +64,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm the fees are the same
 @HapiTestLifecycle
 @DisplayName("Topic custom fees update")
-public class AtomicTopicCustomFeeUpdateTest extends TopicCustomFeeBase {
+class AtomicTopicCustomFeeUpdateTest extends TopicCustomFeeBase {
 
     private static final long FIFTY_BILLION = 50_000_000_000L;
     private static final String BATCH_OPERATOR = "batchOperator";
@@ -73,7 +72,6 @@ public class AtomicTopicCustomFeeUpdateTest extends TopicCustomFeeBase {
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle lifecycle) {
         lifecycle.doAdhoc(setupBaseForUpdate());
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
     }
 
     @Nested

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AtomicBatchFuzzing.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/AtomicBatchFuzzing.java
@@ -9,26 +9,14 @@ import static com.hedera.services.bdd.suites.regression.factories.AtomicBatchPro
 import static com.hedera.services.bdd.suites.regression.factories.IdFuzzingProviderFactory.initOperations;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
-import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 @Tag(NOT_REPEATABLE)
-@HapiTestLifecycle
-public class AtomicBatchFuzzing {
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
+class AtomicBatchFuzzing {
 
     private static final String PROPERTIES = "id-fuzzing.properties";
     private final AtomicInteger maxOpsPerSec = new AtomicInteger(10);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicBatchTokenServiceEndToEndTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicBatchTokenServiceEndToEndTests.java
@@ -67,27 +67,21 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.SpecOperation;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenCreate;
 import com.hedera.services.bdd.spec.transactions.token.HapiTokenMint;
 import com.hederahashgraph.api.proto.java.TokenPauseStatus;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Tag;
 
-@HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicBatchTokenServiceEndToEndTests {
+class AtomicBatchTokenServiceEndToEndTests {
 
     private static final double BASE_FEE_BATCH_TRANSACTION = 0.001;
     private static final String FT_FOR_END_TO_END = "ftForEndToEnd";
@@ -120,18 +114,13 @@ public class AtomicBatchTokenServiceEndToEndTests {
     private static final String kycKey = "kycKey";
     private static final String newKycKey = "newKycKey";
 
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
-        lifecycle.overrideInClass(Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
-
     // Token Lifecycle tests
     @Nested
     @DisplayName("Token Associate and Transfer Tests - including auto-associations and airdrops")
     class TokenAssociateAndTransferTests {
         @HapiTest
         @DisplayName("Associate and multiple transfers of FT token without custom fees success in batch")
-        public Stream<DynamicTest> associateAndMultipleTransfersFTWithoutCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> associateAndMultipleTransfersFTWithoutCustomFeesSuccessInBatch() {
 
             // create associate receiver inner transactions
             final var associateFirstReceiver = tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_FOR_END_TO_END)
@@ -209,7 +198,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Associate and multiple transfers of NFT token without custom fees success in batch")
-        public Stream<DynamicTest> associateAndMultipleTransfersNFTWithoutCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> associateAndMultipleTransfersNFTWithoutCustomFeesSuccessInBatch() {
 
             // create associate receiver inner transactions
             final var associateFirstReceiver = tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NFT_FOR_END_TO_END)
@@ -290,7 +279,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Mint, Associate and Transfer NFT token without custom fees success in batch")
-        public Stream<DynamicTest> mintAssociateAndTransferNFTWithoutCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> mintAssociateAndTransferNFTWithoutCustomFeesSuccessInBatch() {
 
             // create token mint transaction
             final var mintNFT = mintNFT(NFT_FOR_END_TO_END, 0, 10)
@@ -377,7 +366,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Mint, Associate and Transfer Non-Existent NFT token without custom fees fails in batch")
-        public Stream<DynamicTest> mintAssociateAndTransferNonExistentNFTWithoutCustomFeesFailsInBatch() {
+        Stream<DynamicTest> mintAssociateAndTransferNonExistentNFTWithoutCustomFeesFailsInBatch() {
 
             // create token mint transaction
             final var mintNFT = mintNFT(NFT_FOR_END_TO_END, 0, 10)
@@ -420,7 +409,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Mint, Associate, Transfer and Delete NFT token without custom fees success in batch")
-        public Stream<DynamicTest> mintAssociateTransferAndDeleteNFTWithoutCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> mintAssociateTransferAndDeleteNFTWithoutCustomFeesSuccessInBatch() {
 
             // create token mint transaction
             final var mintNFT = mintNFT(NFT_FOR_END_TO_END, 0, 10)
@@ -491,7 +480,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Mint, Burn and Delete NFT token without custom fees success in batch")
-        public Stream<DynamicTest> mintBurnAndDeleteNFTWithoutCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> mintBurnAndDeleteNFTWithoutCustomFeesSuccessInBatch() {
 
             // create token mint transaction
             final var mintNFT = mintNFT(NFT_FOR_END_TO_END, 0, 10)
@@ -537,7 +526,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Associate, Grant KYC and Transfer FT success in batch")
-        public Stream<DynamicTest> associateGrantKYCAndTransferFTSuccessInBatch() {
+        Stream<DynamicTest> associateGrantKYCAndTransferFTSuccessInBatch() {
 
             // create associate receiver inner transactions
             final var associateFirstReceiver = tokenAssociate(RECEIVER_ASSOCIATED_FIRST, FT_FOR_TOKEN_KYC)
@@ -582,7 +571,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Associate, Freeze Token and Transfer FT fails in batch")
-        public Stream<DynamicTest> associateFreezeAndTransferFTFailsInBatch() {
+        Stream<DynamicTest> associateFreezeAndTransferFTFailsInBatch() {
 
             // create associate receiver inner transactions
             final var associateFirstReceiver = tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NFT_FOR_TOKEN_FREEZE)
@@ -627,7 +616,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Associate, Unfreeze Token and Transfer FT success in batch")
-        public Stream<DynamicTest> associateUnfreezeAndTransferFTSuccessInBatch() {
+        Stream<DynamicTest> associateUnfreezeAndTransferFTSuccessInBatch() {
 
             // create associate receiver inner transactions
             final var associateFirstReceiver = tokenAssociate(RECEIVER_ASSOCIATED_FIRST, NFT_FOR_TOKEN_FREEZE)
@@ -671,7 +660,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Associate and multiple transfers of FT and NFT tokens without custom fees success in batch")
-        public Stream<DynamicTest> associateAndMultipleTransfersFTAndNFTWithoutCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> associateAndMultipleTransfersFTAndNFTWithoutCustomFeesSuccessInBatch() {
 
             // create associate receiver inner transactions
             final var associateFirstReceiver = tokenAssociate(
@@ -728,7 +717,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Multiple airdrops of FT and NFT tokens without custom fees success in batch")
-        public Stream<DynamicTest> multipleAirdropsFTAndNFTWithoutCustomFeesSuccessInBatch() {
+        Stream<DynamicTest> multipleAirdropsFTAndNFTWithoutCustomFeesSuccessInBatch() {
 
             final var tokenAirdrops = tokenAirdrop(
                             moving(10L, FT_FOR_END_TO_END).between(OWNER, RECEIVER_WITH_FREE_AUTO_ASSOCIATIONS),
@@ -794,7 +783,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Dissociate and transfer of FT token without custom fees fails in batch")
-        public Stream<DynamicTest> dissociateAndTransferFTWithoutCustomFeesFailsInBatch() {
+        Stream<DynamicTest> dissociateAndTransferFTWithoutCustomFeesFailsInBatch() {
 
             // create dissociate receiver inner transactions
             final var dissociateFirstReceiver = tokenDissociate(RECEIVER_ASSOCIATED_FIRST, FT_FOR_END_TO_END)
@@ -839,7 +828,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
         class PauseAndUnpauseTests {
             @HapiTest
             @DisplayName("Unpause and Transfer fungible token success in batch")
-            public Stream<DynamicTest> unpauseAndTransferFTSuccessInBatch() {
+            Stream<DynamicTest> unpauseAndTransferFTSuccessInBatch() {
 
                 // unpause the fungible token
                 final var unpauseFungibleToken = tokenUnpause(FT_FOR_TOKEN_PAUSE)
@@ -887,7 +876,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Transfer and Pause fungible token success in batch")
-            public Stream<DynamicTest> transferAndPauseFTSuccessInBatch() {
+            Stream<DynamicTest> transferAndPauseFTSuccessInBatch() {
 
                 // transfer tokens to associated accounts
                 final var tokenTransferFirstReceiver = cryptoTransfer(
@@ -934,7 +923,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Unpause, Transfer and Pause fungible token success in batch")
-            public Stream<DynamicTest> unpauseTransferAndPauseFTSuccessInBatch() {
+            Stream<DynamicTest> unpauseTransferAndPauseFTSuccessInBatch() {
 
                 // unpause the fungible token
                 final var unpauseFungibleToken = tokenUnpause(FT_FOR_TOKEN_PAUSE)
@@ -993,7 +982,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Pause fungible token not signed by pause key fails in batch")
-            public Stream<DynamicTest> pauseFTNotSignedByPauseKeyFailsInBatch() {
+            Stream<DynamicTest> pauseFTNotSignedByPauseKeyFailsInBatch() {
 
                 // transfer tokens to associated accounts
                 final var tokenTransferFirstReceiver = cryptoTransfer(
@@ -1041,7 +1030,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Unpause fungible token not signed by pause key fails in batch")
-            public Stream<DynamicTest> unpauseFTNotSignedByPauseKeyFailsInBatch() {
+            Stream<DynamicTest> unpauseFTNotSignedByPauseKeyFailsInBatch() {
 
                 // unpause the fungible token
                 final var unpauseFungibleToken = tokenUnpause(FT_FOR_TOKEN_PAUSE)
@@ -1090,7 +1079,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Transfer of Paused token fails in batch")
-            public Stream<DynamicTest> tokenTransferOfPausedFTFailsInBatch() {
+            Stream<DynamicTest> tokenTransferOfPausedFTFailsInBatch() {
 
                 // transfer tokens to associated accounts
                 final var tokenTransferFirstReceiver = cryptoTransfer(
@@ -1130,7 +1119,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Transfer and Pause of token without pause key fails in batch")
-            public Stream<DynamicTest> tokenTransferAndPauseOfFTWithoutPauseKeyFailsInBatch() {
+            Stream<DynamicTest> tokenTransferAndPauseOfFTWithoutPauseKeyFailsInBatch() {
 
                 // transfer tokens to associated accounts
                 final var tokenTransferFirstReceiver = cryptoTransfer(
@@ -1170,7 +1159,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Unpause and Transfer of token without pause key fails in batch")
-            public Stream<DynamicTest> unpauseAndTransferOfFTWithoutPauseKeyFailsInBatch() {
+            Stream<DynamicTest> unpauseAndTransferOfFTWithoutPauseKeyFailsInBatch() {
 
                 // transfer tokens to associated accounts
                 final var tokenTransferFirstReceiver = cryptoTransfer(
@@ -1210,7 +1199,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Update Pause key, Transfer and Pause token successfully in batch")
-            public Stream<DynamicTest> updatePauseKeyTransferAndPauseOfFTSuccessInBatchTest() {
+            Stream<DynamicTest> updatePauseKeyTransferAndPauseOfFTSuccessInBatchTest() {
 
                 // update the pause key
                 final var updatePauseKey = tokenUpdate(FT_FOR_TOKEN_PAUSE)
@@ -1261,7 +1250,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Update Pause key of token created without pause key fails in batch")
-            public Stream<DynamicTest> updatePauseKeyOfFTCreatedWithoutPauseKeyFailsInBatch() {
+            Stream<DynamicTest> updatePauseKeyOfFTCreatedWithoutPauseKeyFailsInBatch() {
 
                 // update the pause key
                 final var updatePauseKey = tokenUpdate(FT_FOR_TOKEN_PAUSE)
@@ -1301,7 +1290,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
         class FreezeAndUnfreezeTests {
             @HapiTest
             @DisplayName("Unfreeze and Transfer non-fungible token success in batch")
-            public Stream<DynamicTest> unfreezeAndTransferNFTSuccessInBatch() {
+            Stream<DynamicTest> unfreezeAndTransferNFTSuccessInBatch() {
 
                 // unfreeze the non-fungible token
                 final var unfreezeNonFungibleToken = tokenUnfreeze(NFT_FOR_TOKEN_FREEZE, RECEIVER_ASSOCIATED_FIRST)
@@ -1342,7 +1331,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Transfer and Freeze non-fungible token success in batch")
-            public Stream<DynamicTest> transferAndFreezeNFTSuccessInBatch() {
+            Stream<DynamicTest> transferAndFreezeNFTSuccessInBatch() {
 
                 // freeze the non-fungible token
                 final var freezeNonFungibleToken = tokenFreeze(NFT_FOR_TOKEN_FREEZE, RECEIVER_ASSOCIATED_FIRST)
@@ -1382,7 +1371,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Unfreeze, Transfer and Freeze non-fungible token success in batch")
-            public Stream<DynamicTest> unfreezeTransferAndFreezeNFTSuccessInBatch() {
+            Stream<DynamicTest> unfreezeTransferAndFreezeNFTSuccessInBatch() {
 
                 // unfreeze the non-fungible token
                 final var unfreezeNonFungibleToken = tokenUnfreeze(NFT_FOR_TOKEN_FREEZE, RECEIVER_ASSOCIATED_FIRST)
@@ -1430,7 +1419,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Freeze non-fungible token not signed by freeze key fails in batch")
-            public Stream<DynamicTest> freezeNFTNotSignedByFreezeKeyFailsInBatch() {
+            Stream<DynamicTest> freezeNFTNotSignedByFreezeKeyFailsInBatch() {
 
                 // transfer tokens to associated accounts
                 final var tokenTransferFirstReceiver = cryptoTransfer(
@@ -1471,7 +1460,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Unfreeze non-fungible token not signed by freeze key fails in batch")
-            public Stream<DynamicTest> unfreezeNFTNotSignedByFreezeKeyFailsInBatch() {
+            Stream<DynamicTest> unfreezeNFTNotSignedByFreezeKeyFailsInBatch() {
 
                 // unfreeze the non-fungible token
                 final var unfreezeNonFungibleToken = tokenUnfreeze(NFT_FOR_TOKEN_FREEZE, RECEIVER_ASSOCIATED_FIRST)
@@ -1513,7 +1502,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Transfer of Freezed NFT token fails in batch")
-            public Stream<DynamicTest> tokenTransferOfFreezedNFTFailsInBatch() {
+            Stream<DynamicTest> tokenTransferOfFreezedNFTFailsInBatch() {
 
                 // transfer tokens to associated accounts
                 final var tokenTransferFirstReceiver = cryptoTransfer(
@@ -1554,7 +1543,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Unfreeze and Transfer non-fungible token without freeze key fails in batch")
-            public Stream<DynamicTest> tokenUnfreezeAndTransferOfNFTWithoutFreezeKeyFailsInBatch() {
+            Stream<DynamicTest> tokenUnfreezeAndTransferOfNFTWithoutFreezeKeyFailsInBatch() {
 
                 // transfer tokens to associated accounts
                 final var tokenTransferFirstReceiver = cryptoTransfer(
@@ -1595,7 +1584,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Transfer and Freeze non-fungible token without freeze key fails in batch")
-            public Stream<DynamicTest> tokenTransferAndFreezeOfNFTWithoutFreezeKeyFailsInBatch() {
+            Stream<DynamicTest> tokenTransferAndFreezeOfNFTWithoutFreezeKeyFailsInBatch() {
 
                 // transfer tokens to associated accounts
                 final var tokenTransferFirstReceiver = cryptoTransfer(
@@ -1636,7 +1625,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Multiple transfers of non-fungible token Unfreezed for one account only fails in batch")
-            public Stream<DynamicTest> multipleTransferOfNFTUnfreezedForOneAccountOnlyFailInBatch() {
+            Stream<DynamicTest> multipleTransferOfNFTUnfreezedForOneAccountOnlyFailInBatch() {
 
                 // unfreeze the non-fungible token
                 final var unfreezeNonFungibleTokenForOneAccount = tokenUnfreeze(
@@ -1698,7 +1687,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Update Freeze key, Transfer and Freeze non-fungible token successfully in batch")
-            public Stream<DynamicTest> updateFreezeKeyTransferAndFreezeNFTSuccessInBatch() {
+            Stream<DynamicTest> updateFreezeKeyTransferAndFreezeNFTSuccessInBatch() {
 
                 // update the non-fungible token
                 final var updateFreezeKey = tokenUpdate(NFT_FOR_TOKEN_FREEZE)
@@ -1746,7 +1735,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Update Freeze key of non-fungible token created without freeze key fails in batch")
-            public Stream<DynamicTest> updateFreezeKeyOfNFTCreatedWithoutFreezeKeyFailsInBatch() {
+            Stream<DynamicTest> updateFreezeKeyOfNFTCreatedWithoutFreezeKeyFailsInBatch() {
 
                 // update the non-fungible token
                 final var updateFreezeKey = tokenUpdate(NFT_FOR_TOKEN_FREEZE)
@@ -1792,7 +1781,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
         class BurnWipeAndDeleteTests {
             @HapiTest
             @DisplayName("Burn and Wipe fungible token success in batch")
-            public Stream<DynamicTest> burnAndWipeFTSuccessInBatch() {
+            Stream<DynamicTest> burnAndWipeFTSuccessInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 10L)
@@ -1836,7 +1825,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Delete after Burn and Wipe fungible token success in batch")
-            public Stream<DynamicTest> deleteAfterBurnAndWipeFTSuccessInBatch() {
+            Stream<DynamicTest> deleteAfterBurnAndWipeFTSuccessInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 10L)
@@ -1897,7 +1886,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Token Transfer after Burn fungible token when there is insufficient balance fails in batch")
-            public Stream<DynamicTest> transferAfterBurnFTWhenInsufficientBalanceFailsInBatch() {
+            Stream<DynamicTest> transferAfterBurnFTWhenInsufficientBalanceFailsInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 100L)
@@ -1943,7 +1932,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Token Transfer after Wipe fungible token when there is insufficient balance fails in batch")
-            public Stream<DynamicTest> transferAfterWipeFTWhenInsufficientBalanceFailsInBatch() {
+            Stream<DynamicTest> transferAfterWipeFTWhenInsufficientBalanceFailsInBatch() {
 
                 // wipe the fungible token
                 final var wipeFungibleToken = wipeTokenAccount(FT_FOR_TOKEN_BURN, RECEIVER_ASSOCIATED_FIRST, 10L)
@@ -1990,7 +1979,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
             @HapiTest
             @DisplayName(
                     "Token Transfer after Burn and Wipe fungible token when there is insufficient balance fails in batch")
-            public Stream<DynamicTest> transferAfterBurnAndWipeFTWhenInsufficientBalanceFailsInBatch() {
+            Stream<DynamicTest> transferAfterBurnAndWipeFTWhenInsufficientBalanceFailsInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 90L)
@@ -2047,7 +2036,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Token Transfer after Burn, Wipe and Delete fungible token fails in batch")
-            public Stream<DynamicTest> transferAfterBurnWipeAndDeleteFTFailsInBatch() {
+            Stream<DynamicTest> transferAfterBurnWipeAndDeleteFTFailsInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 10L)
@@ -2112,7 +2101,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Token Burn after Delete fungible token fails in batch")
-            public Stream<DynamicTest> burnAfterDeleteFTFailsInBatch() {
+            Stream<DynamicTest> burnAfterDeleteFTFailsInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 10L)
@@ -2152,7 +2141,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Token Wipe after Delete fungible token fails in batch")
-            public Stream<DynamicTest> WipeAfterDeleteFTFailsInBatch() {
+            Stream<DynamicTest> WipeAfterDeleteFTFailsInBatch() {
 
                 // wipe the fungible token
                 final var wipeFungibleToken = wipeTokenAccount(FT_FOR_TOKEN_BURN, RECEIVER_ASSOCIATED_FIRST, 5L)
@@ -2192,7 +2181,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Burn and Wipe fungible token not signed by supply key fails in batch")
-            public Stream<DynamicTest> burnAndWipeFTNotSignedBySupplyKeyInBatch() {
+            Stream<DynamicTest> burnAndWipeFTNotSignedBySupplyKeyInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 10L)
@@ -2237,7 +2226,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Burn and Wipe fungible token not signed by wipe key fails in batch")
-            public Stream<DynamicTest> burnAndWipeFTNotSignedByWipeKeyInBatch() {
+            Stream<DynamicTest> burnAndWipeFTNotSignedByWipeKeyInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 10L)
@@ -2282,7 +2271,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Burn and Wipe of fungible token without supply key fails in batch")
-            public Stream<DynamicTest> burnAndWipeFTWithoutSupplyKeyFailsInBatch() {
+            Stream<DynamicTest> burnAndWipeFTWithoutSupplyKeyFailsInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 10L)
@@ -2327,7 +2316,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Burn and Wipe of fungible token without wipe key fails in batch")
-            public Stream<DynamicTest> burnAndWipeFTWithoutWipeKeyFailsInBatch() {
+            Stream<DynamicTest> burnAndWipeFTWithoutWipeKeyFailsInBatch() {
 
                 // burn the fungible token
                 final var burnFungibleToken = burnToken(FT_FOR_TOKEN_BURN, 10L)
@@ -2372,7 +2361,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Burn and Wipe fungible token after Update Burn and Wipe keys success in batch")
-            public Stream<DynamicTest> burnAndWipeFTAfterUpdateOfKeysSuccessInBatch() {
+            Stream<DynamicTest> burnAndWipeFTAfterUpdateOfKeysSuccessInBatch() {
 
                 // update the fungible token
                 final var updateBurnAndWipeKeys = tokenUpdate(FT_FOR_TOKEN_BURN)
@@ -2429,7 +2418,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Delete token after Update Admin key success in batch")
-            public Stream<DynamicTest> DeleteFTAfterUpdateOfAdminKeySuccessInBatch() {
+            Stream<DynamicTest> DeleteFTAfterUpdateOfAdminKeySuccessInBatch() {
 
                 // update the fungible token
                 final var updateAdminKey = tokenUpdate(FT_FOR_TOKEN_BURN)
@@ -2472,7 +2461,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Update Burn and Wipe keys of fungible token not signed by the admin key fails in batch")
-            public Stream<DynamicTest> updateBurnAndWipeKeysNotSignedByAdminKeyFailsInBatch() {
+            Stream<DynamicTest> updateBurnAndWipeKeysNotSignedByAdminKeyFailsInBatch() {
 
                 // update the fungible token
                 final var updateBurnAndWipeKeys = tokenUpdate(FT_FOR_TOKEN_BURN)
@@ -2531,7 +2520,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
             @HapiTest
             @DisplayName(
                     "Update Burn and Wipe keys of fungible token created without burn and wipe keys fails in batch")
-            public Stream<DynamicTest> updateBurnAndWipeKeysOfFTWithoutKeysFailsInBatch() {
+            Stream<DynamicTest> updateBurnAndWipeKeysOfFTWithoutKeysFailsInBatch() {
 
                 // update the fungible token
                 final var updateBurnAndWipeKeys = tokenUpdate(FT_FOR_TOKEN_BURN)
@@ -2589,7 +2578,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
             @HapiTest
             @DisplayName("Delete token after Update Admin key of FT created without admin key fails in batch")
-            public Stream<DynamicTest> DeleteAfterUpdateOfAdminKeyOfFTCreatedWithoutAdminKeyFailsInBatch() {
+            Stream<DynamicTest> DeleteAfterUpdateOfAdminKeyOfFTCreatedWithoutAdminKeyFailsInBatch() {
 
                 // update the fungible token
                 final var updateAdminKey = tokenUpdate(FT_FOR_TOKEN_BURN)
@@ -2633,7 +2622,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Grant KYC, Transfer FT and Revoke kYC success in batch")
-        public Stream<DynamicTest> grantKYCTransferAndRevokeKycForFTSuccessInBatch() {
+        Stream<DynamicTest> grantKYCTransferAndRevokeKycForFTSuccessInBatch() {
 
             // grant KYC to the fungible token
             final var grantTokenKYC = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)
@@ -2678,7 +2667,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Grant KYC, Transfer FT and Second Transfer from Account With kYC success in batch")
-        public Stream<DynamicTest> grantKYCTransferAndSecondTransferFromAccountWithKYCForFTSuccessInBatch() {
+        Stream<DynamicTest> grantKYCTransferAndSecondTransferFromAccountWithKYCForFTSuccessInBatch() {
 
             // grant KYC to the fungible token
             final var grantTokenKYCFirstReceiver = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)
@@ -2734,7 +2723,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Grant KYC And Transfer FT not signed by kYC key fails in batch")
-        public Stream<DynamicTest> grantKYCAndTransferNotSignedByKycKeyForFTFailsInBatch() {
+        Stream<DynamicTest> grantKYCAndTransferNotSignedByKycKeyForFTFailsInBatch() {
 
             // grant KYC to the fungible token
             final var grantTokenKYC = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)
@@ -2773,7 +2762,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Transfer FT and Revoke KYC not signed by kYC key fails in batch")
-        public Stream<DynamicTest> transferAndRevokeKYCNotSignedByKycKeyForFTFailsInBatch() {
+        Stream<DynamicTest> transferAndRevokeKYCNotSignedByKycKeyForFTFailsInBatch() {
 
             // revoke KYC to the fungible token
             final var revokeTokenKYC = revokeTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)
@@ -2813,7 +2802,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Transfer FT after Revoke kYC fails in batch")
-        public Stream<DynamicTest> transferFTAfterRevokeKYCFailsInBatch() {
+        Stream<DynamicTest> transferFTAfterRevokeKYCFailsInBatch() {
 
             // grant KYC to the fungible token
             final var grantTokenKYCFirstReceiver = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)
@@ -2880,7 +2869,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Grant kYC and Transfer to not Associated Account fails in batch")
-        public Stream<DynamicTest> GrantKYCAndTransferToNotAssociatedAccountFailsInBatch() {
+        Stream<DynamicTest> GrantKYCAndTransferToNotAssociatedAccountFailsInBatch() {
 
             // grant KYC to the fungible token
             final var grantTokenKYC = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_NOT_ASSOCIATED)
@@ -2917,7 +2906,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Grant KYC and Transfer to Receiver for FT without KYC key fails in batch")
-        public Stream<DynamicTest> grantKycForFTWithoutKYCKeyFailsInBatch() {
+        Stream<DynamicTest> grantKycForFTWithoutKYCKeyFailsInBatch() {
 
             // grant KYC to the fungible token for one account only
             final var grantTokenKYCFirstReceiver = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)
@@ -2956,7 +2945,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Transfer FT with KYC to Receiver without KYC granted fails in batch")
-        public Stream<DynamicTest> transferFTWithKYCToReceiverWithoutKYCFailsInBatch() {
+        Stream<DynamicTest> transferFTWithKYCToReceiverWithoutKYCFailsInBatch() {
 
             // grant KYC to the fungible token for one account only
             final var grantTokenKYCFirstReceiver = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)
@@ -3008,7 +2997,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Grant KYC, Update KYC key for FT and Transfer success in batch")
-        public Stream<DynamicTest> grantUpdateKYCAndTransferFTSuccessInBatch() {
+        Stream<DynamicTest> grantUpdateKYCAndTransferFTSuccessInBatch() {
 
             // grant KYC to the fungible token
             final var grantTokenKYCFirstReceiver = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)
@@ -3061,7 +3050,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Update KYC key for FT, Grant and Transfer success in batch")
-        public Stream<DynamicTest> updateKYCGrantAndTransferFTSuccessInBatch() {
+        Stream<DynamicTest> updateKYCGrantAndTransferFTSuccessInBatch() {
 
             // update the KYC key for the fungible token
             final var updateTokenKYCKey = tokenUpdate(FT_FOR_TOKEN_KYC)
@@ -3114,7 +3103,7 @@ public class AtomicBatchTokenServiceEndToEndTests {
 
         @HapiTest
         @DisplayName("Update KYC key for FT not signed by admin key fails in batch")
-        public Stream<DynamicTest> updateKYCNotSignedByAdminKeyFailsInBatch() {
+        Stream<DynamicTest> updateKYCNotSignedByAdminKeyFailsInBatch() {
 
             // grant KYC to the fungible token
             final var grantTokenKYCFirstReceiver = grantTokenKyc(FT_FOR_TOKEN_KYC, RECEIVER_ASSOCIATED_FIRST)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicHip17UnhappyAccountsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicHip17UnhappyAccountsSuite.java
@@ -34,7 +34,6 @@ import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hederahashgraph.api.proto.java.TokenType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -46,7 +45,7 @@ import org.junit.jupiter.api.Tag;
 @OrderedInIsolation
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicHip17UnhappyAccountsSuite {
+class AtomicHip17UnhappyAccountsSuite {
 
     private static final String MEMO_1 = "memo1";
     private static final String MEMO_2 = "memo2";
@@ -63,8 +62,6 @@ public class AtomicHip17UnhappyAccountsSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicHip17UnhappyTokensSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicHip17UnhappyTokensSuite.java
@@ -45,7 +45,6 @@ import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -56,7 +55,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicHip17UnhappyTokensSuite {
+class AtomicHip17UnhappyTokensSuite {
 
     private static final String ANOTHER_USER = "AnotherUser";
     private static final String ANOTHER_KEY = "AnotherKey";
@@ -87,8 +86,6 @@ public class AtomicHip17UnhappyTokensSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenAssociationSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenAssociationSpecs.java
@@ -69,7 +69,6 @@ import com.hederahashgraph.api.proto.java.TokenID;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
@@ -81,7 +80,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenAssociationSpecs {
+class AtomicTokenAssociationSpecs {
 
     public static final String FREEZABLE_TOKEN_ON_BY_DEFAULT = "TokenA";
     public static final String KNOWABLE_TOKEN = "TokenC";
@@ -96,8 +95,6 @@ public class AtomicTokenAssociationSpecs {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenCreateCustomFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenCreateCustomFeesTest.java
@@ -47,26 +47,20 @@ import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.TestTags;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hederahashgraph.api.proto.java.TokenType;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.OptionalLong;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.Pair;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of TokenCreateSpecs. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @Tag(TestTags.TOKEN)
-@HapiTestLifecycle
-public class AtomicTokenCreateCustomFeesTest {
+class AtomicTokenCreateCustomFeesTest {
 
     private static final String TOKEN_TREASURY = "treasury";
     private static final String A_TOKEN = "TokenA";
@@ -86,12 +80,6 @@ public class AtomicTokenCreateCustomFeesTest {
 
     private static final String BATCH_OPERATOR = "batchOperator";
     private static final String ATOMIC_BATCH = "atomicBatch";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> idVariantsTreatedAsExpected() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenCreateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenCreateSpecs.java
@@ -94,7 +94,6 @@ import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.OptionalLong;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -115,7 +114,7 @@ import org.junit.jupiter.api.Tag;
  * </ul>
  */
 @Tag(TOKEN)
-public class AtomicTokenCreateSpecs {
+class AtomicTokenCreateSpecs {
 
     private static final String NON_FUNGIBLE_UNIQUE_FINITE = "non-fungible-unique-finite";
     private static final String PRIMARY = "primary";
@@ -139,8 +138,6 @@ public class AtomicTokenCreateSpecs {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenDeleteSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenDeleteSpecs.java
@@ -23,7 +23,6 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -34,7 +33,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenDeleteSpecs {
+class AtomicTokenDeleteSpecs {
 
     private static final String FIRST_TBD = "firstTbd";
     private static final String SECOND_TBD = "secondTbd";
@@ -45,8 +44,6 @@ public class AtomicTokenDeleteSpecs {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenFeeScheduleUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenFeeScheduleUpdateSpecs.java
@@ -53,14 +53,12 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenFeeScheduleUpdateSpecs {
+class AtomicTokenFeeScheduleUpdateSpecs {
 
     private static final String BATCH_OPERATOR = "batchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenManagementSpecs.java
@@ -42,7 +42,6 @@ import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuc
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
-import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.TOKEN_TREASURY;
 import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.CIVILIAN;
@@ -68,25 +67,19 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of TokenManagementSpecs. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
 @Tag(TOKEN)
-public class AtomicTokenManagementSpecs {
+class AtomicTokenManagementSpecs {
 
     private static final String SUPPLE = "supple";
     private static final String SHOULD_NOT_APPEAR = "should-not-appear";
@@ -97,13 +90,6 @@ public class AtomicTokenManagementSpecs {
     private static final String RIGID = "rigid";
     public static final String INVALID_ACCOUNT = "999.999.999";
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-        testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
-    }
 
     private HapiSpecOperation[] aliasFormFailsForAllTokenOpsBase() {
         final var CIVILIAN = "civilian";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenManagementSpecs.java
@@ -42,9 +42,9 @@ import static com.hedera.services.bdd.spec.utilops.mod.ModificationUtils.withSuc
 import static com.hedera.services.bdd.suites.HapiSuite.DEFAULT_PAYER;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
 import static com.hedera.services.bdd.suites.HapiSuite.TOKEN_TREASURY;
 import static com.hedera.services.bdd.suites.HapiSuite.flattened;
-import static com.hedera.services.bdd.suites.token.TokenTransactSpecs.CIVILIAN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_FROZEN_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.ACCOUNT_KYC_NOT_GRANTED_FOR_TOKEN;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CANNOT_WIPE_TOKEN_TREASURY_ACCOUNT;
@@ -67,17 +67,22 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.keys.KeyFactory;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of TokenManagementSpecs. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
+@HapiTestLifecycle
 @Tag(TOKEN)
 class AtomicTokenManagementSpecs {
 
@@ -90,6 +95,11 @@ class AtomicTokenManagementSpecs {
     private static final String RIGID = "rigid";
     public static final String INVALID_ACCOUNT = "999.999.999";
     private static final String BATCH_OPERATOR = "batchOperator";
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
+        testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
+    }
 
     private HapiSpecOperation[] aliasFormFailsForAllTokenOpsBase() {
         final var CIVILIAN = "civilian";

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenManagementSpecsStateful.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenManagementSpecsStateful.java
@@ -48,7 +48,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenManagementSpecsStateful {
+class AtomicTokenManagementSpecsStateful {
 
     private static final String FUNGIBLE_TOKEN = "fungibleToken";
     public static final String INVALID_ACCOUNT = "999.999.999";
@@ -56,8 +56,6 @@ public class AtomicTokenManagementSpecsStateful {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenMetadataSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenMetadataSpecs.java
@@ -28,7 +28,6 @@ import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -46,7 +45,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenMetadataSpecs {
+class AtomicTokenMetadataSpecs {
 
     private static final String PRIMARY = "primary";
     private static final String ADMIN_KEY = "adminKey";
@@ -58,8 +57,6 @@ public class AtomicTokenMetadataSpecs {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenPauseSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenPauseSpecs.java
@@ -56,7 +56,6 @@ import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -67,7 +66,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenPauseSpecs {
+class AtomicTokenPauseSpecs {
 
     private static final String PAUSE_KEY = "pauseKey";
     private static final String SUPPLY_KEY = "supplyKey";
@@ -87,8 +86,6 @@ public class AtomicTokenPauseSpecs {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenTotalSupplyAfterMintBurnWipeSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenTotalSupplyAfterMintBurnWipeSuite.java
@@ -26,7 +26,6 @@ import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hederahashgraph.api.proto.java.TokenType;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -37,15 +36,13 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenTotalSupplyAfterMintBurnWipeSuite {
+class AtomicTokenTotalSupplyAfterMintBurnWipeSuite {
 
     private static String TOKEN_TREASURY = "treasury";
     private static final String BATCH_OPERATOR = "batchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenTransactSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenTransactSpecs.java
@@ -48,28 +48,22 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.google.protobuf.ByteString;
 import com.hedera.services.bdd.junit.HapiTest;
-import com.hedera.services.bdd.junit.HapiTestLifecycle;
-import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hederahashgraph.api.proto.java.CustomFee;
 import com.hederahashgraph.api.proto.java.TokenType;
-import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.OptionalLong;
 import java.util.function.Function;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 // This test cases are direct copies of TokenTransactSpecs. The difference here is that
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
-@HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenTransactSpecs {
+class AtomicTokenTransactSpecs {
 
     public static final String PAYER = "payer";
     public static final String CIVILIAN = "civilian";
@@ -90,12 +84,6 @@ public class AtomicTokenTransactSpecs {
     public static final String SUPPLY = "supply";
     public static final String TRANSFER_TXN = "transferTxn";
     private static final String BATCH_OPERATOR = "batchOperator";
-
-    @BeforeAll
-    static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
-    }
 
     @HapiTest
     final Stream<DynamicTest> fixedHbarCaseStudy() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenUpdateNftsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenUpdateNftsSuite.java
@@ -36,7 +36,6 @@ import com.hedera.services.bdd.spec.transactions.token.TokenMovement;
 import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -47,7 +46,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenUpdateNftsSuite {
+class AtomicTokenUpdateNftsSuite {
 
     private static String TOKEN_TREASURY = "treasury";
     private static final String NON_FUNGIBLE_TOKEN = "nonFungible";
@@ -61,8 +60,6 @@ public class AtomicTokenUpdateNftsSuite {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenUpdateSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicTokenUpdateSpecs.java
@@ -60,7 +60,6 @@ import com.hedera.services.bdd.spec.transactions.TxnUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -71,7 +70,7 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicTokenUpdateSpecs {
+class AtomicTokenUpdateSpecs {
 
     private static final int MAX_NAME_LENGTH = 100;
     private static final int MAX_SYMBOL_LENGTH = 100;
@@ -82,8 +81,6 @@ public class AtomicTokenUpdateSpecs {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicUniqueTokenManagementSpecs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/token/batch/AtomicUniqueTokenManagementSpecs.java
@@ -59,7 +59,6 @@ import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenType;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
@@ -74,7 +73,7 @@ import org.junit.jupiter.api.Tag;
 // we are wrapping the operations in an atomic batch to confirm that everything works as expected.
 @HapiTestLifecycle
 @Tag(TOKEN)
-public class AtomicUniqueTokenManagementSpecs {
+class AtomicUniqueTokenManagementSpecs {
 
     private static final Logger log = LogManager.getLogger(AtomicUniqueTokenManagementSpecs.class);
     private static final String A_TOKEN = "TokenA";
@@ -98,8 +97,6 @@ public class AtomicUniqueTokenManagementSpecs {
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/util/AtomicUtilPrngSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/util/AtomicUtilPrngSuite.java
@@ -17,7 +17,6 @@ import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.util.Map;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -28,15 +27,13 @@ import org.junit.jupiter.api.Tag;
 @HapiTestLifecycle
 @Tag(TOKEN)
 @Tag(MATS)
-public class AtomicUtilPrngSuite {
+class AtomicUtilPrngSuite {
 
     public static final String BOB = "bob";
     private static final String BATCH_OPERATOR = "batchOperator";
 
     @BeforeAll
     static void beforeAll(@NonNull final TestLifecycle testLifecycle) {
-        testLifecycle.overrideInClass(
-                Map.of("atomicBatch.isEnabled", "true", "atomicBatch.maxNumberOfTransactions", "50"));
         testLifecycle.doAdhoc(cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS));
     }
 


### PR DESCRIPTION
This PR looks big, but it's actually very simple. There are only two changes:

* Now that `atomicBatch.isEnabled` is `true` in our config files, it's redundant to set explicitly in hapi tests. Therefore, this property—and its oft-accompanied `maxTransfers` of `50`—are removed
* Of the test classes changed, any instances of `public` in the class or method signatures are removed

Closes #20695