### PR TITLE
test: Fix bugs in `JumpstartFileSuite`

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -230,14 +230,22 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
 
         // Initialize wrapped record block hash tracking
         if (initTrigger != InitTrigger.GENESIS && liveWritePrevWrappedRecordHashes()) {
-            final var intermediateHashes = this.lastBlockInfo.wrappedIntermediatePreviousBlockRootHashes().stream()
-                    .map(Bytes::toByteArray)
-                    .toList();
+            final var rawHashes = this.lastBlockInfo.wrappedIntermediatePreviousBlockRootHashes();
+            final var intermediateHashes =
+                    rawHashes.stream().map(Bytes::toByteArray).toList();
             this.prevWrappedRecordBlockHashes = new IncrementalStreamingHasher(
                     sha384DigestOrThrow(),
                     intermediateHashes,
                     this.lastBlockInfo.wrappedIntermediateBlockRootsLeafCount());
             this.previousWrappedRecordBlockRootHash = this.lastBlockInfo.previousWrappedRecordBlockRootHash();
+            logger.info(
+                    "[LIVE_HASH_INIT] Restored live hash state from BlockInfo:"
+                            + " lastBlockNumber={} prevWrappedBlockHash={}"
+                            + " hasherLeafCount={} hasherIntermediateHashes={}",
+                    this.lastBlockInfo.lastBlockNumber(),
+                    this.previousWrappedRecordBlockRootHash,
+                    this.lastBlockInfo.wrappedIntermediateBlockRootsLeafCount(),
+                    String.join(",", rawHashes.stream().map(Bytes::toString).toList()));
         } else if (initTrigger == InitTrigger.GENESIS) {
             // Initialize with empty defaults at genesis
             this.prevWrappedRecordBlockHashes = new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
@@ -112,7 +112,10 @@ public class HgcaaLogValidator {
                 List.of("WRAPS proving key download failed"),
                 List.of("Downloaded WRAPS proving key hash mismatch"),
                 List.of("WRAPS proving key download did not complete"),
-                List.of("Failed to initiate async download of WRAPS proving key (from URL "));
+                List.of("Failed to initiate async download of WRAPS proving key (from URL "),
+                List.of(
+                        "Jumpstart currentBlockConsensusTimestampHash for block",
+                        "does not match wrapped record hashes file entry (aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"));
 
         private int numProblems = 0;
         private int linesSinceInitialProblem = -1;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -974,15 +974,27 @@ public class UtilVerbs {
 
     /**
      * Verifies the node's persisted live wrapped record block root hash by replaying
-     * {@code .rcd} files from genesis through the given block and comparing the final
-     * chained hash against the node's persisted value.
+     * {@code .rcd} files from a jumpstart block through the live-hash freeze block
+     * and comparing the final chained hash against the node's persisted value.
      *
-     * @param nodeComputedHash the hash the node persisted (from log scraping)
-     * @param liveBlockNum     the block number at which the live hash was persisted
+     * @param nodeComputedHash             the hash the node persisted (from log scraping)
+     * @param liveBlockNum                 the block number at which the live hash was persisted
+     * @param priorFreezeBlockNum          the {@code lastBlockNumber} from Phase 6's LIVE_HASH_INIT log
+     * @param priorFreezePrevHash          the {@code prevWrappedBlockHash} from Phase 6's LIVE_HASH_INIT log
+     * @param priorFreezeLeafCount         the {@code hasherLeafCount} from Phase 6's LIVE_HASH_INIT log
+     * @param priorFreezeIntermediateHashes comma-separated hex hashes from Phase 6's LIVE_HASH_INIT log
      */
     public static VerifyLiveWrappedHashOp verifyLiveWrappedHash(
-            @NonNull final String nodeComputedHash, @NonNull final String liveBlockNum) {
-        return new VerifyLiveWrappedHashOp(nodeComputedHash, liveBlockNum);
+            @NonNull final String nodeComputedHash,
+            @NonNull final String liveBlockNum,
+            @NonNull final String priorFreezeBlockNum,
+            @NonNull final String priorFreezePrevHash,
+            @NonNull final String priorFreezeLeafCount,
+            @NonNull final String priorFreezeIntermediateHashes) {
+        return new VerifyLiveWrappedHashOp(
+                nodeComputedHash, liveBlockNum,
+                priorFreezeBlockNum, priorFreezePrevHash,
+                priorFreezeLeafCount, priorFreezeIntermediateHashes);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/RcdFileBlockHashReplay.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/RcdFileBlockHashReplay.java
@@ -104,6 +104,13 @@ public final class RcdFileBlockHashReplay {
                     sidecarsByTime.size());
         }
 
+        log.info(
+                "[RcdFileBlockHashReplay] Starting replay: startBlockExclusive={} endBlockInclusive={} initialPrevHash={} initialHasherLeafCount={}",
+                startBlockExclusive,
+                endBlockInclusive,
+                initialPrevHash,
+                initialHasher.leafCount());
+
         // 3. Process each record file
         final var entriesByBlock = new LinkedHashMap<Long, WrappedRecordFileBlockHashes>();
         var prevWrappedBlockHash = initialPrevHash;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/VerifyLiveWrappedHashOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/VerifyLiveWrappedHashOp.java
@@ -1,49 +1,101 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.utilops.upgrade;
 
-import static com.hedera.node.app.blocks.BlockStreamManager.HASH_OF_ZERO;
 import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilOp;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+import java.util.HexFormat;
 import java.util.List;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
 /**
- * Verifies live wrapped record block hashes by replaying {@code .rcd} files from
- * genesis through the live-hash freeze block and asserting the final chained hash
- * matches the node's persisted live hash.
+ * Verifies live wrapped record block hashes by replaying {@code .rcd} files from the Phase 6
+ * freeze block through the live-hash freeze block and asserting the final chained hash matches
+ * the node's persisted live hash.
  *
- * <p>Per-block entry verification against the wrapped hashes file is handled
- * separately by {@link VerifyJumpstartHashOp} in Phase 4; this operation focuses
- * solely on the end-to-end chained hash correctness.
+ * <p>The replay is seeded from the Phase 6 freeze state (block number, prev hash, leaf count,
+ * and intermediate hashes) captured from the node's {@code [LIVE_HASH_INIT]} log line, so that
+ * the {@code allPrevBlocksRootHash} at each step matches what the node computed live.
+ *
+ * <p>Per-block entry verification against the wrapped hashes file is handled separately by
+ * {@link VerifyJumpstartHashOp} in Phase 4; this operation focuses solely on the chained
+ * hash correctness from Phase 6 onward.
  */
 public class VerifyLiveWrappedHashOp extends UtilOp {
+    private static final Logger log = LogManager.getLogger(VerifyLiveWrappedHashOp.class);
 
     private final String nodeComputedHash;
     private final String liveBlockNum;
+    private final String priorFreezeBlockNum;
+    private final String priorFreezePrevHash;
+    private final String priorFreezeLeafCount;
+    private final String priorFreezeIntermediateHashes;
 
     /**
-     * @param nodeComputedHash the hash the node persisted (from log scraping)
-     * @param liveBlockNum     the block number the node persisted its live hash at
+     * @param nodeComputedHash             the hash the node persisted (from log scraping)
+     * @param liveBlockNum                 the block number the node persisted its live hash at
+     * @param priorFreezeBlockNum          the {@code lastBlockNumber} from Phase 6's LIVE_HASH_INIT log
+     * @param priorFreezePrevHash          the {@code prevWrappedBlockHash} from Phase 6's LIVE_HASH_INIT log
+     * @param priorFreezeLeafCount         the {@code hasherLeafCount} from Phase 6's LIVE_HASH_INIT log
+     * @param priorFreezeIntermediateHashes comma-separated hex hashes from Phase 6's LIVE_HASH_INIT log
      */
-    public VerifyLiveWrappedHashOp(@NonNull final String nodeComputedHash, @NonNull final String liveBlockNum) {
+    public VerifyLiveWrappedHashOp(
+            @NonNull final String nodeComputedHash,
+            @NonNull final String liveBlockNum,
+            @NonNull final String priorFreezeBlockNum,
+            @NonNull final String priorFreezePrevHash,
+            @NonNull final String priorFreezeLeafCount,
+            @NonNull final String priorFreezeIntermediateHashes) {
         this.nodeComputedHash = requireNonNull(nodeComputedHash);
         this.liveBlockNum = requireNonNull(liveBlockNum);
+        this.priorFreezeBlockNum = requireNonNull(priorFreezeBlockNum);
+        this.priorFreezePrevHash = requireNonNull(priorFreezePrevHash);
+        this.priorFreezeLeafCount = requireNonNull(priorFreezeLeafCount);
+        this.priorFreezeIntermediateHashes = requireNonNull(priorFreezeIntermediateHashes);
     }
 
     @Override
     protected boolean submitOp(@NonNull final HapiSpec spec) throws Throwable {
         final long endBlock = Long.parseLong(liveBlockNum);
+        // priorFreezeBlockNum is lastBlockNumber from LIVE_HASH_INIT; the actual freeze block
+        // (lastBlockNumber+1) is already included as a leaf in the restored hasher, so skip it.
+        final long startBlock = Long.parseLong(priorFreezeBlockNum) + 1;
+        final var initialPrevHash = Bytes.wrap(HexFormat.of().parseHex(priorFreezePrevHash));
+        final long leafCount = Long.parseLong(priorFreezeLeafCount);
+        final List<byte[]> subtreeHashes = Arrays.stream(priorFreezeIntermediateHashes.split(","))
+                .filter(s -> !s.isEmpty())
+                .map(h -> HexFormat.of().parseHex(h))
+                .toList();
 
-        // Replay .rcd files from genesis through the live-hash block
-        final var hasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0L);
-        final var result = RcdFileBlockHashReplay.replay(spec, -1, endBlock, HASH_OF_ZERO, hasher);
+        log.info(
+                "[VerifyLiveWrappedHash] Starting replay from Phase 6 freeze state."
+                        + " startBlock={} endBlock={} leafCount={} subtreeHashCount={} nodeComputedHash={}",
+                startBlock,
+                endBlock,
+                leafCount,
+                subtreeHashes.size(),
+                nodeComputedHash);
 
-        // Final hash assertion: .rcd chain vs node logged hash
+        final var hasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), subtreeHashes, leafCount);
+        final var result = RcdFileBlockHashReplay.replay(spec, startBlock, endBlock, initialPrevHash, hasher);
+
+        log.info(
+                "[VerifyLiveWrappedHash] Replay complete."
+                        + " endBlock={} blocksProcessed={} nodeHash={} replayHash={} match={}",
+                endBlock,
+                result.blocksProcessed(),
+                nodeComputedHash,
+                result.finalChainedHash(),
+                nodeComputedHash.equals(result.finalChainedHash().toString()));
+
         Assertions.assertEquals(
                 nodeComputedHash,
                 result.finalChainedHash().toString(),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/JumpstartFileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/JumpstartFileSuite.java
@@ -9,7 +9,6 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertHgcaaLogContainsPattern;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.buildDynamicJumpstartConfig;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doAdhoc;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.getWrappedRecordHashes;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
@@ -86,6 +85,10 @@ class JumpstartFileSuite implements LifecycleTest {
         final AtomicReference<String> liveBlockNum = new AtomicReference<>();
         final AtomicReference<BlockInfo> capturedBlockInfo = new AtomicReference<>();
         final AtomicReference<RunningHashes> capturedRunningHashes = new AtomicReference<>();
+        final AtomicReference<String> phase6FreezeBlockNum = new AtomicReference<>();
+        final AtomicReference<String> phase6FreezePrevHash = new AtomicReference<>();
+        final AtomicReference<String> phase6FreezeLeafCount = new AtomicReference<>();
+        final AtomicReference<String> phase6FreezeIntermediateHashes = new AtomicReference<>();
 
         // Mutable map so buildDynamicJumpstartConfig can add jumpstart config properties
         // before the restart reads them
@@ -115,13 +118,12 @@ class JumpstartFileSuite implements LifecycleTest {
                 }),
                 prepareFakeUpgrade(),
                 // Restart the network with the corrupted environment overrides
-                doAdhoc(() -> upgradeToNextConfigVersion(
-                        corruptedEnvOverridesRef.get(),
-                        assertHgcaaLogContainsPattern(
-                                NodeSelector.exceptNodeIds(LATER_NODE_IDS),
-                                "Jumpstart currentBlockConsensusTimestampHash for block \\d+ does not match wrapped record hashes file entry",
-                                Duration.ofSeconds(30)))),
+                sourcing(() -> upgradeToNextConfigVersion(corruptedEnvOverridesRef.get())),
                 waitForActive(NodeSelector.allNodes(), Duration.ofSeconds(60)),
+                assertHgcaaLogContainsPattern(
+                        NodeSelector.exceptNodeIds(LATER_NODE_IDS),
+                        "Jumpstart currentBlockConsensusTimestampHash for block \\d+ does not match wrapped record hashes file entry \\(aaaaaaaaa",
+                        Duration.ofSeconds(30)),
                 logIt("Phase 3: Restarting with valid jumpstart config"),
                 prepareFakeUpgrade(),
                 upgradeToNextConfigVersion(
@@ -160,6 +162,17 @@ class JumpstartFileSuite implements LifecycleTest {
                         NodeSelector.exceptNodeIds(LATER_NODE_IDS),
                         "Jumpstart migration already applied \\(votingComplete=true\\), skipping",
                         Duration.ofSeconds(30)),
+                assertHgcaaLogContainsPattern(
+                                NodeSelector.exceptNodeIds(LATER_NODE_IDS),
+                                "\\[LIVE_HASH_INIT\\] Restored live hash state from BlockInfo:"
+                                        + " lastBlockNumber=(\\d+) prevWrappedBlockHash=(\\S+)"
+                                        + " hasherLeafCount=(\\d+) hasherIntermediateHashes=(\\S+)",
+                                Duration.ofSeconds(1))
+                        .matchingLast()
+                        .exposingMatchGroupTo(1, phase6FreezeBlockNum)
+                        .exposingMatchGroupTo(2, phase6FreezePrevHash)
+                        .exposingMatchGroupTo(3, phase6FreezeLeafCount)
+                        .exposingMatchGroupTo(4, phase6FreezeIntermediateHashes),
                 logIt("Phase 7: Third burst with live wrapped record hashes"),
                 MixedOperations.burstOfTps(5, Duration.ofSeconds(30)),
                 logIt("Phase 8: Freeze and live hash verification"),
@@ -177,7 +190,10 @@ class JumpstartFileSuite implements LifecycleTest {
                                 .exposingMatchGroupTo(1, liveBlockNum)
                                 .exposingMatchGroupTo(2, liveWrappedHash)),
                 waitForActive(NodeSelector.allNodes(), Duration.ofSeconds(60)),
-                sourcing(() -> verifyLiveWrappedHash(liveWrappedHash.get(), liveBlockNum.get())),
+                sourcing(() -> verifyLiveWrappedHash(
+                        liveWrappedHash.get(), liveBlockNum.get(),
+                        phase6FreezeBlockNum.get(), phase6FreezePrevHash.get(),
+                        phase6FreezeLeafCount.get(), phase6FreezeIntermediateHashes.get())),
                 logIt("Phase 9: Ops burst prior to cutover"),
                 MixedOperations.burstOfTps(5, Duration.ofSeconds(30)),
                 logIt("Phase 10: Execute cutover"),


### PR DESCRIPTION
**Description**:

This PR fixes some bugs in the `JumpstartFileSuite`:

- VerifyLiveWrappedHashOp hash mismatch: Replay was seeded from the wrong state instead of the Phase 6 freeze state (leafCount=47), causing the chained hash to diverge from the node's persisted live hash; fixed by capturing the [LIVE_HASH_INIT] log at Phase 6 and using those values to seed the replay.
- VerifyLiveWrappedHashOp off-by-one: The Phase 6 freeze block was being double-counted — replayed as a new block even though it was already included as a leaf in the restored hasher; fixed by setting startBlockExclusive = lastBlockNumber + 1 so the freeze block is skipped.
- [LIVE_HASH_INIT] log format: The log only emitted an intermediate hash count, not the actual hex
  values; fixed by capturing the raw List<Bytes> before mapping to byte[] and joining the hex strings
  into the log message so the test can scrape and replay them.

Part of #25245