### PR TITLE
chore: Disable BlockBufferPersistence and only write unack'd

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
@@ -534,9 +534,11 @@ public class BlockBufferService {
             return;
         }
 
-        // collect all closed blocks
-        final List<BlockState> blocksToPersist =
-                blockBuffer.values().stream().filter(BlockState::isClosed).toList();
+        // collect all closed blocks which are not acked yet
+        final List<BlockState> blocksToPersist = blockBuffer.values().stream()
+                .filter(BlockState::isClosed)
+                .filter(blockState -> blockState.blockNumber() > highestAckedBlockNumber.get())
+                .toList();
 
         // ensure all closed blocks have their items packed in requests before writing them out
         final int batchSize = blockItemBatchSize();

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
@@ -37,5 +37,5 @@ public record BlockBufferConfig(
         @ConfigProperty(defaultValue = "50.0") @Min(0) @NetworkProperty double actionStageThreshold,
         @ConfigProperty(defaultValue = "20s") @Min(0) @NetworkProperty Duration actionGracePeriod,
         @ConfigProperty(defaultValue = "85.0") @Min(0) @NetworkProperty double recoveryThreshold,
-        @ConfigProperty(defaultValue = "true") @NodeProperty boolean isBufferPersistenceEnabled,
+        @ConfigProperty(defaultValue = "false") @NodeProperty boolean isBufferPersistenceEnabled,
         @ConfigProperty(defaultValue = "/opt/hgcapp/blockStreams/buffer") @NodeProperty String bufferDirectory) {}


### PR DESCRIPTION
**Description**:
This pull request makes sure only unacknowledged closed blocks are persisted and disables buffer persistence by default as it is not currently needed for preview blockstreams.

Block buffer persistence logic:

* Updated the `persistBuffer()` method in `BlockBufferService.java` to persist only closed blocks with a block number greater than the highest acknowledged block number, preventing redundant persistence of already acknowledged blocks.

Configuration changes:

* Changed the default value of `isBufferPersistenceEnabled` in `BlockBufferConfig.java` from `true` to `false`, so buffer persistence is now disabled by default.

**Related issue(s)**:

Fixes #21461 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
