### PR TITLE
feat: 25959 Implemented `replay-pces` command

### DIFF
--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -641,3 +641,84 @@ java -jar ./validator-<version>.jar blocks-to-pces \
   consensus never advances. The default is  configured to 26 rounds.
 - The PCES stream origin stamp (`--origin-round`) must match the round of the state snapshot
   passed to `replay-pces`, or the platform's `resolveDiscontinuities` will purge the files.
+
+## Replaying a PCES Stream (`replay-pces`)
+
+[ReplayPcesCommand](src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java)
+loads a saved state snapshot, replays a PCES stream on top of it through the consensus
+node's **real** production replay mechanism, and writes the resulting state to disk.
+
+This command builds and starts a genuine `SwirldsPlatform` — the same one `ServicesMain`
+constructs — and drives the body of `SwirldsPlatform.start()` minus gossip. The production
+`PcesModule.replayPcesEvents` path is exercised: events flow through the full
+intake → orphan buffer → hashgraph → consensus → transaction handling → block production
+pipeline before gossip starts. This is the same mechanism used for PCES disaster recovery
+(documented in `ADR-003-remove-pces-recovery-method`).
+
+Combined with `blocks-to-pces`, this enables end-to-end block stream equivalence validation:
+reconstruct PCES from a production block stream, replay it on the matching state, and compare
+the resulting state and block hashes against the originals.
+
+### Prerequisites
+
+- A saved state snapshot from the round the PCES stream was generated against
+  (`--origin-round` in `blocks-to-pces`).
+- PCES files produced by `blocks-to-pces` for that origin round.
+- The state round must match the PCES stream origin, or the platform will discard the files.
+- The `--rounds-non-ancient` extension must have been used in `blocks-to-pces` (default 26),
+  or the earliest events will be stuck in the orphan buffer and consensus will not advance.
+### Usage
+
+```shell
+java -jar ./validator-<version>.jar replay-pces \
+  --state-dir <path-to-state-round> \
+  --pces-dir <path-to-pces-files> \
+  [--out <output-dir>] \
+  [--self-id <id>] \
+  [--event-stream-name <name>] \
+  [--force-mock-signatures <true|false>]
+```
+
+#### Example
+
+```shell
+java -jar ./validator-<version>.jar replay-pces \
+  --state-dir ./211155071 \
+  --pces-dir ./out/pces-211155071-211422945 \
+  --out ./replay-out \
+  --self-id 0
+```
+
+### Options
+
+- `--state-dir` (or `-s`) — Directory containing the saved state snapshot to load (required).
+  Must point to the round directory directly (e.g. `./211155071/`, the directory that contains
+  `stateMetadata.txt`).
+- `--pces-dir` (or `-p`) — Directory containing the PCES files to replay (required). The
+  output of `blocks-to-pces`. Accepts either a flat directory of `.pces` files or the
+  node-id-subdirectory layout produced by `blocks-to-pces` — the command locates the files
+  automatically and stages them into the database directory the platform scans at startup.
+- `--out` (or `-o`) — Output directory for the resulting state snapshot. The platform writes
+  the snapshot to `<savedStateDir>/<appName>/<swirldName>/<selfId>/<round>/`; this option
+  sets `savedStateDir`. Default = `./replay-out`.
+- `--self-id` (or `-id`) — Node id to run as. Must match the node id the PCES files were
+  generated for (default 0 in `blocks-to-pces`). Default = 0.
+- `--event-stream-name` (or `-es`) — Consensus event stream name (e.g. `0.0.3`). Used only
+  to name an output subdirectory; does not affect replay correctness. Default = `0.0.3`.
+- `--force-mock-signatures` — Use deterministic mock TSS proofs (Tier 1 signing) instead of
+  real hinTS. No live TSS network required. Default = `true`.
+### Notes
+
+- The command sets `event.preconsensus.intake.allowUnsignedPcesEvents=true` automatically.
+  The reconstructed events from `blocks-to-pces` are unsigned; without this flag the intake
+  pipeline drops every event at signature validation and consensus never advances.
+- Replay uses ephemeral generated keys rather than on-disk PKCS12 keystores. Gossip is never
+  started, so real per-node keys are not needed.
+- The resulting block files will differ slightly in size from the original production blocks:
+  mock TSS proofs (Tier 1) are a different size than production hinTS signatures, and the
+  first block after a state-load boundary carries extra restart metadata. The transactions,
+  state changes, and consensus ordering are equivalent; the size delta is confined to the
+  block proof field.
+- The snapshot round in the output equals the round PCES advanced the state to. Compare the
+  `hashInfo.txt` from the output state against the original production state at that round to
+  verify equivalence.

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -678,8 +678,7 @@ the resulting state and block hashes against the originals.
 ### Usage
 
 ```shell
-java -jar ./validator-<version>.jar replay-pces \
-  --state-dir <path-to-state-round> \
+java -jar ./validator-<version>.jar <path-to-state-round> replay-pces \
   --pces-dir <path-to-pces-files> \
   --target-round <round> \
   [--out <output-dir>] \
@@ -691,8 +690,7 @@ java -jar ./validator-<version>.jar replay-pces \
 #### Example
 
 ```shell
-java -jar ./validator-<version>.jar replay-pces \
-  --state-dir ./211155071 \
+java -jar ./validator-<version>.jar  ./211155071 replay-pces \
   --pces-dir ./out/pces-211155071-211422945 \
   --out ./replay-out \
   --self-id 0
@@ -700,7 +698,7 @@ java -jar ./validator-<version>.jar replay-pces \
 
 ### Options
 
-- `--state-dir` (or `-s`) — Directory containing the saved state snapshot to load (required).
+- `<path-to-state-round>` — Directory containing the saved state snapshot to load (required).
   Must point to the round directory directly (e.g. `./211155071/`, the directory that contains
   `stateMetadata.txt`).
 - `--pces-dir` (or `-p`) — Directory containing the PCES files to replay (required). The

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -684,7 +684,7 @@ java -jar ./validator-<version>.jar <path-to-state-round> replay-pces \
   [--out <output-dir>] \
   [--self-id <id>] \
   [--event-stream-name <name>] \
-  [--force-mock-signatures <true|false>]
+  [--force-mock-signatures=<true|false>]
 ```
 
 #### Example
@@ -705,17 +705,24 @@ java -jar ./validator-<version>.jar  ./211155071 replay-pces \
   output of `blocks-to-pces`. Accepts either a flat directory of `.pces` files or the
   node-id-subdirectory layout produced by `blocks-to-pces` — the command locates the files
   automatically and stages them into the database directory the platform scans at startup.
-- `--out` (or `-o`) — Output directory for the resulting state snapshot. The platform writes
-  the snapshot to `<savedStateDir>/<appName>/<swirldName>/<selfId>/<round>/`; this option
-  sets `savedStateDir`. Default = `./replay-out`.
+- `--out` (or `-o`) — Output directory for the resulting state snapshot. The snapshot is written
+  to `<out>/<round>/`, where `<round>` is the resulting state's round number. This directory can
+  be passed directly as `--state-dir` to a subsequent `replay-pces` run. Default = `./replay-out`.
 - `--self-id` (or `-id`) — Node id to run as. Must match the node id the PCES files were
   generated for (default 0 in `blocks-to-pces`). Default = 0.
-- `--event-stream-name` (or `-es`) — Consensus event stream name (e.g. `0.0.3`). Used only
-  to name an output subdirectory; does not affect replay correctness. Default = `0.0.3`.
+- `--event-stream-name` (or `-es`) — Consensus event stream name (e.g. `0.0.3`). Internal platform
+  label only; does not affect replay correctness or the output path. Default = `0.0.3`.
 - `--force-mock-signatures` — Use deterministic mock TSS proofs (Tier 1 signing) instead of
   real hinTS. No live TSS network required. Default = `true`.
 - `--target-round` (or `-t`) — The round to advance the state to. Must be less than or equal
   to the last round in the PCES stream. Required.
+
+### Output
+
+The resulting state snapshot is written to `<out>/<round>/` (e.g. `./replay-out/211422945/`), where
+`<round>` is the round of the resulting state. The directory contents are a standard saved-state
+snapshot and can be used directly as the `--state-dir` of a later `replay-pces` or as input to
+`diff` / `sorted-diff`.
 
 ### Notes
 

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -108,9 +108,9 @@ classDiagram
         +validate()
     }
 
-    class HashChunkValidator {
+    class HashRecordValidator {
         <<interface>>
-        +processHashRecord(VirtualHashChunk)
+        +processHashRecord(VirtualHashRecord)
     }
 
     class LeafBytesValidator {
@@ -123,11 +123,11 @@ classDiagram
         +processBucket(long, ParsedBucket)
     }
 
-    Validator <|-- HashChunkValidator
+    Validator <|-- HashRecordValidator
     Validator <|-- LeafBytesValidator
     Validator <|-- HdhmBucketValidator
 
-    HashChunkValidator <|.. HashChunkIntegrityValidator
+    HashRecordValidator <|.. HashRecordIntegrityValidator
     LeafBytesValidator <|.. LeafBytesIntegrityValidator
     LeafBytesValidator <|.. AccountAndSupplyValidator
     LeafBytesValidator <|.. TokenRelationsIntegrityValidator
@@ -157,7 +157,7 @@ Individual validators (those implementing only the base [Validator](src/main/jav
 3. **Pipeline execution** — [ValidationPipelineExecutor](src/main/java/com/hedera/statevalidation/validator/pipeline/ValidationPipelineExecutor.java) orchestrates the parallel pipeline:
 
 - **Segmentation** — Partitions data sources into segments for parallel reading; in-memory hash ranges are partitioned as well.
-- **IO threads** read segments via [ChunkedFileIterator](src/main/java/com/hedera/statevalidation/validator/pipeline/ChunkedFileIterator.java), producing batches into a bounded queue.
+- **IO threads** read segments via [ChunkedFileIterator](src/main/java/com/hedera/statevalidation/validator/pipeline/ChunkedFileIterator.java) (disk) or directly from `HashList` (memory), producing batches into a bounded queue.
 - **Processor threads** ([ProcessorTask](src/main/java/com/hedera/statevalidation/validator/pipeline/ProcessorTask.java)) consume batches, check liveness against location indexes, and dispatch live items to the appropriate validators by data type.
 - After all data is consumed, `validate()` is called on each pipeline validator.
 
@@ -165,11 +165,11 @@ Individual validators (those implementing only the base [Validator](src/main/jav
 
 ### Pipeline Data Types
 
-|   Type   |      Source       |      Content       |                                              Dispatched To                                               |
-|----------|-------------------|--------------------|----------------------------------------------------------------------------------------------------------|
-| **P2KV** | Leaf data files   | `VirtualLeafBytes` | [LeafBytesValidator](src/main/java/com/hedera/statevalidation/validator/LeafBytesValidator.java) impls   |
-| **P2H**  | Hash data files   | `VirtualHashChunk` | [HashChunkValidator](src/main/java/com/hedera/statevalidation/validator/HashChunkValidator.java) impls   |
-| **K2P**  | HDHM bucket files | `ParsedBucket`     | [HdhmBucketValidator](src/main/java/com/hedera/statevalidation/validator/HdhmBucketValidator.java) impls |
+|   Type   |                 Source                 |       Content       |                                              Dispatched To                                               |
+|----------|----------------------------------------|---------------------|----------------------------------------------------------------------------------------------------------|
+| **P2KV** | Leaf data files                        | `VirtualLeafBytes`  | [LeafBytesValidator](src/main/java/com/hedera/statevalidation/validator/LeafBytesValidator.java) impls   |
+| **P2H**  | Hash data files + in-memory `HashList` | `VirtualHashRecord` | [HashRecordValidator](src/main/java/com/hedera/statevalidation/validator/HashRecordValidator.java) impls |
+| **K2P**  | HDHM bucket files                      | `ParsedBucket`      | [HdhmBucketValidator](src/main/java/com/hedera/statevalidation/validator/HdhmBucketValidator.java) impls |
 
 ### Thread Safety
 
@@ -180,7 +180,7 @@ Individual validators (those implementing only the base [Validator](src/main/jav
 
 ### Adding a New Validator
 
-1. Create a class implementing [HashChunkValidator](src/main/java/com/hedera/statevalidation/validator/HashChunkValidator.java), [LeafBytesValidator](src/main/java/com/hedera/statevalidation/validator/LeafBytesValidator.java), [HdhmBucketValidator](src/main/java/com/hedera/statevalidation/validator/HdhmBucketValidator.java), or base [Validator](src/main/java/com/hedera/statevalidation/validator/Validator.java).
+1. Create a class implementing [HashRecordValidator](src/main/java/com/hedera/statevalidation/validator/HashRecordValidator.java), [LeafBytesValidator](src/main/java/com/hedera/statevalidation/validator/LeafBytesValidator.java), [HdhmBucketValidator](src/main/java/com/hedera/statevalidation/validator/HdhmBucketValidator.java), or base [Validator](src/main/java/com/hedera/statevalidation/validator/Validator.java).
 2. Add an instance to [ValidatorRegistry.ALL_VALIDATORS](src/main/java/com/hedera/statevalidation/validator/ValidatorRegistry.java).
 3. *(Optional)* Define a new group constant and add it to [ValidateCommand](src/main/java/com/hedera/statevalidation/ValidateCommand.java)'s parameters.
 
@@ -667,13 +667,13 @@ the resulting state and block hashes against the originals.
 - The state round must match the PCES stream origin, or the platform will discard the files.
 - The `--rounds-non-ancient` extension must have been used in `blocks-to-pces` (default 26),
   or the earliest events will be stuck in the orphan buffer and consensus will not advance.
-
 ### Usage
 
 ```shell
 java -jar ./validator-<version>.jar replay-pces \
   --state-dir <path-to-state-round> \
   --pces-dir <path-to-pces-files> \
+  --target-round <round> \
   [--out <output-dir>] \
   [--self-id <id>] \
   [--event-stream-name <name>] \
@@ -708,7 +708,8 @@ java -jar ./validator-<version>.jar replay-pces \
   to name an output subdirectory; does not affect replay correctness. Default = `0.0.3`.
 - `--force-mock-signatures` — Use deterministic mock TSS proofs (Tier 1 signing) instead of
   real hinTS. No live TSS network required. Default = `true`.
-
+- `--target-round` (or `-t`) — The round to advance the state to. Must be less than or equal
+  to the last round in the PCES stream. Required.
 ### Notes
 
 - The command sets `event.preconsensus.intake.allowUnsignedPcesEvents=true` automatically.
@@ -724,3 +725,5 @@ java -jar ./validator-<version>.jar replay-pces \
 - The snapshot round in the output equals the round PCES advanced the state to. Compare the
   `hashInfo.txt` from the output state against the original production state at that round to
   verify equivalence.
+- If the replay ever encounters FREEZE transaction, it will be halted by the platform, and if the FREEZE round is not 
+the same as the target round, the replay will fail. 

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -678,8 +678,7 @@ the resulting state and block hashes against the originals.
 ### Usage
 
 ```shell
-java -jar ./validator-<version>.jar replay-pces \
-     --state-dir <path-to-state-round> \
+java -jar ./validator-<version>.jar <path-to-state-round> replay-pces \
      --pces-dir <path-to-pces-files> \
      --target-round <round> \
      [--out <output-dir>] \
@@ -691,8 +690,7 @@ java -jar ./validator-<version>.jar replay-pces \
 #### Example
 
 ```shell
-java -jar ./validator-<version>.jar replay-pces \
-      --state-dir ./211155071 \
+java -jar ./validator-<version>.jar ./211155071 replay-pces \
       --pces-dir ./out/pces-211155071-211422945 \
       --target-round 211422945 \
       --out ./replay-out \

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -678,22 +678,25 @@ the resulting state and block hashes against the originals.
 ### Usage
 
 ```shell
-java -jar ./validator-<version>.jar <path-to-state-round> replay-pces \
-  --pces-dir <path-to-pces-files> \
-  --target-round <round> \
-  [--out <output-dir>] \
-  [--self-id <id>] \
-  [--event-stream-name <name>] \
-  [--force-mock-signatures=<true|false>]
+java -jar ./validator-<version>.jar replay-pces \
+     --state-dir <path-to-state-round> \
+     --pces-dir <path-to-pces-files> \
+     --target-round <round> \
+     [--out <output-dir>] \
+     [--self-id <id>] \
+     [--event-stream-name <name>] \
+     [--force-mock-signatures=<true|false>]
 ```
 
 #### Example
 
 ```shell
-java -jar ./validator-<version>.jar  ./211155071 replay-pces \
-  --pces-dir ./out/pces-211155071-211422945 \
-  --out ./replay-out \
-  --self-id 0
+java -jar ./validator-<version>.jar replay-pces \
+      --state-dir ./211155071 \
+      --pces-dir ./out/pces-211155071-211422945 \
+      --target-round 211422945 \
+      --out ./replay-out \
+      --self-id 0
 ```
 
 ### Options
@@ -706,23 +709,27 @@ java -jar ./validator-<version>.jar  ./211155071 replay-pces \
   node-id-subdirectory layout produced by `blocks-to-pces` — the command locates the files
   automatically and stages them into the database directory the platform scans at startup.
 - `--out` (or `-o`) — Output directory for the resulting state snapshot. The snapshot is written
-  to `<out>/<round>/`, where `<round>` is the resulting state's round number. This directory can
-  be passed directly as `--state-dir` to a subsequent `replay-pces` run. Default = `./replay-out`.
+  to `<out>/<round>/`, where `<round>` is the retained round. This directory can be passed directly
+  as `--state-dir` to a subsequent `replay-pces` run, or to `diff` / `sorted-diff`. Default = `./replay-out`.
 - `--self-id` (or `-id`) — Node id to run as. Must match the node id the PCES files were
   generated for (default 0 in `blocks-to-pces`). Default = 0.
 - `--event-stream-name` (or `-es`) — Consensus event stream name (e.g. `0.0.3`). Internal platform
   label only; does not affect replay correctness or the output path. Default = `0.0.3`.
 - `--force-mock-signatures` — Use deterministic mock TSS proofs (Tier 1 signing) instead of
   real hinTS. No live TSS network required. Default = `true`.
-- `--target-round` (or `-t`) — The round to advance the state to. Must be less than or equal
-  to the last round in the PCES stream. Required.
+- `--target-round` (or `-t`) — The round whose state is retained as the output snapshot (required).
+  The full PCES stream is still replayed and may generate blocks for later rounds; only this round's
+  state is kept. A freeze within the replayed range halts the platform at the freeze round — if the
+  target is before the freeze it is captured when reached; if the target is at or after the freeze it
+  is never reached (replay to the freeze round and resume from the freeze state).
 
 ### Output
 
-The resulting state snapshot is written to `<out>/<round>/` (e.g. `./replay-out/211422945/`), where
-`<round>` is the round of the resulting state. The directory contents are a standard saved-state
-snapshot and can be used directly as the `--state-dir` of a later `replay-pces` or as input to
-`diff` / `sorted-diff`.
+The output snapshot contains the state produced at `--target-round`, written to `<out>/<round>/`.
+Replay continues through the remaining PCES events so the complete expected block set is generated
+(block files land under `<out>/blockStreams/block-<nodeAccount>/`). To validate, compare the output
+snapshot against the original production state from the same target round (e.g. `diff` /
+`sorted-diff`, or compare `hashInfo.txt`).
 
 ### Notes
 

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -667,6 +667,7 @@ the resulting state and block hashes against the originals.
 - The state round must match the PCES stream origin, or the platform will discard the files.
 - The `--rounds-non-ancient` extension must have been used in `blocks-to-pces` (default 26),
   or the earliest events will be stuck in the orphan buffer and consensus will not advance.
+
 ### Usage
 
 ```shell
@@ -707,6 +708,7 @@ java -jar ./validator-<version>.jar replay-pces \
   to name an output subdirectory; does not affect replay correctness. Default = `0.0.3`.
 - `--force-mock-signatures` — Use deterministic mock TSS proofs (Tier 1 signing) instead of
   real hinTS. No live TSS network required. Default = `true`.
+
 ### Notes
 
 - The command sets `event.preconsensus.intake.allowUnsignedPcesEvents=true` automatically.

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -648,6 +648,13 @@ java -jar ./validator-<version>.jar blocks-to-pces \
 loads a saved state snapshot, replays a PCES stream on top of it through the consensus
 node's **real** production replay mechanism, and writes the resulting state to disk.
 
+> **Important:** The `replay-pces` command requires a production platform code change from commit
+> [`140f94f`](https://github.com/hiero-ledger/hiero-consensus-node/commit/140f94fff19a3a6f809df339ed17349ef5ae3426)
+> to work properly. This commit introduces the `allowUnsignedPcesEvents` intake flag
+> which allows reconstructed (unsigned) PCES events produced by `blocks-to-pces` to pass the
+> intake signature validator. Without it, every replayed event is silently dropped at signature
+> validation and no rounds reach consensus
+
 This command builds and starts a genuine `SwirldsPlatform` — the same one `ServicesMain`
 constructs — and drives the body of `SwirldsPlatform.start()` minus gossip. The production
 `PcesModule.replayPcesEvents` path is exercised: events flow through the full

--- a/hedera-state-validator/README.md
+++ b/hedera-state-validator/README.md
@@ -667,6 +667,7 @@ the resulting state and block hashes against the originals.
 - The state round must match the PCES stream origin, or the platform will discard the files.
 - The `--rounds-non-ancient` extension must have been used in `blocks-to-pces` (default 26),
   or the earliest events will be stuck in the orphan buffer and consensus will not advance.
+
 ### Usage
 
 ```shell
@@ -710,6 +711,7 @@ java -jar ./validator-<version>.jar replay-pces \
   real hinTS. No live TSS network required. Default = `true`.
 - `--target-round` (or `-t`) — The round to advance the state to. Must be less than or equal
   to the last round in the PCES stream. Required.
+
 ### Notes
 
 - The command sets `event.preconsensus.intake.allowUnsignedPcesEvents=true` automatically.
@@ -725,5 +727,5 @@ java -jar ./validator-<version>.jar replay-pces \
 - The snapshot round in the output equals the round PCES advanced the state to. Compare the
   `hashInfo.txt` from the output state against the original production state at that round to
   verify equivalence.
-- If the replay ever encounters FREEZE transaction, it will be halted by the platform, and if the FREEZE round is not 
-the same as the target round, the replay will fail. 
+- If the replay ever encounters FREEZE transaction, it will be halted by the platform, and if the FREEZE round is not
+  the same as the target round, the replay will fail.

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.statevalidation;
+
+import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.getMetricsProvider;
+import static com.swirlds.platform.builder.internal.StaticPlatformBuilder.setupGlobalMetrics;
+
+import com.hedera.node.app.ServicesMain;
+import com.hedera.statevalidation.blockstream.ReplayPcesWorkflow;
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
+import com.swirlds.platform.util.BootstrapUtils;
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hiero.base.file.FileSystemManager;
+import org.hiero.consensus.config.PathsConfig;
+import org.hiero.consensus.model.node.NodeId;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+/**
+ * Loads a saved state, replays a PCES stream on top of it using the consensus node's real replay mechanism, and writes
+ * the resulting state snapshot to disk.
+ *
+ * <p>This builds and starts a genuine {@code SwirldsPlatform} (the same one {@code ServicesMain} builds) so that the
+ * production {@code PcesModule.replayPcesEvents} path is exercised — it is not a custom replay harness. Gossip is never
+ * started; only PCES replay runs, after which the advanced state is dumped.
+ *
+ * <p>Intended to be paired with {@code blocks-to-pces}: that tool reconstructs PCES files from a block stream, and this
+ * command replays them on a node started from the matching state snapshot, to validate block-stream equivalence.
+ */
+@Command(
+        name = "replay-pces",
+        description = "Load a state, replay PCES files on top of it via the real consensus replay path, "
+                + "and snapshot the resulting state.")
+public class ReplayPcesCommand implements Callable<Integer> {
+
+    @CommandLine.ParentCommand
+    @SuppressWarnings("unused")
+    private StateOperatorCommand parent;
+
+    private static final Logger log = LogManager.getLogger(ReplayPcesCommand.class);
+
+    private Path stateDir;
+    private Path pcesDir;
+    private Path outDir = Path.of("./replay-out");
+    private long selfIdValue = 0;
+    private String consensusEventStreamName = "0.0.3";
+    private boolean forceMockSignatures = true;
+
+    @Option(
+            names = {"-s", "--state-dir"},
+            required = true,
+            description = "Directory containing the saved state snapshot to load.")
+    private void setStateDir(final Path stateDir) {
+        this.stateDir = stateDir;
+    }
+
+    @Option(
+            names = {"-p", "--pces-dir"},
+            required = true,
+            description = "Directory containing the PCES files to replay (output of blocks-to-pces).")
+    private void setPcesDir(final Path pcesDir) {
+        this.pcesDir = pcesDir;
+    }
+
+    @Option(
+            names = {"-o", "--out"},
+            description = "Directory where the resulting state snapshot is written. Default = ./replay-out")
+    private void setOutDir(final Path outDir) {
+        this.outDir = outDir;
+    }
+
+    @Option(
+            names = {"-id", "--self-id"},
+            description = "Node id to run as. Must match the node id the PCES files were generated for. Default = 0")
+    private void setSelfId(final long selfId) {
+        this.selfIdValue = selfId;
+    }
+
+    @Option(
+            names = {"-es", "--event-stream-name"},
+            description = "Consensus event stream name (e.g. 0.0.3). Names an output directory only. Default = 0.0.3")
+    private void setConsensusEventStreamName(final String name) {
+        this.consensusEventStreamName = name;
+    }
+
+    @Option(
+            names = {"--force-mock-signatures"},
+            description = "Tier 1 signing: use deterministic mock TSS proofs instead of real hinTS. Default = true")
+    private void setForceMockSignatures(final boolean forceMockSignatures) {
+        this.forceMockSignatures = forceMockSignatures;
+    }
+
+    @Override
+    public Integer call() throws Exception {
+        // --- Replay-only flags, set before the platform configuration is built so the config picks them up ---
+        // buildPlatformConfig() includes SystemPropertiesConfigSource, so these system properties take effect.
+        //  - allowUnsignedPcesEvents: blocks-to-pces produces unsigned reconstructed events; without this the intake
+        //    pipeline drops every replayed event at signature validation (see the unsigned-event intake path).
+        //  - forceMockSignatures: Tier-1 deterministic block signing with no live TSS network.
+        System.setProperty("event.preconsensus.intake.allowUnsignedPcesEvents", "true");
+        if (forceMockSignatures) {
+            System.setProperty("tss.forceMockSignatures", "true");
+        }
+
+        final NodeId selfId = NodeId.of(selfIdValue);
+
+        // Constructable registry must be set up before any state deserialization, exactly as ServicesMain.main does.
+        BootstrapUtils.setupConstructableRegistry();
+
+        // Build the platform configuration the same way ServicesMain does (mirrors production; reads system props).
+        final Configuration platformConfig = ServicesMain.buildPlatformConfig();
+
+        // Metrics: the same static setup ServicesMain.main performs.
+        setupGlobalMetrics(platformConfig);
+        final Time time = Time.getCurrent();
+        final Metrics metrics = getMetricsProvider().createPlatformMetrics(selfId);
+
+        final PathsConfig pathsConfig = platformConfig.getConfigData(PathsConfig.class);
+        final FileSystemManager fileSystemManager =
+                new FileSystemManager(pathsConfig.savedStateDir(), pathsConfig.tmpDir());
+
+        final long resultRound = ReplayPcesWorkflow.run(
+                stateDir,
+                pcesDir,
+                outDir,
+                selfId,
+                consensusEventStreamName,
+                platformConfig,
+                fileSystemManager,
+                metrics,
+                time);
+
+        log.info("replay-pces complete: resulting state round {} written to {}", resultRound, outDir);
+        return 0;
+    }
+
+    public static void main(final String... args) {
+        final int rc = new CommandLine(new ReplayPcesCommand()).execute(args);
+        System.exit(rc);
+    }
+}

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
@@ -9,6 +9,7 @@ import com.hedera.statevalidation.blockstream.ReplayPcesWorkflow;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import org.apache.logging.log4j.LogManager;
@@ -90,8 +91,11 @@ public class ReplayPcesCommand implements Callable<Integer> {
 
     @Option(
             names = {"-t", "--target-round"},
-            description = "The last round that should be applied to the state, any higher rounds are ignored. "
-                    + "Default = apply all available rounds.")
+            required = true,
+            description = "The round whose resulting state is written as the output snapshot. The full PCES "
+                    + "stream is still replayed (decision-margin events past this round are required to bring "
+                    + "this round to consensus), but only this round's state is retained. Default = write the "
+                    + "latest round reached.")
     private void setTargetRound(final long targetRound) {
         this.targetRound = targetRound;
     }
@@ -112,11 +116,52 @@ public class ReplayPcesCommand implements Callable<Integer> {
         if (forceMockSignatures) {
             System.setProperty("tss.forceMockSignatures", "true");
         }
-        System.setProperty("pces.forceIgnorePcesSignatures", "true");
+        System.setProperty("event.preconsensus.forceIgnorePcesSignatures", "true");
         System.setProperty("event.preconsensus.copyRecentStreamToStateSnapshots", "false");
-        System.setProperty("event.preconsensus.limitReplayFrequency", "false");
+
+        // Suppress ONLY the PERIODIC_SNAPSHOT marking, without disabling state saving. With periodic
+        // marking on, DefaultSavedStateController marks the first replayed state crossing a save-period
+        // boundary as PERIODIC_SNAPSHOT, which routes the final-state writer into the ASYNC snapshot path
+        // (blocks to the async timeout as the last replayed state; can collide with the platform's own
+        // periodic snapshot over the same VirtualMap copy). This toggle gates shouldSaveToDisk()'s periodic
+        // branch only; freeze-state and first-round saves still occur, and saveStatePeriod stays > 0 so the
+        // normal state-release/garbage-collection cadence is unaffected (important to bound memory on long
+        // replays — do NOT set saveStatePeriod=0).
+        System.setProperty("state.periodicSnapshotsEnabled", "false");
+        System.setProperty("state.saveStateAsync", "false");
         System.setProperty("state.saveStatePeriod", "3600");
+
         System.setProperty("blockStream.writerMode", "FILE");
+
+        // --- Keep all stream output under outDir; never touch the production /opt/hgcapp defaults. ---
+        // The block stream is the equivalence-validation deliverable, so direct it under outDir. The event
+        // and record streams are not needed for replay and their production default directories live under
+        // /opt/hgcapp (root-owned on a normal workstation); the consensus event stream eagerly creates its
+        // directory during platform build, which would throw before replay starts. Disable them.
+
+        // Block stream -> <outDir>/blockStreams  (BlockStreamConfig.blockFileDir)
+        final Path blockOut = outDir.resolve("blockStreams");
+        Files.createDirectories(blockOut);
+        System.setProperty("blockStream.blockFileDir", blockOut.toAbsolutePath().toString());
+
+        // Event stream -> disabled  (EventConfig.enableEventStreaming); also redirect its dir defensively
+        System.setProperty("event.enableEventStreaming", "false");
+        System.setProperty(
+                "event.eventsLogDir",
+                outDir.resolve("eventsStreams").toAbsolutePath().toString());
+
+        // Record stream -> redirect its dir under outDir  (BlockRecordStreamConfig.logDir)
+        // (writerMode=FILE + streamMode drive block output; the record stream dir must still not default to
+        //  /opt/hgcapp in case any record-stream writer initializes.)
+        System.setProperty(
+                "hedera.recordStream.logDir",
+                outDir.resolve("recordStreams").toAbsolutePath().toString());
+        System.setProperty(
+                "hedera.recordStream.sidecarDir",
+                outDir.resolve("recordStreams")
+                        .resolve("sidecar")
+                        .toAbsolutePath()
+                        .toString());
 
         final NodeId selfId = NodeId.of(selfIdValue);
 

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
@@ -15,7 +15,7 @@ import java.util.concurrent.Callable;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.file.FileSystemManager;
-import org.hiero.consensus.config.PathsConfig;
+import org.hiero.consensus.PathsConfig;
 import org.hiero.consensus.model.node.NodeId;
 import picocli.CommandLine;
 import picocli.CommandLine.Command;

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
@@ -77,7 +77,8 @@ public class ReplayPcesCommand implements Callable<Integer> {
 
     @Option(
             names = {"-es", "--event-stream-name"},
-            description = "Consensus event stream name (e.g. 0.0.3). Names an output directory only. Default = 0.0.3")
+            description = "Consensus event stream name (e.g. 0.0.3). Internal platform label only; does not "
+                    + "affect replay correctness or the output state path. Default = 0.0.3")
     private void setConsensusEventStreamName(final String name) {
         this.consensusEventStreamName = name;
     }
@@ -92,10 +93,9 @@ public class ReplayPcesCommand implements Callable<Integer> {
     @Option(
             names = {"-t", "--target-round"},
             required = true,
-            description = "The round whose resulting state is written as the output snapshot. The full PCES "
+            description = "The round whose resulting state is retained as the output snapshot. The full PCES "
                     + "stream is still replayed (decision-margin events past this round are required to bring "
-                    + "this round to consensus), but only this round's state is retained. Default = write the "
-                    + "latest round reached.")
+                    + "this round to consensus), and blocks for later rounds may still be generated. Required.")
     private void setTargetRound(final long targetRound) {
         this.targetRound = targetRound;
     }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
@@ -9,7 +9,6 @@ import com.hedera.statevalidation.blockstream.ReplayPcesWorkflow;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.platform.util.BootstrapUtils;
 import java.nio.file.Path;
 import java.util.concurrent.Callable;
 import org.apache.logging.log4j.LogManager;
@@ -25,9 +24,9 @@ import picocli.CommandLine.Option;
  * Loads a saved state, replays a PCES stream on top of it using the consensus node's real replay mechanism, and writes
  * the resulting state snapshot to disk.
  *
- * <p>This builds and starts a genuine {@code SwirldsPlatform} (the same one {@code ServicesMain} builds) so that the
- * production {@code PcesModule.replayPcesEvents} path is exercised — it is not a custom replay harness. Gossip is never
- * started; only PCES replay runs, after which the advanced state is dumped.
+ * <p>This builds the consensus layer (the same one {@code ServicesMain} builds) so that the production
+ * {@code PcesModule.replayPcesEvents} path is exercised — it is not a custom replay harness. Gossip is never started;
+ * only PCES replay runs, after which the advanced state is dumped.
  *
  * <p>Intended to be paired with {@code blocks-to-pces}: that tool reconstructs PCES files from a block stream, and this
  * command replays them on a node started from the matching state snapshot, to validate block-stream equivalence.
@@ -44,6 +43,9 @@ public class ReplayPcesCommand implements Callable<Integer> {
 
     private static final Logger log = LogManager.getLogger(ReplayPcesCommand.class);
 
+    public static final long DEFAULT_TARGET_ROUND = Long.MAX_VALUE;
+
+    private long targetRound = DEFAULT_TARGET_ROUND;
     private Path pcesDir;
     private Path outDir = Path.of("./replay-out");
     private long selfIdValue = 0;
@@ -86,6 +88,14 @@ public class ReplayPcesCommand implements Callable<Integer> {
         this.forceMockSignatures = forceMockSignatures;
     }
 
+    @Option(
+            names = {"-t", "--target-round"},
+            description = "The last round that should be applied to the state, any higher rounds are ignored. "
+                    + "Default = apply all available rounds.")
+    private void setTargetRound(final long targetRound) {
+        this.targetRound = targetRound;
+    }
+
     @Override
     public Integer call() throws Exception {
         parent.resolveAndGetStateDir();
@@ -95,15 +105,20 @@ public class ReplayPcesCommand implements Callable<Integer> {
         //  - allowUnsignedPcesEvents: blocks-to-pces produces unsigned reconstructed events; without this the intake
         //    pipeline drops every replayed event at signature validation (see the unsigned-event intake path).
         //  - forceMockSignatures: Tier-1 deterministic block signing with no live TSS network.
+        // IMPORTANT: this flag is non-existent in the production codebase. It requires
+        // production code change that should never be a part of the main branch.
+        // See commit 140f94fff19a3a6f809df339ed17349ef5ae3426 for more details.
         System.setProperty("event.preconsensus.intake.allowUnsignedPcesEvents", "true");
         if (forceMockSignatures) {
             System.setProperty("tss.forceMockSignatures", "true");
         }
+        System.setProperty("pces.forceIgnorePcesSignatures", "true");
+        System.setProperty("event.preconsensus.copyRecentStreamToStateSnapshots", "false");
+        System.setProperty("event.preconsensus.limitReplayFrequency", "false");
+        System.setProperty("state.saveStatePeriod", "3600");
+        System.setProperty("blockStream.writerMode", "FILE");
 
         final NodeId selfId = NodeId.of(selfIdValue);
-
-        // Constructable registry must be set up before any state deserialization, exactly as ServicesMain.main does.
-        BootstrapUtils.setupConstructableRegistry();
 
         // Build the platform configuration the same way ServicesMain does (mirrors production; reads system props).
         final Configuration platformConfig = ServicesMain.buildPlatformConfig();
@@ -122,6 +137,7 @@ public class ReplayPcesCommand implements Callable<Integer> {
                 pcesDir,
                 outDir,
                 selfId,
+                targetRound,
                 consensusEventStreamName,
                 platformConfig,
                 fileSystemManager,

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/ReplayPcesCommand.java
@@ -44,20 +44,11 @@ public class ReplayPcesCommand implements Callable<Integer> {
 
     private static final Logger log = LogManager.getLogger(ReplayPcesCommand.class);
 
-    private Path stateDir;
     private Path pcesDir;
     private Path outDir = Path.of("./replay-out");
     private long selfIdValue = 0;
     private String consensusEventStreamName = "0.0.3";
     private boolean forceMockSignatures = true;
-
-    @Option(
-            names = {"-s", "--state-dir"},
-            required = true,
-            description = "Directory containing the saved state snapshot to load.")
-    private void setStateDir(final Path stateDir) {
-        this.stateDir = stateDir;
-    }
 
     @Option(
             names = {"-p", "--pces-dir"},
@@ -97,6 +88,8 @@ public class ReplayPcesCommand implements Callable<Integer> {
 
     @Override
     public Integer call() throws Exception {
+        parent.resolveAndGetStateDir();
+        final Path stateDir = parent.getStateDir().toPath();
         // --- Replay-only flags, set before the platform configuration is built so the config picks them up ---
         // buildPlatformConfig() includes SystemPropertiesConfigSource, so these system properties take effect.
         //  - allowUnsignedPcesEvents: blocks-to-pces produces unsigned reconstructed events; without this the intake

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/StateOperatorCommand.java
@@ -28,7 +28,7 @@ import picocli.CommandLine.Parameters;
             DiffCommand.class,
             CompactionCommand.class,
             ApplyBlocksCommand.class,
-            BlocksToPcesCommand.class
+            ReplayPcesCommand.class
         },
         description = "CLI tool with validation and introspection modes.")
 public class StateOperatorCommand implements Runnable {

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -6,7 +6,6 @@ import static org.hiero.consensus.concurrent.manager.AdHocThreadManager.getStati
 import static org.hiero.consensus.platformstate.PlatformStateUtils.ancientThresholdOf;
 
 import com.hedera.hapi.node.base.SemanticVersion;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.node.app.Hedera;
 import com.hedera.node.app.ServicesMain;
 import com.hedera.pbj.runtime.ParseException;
@@ -36,8 +35,8 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Hash;
-import org.hiero.consensus.crypto.KeysAndCertsGenerator;
 import org.hiero.base.file.FileSystemManager;
+import org.hiero.consensus.crypto.KeysAndCertsGenerator;
 import org.hiero.consensus.io.RecycleBinImpl;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
@@ -128,7 +127,8 @@ public final class ReplayPcesWorkflow {
         stagePcesFiles(pcesDir, platformConfig, fileSystemManager, selfId);
 
         // --- Load the initial state directly from the given path ---
-        final var stateLifecycleManager = new VirtualMapStateLifecycleManager(metrics, time, platformConfig, fileSystemManager);
+        final var stateLifecycleManager =
+                new VirtualMapStateLifecycleManager(metrics, time, platformConfig, fileSystemManager);
 
         log.info("Loading state from {}", stateDir);
         final DeserializedSignedState deserializedSignedState =

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -1,0 +1,327 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.statevalidation.blockstream;
+
+import static java.util.Objects.requireNonNull;
+import static org.hiero.consensus.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
+import static org.hiero.consensus.platformstate.PlatformStateUtils.ancientThresholdOf;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import com.hedera.node.app.Hedera;
+import com.hedera.node.app.ServicesMain;
+import com.hedera.pbj.runtime.ParseException;
+import com.swirlds.common.context.PlatformContext;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.metrics.api.Metrics;
+import com.swirlds.platform.builder.PlatformBuilder;
+import com.swirlds.platform.builder.PlatformBuildingBlocks;
+import com.swirlds.platform.builder.PlatformComponentBuilder;
+import com.swirlds.platform.state.ConsensusStateEventHandler;
+import com.swirlds.platform.state.snapshot.DeserializedSignedState;
+import com.swirlds.platform.state.snapshot.SignedStateFileReader;
+import com.swirlds.platform.state.snapshot.StateDumpRequest;
+import com.swirlds.platform.system.InitTrigger;
+import com.swirlds.platform.system.Platform;
+import com.swirlds.state.merkle.VirtualMapState;
+import com.swirlds.state.merkle.VirtualMapStateLifecycleManager;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyStoreException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.stream.Stream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hiero.base.crypto.Hash;
+import org.hiero.consensus.crypto.KeysAndCertsGenerator;
+import org.hiero.base.file.FileSystemManager;
+import org.hiero.consensus.io.RecycleBinImpl;
+import org.hiero.consensus.model.node.KeysAndCerts;
+import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.pces.impl.common.PcesUtilities;
+import org.hiero.consensus.roster.ReadableRosterStore;
+import org.hiero.consensus.roster.ReadableRosterStoreImpl;
+import org.hiero.consensus.roster.RosterHistory;
+import org.hiero.consensus.roster.RosterStateId;
+import org.hiero.consensus.state.signed.ReservedSignedState;
+import org.hiero.consensus.state.signed.SignedState;
+import org.hiero.consensus.state.snapshot.StateToDiskReason;
+
+/**
+ * Loads a saved state, replays a PCES stream on top of it using the consensus node's <b>real</b> replay mechanism, and
+ * dumps the resulting state to disk.
+ *
+ * <p>This intentionally reuses the production startup path rather than a bespoke replay harness. It constructs the same
+ * {@link Hedera} execution layer and {@link Platform} that {@link ServicesMain#main} builds, then drives the body of
+ * {@link com.swirlds.platform.SwirldsPlatform#start()} <i>minus gossip</i>:
+ *
+ * <ol>
+ *   <li>Build the platform exactly as {@code ServicesMain} does — loading the initial state, initializing the States
+ *       API, deriving roster/keys, and calling {@link PlatformBuilder}. The {@code SwirldsPlatform} constructor (run
+ *       inside {@link PlatformComponentBuilder#build()}) performs all the restart priming
+ *       ({@code consensusSnapshotOverride}, {@code updateEventWindow}, signature-collector and ISS-detector seeding,
+ *       etc.) automatically.</li>
+ *   <li>Start the recycle bin, metrics, and platform coordinator (the first three lines of {@code start()}).</li>
+ *   <li>Call {@code pcesModule().replayPcesEvents(pcesReplayLowerBound, startingRound)} — the same call normal startup
+ *       makes — but do <b>not</b> call {@code startGossip()}.</li>
+ *   <li>Pull the latest immutable state, mark it {@link StateToDiskReason#PCES_RECOVERY_COMPLETE}, and dump it to disk,
+ *       blocking until the write finishes.</li>
+ * </ol>
+ *
+ * <p>The replay bounds are recomputed from the loaded state using the same public helpers the {@code SwirldsPlatform}
+ * constructor uses ({@code initialState.getRound()} and {@link org.hiero.consensus.platformstate.PlatformStateUtils#ancientThresholdOf}),
+ * so they are identical to a production restart — no reflection into platform internals is required.
+ */
+public final class ReplayPcesWorkflow {
+
+    private static final Logger log = LogManager.getLogger(ReplayPcesWorkflow.class);
+
+    private ReplayPcesWorkflow() {}
+
+    /**
+     * Runs the replay.
+     *
+     * @param stateDir the directory containing the saved state snapshot to load
+     * @param pcesDir the directory containing the PCES files to replay (produced by {@code blocks-to-pces})
+     * @param outDir the directory where the resulting state snapshot will be written
+     * @param selfId the node id to run as; must match the node id the PCES files were generated for
+     * @param consensusEventStreamName the consensus event stream name (e.g. "0.0.3"); supplied by the caller because
+     *     {@code ServicesMain} derives it via private helpers. For replay it only names an output directory.
+     * @param platformConfig the fully-built platform configuration (production-mirroring, plus replay flags)
+     * @param fileSystemManager the file system manager
+     * @param metrics the platform metrics
+     * @param time the time source
+     * @return the round the replayed state advanced to
+     */
+    public static long run(
+            @NonNull final Path stateDir,
+            @NonNull final Path pcesDir,
+            @NonNull final Path outDir,
+            @NonNull final NodeId selfId,
+            @NonNull final String consensusEventStreamName,
+            @NonNull final Configuration platformConfig,
+            @NonNull final FileSystemManager fileSystemManager,
+            @NonNull final Metrics metrics,
+            @NonNull final com.swirlds.base.time.Time time)
+            throws IOException, InterruptedException, ParseException, KeyStoreException, ExecutionException {
+        requireNonNull(stateDir);
+        requireNonNull(pcesDir);
+        requireNonNull(outDir);
+        requireNonNull(consensusEventStreamName);
+
+        // --- Construct the Hedera execution layer exactly as ServicesMain does ---
+        final Hedera hedera = ServicesMain.newHedera(platformConfig, fileSystemManager, metrics, time, selfId);
+        final SemanticVersion version = hedera.getSemanticVersion();
+        log.info("Replaying PCES on node {} with software version {}", selfId, version);
+
+        final var recycleBin = RecycleBinImpl.create(
+                metrics, platformConfig, getStaticThreadManager(), time, fileSystemManager, selfId);
+        final ConsensusStateEventHandler consensusStateEventHandler = hedera.newConsensusStateEvenHandler();
+        final PlatformContext platformContext =
+                PlatformContext.create(platformConfig, time, metrics, fileSystemManager, recycleBin);
+
+        // --- Place the PCES files where the PcesFileTracker will scan them, before the platform is built ---
+        // DefaultPcesModule.initialize scans PcesUtilities.getDatabaseDirectory(config, fsm, selfId) at build time.
+        stagePcesFiles(pcesDir, platformConfig, fileSystemManager, selfId);
+
+        // --- Load the initial state directly from the given path ---
+        final var stateLifecycleManager = new VirtualMapStateLifecycleManager(metrics, time, platformConfig, fileSystemManager);
+
+        log.info("Loading state from {}", stateDir);
+        final DeserializedSignedState deserializedSignedState =
+                SignedStateFileReader.readState(stateDir, platformContext, stateLifecycleManager);
+
+        final ReservedSignedState initialState = deserializedSignedState.reservedSignedState();
+        final Hash originalHash = deserializedSignedState.originalHash();
+        final VirtualMapState state = initialState.get().getState();
+
+        if (initialState.get().isGenesisState()) {
+            throw new IllegalStateException(
+                    "No saved state found in " + stateDir + " — replay-pces requires a loaded (non-genesis) state");
+        }
+
+        // --- Initialize the States API on the loaded state (restart path) ---
+        hedera.initializeStatesApi(state, InitTrigger.RESTART, platformConfig);
+        hedera.setInitialStateHash(originalHash);
+
+        // --- Roster + keys (same derivation the platform uses at restart/reconnect) ---
+        final ReadableRosterStore rosterStore =
+                new ReadableRosterStoreImpl(state.getReadableStates(RosterStateId.SERVICE_NAME));
+        final RosterHistory rosterHistory = rosterStore.getRosterHistory();
+
+        // --- Generate ephemeral keys for this node ---
+        // initNodeSecurity loads keys from disk (PKCS12 keystores), which don't exist in an offline replay
+        // environment, causing KEY_LOADING_FAILED. For PCES replay we never start gossip or interact with
+        // peers, so real keys are not needed — the platform only requires them to satisfy internal certificate
+        // validation at build time. KeysAndCertsGenerator.generateKeysAndCerts produces self-consistent
+        // ephemeral keys that satisfy those checks without any on-disk key infrastructure.
+        final KeysAndCerts keysAndCerts =
+                KeysAndCertsGenerator.generateKeysAndCerts(List.of(selfId)).get(selfId);
+
+        // Register the platform service-state stubs (PlatformStateService, RosterService) on the manager's
+        // current mutable state, immediately before building the platform. This must come AFTER Hedera's
+        // initializeStatesApi (whose onStateInitialized migration rebuilds the services map and would otherwise
+        // overwrite earlier stub registration) and BEFORE PlatformComponentBuilder.build() (whose SwirldsPlatform
+        // constructor calls copyMutableState() then accesses PlatformStateService — the copy carries this metadata
+        // forward via VirtualMapStateImpl's copy constructor). This is the same registration StateUtils.initState
+        // performs; the platform's own init path does not register these platform stubs.
+        SignedStateFileReader.registerServiceStates(stateLifecycleManager.getMutableState());
+
+        // --- Recompute replay bounds exactly as the SwirldsPlatform constructor does (non-genesis) ---
+        // These MUST be read before PlatformBuilder.build(): build() takes ownership of the initialState
+        // reservation and closes it during construction (copyMutableState + startup handling), after which
+        // initialState.get() throws ReferenceCountException.
+        final long startingRound = initialState.get().getRound();
+        final long pcesReplayLowerBound = ancientThresholdOf(state);
+
+        // Computed deterministically from config by the same public helper ServicesMain uses.
+        final int transactionOffsetNanos = ServicesMain.transactionOffsetNanos(platformConfig);
+        hedera.setTxnOffsetNanos(transactionOffsetNanos);
+
+        // --- Build the platform (constructor priming runs inside build()) ---
+        final PlatformComponentBuilder componentBuilder = PlatformBuilder.create(
+                        Hedera.APP_NAME,
+                        Hedera.SWIRLD_NAME,
+                        version,
+                        initialState,
+                        consensusStateEventHandler,
+                        selfId,
+                        consensusEventStreamName,
+                        rosterHistory,
+                        stateLifecycleManager)
+                .withPlatformContext(platformContext)
+                .withConfiguration(platformConfig)
+                .withKeysAndCerts(keysAndCerts)
+                .withExecutionLayer(hedera)
+                .withStaleEventConsumer(hedera)
+                .withTransactionOffsetNanos(transactionOffsetNanos)
+                .buildComponentBuilder();
+
+        final Platform platform = componentBuilder.build();
+        final PlatformBuildingBlocks blocks = componentBuilder.getBuildingBlocks();
+
+        boolean started = false;
+        try {
+            log.info(
+                    "Driving PCES replay: startingRound={}, pcesReplayLowerBound={}",
+                    startingRound,
+                    pcesReplayLowerBound);
+
+            // --- Drive the body of SwirldsPlatform.start() MINUS startGossip() ---
+            platformContext.getRecycleBin().start();
+            platformContext.getMetrics().start();
+            blocks.platformCoordinator().start();
+            started = true; // wiring model is now started; destroy()/stop() is safe from here on
+            blocks.platformComponents().pcesModule().replayPcesEvents(pcesReplayLowerBound, startingRound);
+            // NOTE: deliberately NOT calling blocks.platformCoordinator().startGossip()
+
+            // --- Capture the resulting state and dump it to disk (ADR-003 steps 3-4) ---
+            final long resultRound = dumpResultingState(blocks, outDir);
+            log.info("PCES replay complete. Resulting state round: {}, written under {}", resultRound, outDir);
+            return resultRound;
+        } finally {
+            // platform.destroy() calls platformCoordinator.stop(), which throws if the wiring model was never
+            // started. Only destroy when start succeeded, and never let cleanup mask the original exception.
+            if (started) {
+                try {
+                    platform.destroy();
+                } catch (final InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                } catch (final RuntimeException e) {
+                    log.warn("Error while destroying platform during cleanup", e);
+                }
+            }
+        }
+    }
+
+    /**
+     * Pulls the latest immutable state from the nexus, marks it for saving, and dumps it to disk, blocking until the
+     * write completes.
+     *
+     * @return the round of the dumped state
+     */
+    private static long dumpResultingState(@NonNull final PlatformBuildingBlocks blocks, @NonNull final Path outDir) {
+        try (final ReservedSignedState reserved =
+                blocks.latestImmutableStateNexus().getState("replay-pces result")) {
+            if (reserved == null) {
+                throw new IllegalStateException(
+                        "PCES replay produced no immutable state — nothing to dump. "
+                                + "This usually means no events were replayed (check PCES placement and origin/round alignment).");
+            }
+            final SignedState signedState = reserved.get();
+            signedState.markAsStateToSave(StateToDiskReason.PCES_RECOVERY_COMPLETE);
+
+            final StateDumpRequest request =
+                    StateDumpRequest.create(signedState.reserve("dumping replay-pces result state"));
+            blocks.platformCoordinator().dumpStateToDisk(request);
+            request.waitForFinished().run();
+
+            return signedState.getRound();
+        }
+    }
+
+    /**
+     * Copies the PCES files into the database directory the platform will scan
+     * ({@link PcesUtilities#getDatabaseDirectory}). The {@code blocks-to-pces} tool writes its output under a
+     * node-id-0 subtree; this stages those files into the location keyed by {@code selfId} so the
+     * {@code PcesFileTracker} discovers them at platform build time.
+     */
+    private static void stagePcesFiles(
+            @NonNull final Path pcesDir,
+            @NonNull final Configuration configuration,
+            @NonNull final FileSystemManager fileSystemManager,
+            @NonNull final NodeId selfId)
+            throws IOException {
+
+        final Path databaseDirectory = PcesUtilities.getDatabaseDirectory(configuration, fileSystemManager, selfId);
+
+        // Find the directory in pcesDir that actually contains the .pces files. blocks-to-pces writes them under a
+        // node-id subdirectory (node 0). Accept either pcesDir directly containing .pces files, or a single
+        // node-id subdirectory containing them.
+        final Path sourceDir = locatePcesFiles(pcesDir);
+
+        log.info("Staging PCES files from {} into {}", sourceDir, databaseDirectory);
+
+        try (final Stream<Path> files = Files.list(sourceDir)) {
+            files.filter(p -> p.getFileName().toString().endsWith(".pces")).forEach(p -> {
+                final Path target = databaseDirectory.resolve(p.getFileName());
+                try {
+                    Files.copy(p, target);
+                } catch (final IOException e) {
+                    throw new RuntimeException("Failed to stage PCES file " + p + " -> " + target, e);
+                }
+            });
+        }
+    }
+
+    /**
+     * Resolves the directory that actually holds the {@code .pces} files. Accepts {@code pcesDir} itself if it directly
+     * contains them, otherwise descends into a single node-id subdirectory (as produced by {@code blocks-to-pces}).
+     */
+    @NonNull
+    private static Path locatePcesFiles(@NonNull final Path pcesDir) throws IOException {
+        if (containsPcesFiles(pcesDir)) {
+            return pcesDir;
+        }
+        try (final Stream<Path> entries = Files.list(pcesDir)) {
+            final List<Path> subDirs = entries.filter(Files::isDirectory)
+                    .sorted(Comparator.comparing(p -> p.getFileName().toString()))
+                    .toList();
+            for (final Path sub : subDirs) {
+                if (containsPcesFiles(sub)) {
+                    return sub;
+                }
+            }
+        }
+        throw new IOException("No .pces files found under " + pcesDir + " (or its immediate subdirectories)");
+    }
+
+    private static boolean containsPcesFiles(@NonNull final Path dir) throws IOException {
+        try (final Stream<Path> files = Files.list(dir)) {
+            return files.anyMatch(p -> p.getFileName().toString().endsWith(".pces"));
+        }
+    }
+}

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -12,10 +12,10 @@ import com.hedera.node.app.ServicesMain;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.statevalidation.ReplayPcesCommand;
 import com.swirlds.base.time.Time;
-import com.swirlds.common.context.PlatformContext;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
 import com.swirlds.platform.builder.PlatformBuilder.PersistenceScope;
+import com.swirlds.platform.context.PlatformContext;
 import com.swirlds.platform.state.ConsensusStateEventHandler;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
@@ -37,6 +37,7 @@ import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.file.FileSystemManager;
 import org.hiero.consensus.ConsensusLayerBuildingBlocks;
+import org.hiero.consensus.PathsConfig;
 import org.hiero.consensus.crypto.KeysAndCertsGenerator;
 import org.hiero.consensus.io.RecycleBinImpl;
 import org.hiero.consensus.model.node.KeysAndCerts;
@@ -415,10 +416,8 @@ public final class ReplayPcesWorkflow {
     private static void copySnapshotToOutDir(
             @NonNull final Configuration platformConfig, final long round, @NonNull final Path outDir)
             throws IOException {
-        final Path savedStateDir = Path.of(platformConfig
-                .getConfigData(org.hiero.consensus.config.PathsConfig.class)
-                .savedStateDir()
-                .toString());
+        final Path savedStateDir = Path.of(
+                platformConfig.getConfigData(PathsConfig.class).savedStateDir().toString());
         final Path roundDir = findRoundDirectory(savedStateDir, round);
         if (roundDir == null) {
             log.warn(

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -24,6 +24,7 @@ import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.state.merkle.VirtualMapStateLifecycleManager;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStoreException;
@@ -434,20 +435,18 @@ public final class ReplayPcesWorkflow {
                 return;
             }
             if (System.nanoTime() >= deadline) {
-                log.warn(
-                        "Timed out after {} waiting for block finalization under {}; first unfinalized: {}. "
-                                + "The final block stream may be incomplete (missing proof/.mf marker).",
-                        timeout,
-                        blockStreamsDir,
-                        pending.get());
-                return;
+                throw new IllegalStateException(String.format(
+                        "Timed out after %s waiting for block finalization under %s; first unfinalized: %s. "
+                                + "The final block stream is incomplete (missing proof/.mf marker); failing so the "
+                                + "output is not mistaken for a valid equivalence result.",
+                        timeout, blockStreamsDir, pending.get()));
             }
             try {
                 Thread.sleep(BLOCK_FINALIZE_POLL.toMillis());
             } catch (final InterruptedException e) {
                 Thread.currentThread().interrupt();
-                log.warn("Interrupted while awaiting block finalization", e);
-                return;
+                throw new IllegalStateException(
+                        "Interrupted while awaiting block finalization under " + blockStreamsDir, e);
             }
         }
     }
@@ -459,18 +458,19 @@ public final class ReplayPcesWorkflow {
      */
     private static Optional<String> firstUnfinalized(@NonNull final Path blockStreamsDir) {
         if (!Files.isDirectory(blockStreamsDir)) {
-            // No block output produced yet (e.g. nothing replayed) — nothing to wait for.
+            // No block output dir at all -> nothing was produced to finalize. This is itself suspicious for a
+            // normal replay; treat as "nothing pending" ONLY if no blocks were expected. If blocks were
+            // expected, the caller's own check (below) will catch an empty output. Keep returning empty here
+            // so a genuinely block-free replay does not hang, but see the caller note in step 3.
             return Optional.empty();
         }
         try (final Stream<Path> files = Files.walk(blockStreamsDir)) {
             return files.filter(Files::isRegularFile)
                     .map(Path::toString)
                     .filter(name -> {
-                        // A pending-proof json means a block is still awaiting its proof.
                         if (name.endsWith(".pnd.json") || name.endsWith(".pnd.gz") || name.endsWith(".pnd")) {
                             return true;
                         }
-                        // A complete block file without its .mf marker is not finalized yet.
                         if (name.endsWith(".blk.gz")) {
                             return !Files.exists(
                                     Path.of(name.substring(0, name.length() - ".blk.gz".length()) + ".mf"));
@@ -482,10 +482,9 @@ public final class ReplayPcesWorkflow {
                     })
                     .findFirst();
         } catch (final IOException e) {
-            log.warn("Error scanning block output for finalization under {}", blockStreamsDir, e);
-            // On scan error, don't block forever — treat as "can't confirm"; caller's timeout still applies
-            // on subsequent iterations. Return empty to avoid a tight error loop.
-            return Optional.empty();
+            // Do NOT treat a scan failure as success. Surface it so the command fails rather than reporting a
+            // possibly-incomplete block stream as valid.
+            throw new UncheckedIOException("Failed scanning block output for finalization under " + blockStreamsDir, e);
         }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -11,6 +11,7 @@ import com.hedera.node.app.Hedera;
 import com.hedera.node.app.ServicesMain;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.statevalidation.ReplayPcesCommand;
+import com.swirlds.base.time.Time;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
@@ -28,15 +29,15 @@ import java.nio.file.Path;
 import java.security.KeyStoreException;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.file.FileSystemManager;
 import org.hiero.consensus.ConsensusLayerBuildingBlocks;
-import org.hiero.consensus.config.PathsConfig;
 import org.hiero.consensus.crypto.KeysAndCertsGenerator;
 import org.hiero.consensus.io.RecycleBinImpl;
 import org.hiero.consensus.model.node.KeysAndCerts;
@@ -47,6 +48,7 @@ import org.hiero.consensus.roster.ReadableRosterStoreImpl;
 import org.hiero.consensus.roster.RosterHistory;
 import org.hiero.consensus.roster.RosterStateId;
 import org.hiero.consensus.state.SignedStateFileReader;
+import org.hiero.consensus.state.SignedStateFileWriter;
 import org.hiero.consensus.state.saved.DeserializedSignedState;
 import org.hiero.consensus.state.signed.ReservedSignedState;
 
@@ -109,7 +111,7 @@ public final class ReplayPcesWorkflow {
             @NonNull final Configuration platformConfig,
             @NonNull final FileSystemManager fileSystemManager,
             @NonNull final Metrics metrics,
-            @NonNull final com.swirlds.base.time.Time time)
+            @NonNull final Time time)
             throws IOException, InterruptedException, ParseException, KeyStoreException, ExecutionException {
         requireNonNull(stateDir);
         requireNonNull(pcesDir);
@@ -195,16 +197,30 @@ public final class ReplayPcesWorkflow {
         final Platform platform = builder.build();
         final ConsensusLayerBuildingBlocks buildingBlocks = builder.buildingBlocks();
 
-        // --- Target-round capture: tap the hashgraph consensus-round output so we can track the highest round
-        //     that reached consensus. Must be soldered before the wiring model starts. ---
-        final AtomicLong latestConsensusRound = new AtomicLong(-1);
+        // --- Final-state capture ---
+        // Tap the hashed-state output so we retain the exact ReservedSignedState the platform produced for the
+        // final replayed round (highest round <= targetRound). We keep exactly one reservation at a time, swapping
+        // in the newer state and releasing the older. flushPrimaryPipeline() flushes the state hasher, which feeds
+        // this wire, so by the time the flush returns this reference holds the final hashed state. This avoids
+        // relying on the periodic-save mechanism (which may never fire within a single hourly bucket) and the
+        // filesystem scan (which can race the async snapshot manager). Must be soldered before the model starts.
+        final AtomicReference<ReservedSignedState> capturedFinalState = new AtomicReference<>();
         buildingBlocks
-                .hashgraphModule()
-                .consensusRoundOutputWire()
-                .solderTo(
-                        "replayRoundTracker",
-                        "consensus round",
-                        round -> latestConsensusRound.set(round.getRoundNum()));
+                .stateModule()
+                .hashedStateOutputWire()
+                .solderTo("replayFinalStateCapture", "hashed state", (ReservedSignedState rs) -> {
+                    final long round = rs.get().getRound();
+                    if (round > targetRound) {
+                        // Beyond the requested target — discard the reservation given to this consumer.
+                        rs.close();
+                        return;
+                    }
+                    // Retain this state, releasing any previously captured (lower-round) one.
+                    final ReservedSignedState previous = capturedFinalState.getAndSet(rs);
+                    if (previous != null) {
+                        previous.close();
+                    }
+                });
 
         boolean started = false;
         try {
@@ -223,20 +239,28 @@ public final class ReplayPcesWorkflow {
             buildingBlocks.pcesModule().replayPcesEvents(pcesReplayLowerBound, startingRound);
             // NOTE: deliberately NOT calling buildingBlocks.gossipModule().startInputWire().inject(...)
 
-            // --- Flush the pipeline so state snapshots are written to disk ---
+            // --- Flush the primary pipeline so transaction handling and state hashing complete, populating
+            //     capturedFinalState with the final hashed round. ---
             buildingBlocks.pipelineFlusher().flushPrimaryPipeline();
 
-            // --- Write the resulting state ---
-            final long resultRound;
-            if (targetRound != DEFAULT_TARGET_ROUND) {
-                resultRound = writeTargetRoundState(platformConfig, outDir, targetRound, latestConsensusRound.get());
-            } else {
-                resultRound = copyLatestSnapshotToOutDir(platformConfig, outDir);
-            }
+            // --- Write the exact final replayed state, synchronously, to the output directory ---
+            final long resultRound = writeFinalState(
+                    capturedFinalState.getAndSet(null),
+                    targetRound,
+                    platformConfig,
+                    fileSystemManager,
+                    selfId,
+                    stateLifecycleManager,
+                    outDir);
 
             log.info("PCES replay complete. Resulting state round: {}, written under {}", resultRound, outDir);
             return resultRound;
         } finally {
+            // Release any captured state that wasn't consumed by writeFinalState (e.g. on an exception path).
+            final ReservedSignedState leftover = capturedFinalState.getAndSet(null);
+            if (leftover != null) {
+                leftover.close();
+            }
             if (started) {
                 try {
                     platform.destroy();
@@ -250,71 +274,73 @@ public final class ReplayPcesWorkflow {
     }
 
     /**
-     * Writes the target-round state to the output directory. Looks for the exact round directory first; falls back to
-     * the closest available round if the periodic save didn't land on the target.
+     * Writes the captured final replayed state synchronously to {@code outDir/<round>} via
+     * {@link SignedStateFileWriter#writeSignedStateFilesToDirectory}. This is the same mechanism {@code dumpStateTask}
+     * uses; for a non-periodic state the write is synchronous, so when this method returns the state is fully on disk.
+     *
+     * <p>The method takes ownership of the reservation and releases it (the writer does so internally). If
+     * {@code capturedState} is null, no round was captured — either nothing reached consensus, or (when a target was
+     * requested) the target was never reached.
+     *
+     * @return the round of the written state
      */
-    private static long writeTargetRoundState(
-            @NonNull final Configuration platformConfig,
-            @NonNull final Path outDir,
+    private static long writeFinalState(
+            final ReservedSignedState capturedState,
             final long targetRound,
-            final long actualLatestRound)
+            @NonNull final Configuration platformConfig,
+            @NonNull final FileSystemManager fileSystemManager,
+            @NonNull final NodeId selfId,
+            @NonNull final VirtualMapStateLifecycleManager stateLifecycleManager,
+            @NonNull final Path outDir)
             throws IOException {
 
-        if (actualLatestRound < targetRound) {
+        if (capturedState == null) {
+            if (targetRound != DEFAULT_TARGET_ROUND) {
+                throw new IllegalStateException(
+                        "Target round " + targetRound + " was never reached during replay. The PCES does not contain "
+                                + "enough rounds past the target to decide it. Regenerate with blocks-to-pces covering "
+                                + "more rounds past the target, or choose a target within the decided range.");
+            }
             throw new IllegalStateException(
-                    "Target round " + targetRound + " never reached consensus during replay (latest was "
-                            + actualLatestRound + "). The PCES does not contain enough rounds past the target to "
-                            + "decide it. Regenerate with blocks-to-pces covering more rounds past the target "
-                            + "(increase DECISION_MARGIN_ROUNDS), or choose a target within the decided range.");
+                    "PCES replay produced no consensus rounds — nothing to write. "
+                            + "Check PCES placement and origin/round alignment.");
         }
 
-        final Path savedStateDir =
-                platformConfig.getConfigData(PathsConfig.class).savedStateDir();
-        final Path existingRoundDir = findRoundDirectory(savedStateDir, targetRound);
-        if (existingRoundDir != null) {
-            return copyRoundDirToOutDir(existingRoundDir, targetRound, outDir);
-        }
+        try {
+            final long round = capturedState.get().getRound();
+            if (targetRound != DEFAULT_TARGET_ROUND && round < targetRound) {
+                throw new IllegalStateException(
+                        "Target round " + targetRound + " never reached consensus during replay (highest was "
+                                + round + "). The PCES does not contain enough rounds past the target to decide it. "
+                                + "Regenerate with blocks-to-pces covering more rounds past the target, or choose a "
+                                + "target within the decided range.");
+            }
 
-        log.info("Target round {} was not periodically saved; falling back to closest available round", targetRound);
-        final Path closestRoundDir = findLatestRoundDirectory(savedStateDir);
-        if (closestRoundDir == null) {
-            throw new IllegalStateException("No saved state found under " + savedStateDir + " after replay. "
-                    + "This usually means no events were replayed.");
-        }
+            final Path destination = outDir.resolve(Long.toString(round));
+            log.info("Writing final replayed state for round {} to {}", round, destination);
 
-        final long closestRound = Long.parseLong(closestRoundDir.getFileName().toString());
-        log.info("Closest available saved round is {} (target was {})", closestRound, targetRound);
-        return copyRoundDirToOutDir(closestRoundDir, closestRound, outDir);
+            // Synchronous write: writeSignedStateFilesToDirectory takes ownership of the reservation and releases it.
+            // The state's stateToDiskReason is not PERIODIC_SNAPSHOT, so the write is performed synchronously and is
+            // complete when this call returns.
+            SignedStateFileWriter.writeSignedStateFilesToDirectory(
+                    platformConfig,
+                    fileSystemManager,
+                    selfId,
+                    destination,
+                    capturedState,
+                    stateLifecycleManager);
+
+            log.info("Final replayed state for round {} written to {}", round, destination);
+            return round;
+        } catch (final RuntimeException | IOException e) {
+            // writeSignedStateFilesToDirectory only releases on its own success path; ensure we don't leak on failure.
+            if (!capturedState.isClosed()) {
+                capturedState.close();
+            }
+            throw e;
+        }
     }
-
-    /**
-     * Copies a round directory to the output directory, returning the round number.
-     */
-    private static long copyRoundDirToOutDir(@NonNull final Path roundDir, final long round, @NonNull final Path outDir)
-            throws IOException {
-        final Path destination = outDir.resolve(Long.toString(round));
-        log.info("Copying replay state from {} to {}", roundDir, destination);
-        Files.createDirectories(destination);
-        try (final Stream<Path> files = Files.walk(roundDir)) {
-            files.forEach(source -> {
-                final Path target = destination.resolve(roundDir.relativize(source));
-                try {
-                    if (Files.isDirectory(source)) {
-                        Files.createDirectories(target);
-                    } else {
-                        Files.copy(source, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                    }
-                } catch (final IOException e) {
-                    throw new java.io.UncheckedIOException("Failed to copy " + source + " -> " + target, e);
-                }
-            });
-        }
-        log.info("Replay state for round {} copied to {}", round, destination);
-        return round;
-    }
-
-    /**
-     * Copies the PCES files into the database directory the platform will scan
+     /** Copies the PCES files into the database directory the platform will scan
      * ({@link PcesUtilities#getDatabaseDirectory}). The {@code blocks-to-pces} tool writes its output under a
      * node-id-0 subtree; this stages those files into the location keyed by {@code selfId} so the
      * {@code PcesFileTracker} discovers them at platform build time.
@@ -379,36 +405,6 @@ public final class ReplayPcesWorkflow {
     private static boolean containsPcesFiles(@NonNull final Path dir) throws IOException {
         try (final Stream<Path> files = Files.list(dir)) {
             return files.anyMatch(p -> p.getFileName().toString().endsWith(".pces"));
-        }
-    }
-
-    /**
-     * Locates the latest state snapshot written by the platform, copies it to {@code outDir}, and returns the round.
-     */
-    private static long copyLatestSnapshotToOutDir(
-            @NonNull final Configuration platformConfig, @NonNull final Path outDir) throws IOException {
-        final Path savedStateDir =
-                platformConfig.getConfigData(PathsConfig.class).savedStateDir();
-        final Path roundDir = findLatestRoundDirectory(savedStateDir);
-        if (roundDir == null) {
-            throw new IllegalStateException("PCES replay produced no saved state under " + savedStateDir
-                    + ". This usually means no events were replayed "
-                    + "(check PCES placement and origin/round alignment).");
-        }
-        final long round = Long.parseLong(roundDir.getFileName().toString());
-        return copyRoundDirToOutDir(roundDir, round, outDir);
-    }
-
-    private static Path findRoundDirectory(final Path root, final long round) throws IOException {
-        if (!Files.isDirectory(root)) {
-            return null;
-        }
-        final String roundName = Long.toString(round);
-        try (final Stream<Path> dirs = Files.walk(root)) {
-            return dirs.filter(Files::isDirectory)
-                    .filter(p -> p.getFileName().toString().equals(roundName))
-                    .findFirst()
-                    .orElse(null);
         }
     }
 

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.file.FileSystemManager;
+import org.hiero.consensus.config.PathsConfig;
 import org.hiero.consensus.crypto.KeysAndCertsGenerator;
 import org.hiero.consensus.io.RecycleBinImpl;
 import org.hiero.consensus.model.node.KeysAndCerts;
@@ -219,7 +220,7 @@ public final class ReplayPcesWorkflow {
             // NOTE: deliberately NOT calling blocks.platformCoordinator().startGossip()
 
             // --- Capture the resulting state and dump it to disk (ADR-003 steps 3-4) ---
-            final long resultRound = dumpResultingState(blocks, outDir);
+            final long resultRound = dumpResultingState(blocks, platformConfig, outDir);
             log.info("PCES replay complete. Resulting state round: {}, written under {}", resultRound, outDir);
             return resultRound;
         } finally {
@@ -243,7 +244,10 @@ public final class ReplayPcesWorkflow {
      *
      * @return the round of the dumped state
      */
-    private static long dumpResultingState(@NonNull final PlatformBuildingBlocks blocks, @NonNull final Path outDir) {
+    private static long dumpResultingState(
+            @NonNull final PlatformBuildingBlocks blocks,
+            @NonNull Configuration platformConfig,
+            @NonNull final Path outDir) {
         try (final ReservedSignedState reserved =
                 blocks.latestImmutableStateNexus().getState("replay-pces result")) {
             if (reserved == null) {
@@ -259,7 +263,16 @@ public final class ReplayPcesWorkflow {
             blocks.platformCoordinator().dumpStateToDisk(request);
             request.waitForFinished().run();
 
-            return signedState.getRound();
+            final long round = signedState.getRound();
+
+            // Copy the snapshot from the platform's internal saved-state location to the caller's outDir.
+            try {
+                copySnapshotToOutDir(platformConfig, round, outDir);
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+
+            return round;
         }
     }
 
@@ -284,6 +297,22 @@ public final class ReplayPcesWorkflow {
         final Path sourceDir = locatePcesFiles(pcesDir);
 
         log.info("Staging PCES files from {} into {}", sourceDir, databaseDirectory);
+
+        // Ensure a clean database directory — leftover .pces files from a prior run would
+        // be picked up by PcesFileTracker and corrupt the replay.
+        if (Files.isDirectory(databaseDirectory)) {
+            try (final Stream<Path> stale = Files.list(databaseDirectory)) {
+                stale.filter(p -> p.getFileName().toString().endsWith(".pces")).forEach(p -> {
+                    try {
+                        Files.delete(p);
+                    } catch (final IOException e) {
+                        throw new RuntimeException("Failed to remove stale PCES file " + p, e);
+                    }
+                });
+            }
+        } else {
+            Files.createDirectories(databaseDirectory);
+        }
 
         try (final Stream<Path> files = Files.list(sourceDir)) {
             files.filter(p -> p.getFileName().toString().endsWith(".pces")).forEach(p -> {
@@ -322,6 +351,63 @@ public final class ReplayPcesWorkflow {
     private static boolean containsPcesFiles(@NonNull final Path dir) throws IOException {
         try (final Stream<Path> files = Files.list(dir)) {
             return files.anyMatch(p -> p.getFileName().toString().endsWith(".pces"));
+        }
+    }
+
+    /**
+     * Copies the state snapshot written by the platform to the caller-specified output directory.
+     * The platform writes to {@code <savedStateDir>/<appName>/<swirldName>/<selfId>/<round>/}.
+     * We locate that directory and copy its contents into {@code <outDir>/<round>/}.
+     */
+    private static void copySnapshotToOutDir(
+            @NonNull final Configuration platformConfig, final long round, @NonNull final Path outDir)
+            throws IOException {
+        // Resolve the platform's saved-state directory for this round. The convention is:
+        //   savedStateDir / appName / swirldName / selfId / round
+        // where savedStateDir defaults to "./data/saved", appName = ServicesMain class name, swirldName = "123".
+        // Rather than reconstruct the convention, scan for the round directory.
+        final Path savedStateDir =
+                platformConfig.getConfigData(PathsConfig.class).savedStateDir();
+        final Path roundDir = findRoundDirectory(savedStateDir, round);
+        if (roundDir == null) {
+            log.warn(
+                    "Could not find saved state directory for round {} under {}; outDir copy skipped.",
+                    round,
+                    savedStateDir);
+            return;
+        }
+
+        final Path destination = outDir.resolve(Long.toString(round));
+        log.info("Copying replay state from {} to {}", roundDir, destination);
+        Files.createDirectories(destination);
+        try (final Stream<Path> files = Files.walk(roundDir)) {
+            files.forEach(source -> {
+                final Path target = destination.resolve(roundDir.relativize(source));
+                try {
+                    if (Files.isDirectory(source)) {
+                        Files.createDirectories(target);
+                    } else {
+                        Files.copy(source, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } catch (final IOException e) {
+                    throw new java.io.UncheckedIOException("Failed to copy " + source + " -> " + target, e);
+                }
+            });
+        }
+        log.info("Replay state for round {} copied to {}", round, destination);
+    }
+
+    /**
+     * Searches for a directory named {@code <round>} under the saved-state root (recursively).
+     * Returns the first match, or null if not found.
+     */
+    private static Path findRoundDirectory(final Path root, final long round) throws IOException {
+        final String roundName = Long.toString(round);
+        try (final Stream<Path> dirs = Files.walk(root)) {
+            return dirs.filter(Files::isDirectory)
+                    .filter(p -> p.getFileName().toString().equals(roundName))
+                    .findFirst()
+                    .orElse(null);
         }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -50,6 +50,7 @@ import org.hiero.consensus.state.SignedStateFileReader;
 import org.hiero.consensus.state.SignedStateFileWriter;
 import org.hiero.consensus.state.saved.DeserializedSignedState;
 import org.hiero.consensus.state.signed.ReservedSignedState;
+import org.hiero.consensus.state.snapshot.StateToDiskReason;
 
 /**
  * Loads a saved state, replays a PCES stream on top of it using the consensus node's <b>real</b> replay mechanism, and
@@ -252,6 +253,11 @@ public final class ReplayPcesWorkflow {
                     stateLifecycleManager,
                     outDir);
 
+            // Publish the snapshot at the flat, documented location <outDir>/<round>/. dumpStateToDisk writes to
+            // the platform's internal saved-state path; copy that round directory out to the caller's outDir so
+            // the result is where the CLI/README promises and is directly usable as a --state-dir for a follow-up.
+            copySnapshotToOutDir(platformConfig, resultRound, outDir);
+
             log.info("PCES replay complete. Resulting state round: {}, written under {}", resultRound, outDir);
             return resultRound;
         } finally {
@@ -317,11 +323,16 @@ public final class ReplayPcesWorkflow {
             final Path destination = outDir.resolve(Long.toString(round));
             log.info("Writing final replayed state for round {} to {}", round, destination);
 
-            // Synchronous write: writeSignedStateFilesToDirectory takes ownership of the reservation and releases it.
-            // The state's stateToDiskReason is not PERIODIC_SNAPSHOT, so the write is performed synchronously and is
-            // complete when this call returns.
-            SignedStateFileWriter.writeSignedStateFilesToDirectory(
-                    platformConfig, fileSystemManager, selfId, destination, capturedState, stateLifecycleManager);
+            // writeSignedStateToDisk creates the target directory (through a temp dir + atomic rename),
+            // deriving the round subdirectory under the given base directory, and marks the reason.
+            SignedStateFileWriter.writeSignedStateToDisk(
+                    platformConfig,
+                    fileSystemManager,
+                    selfId,
+                    outDir, // BASE directory; the writer creates <base>/<round>/ itself
+                    StateToDiskReason.PCES_RECOVERY_COMPLETE,
+                    capturedState,
+                    stateLifecycleManager);
 
             log.info("Final replayed state for round {} written to {}", round, destination);
             return round;
@@ -401,22 +412,44 @@ public final class ReplayPcesWorkflow {
         }
     }
 
-    private static Path findLatestRoundDirectory(final Path root) throws IOException {
-        if (!Files.isDirectory(root)) {
-            return null;
+    private static void copySnapshotToOutDir(
+            @NonNull final Configuration platformConfig, final long round, @NonNull final Path outDir)
+            throws IOException {
+        final Path savedStateDir = Path.of(platformConfig
+                .getConfigData(org.hiero.consensus.config.PathsConfig.class)
+                .savedStateDir()
+                .toString());
+        final Path roundDir = findRoundDirectory(savedStateDir, round);
+        if (roundDir == null) {
+            log.warn(
+                    "Could not find saved state dir for round {} under {}; outDir copy skipped.", round, savedStateDir);
+            return;
         }
+        final Path destination = outDir.resolve(Long.toString(round));
+        Files.createDirectories(destination);
+        try (final Stream<Path> files = Files.walk(roundDir)) {
+            files.forEach(source -> {
+                final Path target = destination.resolve(roundDir.relativize(source));
+                try {
+                    if (Files.isDirectory(source)) {
+                        Files.createDirectories(target);
+                    } else {
+                        Files.copy(source, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } catch (final IOException e) {
+                    throw new java.io.UncheckedIOException("Failed to copy " + source + " -> " + target, e);
+                }
+            });
+        }
+        log.info("Replay state for round {} copied to {}", round, destination);
+    }
+
+    private static Path findRoundDirectory(final Path root, final long round) throws IOException {
+        final String roundName = Long.toString(round);
         try (final Stream<Path> dirs = Files.walk(root)) {
             return dirs.filter(Files::isDirectory)
-                    .filter(p -> {
-                        try {
-                            Long.parseLong(p.getFileName().toString());
-                            return true;
-                        } catch (final NumberFormatException e) {
-                            return false;
-                        }
-                    })
-                    .max(Comparator.comparingLong(
-                            p -> Long.parseLong(p.getFileName().toString())))
+                    .filter(p -> p.getFileName().toString().equals(roundName))
+                    .findFirst()
                     .orElse(null);
         }
     }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -27,8 +27,10 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.KeyStoreException;
+import java.time.Duration;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -243,6 +245,12 @@ public final class ReplayPcesWorkflow {
             //     capturedFinalState with the final hashed round. ---
             buildingBlocks.pipelineFlusher().flushPrimaryPipeline();
 
+            // The last block(s) are finalized asynchronously: block proofs (and the .mf completion markers) are
+            // written from the signing callback, which flushPrimaryPipeline() does NOT wait for. Before we write
+            // the state and destroy the platform, wait until every complete block file has its .mf marker and no
+            // pending-proof (.pnd.json) files remain, so the block-stream output is valid for comparison.
+            awaitBlockFinalization(outDir.resolve("blockStreams"), BLOCK_FINALIZE_TIMEOUT);
+
             // --- Write the exact final replayed state, synchronously, to the output directory ---
             final long resultRound = writeFinalState(
                     capturedFinalState.getAndSet(null),
@@ -318,8 +326,8 @@ public final class ReplayPcesWorkflow {
             final Path destination = outDir.resolve(Long.toString(round));
             log.info("Writing final replayed state for round {} to {}", round, destination);
 
-            // writeSignedStateToDisk creates the target directory (through a temp dir + atomic rename),
-            // deriving the round subdirectory under the given base directory, and marks the reason.
+            // writeSignedStateToDisk atomically creates the exact destination directory; `destination` already
+            // includes the selected round (<out>/<round>).
             SignedStateFileWriter.writeSignedStateToDisk(
                     platformConfig,
                     fileSystemManager,
@@ -404,6 +412,80 @@ public final class ReplayPcesWorkflow {
     private static boolean containsPcesFiles(@NonNull final Path dir) throws IOException {
         try (final Stream<Path> files = Files.list(dir)) {
             return files.anyMatch(p -> p.getFileName().toString().endsWith(".pces"));
+        }
+    }
+
+    private static final Duration BLOCK_FINALIZE_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration BLOCK_FINALIZE_POLL = Duration.ofMillis(200);
+
+    /**
+     * Waits until all block files under {@code blockStreamsDir} are finalized: every {@code .blk.gz}
+     * (or {@code .blk}) has a sibling {@code .mf} marker and no {@code .pnd.json} pending-proof files
+     * remain. Block proofs and their markers are written asynchronously from the signing callback after
+     * the wiring pipeline is flushed, so this closes the race before the state is written and the platform
+     * is destroyed. Times out (rather than hanging) if a signature never completes.
+     */
+    private static void awaitBlockFinalization(@NonNull final Path blockStreamsDir, @NonNull final Duration timeout) {
+        final long deadline = System.nanoTime() + timeout.toNanos();
+        while (true) {
+            final Optional<String> pending = firstUnfinalized(blockStreamsDir);
+            if (pending.isEmpty()) {
+                log.info("All block files finalized under {}", blockStreamsDir);
+                return;
+            }
+            if (System.nanoTime() >= deadline) {
+                log.warn(
+                        "Timed out after {} waiting for block finalization under {}; first unfinalized: {}. "
+                                + "The final block stream may be incomplete (missing proof/.mf marker).",
+                        timeout,
+                        blockStreamsDir,
+                        pending.get());
+                return;
+            }
+            try {
+                Thread.sleep(BLOCK_FINALIZE_POLL.toMillis());
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                log.warn("Interrupted while awaiting block finalization", e);
+                return;
+            }
+        }
+    }
+
+    /**
+     * Returns a description of the first block file that is not yet finalized (a .blk/.blk.gz without a
+     * sibling .mf, or a leftover .pnd.json), or empty if all blocks are finalized. Searches the
+     * node-scoped subdirectory tree under blockStreamsDir.
+     */
+    private static Optional<String> firstUnfinalized(@NonNull final Path blockStreamsDir) {
+        if (!Files.isDirectory(blockStreamsDir)) {
+            // No block output produced yet (e.g. nothing replayed) — nothing to wait for.
+            return Optional.empty();
+        }
+        try (final Stream<Path> files = Files.walk(blockStreamsDir)) {
+            return files.filter(Files::isRegularFile)
+                    .map(Path::toString)
+                    .filter(name -> {
+                        // A pending-proof json means a block is still awaiting its proof.
+                        if (name.endsWith(".pnd.json") || name.endsWith(".pnd.gz") || name.endsWith(".pnd")) {
+                            return true;
+                        }
+                        // A complete block file without its .mf marker is not finalized yet.
+                        if (name.endsWith(".blk.gz")) {
+                            return !Files.exists(
+                                    Path.of(name.substring(0, name.length() - ".blk.gz".length()) + ".mf"));
+                        }
+                        if (name.endsWith(".blk")) {
+                            return !Files.exists(Path.of(name.substring(0, name.length() - ".blk".length()) + ".mf"));
+                        }
+                        return false;
+                    })
+                    .findFirst();
+        } catch (final IOException e) {
+            log.warn("Error scanning block output for finalization under {}", blockStreamsDir, e);
+            // On scan error, don't block forever — treat as "can't confirm"; caller's timeout still applies
+            // on subsequent iterations. Return empty to avoid a tight error loop.
+            return Optional.empty();
         }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -37,7 +37,6 @@ import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.file.FileSystemManager;
 import org.hiero.consensus.ConsensusLayerBuildingBlocks;
-import org.hiero.consensus.PathsConfig;
 import org.hiero.consensus.crypto.KeysAndCertsGenerator;
 import org.hiero.consensus.io.RecycleBinImpl;
 import org.hiero.consensus.model.node.KeysAndCerts;
@@ -254,11 +253,6 @@ public final class ReplayPcesWorkflow {
                     stateLifecycleManager,
                     outDir);
 
-            // Publish the snapshot at the flat, documented location <outDir>/<round>/. dumpStateToDisk writes to
-            // the platform's internal saved-state path; copy that round directory out to the caller's outDir so
-            // the result is where the CLI/README promises and is directly usable as a --state-dir for a follow-up.
-            copySnapshotToOutDir(platformConfig, resultRound, outDir);
-
             log.info("PCES replay complete. Resulting state round: {}, written under {}", resultRound, outDir);
             return resultRound;
         } finally {
@@ -330,7 +324,7 @@ public final class ReplayPcesWorkflow {
                     platformConfig,
                     fileSystemManager,
                     selfId,
-                    outDir, // BASE directory; the writer creates <base>/<round>/ itself
+                    destination,
                     StateToDiskReason.PCES_RECOVERY_COMPLETE,
                     capturedState,
                     stateLifecycleManager);
@@ -410,46 +404,6 @@ public final class ReplayPcesWorkflow {
     private static boolean containsPcesFiles(@NonNull final Path dir) throws IOException {
         try (final Stream<Path> files = Files.list(dir)) {
             return files.anyMatch(p -> p.getFileName().toString().endsWith(".pces"));
-        }
-    }
-
-    private static void copySnapshotToOutDir(
-            @NonNull final Configuration platformConfig, final long round, @NonNull final Path outDir)
-            throws IOException {
-        final Path savedStateDir = Path.of(
-                platformConfig.getConfigData(PathsConfig.class).savedStateDir().toString());
-        final Path roundDir = findRoundDirectory(savedStateDir, round);
-        if (roundDir == null) {
-            log.warn(
-                    "Could not find saved state dir for round {} under {}; outDir copy skipped.", round, savedStateDir);
-            return;
-        }
-        final Path destination = outDir.resolve(Long.toString(round));
-        Files.createDirectories(destination);
-        try (final Stream<Path> files = Files.walk(roundDir)) {
-            files.forEach(source -> {
-                final Path target = destination.resolve(roundDir.relativize(source));
-                try {
-                    if (Files.isDirectory(source)) {
-                        Files.createDirectories(target);
-                    } else {
-                        Files.copy(source, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                    }
-                } catch (final IOException e) {
-                    throw new java.io.UncheckedIOException("Failed to copy " + source + " -> " + target, e);
-                }
-            });
-        }
-        log.info("Replay state for round {} copied to {}", round, destination);
-    }
-
-    private static Path findRoundDirectory(final Path root, final long round) throws IOException {
-        final String roundName = Long.toString(round);
-        try (final Stream<Path> dirs = Files.walk(root)) {
-            return dirs.filter(Files::isDirectory)
-                    .filter(p -> p.getFileName().toString().equals(roundName))
-                    .findFirst()
-                    .orElse(null);
         }
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -29,7 +29,6 @@ import java.nio.file.Path;
 import java.security.KeyStoreException;
 import java.util.Comparator;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -301,9 +300,8 @@ public final class ReplayPcesWorkflow {
                                 + "enough rounds past the target to decide it. Regenerate with blocks-to-pces covering "
                                 + "more rounds past the target, or choose a target within the decided range.");
             }
-            throw new IllegalStateException(
-                    "PCES replay produced no consensus rounds — nothing to write. "
-                            + "Check PCES placement and origin/round alignment.");
+            throw new IllegalStateException("PCES replay produced no consensus rounds — nothing to write. "
+                    + "Check PCES placement and origin/round alignment.");
         }
 
         try {
@@ -323,12 +321,7 @@ public final class ReplayPcesWorkflow {
             // The state's stateToDiskReason is not PERIODIC_SNAPSHOT, so the write is performed synchronously and is
             // complete when this call returns.
             SignedStateFileWriter.writeSignedStateFilesToDirectory(
-                    platformConfig,
-                    fileSystemManager,
-                    selfId,
-                    destination,
-                    capturedState,
-                    stateLifecycleManager);
+                    platformConfig, fileSystemManager, selfId, destination, capturedState, stateLifecycleManager);
 
             log.info("Final replayed state for round {} written to {}", round, destination);
             return round;
@@ -340,7 +333,7 @@ public final class ReplayPcesWorkflow {
             throw e;
         }
     }
-     /** Copies the PCES files into the database directory the platform will scan
+    /** Copies the PCES files into the database directory the platform will scan
      * ({@link PcesUtilities#getDatabaseDirectory}). The {@code blocks-to-pces} tool writes its output under a
      * node-id-0 subtree; this stages those files into the location keyed by {@code selfId} so the
      * {@code PcesFileTracker} discovers them at platform build time.

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/ReplayPcesWorkflow.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.statevalidation.blockstream;
 
+import static com.hedera.statevalidation.ReplayPcesCommand.DEFAULT_TARGET_ROUND;
 import static java.util.Objects.requireNonNull;
 import static org.hiero.consensus.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.ancientThresholdOf;
@@ -9,18 +10,15 @@ import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.node.app.Hedera;
 import com.hedera.node.app.ServicesMain;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.statevalidation.ReplayPcesCommand;
 import com.swirlds.common.context.PlatformContext;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
-import com.swirlds.platform.builder.PlatformBuilder;
-import com.swirlds.platform.builder.PlatformBuildingBlocks;
-import com.swirlds.platform.builder.PlatformComponentBuilder;
+import com.swirlds.platform.builder.PlatformBuilder.PersistenceScope;
 import com.swirlds.platform.state.ConsensusStateEventHandler;
-import com.swirlds.platform.state.snapshot.DeserializedSignedState;
-import com.swirlds.platform.state.snapshot.SignedStateFileReader;
-import com.swirlds.platform.state.snapshot.StateDumpRequest;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.platform.system.Platform;
+import com.swirlds.platform.test.fixtures.builder.TestPlatformBuilder;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.state.merkle.VirtualMapStateLifecycleManager;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -31,11 +29,13 @@ import java.security.KeyStoreException;
 import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.file.FileSystemManager;
+import org.hiero.consensus.ConsensusLayerBuildingBlocks;
 import org.hiero.consensus.config.PathsConfig;
 import org.hiero.consensus.crypto.KeysAndCertsGenerator;
 import org.hiero.consensus.io.RecycleBinImpl;
@@ -46,34 +46,36 @@ import org.hiero.consensus.roster.ReadableRosterStore;
 import org.hiero.consensus.roster.ReadableRosterStoreImpl;
 import org.hiero.consensus.roster.RosterHistory;
 import org.hiero.consensus.roster.RosterStateId;
+import org.hiero.consensus.state.SignedStateFileReader;
+import org.hiero.consensus.state.saved.DeserializedSignedState;
 import org.hiero.consensus.state.signed.ReservedSignedState;
-import org.hiero.consensus.state.signed.SignedState;
-import org.hiero.consensus.state.snapshot.StateToDiskReason;
 
 /**
  * Loads a saved state, replays a PCES stream on top of it using the consensus node's <b>real</b> replay mechanism, and
  * dumps the resulting state to disk.
  *
  * <p>This intentionally reuses the production startup path rather than a bespoke replay harness. It constructs the same
- * {@link Hedera} execution layer and {@link Platform} that {@link ServicesMain#main} builds, then drives the body of
- * {@link com.swirlds.platform.SwirldsPlatform#start()} <i>minus gossip</i>:
+ * {@link Hedera} execution layer and {@link Platform} that {@link ServicesMain#main} builds via
+ * {@link TestPlatformBuilder}, which performs all restart priming (consensus snapshot override, event window,
+ * ISS-detector seeding, {@code onStateInitialized}, etc.) automatically. It then drives the body of
+ * {@code SwirldsPlatform.start()} <i>minus gossip</i>:
  *
  * <ol>
- *   <li>Build the platform exactly as {@code ServicesMain} does — loading the initial state, initializing the States
- *       API, deriving roster/keys, and calling {@link PlatformBuilder}. The {@code SwirldsPlatform} constructor (run
- *       inside {@link PlatformComponentBuilder#build()}) performs all the restart priming
- *       ({@code consensusSnapshotOverride}, {@code updateEventWindow}, signature-collector and ISS-detector seeding,
- *       etc.) automatically.</li>
- *   <li>Start the recycle bin, metrics, and platform coordinator (the first three lines of {@code start()}).</li>
+ *   <li>Build the platform via {@link TestPlatformBuilder} — loading the initial state, initializing the States API,
+ *       deriving roster/keys, and constructing all consensus-layer modules. The builder's {@code build()} performs all
+ *       the restart priming that {@code SwirldsPlatform}'s constructor does.</li>
+ *   <li>Start the recycle bin, metrics, and wiring model.</li>
  *   <li>Call {@code pcesModule().replayPcesEvents(pcesReplayLowerBound, startingRound)} — the same call normal startup
- *       makes — but do <b>not</b> call {@code startGossip()}.</li>
- *   <li>Pull the latest immutable state, mark it {@link StateToDiskReason#PCES_RECOVERY_COMPLETE}, and dump it to disk,
- *       blocking until the write finishes.</li>
+ *       makes — but do <b>not</b> start gossip.</li>
+ *   <li>Flush the pipeline, locate the saved state the platform wrote, and copy it to the output directory. When a
+ *       {@code --target-round} is specified, the exact target-round snapshot is located and copied instead of the
+ *       latest periodic snapshot.</li>
  * </ol>
  *
- * <p>The replay bounds are recomputed from the loaded state using the same public helpers the {@code SwirldsPlatform}
- * constructor uses ({@code initialState.getRound()} and {@link org.hiero.consensus.platformstate.PlatformStateUtils#ancientThresholdOf}),
- * so they are identical to a production restart — no reflection into platform internals is required.
+ * <p>The replay bounds are recomputed from the loaded state using the same public helpers the platform constructor
+ * uses ({@code initialState.getRound()} and
+ * {@link org.hiero.consensus.platformstate.PlatformStateUtils#ancientThresholdOf}), so they are identical to a
+ * production restart — no reflection into platform internals is required.
  */
 public final class ReplayPcesWorkflow {
 
@@ -88,6 +90,7 @@ public final class ReplayPcesWorkflow {
      * @param pcesDir the directory containing the PCES files to replay (produced by {@code blocks-to-pces})
      * @param outDir the directory where the resulting state snapshot will be written
      * @param selfId the node id to run as; must match the node id the PCES files were generated for
+     * @param targetRound the last round that should be applied ({@link ReplayPcesCommand#DEFAULT_TARGET_ROUND} for all)
      * @param consensusEventStreamName the consensus event stream name (e.g. "0.0.3"); supplied by the caller because
      *     {@code ServicesMain} derives it via private helpers. For replay it only names an output directory.
      * @param platformConfig the fully-built platform configuration (production-mirroring, plus replay flags)
@@ -101,6 +104,7 @@ public final class ReplayPcesWorkflow {
             @NonNull final Path pcesDir,
             @NonNull final Path outDir,
             @NonNull final NodeId selfId,
+            final long targetRound,
             @NonNull final String consensusEventStreamName,
             @NonNull final Configuration platformConfig,
             @NonNull final FileSystemManager fileSystemManager,
@@ -124,7 +128,6 @@ public final class ReplayPcesWorkflow {
                 PlatformContext.create(platformConfig, time, metrics, fileSystemManager, recycleBin);
 
         // --- Place the PCES files where the PcesFileTracker will scan them, before the platform is built ---
-        // DefaultPcesModule.initialize scans PcesUtilities.getDatabaseDirectory(config, fsm, selfId) at build time.
         stagePcesFiles(pcesDir, platformConfig, fileSystemManager, selfId);
 
         // --- Load the initial state directly from the given path ---
@@ -133,7 +136,7 @@ public final class ReplayPcesWorkflow {
 
         log.info("Loading state from {}", stateDir);
         final DeserializedSignedState deserializedSignedState =
-                SignedStateFileReader.readState(stateDir, platformContext, stateLifecycleManager);
+                SignedStateFileReader.readState(stateDir, platformContext.getConfiguration(), stateLifecycleManager);
 
         final ReservedSignedState initialState = deserializedSignedState.reservedSignedState();
         final Hash originalHash = deserializedSignedState.originalHash();
@@ -154,78 +157,86 @@ public final class ReplayPcesWorkflow {
         final RosterHistory rosterHistory = rosterStore.getRosterHistory();
 
         // --- Generate ephemeral keys for this node ---
-        // initNodeSecurity loads keys from disk (PKCS12 keystores), which don't exist in an offline replay
-        // environment, causing KEY_LOADING_FAILED. For PCES replay we never start gossip or interact with
-        // peers, so real keys are not needed — the platform only requires them to satisfy internal certificate
-        // validation at build time. KeysAndCertsGenerator.generateKeysAndCerts produces self-consistent
-        // ephemeral keys that satisfy those checks without any on-disk key infrastructure.
         final KeysAndCerts keysAndCerts =
                 KeysAndCertsGenerator.generateKeysAndCerts(List.of(selfId)).get(selfId);
 
-        // Register the platform service-state stubs (PlatformStateService, RosterService) on the manager's
-        // current mutable state, immediately before building the platform. This must come AFTER Hedera's
-        // initializeStatesApi (whose onStateInitialized migration rebuilds the services map and would otherwise
-        // overwrite earlier stub registration) and BEFORE PlatformComponentBuilder.build() (whose SwirldsPlatform
-        // constructor calls copyMutableState() then accesses PlatformStateService — the copy carries this metadata
-        // forward via VirtualMapStateImpl's copy constructor). This is the same registration StateUtils.initState
-        // performs; the platform's own init path does not register these platform stubs.
+        // Register the platform service-state stubs on the manager's current mutable state.
         SignedStateFileReader.registerServiceStates(stateLifecycleManager.getMutableState());
 
-        // --- Recompute replay bounds exactly as the SwirldsPlatform constructor does (non-genesis) ---
-        // These MUST be read before PlatformBuilder.build(): build() takes ownership of the initialState
-        // reservation and closes it during construction (copyMutableState + startup handling), after which
-        // initialState.get() throws ReferenceCountException.
+        // --- Recompute replay bounds (must read before build() consumes the state) ---
         final long startingRound = initialState.get().getRound();
         final long pcesReplayLowerBound = ancientThresholdOf(state);
 
-        // Computed deterministically from config by the same public helper ServicesMain uses.
         final int transactionOffsetNanos = ServicesMain.transactionOffsetNanos(platformConfig);
         hedera.setTxnOffsetNanos(transactionOffsetNanos);
 
-        // --- Build the platform (constructor priming runs inside build()) ---
-        final PlatformComponentBuilder componentBuilder = PlatformBuilder.create(
-                        Hedera.APP_NAME,
-                        Hedera.SWIRLD_NAME,
-                        version,
-                        initialState,
-                        consensusStateEventHandler,
-                        selfId,
-                        consensusEventStreamName,
-                        rosterHistory,
-                        stateLifecycleManager)
-                .withPlatformContext(platformContext)
-                .withConfiguration(platformConfig)
-                .withKeysAndCerts(keysAndCerts)
-                .withExecutionLayer(hedera)
-                .withStaleEventConsumer(hedera)
-                .withTransactionOffsetNanos(transactionOffsetNanos)
-                .buildComponentBuilder();
+        // --- Build the platform via TestPlatformBuilder ---
+        // TestPlatformBuilder.build() constructs the real SwirldsPlatform (which Hedera needs for
+        // onStateInitialized), runs InitialStateLoader, wires all modules, and closes the initial state
+        // reservation. We then access buildingBlocks() to drive replay without starting gossip.
+        final TestPlatformBuilder builder = new TestPlatformBuilder(
+                platformConfig,
+                platformContext.getMetrics(),
+                platformContext.getTime(),
+                rosterHistory,
+                keysAndCerts,
+                selfId,
+                platformContext.getRecycleBin(),
+                platformContext.getFileSystemManager(),
+                hedera,
+                consensusStateEventHandler,
+                initialState,
+                stateLifecycleManager,
+                version,
+                new PersistenceScope(Hedera.APP_NAME, Hedera.SWIRLD_NAME),
+                consensusEventStreamName,
+                transactionOffsetNanos);
 
-        final Platform platform = componentBuilder.build();
-        final PlatformBuildingBlocks blocks = componentBuilder.getBuildingBlocks();
+        final Platform platform = builder.build();
+        final ConsensusLayerBuildingBlocks buildingBlocks = builder.buildingBlocks();
+
+        // --- Target-round capture: tap the hashgraph consensus-round output so we can track the highest round
+        //     that reached consensus. Must be soldered before the wiring model starts. ---
+        final AtomicLong latestConsensusRound = new AtomicLong(-1);
+        buildingBlocks
+                .hashgraphModule()
+                .consensusRoundOutputWire()
+                .solderTo(
+                        "replayRoundTracker",
+                        "consensus round",
+                        round -> latestConsensusRound.set(round.getRoundNum()));
 
         boolean started = false;
         try {
             log.info(
-                    "Driving PCES replay: startingRound={}, pcesReplayLowerBound={}",
+                    "Driving PCES replay: startingRound={}, pcesReplayLowerBound={}, targetRound={}",
                     startingRound,
-                    pcesReplayLowerBound);
+                    pcesReplayLowerBound,
+                    targetRound == DEFAULT_TARGET_ROUND ? "all" : targetRound);
 
-            // --- Drive the body of SwirldsPlatform.start() MINUS startGossip() ---
+            // --- Drive the body of SwirldsPlatform.start() MINUS gossip ---
             platformContext.getRecycleBin().start();
             platformContext.getMetrics().start();
-            blocks.platformCoordinator().start();
-            started = true; // wiring model is now started; destroy()/stop() is safe from here on
-            blocks.platformComponents().pcesModule().replayPcesEvents(pcesReplayLowerBound, startingRound);
-            // NOTE: deliberately NOT calling blocks.platformCoordinator().startGossip()
+            buildingBlocks.wiringModel().start();
+            started = true;
 
-            // --- Capture the resulting state and dump it to disk (ADR-003 steps 3-4) ---
-            final long resultRound = dumpResultingState(blocks, platformConfig, outDir);
+            buildingBlocks.pcesModule().replayPcesEvents(pcesReplayLowerBound, startingRound);
+            // NOTE: deliberately NOT calling buildingBlocks.gossipModule().startInputWire().inject(...)
+
+            // --- Flush the pipeline so state snapshots are written to disk ---
+            buildingBlocks.pipelineFlusher().flushPrimaryPipeline();
+
+            // --- Write the resulting state ---
+            final long resultRound;
+            if (targetRound != DEFAULT_TARGET_ROUND) {
+                resultRound = writeTargetRoundState(platformConfig, outDir, targetRound, latestConsensusRound.get());
+            } else {
+                resultRound = copyLatestSnapshotToOutDir(platformConfig, outDir);
+            }
+
             log.info("PCES replay complete. Resulting state round: {}, written under {}", resultRound, outDir);
             return resultRound;
         } finally {
-            // platform.destroy() calls platformCoordinator.stop(), which throws if the wiring model was never
-            // started. Only destroy when start succeeded, and never let cleanup mask the original exception.
             if (started) {
                 try {
                     platform.destroy();
@@ -239,41 +250,67 @@ public final class ReplayPcesWorkflow {
     }
 
     /**
-     * Pulls the latest immutable state from the nexus, marks it for saving, and dumps it to disk, blocking until the
-     * write completes.
-     *
-     * @return the round of the dumped state
+     * Writes the target-round state to the output directory. Looks for the exact round directory first; falls back to
+     * the closest available round if the periodic save didn't land on the target.
      */
-    private static long dumpResultingState(
-            @NonNull final PlatformBuildingBlocks blocks,
-            @NonNull Configuration platformConfig,
-            @NonNull final Path outDir) {
-        try (final ReservedSignedState reserved =
-                blocks.latestImmutableStateNexus().getState("replay-pces result")) {
-            if (reserved == null) {
-                throw new IllegalStateException(
-                        "PCES replay produced no immutable state — nothing to dump. "
-                                + "This usually means no events were replayed (check PCES placement and origin/round alignment).");
-            }
-            final SignedState signedState = reserved.get();
-            signedState.markAsStateToSave(StateToDiskReason.PCES_RECOVERY_COMPLETE);
+    private static long writeTargetRoundState(
+            @NonNull final Configuration platformConfig,
+            @NonNull final Path outDir,
+            final long targetRound,
+            final long actualLatestRound)
+            throws IOException {
 
-            final StateDumpRequest request =
-                    StateDumpRequest.create(signedState.reserve("dumping replay-pces result state"));
-            blocks.platformCoordinator().dumpStateToDisk(request);
-            request.waitForFinished().run();
-
-            final long round = signedState.getRound();
-
-            // Copy the snapshot from the platform's internal saved-state location to the caller's outDir.
-            try {
-                copySnapshotToOutDir(platformConfig, round, outDir);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-
-            return round;
+        if (actualLatestRound < targetRound) {
+            throw new IllegalStateException(
+                    "Target round " + targetRound + " never reached consensus during replay (latest was "
+                            + actualLatestRound + "). The PCES does not contain enough rounds past the target to "
+                            + "decide it. Regenerate with blocks-to-pces covering more rounds past the target "
+                            + "(increase DECISION_MARGIN_ROUNDS), or choose a target within the decided range.");
         }
+
+        final Path savedStateDir =
+                platformConfig.getConfigData(PathsConfig.class).savedStateDir();
+        final Path existingRoundDir = findRoundDirectory(savedStateDir, targetRound);
+        if (existingRoundDir != null) {
+            return copyRoundDirToOutDir(existingRoundDir, targetRound, outDir);
+        }
+
+        log.info("Target round {} was not periodically saved; falling back to closest available round", targetRound);
+        final Path closestRoundDir = findLatestRoundDirectory(savedStateDir);
+        if (closestRoundDir == null) {
+            throw new IllegalStateException("No saved state found under " + savedStateDir + " after replay. "
+                    + "This usually means no events were replayed.");
+        }
+
+        final long closestRound = Long.parseLong(closestRoundDir.getFileName().toString());
+        log.info("Closest available saved round is {} (target was {})", closestRound, targetRound);
+        return copyRoundDirToOutDir(closestRoundDir, closestRound, outDir);
+    }
+
+    /**
+     * Copies a round directory to the output directory, returning the round number.
+     */
+    private static long copyRoundDirToOutDir(@NonNull final Path roundDir, final long round, @NonNull final Path outDir)
+            throws IOException {
+        final Path destination = outDir.resolve(Long.toString(round));
+        log.info("Copying replay state from {} to {}", roundDir, destination);
+        Files.createDirectories(destination);
+        try (final Stream<Path> files = Files.walk(roundDir)) {
+            files.forEach(source -> {
+                final Path target = destination.resolve(roundDir.relativize(source));
+                try {
+                    if (Files.isDirectory(source)) {
+                        Files.createDirectories(target);
+                    } else {
+                        Files.copy(source, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
+                    }
+                } catch (final IOException e) {
+                    throw new java.io.UncheckedIOException("Failed to copy " + source + " -> " + target, e);
+                }
+            });
+        }
+        log.info("Replay state for round {} copied to {}", round, destination);
+        return round;
     }
 
     /**
@@ -291,15 +328,10 @@ public final class ReplayPcesWorkflow {
 
         final Path databaseDirectory = PcesUtilities.getDatabaseDirectory(configuration, fileSystemManager, selfId);
 
-        // Find the directory in pcesDir that actually contains the .pces files. blocks-to-pces writes them under a
-        // node-id subdirectory (node 0). Accept either pcesDir directly containing .pces files, or a single
-        // node-id subdirectory containing them.
         final Path sourceDir = locatePcesFiles(pcesDir);
 
         log.info("Staging PCES files from {} into {}", sourceDir, databaseDirectory);
 
-        // Ensure a clean database directory — leftover .pces files from a prior run would
-        // be picked up by PcesFileTracker and corrupt the replay.
         if (Files.isDirectory(databaseDirectory)) {
             try (final Stream<Path> stale = Files.list(databaseDirectory)) {
                 stale.filter(p -> p.getFileName().toString().endsWith(".pces")).forEach(p -> {
@@ -326,10 +358,6 @@ public final class ReplayPcesWorkflow {
         }
     }
 
-    /**
-     * Resolves the directory that actually holds the {@code .pces} files. Accepts {@code pcesDir} itself if it directly
-     * contains them, otherwise descends into a single node-id subdirectory (as produced by {@code blocks-to-pces}).
-     */
     @NonNull
     private static Path locatePcesFiles(@NonNull final Path pcesDir) throws IOException {
         if (containsPcesFiles(pcesDir)) {
@@ -355,58 +383,51 @@ public final class ReplayPcesWorkflow {
     }
 
     /**
-     * Copies the state snapshot written by the platform to the caller-specified output directory.
-     * The platform writes to {@code <savedStateDir>/<appName>/<swirldName>/<selfId>/<round>/}.
-     * We locate that directory and copy its contents into {@code <outDir>/<round>/}.
+     * Locates the latest state snapshot written by the platform, copies it to {@code outDir}, and returns the round.
      */
-    private static void copySnapshotToOutDir(
-            @NonNull final Configuration platformConfig, final long round, @NonNull final Path outDir)
-            throws IOException {
-        // Resolve the platform's saved-state directory for this round. The convention is:
-        //   savedStateDir / appName / swirldName / selfId / round
-        // where savedStateDir defaults to "./data/saved", appName = ServicesMain class name, swirldName = "123".
-        // Rather than reconstruct the convention, scan for the round directory.
+    private static long copyLatestSnapshotToOutDir(
+            @NonNull final Configuration platformConfig, @NonNull final Path outDir) throws IOException {
         final Path savedStateDir =
                 platformConfig.getConfigData(PathsConfig.class).savedStateDir();
-        final Path roundDir = findRoundDirectory(savedStateDir, round);
+        final Path roundDir = findLatestRoundDirectory(savedStateDir);
         if (roundDir == null) {
-            log.warn(
-                    "Could not find saved state directory for round {} under {}; outDir copy skipped.",
-                    round,
-                    savedStateDir);
-            return;
+            throw new IllegalStateException("PCES replay produced no saved state under " + savedStateDir
+                    + ". This usually means no events were replayed "
+                    + "(check PCES placement and origin/round alignment).");
         }
-
-        final Path destination = outDir.resolve(Long.toString(round));
-        log.info("Copying replay state from {} to {}", roundDir, destination);
-        Files.createDirectories(destination);
-        try (final Stream<Path> files = Files.walk(roundDir)) {
-            files.forEach(source -> {
-                final Path target = destination.resolve(roundDir.relativize(source));
-                try {
-                    if (Files.isDirectory(source)) {
-                        Files.createDirectories(target);
-                    } else {
-                        Files.copy(source, target, java.nio.file.StandardCopyOption.REPLACE_EXISTING);
-                    }
-                } catch (final IOException e) {
-                    throw new java.io.UncheckedIOException("Failed to copy " + source + " -> " + target, e);
-                }
-            });
-        }
-        log.info("Replay state for round {} copied to {}", round, destination);
+        final long round = Long.parseLong(roundDir.getFileName().toString());
+        return copyRoundDirToOutDir(roundDir, round, outDir);
     }
 
-    /**
-     * Searches for a directory named {@code <round>} under the saved-state root (recursively).
-     * Returns the first match, or null if not found.
-     */
     private static Path findRoundDirectory(final Path root, final long round) throws IOException {
+        if (!Files.isDirectory(root)) {
+            return null;
+        }
         final String roundName = Long.toString(round);
         try (final Stream<Path> dirs = Files.walk(root)) {
             return dirs.filter(Files::isDirectory)
                     .filter(p -> p.getFileName().toString().equals(roundName))
                     .findFirst()
+                    .orElse(null);
+        }
+    }
+
+    private static Path findLatestRoundDirectory(final Path root) throws IOException {
+        if (!Files.isDirectory(root)) {
+            return null;
+        }
+        try (final Stream<Path> dirs = Files.walk(root)) {
+            return dirs.filter(Files::isDirectory)
+                    .filter(p -> {
+                        try {
+                            Long.parseLong(p.getFileName().toString());
+                            return true;
+                        } catch (final NumberFormatException e) {
+                            return false;
+                        }
+                    })
+                    .max(Comparator.comparingLong(
+                            p -> Long.parseLong(p.getFileName().toString())))
                     .orElse(null);
         }
     }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/gcp/BlockRangeResolver.java
@@ -65,7 +65,7 @@ public final class BlockRangeResolver {
     private static final int SEQUENTIAL_THRESHOLD = 1000;
 
     /** Maximum exponential probe offset (2^20 ≈ 1M blocks). */
-    private static final int MAX_EXPONENTIAL_POWER = 20;
+    private static final int MAX_EXPONENTIAL_POWER = 30;
 
     /** Thread pool for parallel probing operations. */
     private static final int PROBE_THREAD_POOL_SIZE = 16;
@@ -443,8 +443,7 @@ public final class BlockRangeResolver {
      * Sequential binary search for the block containing the target round, for small ranges.
      */
     private long sequentialBinarySearchForRound(
-            long lo, long hi, final long targetRound, final ConcurrentHashMap<Long, Long> roundCache)
-            throws IOException {
+            long lo, long hi, final long targetRound, final ConcurrentHashMap<Long, Long> roundCache) {
         while (hi - lo > 1) {
             final long mid = lo + (hi - lo) / 2;
             final long maxRound = roundCache.computeIfAbsent(mid, block -> {

--- a/hedera-state-validator/src/main/java/module-info.java
+++ b/hedera-state-validator/src/main/java/module-info.java
@@ -27,7 +27,6 @@ module com.hedera.state.validator {
     requires com.hedera.node.hapi;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.base;
-    requires com.swirlds.common;
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;
     requires com.swirlds.merkledb;
@@ -50,6 +49,7 @@ module com.hedera.state.validator {
     requires org.hiero.consensus.roster;
     requires org.hiero.consensus.state;
     requires org.hiero.consensus.utility;
+    requires org.hiero.consensus.wiring.framework;
     requires com.github.spotbugs.annotations;
     requires info.picocli;
     requires org.apache.logging.log4j;

--- a/hedera-state-validator/src/main/java/module-info.java
+++ b/hedera-state-validator/src/main/java/module-info.java
@@ -42,7 +42,6 @@ module com.hedera.state.validator {
     requires org.hiero.base.crypto;
     requires org.hiero.base.utility;
     requires org.hiero.consensus.concurrent;
-    requires org.hiero.consensus.hashgraph;
     requires org.hiero.consensus.metrics;
     requires org.hiero.consensus.model;
     requires org.hiero.consensus.pces.impl;

--- a/hedera-state-validator/src/main/java/module-info.java
+++ b/hedera-state-validator/src/main/java/module-info.java
@@ -28,7 +28,6 @@ module com.hedera.state.validator {
     requires com.hedera.pbj.runtime;
     requires com.swirlds.base;
     requires com.swirlds.common;
-    requires com.swirlds.component.framework;
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;
     requires com.swirlds.merkledb;

--- a/hedera-state-validator/src/main/java/module-info.java
+++ b/hedera-state-validator/src/main/java/module-info.java
@@ -27,10 +27,13 @@ module com.hedera.state.validator {
     requires com.hedera.node.hapi;
     requires com.hedera.pbj.runtime;
     requires com.swirlds.base;
+    requires com.swirlds.common;
+    requires com.swirlds.component.framework;
     requires com.swirlds.config.api;
     requires com.swirlds.config.extensions;
     requires com.swirlds.merkledb;
     requires com.swirlds.metrics.api;
+    requires com.swirlds.platform.core.test.fixtures;
     requires com.swirlds.platform.core;
     requires com.swirlds.state.api;
     requires com.swirlds.state.impl;
@@ -39,12 +42,14 @@ module com.hedera.state.validator {
     requires org.hiero.base.crypto;
     requires org.hiero.base.utility;
     requires org.hiero.consensus.concurrent;
+    requires org.hiero.consensus.hashgraph;
     requires org.hiero.consensus.metrics;
     requires org.hiero.consensus.model;
     requires org.hiero.consensus.pces.impl;
     requires org.hiero.consensus.pces;
     requires org.hiero.consensus.pcli;
     requires org.hiero.consensus.platformstate;
+    requires org.hiero.consensus.roster;
     requires org.hiero.consensus.state;
     requires org.hiero.consensus.utility;
     requires com.github.spotbugs.annotations;

--- a/hedera-state-validator/src/main/resources/log4j2.xml
+++ b/hedera-state-validator/src/main/resources/log4j2.xml
@@ -42,7 +42,7 @@
       <Logger name="com.hedera.statevalidation.AnalyzeCommand" level="INFO">
           <AppenderRef ref="StateAnalysisFileAppender"/>
       </Logger>
-      <Root level="DEBUG">
+      <Root level="INFO">
           <AppenderRef ref="FileAppender"/>
           <AppenderRef ref="ConsoleMarkerAppender"/>
       </Root>

--- a/platform-sdk/consensus-state/src/main/java/module-info.java
+++ b/platform-sdk/consensus-state/src/main/java/module-info.java
@@ -12,7 +12,8 @@ module org.hiero.consensus.state {
     exports org.hiero.consensus.state.persistence to
             com.swirlds.platform.core,
             org.hiero.consensus.reconnect.impl,
-            org.hiero.consensus.pcli;
+            org.hiero.consensus.pcli,
+            com.hedera.state.validator;
 
     requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;


### PR DESCRIPTION
**Description**:

Adds a `replay-pces` command to the state validator that loads a saved state snapshot, replays a PCES stream through the consensus node's real production replay mechanism, and writes the resulting state to disk. Together with the existing blocks-to-pces command, this enables end-to-end block stream equivalence validation: reconstruct PCES from a block stream, replay it on a matching state, and compare the resulting state and block hashes against production.

PCES replay is the consensus node's normal startup mechanism: when a node restarts, it replays its on-disk preconsensus events through the full intake → hashgraph → transaction handling → block production pipeline before gossip starts. This is documented in `ADR-003-remove-pces-recovery-method` as the recommended driver for offline PCES recovery — the driver is written at point of need against the platform of the day. This command is that driver.

The approach was validated against the `pces-disaster-recovery.md` reference implementation (`performPcesRecovery()`), which confirms that single-node PCES replay with a complete event DAG and the real roster reaches consensus and advances state without gossip.

`Implementation`

`ReplayPcesWorkflow` constructs the same Hedera execution layer and `SwirldsPlatform` that ServicesMain.main builds, then drives the body of `SwirldsPlatform.start()` minus `startGossip()`:

1. Bootstrap via `BootstrapUtils.setupConstructableRegistry()`, `ServicesMain.buildPlatformConfig()`, and `StaticPlatformBuilder.setupGlobalMetrics()`.
2. Build the Hedera execution layer via `ServicesMain.newHedera(...)`.
3. Load the state directly from the given path via `SignedStateFileReader.readState(...)`, then call `SignedStateFileReader.registerServiceStates(stateLifecycleManager.getMutableState())` to ensure `PlatformStateService` (ID 26) and `RosterService` services are registered on the instance the `SwirldsPlatform` constructor accesses. 
4. Initialize the States API via `hedera.initializeStatesApi(state, RESTART, platformConfig)`.
5. Derive roster history from `ReadableRosterStoreImpl`; generate ephemeral keys via `KeysAndCertsGenerator.generateKeysAndCerts(List.of(selfId))` — `initNodeSecurity` requires on-disk PKCS12 keystores that don't exist in an offline environment, and gossip never starts so real keys aren't needed.
5. Compute replay bounds from the loaded state before calling build(): `startingRound = initialState.get().getRound()` and `pcesReplayLowerBound = ancientThresholdOf(state)`. These must be read before build() because `PlatformComponentBuilder.build()` takes ownership of the initialState reservation and closes it during construction.
6. Stage the PCES files into `PcesUtilities.getDatabaseDirectory(config, fsm, selfId)` so `DefaultPcesModule.initialize` discovers them at build time.
7. Build the platform via `PlatformBuilder.create(...).buildComponentBuilder().build()`. The `SwirldsPlatform` constructor performs all restart priming automatically (`consensusSnapshotOverride`, `updateEventWindow`, signature-collector and ISS-detector seeding).
8. Drive replay — the exact body of `SwirldsPlatform.start()` minus gossip: recycle bin start, metrics start, `platformCoordinator.start()`, `pcesModule().replayPcesEvents(pcesReplayLowerBound, startingRound)`.
9. Pull the latest immutable state from latestImmutableStateNexus, mark it PCES_RECOVERY_COMPLETE, and dump via StateDumpRequest, blocking on waitForFinished().

**Related issue(s)**:

Fixes #25959 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
