### PR TITLE
fix(bug): Fix typos in needs clause and usage for rootly reporting

### DIFF
--- a/.github/workflows/zxc-single-day-performance-test.yaml
+++ b/.github/workflows/zxc-single-day-performance-test.yaml
@@ -1245,10 +1245,10 @@ jobs:
     if: ${{ (needs.performance-tests-start.result != 'success' ||
       needs.performance-NftTransferLoadTest-watch1.result != 'success' ||
       needs.performance-NftTransferLoadTest-report.result != 'success' ||
-      needs.HCSLoadTest.result != 'success' ||
-      needs.CryptoTransferLoadTest.result != 'success' ||
-      needs.HeliSwapLoadTest.result != 'success' ||
-      needs.SmartContractLoadTest.result != 'success' ||
+      needs.performance-HCSLoadTest.result != 'success' ||
+      needs.performance-CryptoTransferLoadTest.result != 'success' ||
+      needs.performance-HeliSwapLoadTest.result != 'success' ||
+      needs.performance-SmartContractLoadTest.result != 'success' ||
       needs.single-day-performance-test-result.result != 'success' ||
       needs.single-day-performance-test-result.outputs.result == 'failure') &&
       !cancelled() && always() }}
@@ -1285,10 +1285,10 @@ jobs:
             echo "- Performance Tests Start: ${{ needs.performance-tests-start.result }}"
             echo "- Performance NFT Transfer Load Test (Watch 1): ${{ needs.performance-NftTransferLoadTest-watch1.result }}"
             echo "- Performance NFT Transfer Load Test (Report): ${{ needs.performance-NftTransferLoadTest-report.result }}"
-            echo "- HCS Load Test: ${{ needs.HCSLoadTest.result }}"
-            echo "- Crypto Transfer Load Test: ${{ needs.CryptoTransferLoadTest.result }}"
-            echo "- HeliSwap Load Test: ${{ needs.HeliSwapLoadTest.result }}"
-            echo "- Smart Contract Load Test: ${{ needs.SmartContractLoadTest.result }}"
+            echo "- HCS Load Test: ${{ needs.performance-HCSLoadTest.result }}"
+            echo "- Crypto Transfer Load Test: ${{ needs.performance-CryptoTransferLoadTest.result }}"
+            echo "- HeliSwap Load Test: ${{ needs.performance-HeliSwapLoadTest.result }}"
+            echo "- Smart Contract Load Test: ${{ needs.performance-SmartContractLoadTest.result }}"
             echo "- Single Day Performance Test Result (Workflow): ${{ needs.single-day-performance-test-result.result }}"
             echo "- Single Day Performance Test Result: ${{ needs.single-day-performance-test-result.outputs.result }}"
             echo "------------------------------------"


### PR DESCRIPTION
## Description

This pull request updates the `.github/workflows/zxc-single-day-performance-test.yaml` workflow to standardize the naming of several dependent performance test jobs. The changes ensure consistency by prefixing these job names with `performance-` throughout the workflow.

Workflow consistency improvements:

* Updated all references to the HCS, Crypto Transfer, HeliSwap, and Smart Contract load test jobs to use the `performance-` prefix in both the job dependency checks and the status output logs. [[1]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L1248-R1251) [[2]](diffhunk://#diff-3a51911168fea8fa3e128c5aa8376603deb99452e40137ebb41798b5780744a6L1288-R1291)

### Related Issue(s)

Fixes #21470

### Testing

- :runner: [Smoke Test - AdHoc8]()