### PR TITLE
test: Increase all timeouts waiting for conditions to be met to 120 seconds.

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/NetworkIsolationTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/NetworkIsolationTest.java
@@ -91,7 +91,7 @@ class NetworkIsolationTest {
 
             // Wait for nodes to become inactive due to network partition
             timeManager.waitForCondition(
-                    node0::isChecking, Duration.ofSeconds(15), "Node did not enter CHECKING state after isolation");
+                    node0::isChecking, Duration.ofSeconds(120L), "Node did not enter CHECKING state after isolation");
 
             timeManager.waitFor(Duration.ofSeconds(5)); // just to be sure
             assertThat(node1.platformStatus()).isEqualTo(ACTIVE);
@@ -116,7 +116,9 @@ class NetworkIsolationTest {
 
             // The nodes should be active again
             timeManager.waitForCondition(
-                    network::allNodesAreActive, Duration.ofSeconds(15), "Not all nodes became ACTIVE after rejoining");
+                    network::allNodesAreActive,
+                    Duration.ofSeconds(120L),
+                    "Not all nodes became ACTIVE after rejoining");
         } finally {
             env.destroy();
         }

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/NetworkPartitionTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/NetworkPartitionTest.java
@@ -100,7 +100,7 @@ class NetworkPartitionTest {
             // Wait for nodes to become inactive
             timeManager.waitForCondition(
                     () -> network.allNodesInStatus(CHECKING),
-                    Duration.ofSeconds(15),
+                    Duration.ofSeconds(120L),
                     "Not all nodes entered CHECKING status within the expected time after creating partition");
 
             // Remove the partition
@@ -116,7 +116,7 @@ class NetworkPartitionTest {
             // The node should be active again
             timeManager.waitForCondition(
                     network::allNodesAreActive,
-                    Duration.ofSeconds(15),
+                    Duration.ofSeconds(120L),
                     "Not all nodes entered ACTIVE status within the expected time after removing partition");
         } finally {
             env.destroy();
@@ -187,7 +187,7 @@ class NetworkPartitionTest {
             // Wait for nodes to become inactive
             timeManager.waitForCondition(
                     () -> network.allNodesInStatus(CHECKING),
-                    Duration.ofSeconds(15),
+                    Duration.ofSeconds(120L),
                     "Not all nodes entered CHECKING status within the expected time after creating partition");
 
         } finally {
@@ -437,7 +437,7 @@ class NetworkPartitionTest {
             assertThat(network.getPartitionContaining(node4)).isNull();
             assertThat(network.getPartitionContaining(node5)).isNull();
 
-            timeManager.waitForCondition(network::allNodesAreActive, Duration.ofSeconds(15));
+            timeManager.waitForCondition(network::allNodesAreActive, Duration.ofSeconds(120L));
         } finally {
             env.destroy();
         }
@@ -484,7 +484,7 @@ class NetworkPartitionTest {
             assertThat(network.getPartitionContaining(node2)).isNull();
             assertThat(network.getPartitionContaining(node3)).isNull();
 
-            timeManager.waitForCondition(network::allNodesAreActive, Duration.ofSeconds(15));
+            timeManager.waitForCondition(network::allNodesAreActive, Duration.ofSeconds(120L));
         } finally {
             env.destroy();
         }

--- a/platform-sdk/consensus-otter-tests/src/testIntegration/java/org/hiero/otter/test/CheckingRecoveryTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testIntegration/java/org/hiero/otter/test/CheckingRecoveryTest.java
@@ -65,14 +65,14 @@ public class CheckingRecoveryTest {
         nodeToThrottle.startSyntheticBottleneck(Duration.ofSeconds(30));
         timeManager.waitForCondition(
                 nodeToThrottle::isChecking,
-                Duration.ofMinutes(2),
+                Duration.ofSeconds(120L),
                 "Node did not enter CHECKING status within the expected time frame after synthetic bottleneck was enabled.");
         nodeToThrottle.stopSyntheticBottleneck();
 
         // Verify that the node recovers when the bottleneck is lifted
         timeManager.waitForCondition(
                 nodeToThrottle::isActive,
-                Duration.ofSeconds(60L),
+                Duration.ofSeconds(120L),
                 "Node did not recover from CHECKING status within the expected time frame after synthetic bottleneck was disabled.");
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testIntegration/java/org/hiero/otter/test/ReconnectTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testIntegration/java/org/hiero/otter/test/ReconnectTest.java
@@ -79,7 +79,7 @@ public class ReconnectTest {
         // Wait for the node we just killed to become behind enough to require a reconnect.
         timeManager.waitForCondition(
                 () -> network.nodeIsBehindByNodeCount(nodeToReconnect, 0.5),
-                Duration.ofSeconds(120),
+                Duration.ofSeconds(120L),
                 "Node did not fall behind in the time allotted.");
 
         // Restart the node that was killed
@@ -88,10 +88,10 @@ public class ReconnectTest {
         // First, we must wait for the node to come back up and report that it is behind.
         // If we wait for it to be active, this check will pass immediately. That was the last status it had,
         // and we will check the value before the node has a change to tell us that it is behind.
-        timeManager.waitForCondition(nodeToReconnect::isBehind, Duration.ofSeconds(30));
+        timeManager.waitForCondition(nodeToReconnect::isBehind, Duration.ofSeconds(120L));
 
         // Now we wait for the node to reconnect and become active again.
-        timeManager.waitForCondition(nodeToReconnect::isActive, Duration.ofSeconds(30));
+        timeManager.waitForCondition(nodeToReconnect::isActive, Duration.ofSeconds(120L));
 
         // Validations
         assertThat(network.newLogResults()).haveNoErrorLevelMessages();

--- a/platform-sdk/consensus-otter-tests/src/testIntegration/java/org/hiero/otter/test/RestartTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testIntegration/java/org/hiero/otter/test/RestartTest.java
@@ -67,7 +67,7 @@ public class RestartTest {
 
         // Wait for all nodes to advance at least 20 rounds beyond the last round reached
         timeManager.waitForCondition(
-                () -> allNodesAdvancedToRound(lastRoundReached + 20, network), Duration.ofSeconds(30L));
+                () -> allNodesAdvancedToRound(lastRoundReached + 20, network), Duration.ofSeconds(120L));
 
         assertThat(network.newLogResults().suppressingLogMarker(LogMarker.SOCKET_EXCEPTIONS))
                 .haveNoErrorLevelMessages();


### PR DESCRIPTION
**Description**:

This PR increases the timeouts when waiting for a condition to be met to 120 seconds. These conditions are usually fulfilled much faster and the timeouts are just there to ensure that tests do not hang forever.

**Related issue(s)**:

Fixes #21440
