### PR TITLE
fix: Update TokenUpdateHandler NFT treasury change logic

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenUpdateHandler.java
@@ -259,7 +259,7 @@ public class TokenUpdateHandler extends BaseTokenHandler implements TransactionH
         final var newFromPositiveBalancesCount =
                 fromRelBalance > 0 ? fromTreasury.numberPositiveBalances() - 1 : fromTreasury.numberPositiveBalances();
         final var newToPositiveBalancesCount =
-                toRelBalance > 0 ? toTreasury.numberPositiveBalances() + 1 : toTreasury.numberPositiveBalances();
+                toRelBalance == 0 ? toTreasury.numberPositiveBalances() + 1 : toTreasury.numberPositiveBalances();
         accountStore.put(fromTreasuryCopy
                 .numberPositiveBalances(newFromPositiveBalancesCount)
                 .numberOwnedNfts(fromNftsOwned - fromRelBalance)

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenUpdateHandlerTest.java
@@ -722,6 +722,8 @@ class TokenUpdateHandlerTest extends CryptoTokenHandlerTestBase {
         final var modifiedOldTreasury = writableAccountStore.get(treasuryId);
         assertThat(modifiedNewTreasury.numberOwnedNfts()).isEqualTo(3);
         assertThat(modifiedOldTreasury.numberOwnedNfts()).isEqualTo(1);
+        assertThat(modifiedNewTreasury.numberPositiveBalances()).isEqualTo(newTreasury.numberPositiveBalances() + 1);
+        assertThat(modifiedOldTreasury.numberPositiveBalances()).isEqualTo(oldTreasury.numberPositiveBalances() - 1);
 
         verify(recordBuilder)
                 .addAutomaticTokenAssociation(TokenAssociation.newBuilder()


### PR DESCRIPTION
**Description**:
This pull request addresses a subtle bug in the logic for updating the positive balances count when changing the treasury for a token, and adds new tests to ensure correctness. The main change corrects how positive balances are incremented for the new treasury, and comprehensive tests are added to verify the fix, especially for scenarios involving NFT treasuries.

**Bug fix in positive balances logic:**

* Corrected the logic in `TokenUpdateHandler.java` so that the positive balances count for the new treasury is incremented only when its previous balance was zero, rather than when it was positive. This ensures accurate tracking of accounts with positive token balances after a treasury change.

**Expanded and improved test coverage:**

* Updated `TokenUpdateHandlerTest.java` to assert that the positive balances count is incremented for the new treasury and decremented for the old treasury, directly verifying the bug fix.
* Added a new integration test `canDeleteIntermediateNftTreasuryAfterTwoUpdates` in `TokenAssociationSpecs.java` to ensure that after multiple treasury updates, intermediate NFT treasuries can be deleted if their token balances are zero. This test guards against regressions in positive balances accounting.

**Related issue(s)**:

Fixes #23778 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
