### PR TITLE
fix: 21333: Current virtualMap.familyThrottleThreshold is too tight

### DIFF
--- a/platform-sdk/swirlds-benchmarks/settings.txt
+++ b/platform-sdk/swirlds-benchmarks/settings.txt
@@ -7,7 +7,5 @@ benchmark.csvOutputFolder,                     data
 benchmark.csvWriteFrequency,                   1000
 benchmark.csvAppend,                           true
 virtualMap.flushInterval,                      20
-virtualMap.preferredFlushQueueSize,            1
-virtualMap.flushThrottleStepSize,              500ms
+virtualMap.familyThrottleThreshold,            10000000000
 merkleDb.hashesRamToDiskThreshold,             8388608
-

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -189,7 +189,7 @@ public class VirtualPipeline {
 
     /**
      * Slow down the fast copy operation if total size of all (unreleased) virtual root copies
-     * in this pipeline exceeds {@link VirtualMapConfig#familyThrottleThreshold()}.
+     * in this pipeline exceeds {@link VirtualMapConfig#getFamilyThrottleThreshold()}.
      */
     private void applyFamilySizeBackpressure() {
         final long sleepTimeMillis = calculateFamilySizeBackpressurePause();
@@ -222,7 +222,7 @@ public class VirtualPipeline {
     }
 
     long calculateFamilySizeBackpressurePause() {
-        final long sizeThreshold = config.familyThrottleThreshold();
+        final long sizeThreshold = config.getFamilyThrottleThreshold();
         if (sizeThreshold <= 0) {
             return 0;
         }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/config/VirtualMapConfigTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/config/VirtualMapConfigTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.virtualmap.config;
 
+import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.config.api.validation.ConfigViolationException;
 import com.swirlds.config.extensions.sources.SimpleConfigSource;
@@ -10,7 +11,7 @@ import org.junit.jupiter.api.Test;
 class VirtualMapConfigTest {
 
     @Test
-    public void testDefaultValuesValid() {
+    void testDefaultValuesValid() {
         // given
         final ConfigurationBuilder configurationBuilder =
                 ConfigurationBuilder.create().withConfigDataType(VirtualMapConfig.class);
@@ -19,7 +20,7 @@ class VirtualMapConfigTest {
     }
 
     @Test
-    public void testPercentHashThreadsOutOfRangeMin() {
+    void testPercentHashThreadsOutOfRangeMin() {
         // given
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
                 .withSources(new SimpleConfigSource("virtualMap.percentHashThreads", -1))
@@ -33,7 +34,7 @@ class VirtualMapConfigTest {
     }
 
     @Test
-    public void testPercentHashThreadsOutOfRangeMax() {
+    void testPercentHashThreadsOutOfRangeMax() {
         // given
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
                 .withSources(new SimpleConfigSource("virtualMap.percentHashThreads", 101))
@@ -47,7 +48,7 @@ class VirtualMapConfigTest {
     }
 
     @Test
-    public void testPercentCleanerThreadsOutOfRangeMin() {
+    void testPercentCleanerThreadsOutOfRangeMin() {
         // given
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
                 .withSources(new SimpleConfigSource("virtualMap.percentCleanerThreads", -1))
@@ -61,7 +62,7 @@ class VirtualMapConfigTest {
     }
 
     @Test
-    public void testPercentCleanerThreadsOutOfRangeMax() {
+    void testPercentCleanerThreadsOutOfRangeMax() {
         // given
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
                 .withSources(new SimpleConfigSource("virtualMap.percentCleanerThreads", 101))
@@ -75,7 +76,7 @@ class VirtualMapConfigTest {
     }
 
     @Test
-    public void testFlushIntervalOutOfRangeMin() {
+    void testFlushIntervalOutOfRangeMin() {
         // given
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
                 .withSources(new SimpleConfigSource("virtualMap.flushInterval", 0L))
@@ -89,7 +90,7 @@ class VirtualMapConfigTest {
     }
 
     @Test
-    public void testNumCleanerThreadsRangeMin() {
+    void testNumCleanerThreadsRangeMin() {
         // given
         final ConfigurationBuilder configurationBuilder = ConfigurationBuilder.create()
                 .withSources(new SimpleConfigSource("virtualMap.numCleanerThreads", -2))
@@ -100,5 +101,109 @@ class VirtualMapConfigTest {
                 ConfigViolationException.class, () -> configurationBuilder.build(), "init must end in a violation");
 
         Assertions.assertEquals(1, exception.getViolations().size(), "We must exactly have 1 violation");
+    }
+
+    @Test
+    void testFamilyThrottleThresholdZero() {
+        // given
+        final Configuration config = ConfigurationBuilder.create()
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottleThreshold", 0))
+                // familyThrottlePercent should be ignored
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottlePercent", 10.0))
+                .withConfigDataType(VirtualMapConfig.class)
+                .build();
+        final VirtualMapConfig virtualMapConfig = config.getConfigData(VirtualMapConfig.class);
+
+        // then
+        Assertions.assertEquals(0, virtualMapConfig.getFamilyThrottleThreshold());
+    }
+
+    @Test
+    void testFamilyThrottleThresholdNonZero() {
+        final long value = 1_234_567_890;
+
+        // given
+        final Configuration config = ConfigurationBuilder.create()
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottleThreshold", value))
+                // familyThrottlePercent should be ignored
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottlePercent", 10.0))
+                .withConfigDataType(VirtualMapConfig.class)
+                .build();
+        final VirtualMapConfig virtualMapConfig = config.getConfigData(VirtualMapConfig.class);
+
+        // then
+        Assertions.assertEquals(value, virtualMapConfig.getFamilyThrottleThreshold());
+    }
+
+    @Test
+    void testFamilyThrottlePercentZero() {
+        // given
+        final Configuration config = ConfigurationBuilder.create()
+                // familyThrottleThreshold should be ignored
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottleThreshold", -1))
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottlePercent", 0))
+                .withConfigDataType(VirtualMapConfig.class)
+                .build();
+        final VirtualMapConfig virtualMapConfig = config.getConfigData(VirtualMapConfig.class);
+
+        // then
+        Assertions.assertEquals(0, virtualMapConfig.getFamilyThrottleThreshold());
+    }
+
+    @Test
+    void testFamilyThrottlePercentToHeapSize() {
+        final double value = 10.0;
+        final long maxHeapSize = Runtime.getRuntime().maxMemory();
+
+        // given
+        final Configuration config = ConfigurationBuilder.create()
+                // familyThrottleThreshold should be ignored
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottleThreshold", -1))
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottlePercent", value))
+                // Copy threshold should be ignored
+                .withSources(new SimpleConfigSource("virtualMap.copyFlushCandidateThreshold", 1))
+                .withConfigDataType(VirtualMapConfig.class)
+                .build();
+        final VirtualMapConfig virtualMapConfig = config.getConfigData(VirtualMapConfig.class);
+
+        // then
+        Assertions.assertEquals((long) (maxHeapSize * value / 100.0), virtualMapConfig.getFamilyThrottleThreshold());
+    }
+
+    @Test
+    void testFamilyThrottlePercentToCopyThreshold() {
+        final double value = 10.0;
+        final long maxHeapSize = Runtime.getRuntime().maxMemory();
+
+        // given
+        final long copyFlushCandidateThreshold = (long) (maxHeapSize * value * 2 / 100.0);
+        final Configuration config = ConfigurationBuilder.create()
+                // familyThrottleThreshold should be ignored
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottleThreshold", -1))
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottlePercent", value))
+                // Copy threshold should be used, since percent * heap size is less than copy threshold
+                .withSources(
+                        new SimpleConfigSource("virtualMap.copyFlushCandidateThreshold", copyFlushCandidateThreshold))
+                .withConfigDataType(VirtualMapConfig.class)
+                .build();
+        final VirtualMapConfig virtualMapConfig = config.getConfigData(VirtualMapConfig.class);
+
+        // then
+        Assertions.assertEquals(copyFlushCandidateThreshold, virtualMapConfig.getFamilyThrottleThreshold());
+    }
+
+    @Test
+    void testFamilyThrottleNegativeThrows() {
+        // given
+        final Configuration config = ConfigurationBuilder.create()
+                // familyThrottleThreshold should be ignored
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottleThreshold", -1))
+                .withSources(new SimpleConfigSource("virtualMap.familyThrottlePercent", -1))
+                .withConfigDataType(VirtualMapConfig.class)
+                .build();
+        final VirtualMapConfig virtualMapConfig = config.getConfigData(VirtualMapConfig.class);
+
+        // then
+        Assertions.assertThrows(IllegalArgumentException.class, virtualMapConfig::getFamilyThrottleThreshold);
     }
 }


### PR DESCRIPTION
Fix summary:
* A new `VirtualMapConfig` config is added: `familyThrottlePercent`
* If both `familyThrottlePercent` and `familyThrottleThreshold` are set, the latter wins
* Default config is `familyThrottlePercent=10.0` and `familyThrottleThreshold=0` (ignored), so in production we will use 10% of -Xmx as the family size threshold
* The threshold may not be less than `copyFlushCandidateThreshold`
* Unit tests are added for the new config
* A couple other virtual map configs, which are not used anywhere, are removed

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/21333
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
