### PR TITLE
chore: KB freshness all doctypes

### DIFF
--- a/platform-sdk/consensus-kb-freshness/.claude/skills/kb-freshness/SKILL.md
+++ b/platform-sdk/consensus-kb-freshness/.claude/skills/kb-freshness/SKILL.md
@@ -55,20 +55,20 @@ Do not re-derive or second-guess the deterministic findings; present them as-is.
 Read `worklist.json`. Process **only** entries whose `status` is `review` or `unknown` (their
 anchored source changed since `last_reviewed`, or freshness is unknown). Skip `fresh` entries.
 
-**Fan out for large worklists.** When more than ~4 topics need processing, or a single topic lists
-many changed sources (say, 10+), spawn one subagent per topic instead of reading everything in one
-context: each subagent reads only its topic doc and that topic's changed sources, judges the claims
+**Fan out for large worklists.** When more than ~4 entries need processing, or a single entry lists
+many changed sources (say, 10+), spawn one subagent per entry instead of reading everything in one
+context: each subagent reads only its document and that entry's changed sources, judges the claims
 by the rules below, and returns its `contradicted`-with-citation items (file + symbol/line per
 claim). Merge the returns into one Advisory section, applying the same only-cited-contradictions
 bar to what comes back — a subagent's uncited judgment is dropped exactly like your own. Small
-worklists are faster inline; do not fan out for one or two topics.
+worklists are faster inline; do not fan out for one or two entries.
 
 For each `review` entry:
 
-1. Read the topic doc at `entryPath`.
-2. Read the **current** source files listed in `changedPaths` (and any other source the topic
+1. Read the document at `entryPath`.
+2. Read the **current** source files listed in `changedPaths` (and any other source the document
    anchors). Never rely on memory of what the code does — open the files.
-3. For each **load-bearing prose claim** about behavior in the topic, judge it three ways:
+3. For each **load-bearing prose claim** about behavior in the document, judge it three ways:
    - `supported` — the current code backs the claim.
    - `contradicted` — the current code makes the claim false, **or** names a symbol (method, class,
      field, path) that no longer exists; a rename or removal counts even if the behavior survives.
@@ -77,13 +77,15 @@ For each `review` entry:
 An `unknown` entry has no `changedPaths` to read — its `note` names why (usually
 `no anchored sources`). Handle it by the note:
 
-- `no anchored sources` — the doc carries no mechanically-checkable code anchor (it also appears in
-  `coverage.md`). Read the doc, **locate** the code it describes (search by the class/component names
-  in its prose), and judge its claims against what you find. If you can identify the code, also
-  recommend anchoring the doc to it (add source citations) so future runs can track freshness. If you
-  cannot identify the code, say so — do not guess.
+- `no anchored sources` — the document carries no mechanically-checkable code anchor. Some documents
+  are **expected** to be unanchored — `glossary.md`, `symptoms.md`, and the `README.md` indexes are
+  definitional or navigational, not code-describing: acknowledge them as `unknown` and move on, do not
+  hunt for code. For a document that *does* describe specific code but cites none (e.g. a topic, or an
+  ADR with no source), **locate** the code it describes (search by the class/component names in its
+  prose), judge its claims against it, and recommend anchoring the doc (add source citations) so future
+  runs can track freshness. If you cannot identify the code, say so — do not guess.
 - `git unavailable` / `no commit dates for anchored sources` — freshness could not be dated; treat the
-  entry like `review` and read the sources the doc anchors.
+  entry like `review` and read the sources the document anchors.
 
 ## Step 3 — Report only contradicted-with-citation
 
@@ -94,7 +96,7 @@ An `unknown` entry has no `changedPaths` to read — its `note` names why (usual
   from* the deterministic report. Never intermix semantic findings with deterministic assertions —
   they are advisory, not facts the engine verified.
 
-Each advisory item cites: the topic + claim, and the current code (path + symbol) that contradicts
+Each advisory item cites: the entry + claim, and the current code (path + symbol) that contradicts
 it. An uncited judgment is dropped, not reported.
 
 ## Step 4 — Present the combined result
@@ -118,15 +120,15 @@ Close with a short, concrete action list derived from this run (skip lines that 
 3. **Close coverage gaps**: mention `coverage.md` items worth acting on (unanchored topics, interface
    docs not opted into Tier-2, undocumented config keys, config records with no tunables section,
    topic slugs with no document).
-4. **Close the review loop**: for each worklisted topic whose semantic pass found every claim
+4. **Close the review loop**: for each worklisted document whose semantic pass found every claim
    `supported` (or whose contradictions have since been fixed), suggest bumping its `last_reviewed`
-   via `--mark-reviewed <entry-key>` (repeatable). A bare spec records the topic's newest
+   via `--mark-reviewed <entry-key>` (repeatable). A bare spec records the document's newest
    anchored-source commit date — the state this run reviewed, shown as `newestAnchoredCommit` in
    `worklist.json` — derived from the scanned checkout, never the wall clock (so a run against a stale
-   `main` never marks commits it did not review as reviewed). Without the bump, every
-   future run re-worklists the same topics. Never
-   suggest bumping a topic that still has an unresolved contradiction (which now includes a dangling
-   reference to a renamed or removed symbol).
+   `main` never marks commits it did not review as reviewed); a document that anchors no source is
+   dated by the reviewed checkout's HEAD commit instead. Without the bump, every future run re-worklists
+   the same documents. Never suggest bumping a document that still has an unresolved contradiction
+   (which now includes a dangling reference to a renamed or removed symbol).
 5. **Adopt the baseline**: after fixes are applied and re-checked, suggest `--write-baseline` (or
    copying `baseline.proposed.tsv`) and triaging the rows.
 

--- a/platform-sdk/consensus-kb-freshness/CLAUDE.md
+++ b/platform-sdk/consensus-kb-freshness/CLAUDE.md
@@ -37,15 +37,17 @@ with `java -jar`.
   coverage check, scoped to `consensus-*` modules plus modules the catalog already documents),
   baseline TSV + join. The engine subsumes a Tier-0 source-path GONE finding when a `CONFIG_PREFIX`
   finding already asserts the same citation as a class move (one root cause, one finding).
-- `worklist/` + `git/` — the semantic worklist (git freshness vs `last_reviewed`): a topic is flagged
-  for review when any anchored source was committed **on or after** `last_reviewed`. The boundary is
-  inclusive because commit dates are day-granular — a same-day merge is never skipped, at the cost of
-  not clearing a topic until the day after its last change. Anchored-source
-  resolution mirrors the resolver (abbreviated `module/.../File.java` and FQN citations both resolve
-  through the `SourceIndex`, and a moved anchor is tracked at its new location), so an abbreviated- or
-  FQN-only topic keeps feeding the freshness signal. Each entry carries `anchoredSourceCount` and
-  `newestAnchoredCommit` (the reviewed-state date `--mark-reviewed` records); a zero count (topic
-  anchors nothing) is surfaced in the coverage lane, not the drift report.
+- `worklist/` + `git/` — the semantic worklist (git freshness vs `last_reviewed`), built for **every**
+  scanned document: it is flagged for review when any anchored source was committed **on or after**
+  `last_reviewed`. The boundary is inclusive because commit dates are day-granular — a same-day merge is
+  never skipped, at the cost of not clearing a document until the day after its last change. A document
+  that anchors no code is `unknown` regardless of its marker (the no-sources check runs first).
+  Anchored-source resolution mirrors the resolver (abbreviated `module/.../File.java` and FQN citations
+  both resolve through the `SourceIndex`, and a moved anchor is tracked at its new location), so an
+  abbreviated- or FQN-only document keeps feeding the freshness signal. Each entry carries
+  `anchoredSourceCount` and `newestAnchoredCommit` (the reviewed-state date `--mark-reviewed` records);
+  a zero count (anchors nothing) reads as `unknown`, and — for topics only — is surfaced in the coverage
+  lane.
 - `engine/` also carries `ScanStats` — what the run scanned and checked (entries, anchors, check
   groups, findings by lane, Tier-2 surfaces), rendered as the report's "Scan coverage" section so
   silence is auditable as checked-and-clean rather than never-scanned.
@@ -60,8 +62,9 @@ with `java -jar`.
   by an exact line match (idempotent); never applies fuzzy `suggestions.md` renames. `ReviewedMarker`
   (`--mark-reviewed <key>[=<date>]`): bumps an entry's *existing* `last_reviewed:` frontmatter line —
   the workflow closure after a semantic pass; it never invents the line, requires an unambiguous key
-  and an ISO date; a bare spec derives the topic's newest anchored-source commit date — the reviewed
-  state, never wall-clock; see `README.md` — and is idempotent.
+  and an ISO date; a bare spec derives the reviewed-state date from git — the document's newest
+  anchored-source commit, or the checkout's `HEAD` commit for an unanchored doc — never wall-clock; see
+  `README.md` — and is idempotent.
 - `engine/` + `cli/` — orchestration and the picocli entry point.
 - `.claude/skills/kb-freshness/` — the skill that runs the engine and performs the semantic pass.
 - `baseline/kb-freshness-baseline.tsv` — the committed, human-owned baseline.

--- a/platform-sdk/consensus-kb-freshness/README.md
+++ b/platform-sdk/consensus-kb-freshness/README.md
@@ -88,7 +88,7 @@ semantic pass rather than scraped into a brittle Tier-2 assertion that would mis
 The semantic pass is the only part that *reasons* rather than *resolves*, so it is fenced in tightly
 to keep it from becoming a false-positive source of its own:
 
-- **It reads the current source, never memory.** For each worklisted topic it opens the exact files
+- **It reads the current source, never memory.** For each worklisted document it opens the exact files
   the engine located and judges each load-bearing prose claim against what the code now says.
 - **Only `contradicted`-with-citation survives.** Each claim is judged `supported`, `contradicted`,
   or `can't-determine`. Only `contradicted` claims that can point at the specific current code
@@ -98,23 +98,26 @@ to keep it from becoming a false-positive source of its own:
   section, after and distinct from the deterministic report — never intermixed with engine-verified
   findings.
 - **It looks only where the code moved.** It processes only worklist entries whose status is
-  `review` or `unknown`; `fresh` topics are skipped.
+  `review` or `unknown`; `fresh` entries are skipped.
 
-The worklist that drives it is built by the engine from git history: for each topic it flags review
-when any anchored source was committed **on or after** the topic's `last_reviewed` date.
+The worklist that drives it is built by the engine from git history for **every** scanned document: it
+flags review when any anchored source was committed **on or after** the document's `last_reviewed` date.
+A document that anchors no code (glossary, symptoms, README indexes) is `unknown` — there is nothing to
+date its prose against.
 
-The loop closes by bumping `last_reviewed`: a topic whose semantic pass found every claim supported
+The loop closes by bumping `last_reviewed`: a document whose semantic pass found every claim supported
 (or whose contradictions were fixed) should be marked reviewed — mechanically, via
 `--mark-reviewed <entry-key>[=<yyyy-MM-dd>]` (repeatable; rewrites only an *existing*
-`last_reviewed:` frontmatter line) — or every future run re-worklists the same topics. A reference to
+`last_reviewed:` frontmatter line) — or every future run re-worklists the same documents. A reference to
 a renamed or removed symbol counts as a contradiction (even if the behavior survives), so it blocks
 the bump.
 
-The date to record is the topic's **newest anchored-source commit date** — the state this run
+The date to record is the document's **newest anchored-source commit date** — the state this run
 reviewed, shown as `newestAnchoredCommit` in `worklist.json`. A bare `--mark-reviewed <key>` records
 it automatically, derived from the scanned checkout, never the wall clock — so a run against a stale
-`main` cannot mark commits it never reviewed as reviewed. (`--date` is used only as a fallback for a
-topic that anchors no dated source, where there is no freshness signal anyway.)
+`main` cannot mark commits it never reviewed as reviewed. A document that anchors no source is dated by
+the reviewed checkout's **HEAD commit** instead (it was still reviewed against that commit); wall-clock
+`--date` is only the last resort when git is unavailable.
 
 ## Lanes — how a result is routed
 
@@ -270,7 +273,7 @@ entries tag a topic that was never written, the fix may be to write it rather th
 citation. Use it to find documentation worth adding or anchoring; tracked apart from the drift
 report on purpose.
 
-**`worklist.md` / `worklist.json` — the semantic-pass input.** For each topic, the engine compares
+**`worklist.md` / `worklist.json` — the semantic-pass input.** For each document, the engine compares
 the last-commit date of its anchored source against its `last_reviewed` date and assigns a status:
 `review` (a source was committed on or after `last_reviewed`), `fresh` (every source predates it), or
 `unknown` (freshness can't be determined — the entry's note names the reason: no anchored sources, git

--- a/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/apply/ReviewedMarker.java
+++ b/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/apply/ReviewedMarker.java
@@ -11,8 +11,8 @@ import org.hiero.consensus.kbfreshness.util.Patterns;
 import org.hiero.consensus.kbfreshness.worklist.WorklistEntry;
 
 /**
- * Applies {@code --mark-reviewed}: mechanically bumps a topic's {@code last_reviewed:} frontmatter
- * date after its semantic review, so the next run's worklist does not re-flag a topic whose prose was
+ * Applies {@code --mark-reviewed}: mechanically bumps a document's {@code last_reviewed:} frontmatter
+ * date after its semantic review, so the next run's worklist does not re-flag a document whose prose was
  * just read against the code. Strictly guarded like every other write: only an <em>existing</em>
  * {@code last_reviewed:} frontmatter line is rewritten (a doc without the marker is reported, never
  * invented), the entry key must resolve unambiguously, and the date must be ISO {@code yyyy-MM-dd}.
@@ -41,12 +41,13 @@ public final class ReviewedMarker {
      * @param result      the run result whose scanned documents resolve the entry keys.
      * @param repoRoot    the repository root the documents' paths are relative to.
      * @param specs       the {@code <key>[=<yyyy-MM-dd>]} specs; a bare spec (no {@code =<date>}) records
-     *                    the topic's newest anchored-source commit date — the state this run reviewed —
-     *                    falling back to {@code defaultDate} only when the topic anchors no dated source.
+     *                    the document's newest anchored-source commit date — the state this run reviewed —
+     *                    falling back to {@code defaultDate} only when the document anchors no dated source.
      *                    A key may be the full entry key ({@code topic:gossip}) or its bare slug when
      *                    unambiguous.
-     * @param defaultDate the fallback date for a bare spec with no derivable anchored date (typically
-     *                    {@code --date}).
+     * @param defaultDate the fallback for a bare spec with no derivable anchored date: the reviewed
+     *                    checkout's {@code HEAD} commit date (the state reviewed), or {@code --date} when
+     *                    git is unavailable.
      * @return a summary of what was rewritten and which specs failed.
      * @throws IOException if reading or writing a KB file fails.
      */
@@ -77,7 +78,7 @@ public final class ReviewedMarker {
     }
 
     /**
-     * Chooses the date to record: an explicit {@code =<date>} spec wins; otherwise the topic's newest
+     * Chooses the date to record: an explicit {@code =<date>} spec wins; otherwise the document's newest
      * anchored-source commit date (the state this run reviewed); otherwise {@code defaultDate}. Deriving
      * from the anchored sources rather than the wall clock is what keeps a run against a stale checkout
      * from marking commits it never reviewed as reviewed.

--- a/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/cli/Main.java
+++ b/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/cli/Main.java
@@ -161,7 +161,11 @@ public final class Main implements Callable<Integer> {
         }
 
         if (!markReviewed.isEmpty()) {
-            final ReviewedMarker.Result marked = ReviewedMarker.apply(result, repoRoot, markReviewed, date);
+            // A doc with no anchored source has no per-source commit to derive from; date it by the
+            // reviewed checkout's HEAD commit (the state the review was performed against), not wall-clock.
+            final String headDate = result.git().headCommitDate();
+            final String markFallback = headDate != null ? headDate : date;
+            final ReviewedMarker.Result marked = ReviewedMarker.apply(result, repoRoot, markReviewed, markFallback);
             System.out.printf(
                     "kb-freshness --mark-reviewed: updated %d doc(s). Re-run to refresh the worklist.%n",
                     marked.updated());

--- a/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/git/Git.java
+++ b/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/git/Git.java
@@ -62,6 +62,22 @@ public final class Git {
     }
 
     /**
+     * The committer date (YYYY-MM-DD) of the current {@code HEAD} commit — the checkout a run was
+     * performed against. Used as the {@code last_reviewed} date for documents that anchor no source
+     * (there is no per-source commit to derive from, but the review still happened against this commit).
+     *
+     * @return the {@code HEAD} committer date, or {@code null} if git is unavailable or the repo has no
+     *     commits.
+     */
+    public String headCommitDate() {
+        if (!available) {
+            return null;
+        }
+        final String out = run(List.of("git", "log", "-1", "--format=%cs"));
+        return out == null || out.isBlank() ? null : out.strip();
+    }
+
+    /**
      * The path a now-gone file was most recently renamed to, if git can trace it and the target still
      * exists. Follows the cited path's history for rename ({@code R}) commits; the newest one names the
      * current location. Returns {@code null} when git is unavailable, no rename is recorded, or the traced

--- a/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/worklist/WorklistBuilder.java
+++ b/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/worklist/WorklistBuilder.java
@@ -5,22 +5,24 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.TreeSet;
 import org.hiero.consensus.kbfreshness.extract.AnchorExtractor;
 import org.hiero.consensus.kbfreshness.extract.KbDocument;
 import org.hiero.consensus.kbfreshness.git.Git;
 import org.hiero.consensus.kbfreshness.model.Anchor;
 import org.hiero.consensus.kbfreshness.model.AnchorKind;
-import org.hiero.consensus.kbfreshness.model.EntryType;
 import org.hiero.consensus.kbfreshness.resolve.SourceCandidates;
 import org.hiero.consensus.kbfreshness.resolve.SourceIndex;
 import org.hiero.consensus.kbfreshness.util.Patterns;
 
 /**
- * Builds the semantic worklist: for each architecture topic/interface, whether any anchored source
- * file changed since the topic's {@code last_reviewed} date, decided purely from committed git
- * history. The result scopes the Tier-3 semantic pass so it re-reads only topics whose code moved.
+ * Builds the semantic worklist: for every scanned KB document, whether any anchored source file changed
+ * since its {@code last_reviewed} date, decided purely from committed git history. The result scopes the
+ * Tier-3 semantic pass so it re-reads only documents whose code moved (a document that anchors no code is
+ * reported {@code UNKNOWN} — there is nothing to date its prose against).
  */
 public final class WorklistBuilder {
 
@@ -53,19 +55,14 @@ public final class WorklistBuilder {
     }
 
     /**
-     * Builds the semantic worklist for the architecture topics and interfaces among the documents, sorted
-     * by entry key.
+     * Builds the semantic worklist for every scanned document, sorted by entry key.
      *
      * @param docs the KB documents to evaluate.
-     * @return one worklist entry per architecture topic/interface.
+     * @return one worklist entry per document.
      */
     public List<WorklistEntry> build(final List<KbDocument> docs) {
         final List<WorklistEntry> entries = new ArrayList<>();
         for (final KbDocument doc : docs) {
-            final EntryType type = doc.entry().type();
-            if (type != EntryType.ARCHITECTURE_TOPIC && type != EntryType.ARCHITECTURE_INTERFACE) {
-                continue;
-            }
             entries.add(evaluate(doc));
         }
         entries.sort(Comparator.comparing(WorklistEntry::entryKey));
@@ -73,17 +70,17 @@ public final class WorklistBuilder {
     }
 
     /**
-     * Evaluates one topic's freshness: {@code REVIEW} when the marker is missing/non-date or an anchored
-     * source was last committed on or after it, {@code FRESH} when every anchored source predates it,
-     * {@code UNKNOWN} — with a note naming the reason — when the topic anchors no sources, git is
-     * unavailable, or no commit date could be determined. The comparison is inclusive because commit
-     * dates are day-granular: a source touched on the {@code last_reviewed} day itself counts as changed,
-     * so a change merged later that same day is never skipped (at the cost of not clearing a topic until
-     * the day after its last change). The doc-intrinsic no-sources reason is checked before git
-     * availability so it reports the same way in every environment.
+     * Evaluates one document's freshness. A document that anchors no code is {@code UNKNOWN} (no anchored
+     * sources) regardless of its marker — there is no code to date its prose against, so this is checked
+     * first. Otherwise: {@code REVIEW} when the marker is missing/non-date or an anchored source was last
+     * committed on or after it, {@code FRESH} when every anchored source predates it, and {@code UNKNOWN}
+     * — with a note naming the reason — when git is unavailable or no commit date could be determined. The
+     * comparison is inclusive because commit dates are day-granular: a source touched on the
+     * {@code last_reviewed} day itself counts as changed, so a change merged later that same day is never
+     * skipped.
      *
      * @param doc the KB document to evaluate.
-     * @return the topic's worklist entry.
+     * @return the document's worklist entry.
      */
     private WorklistEntry evaluate(final KbDocument doc) {
         final String key = doc.entry().key();
@@ -92,40 +89,46 @@ public final class WorklistBuilder {
 
         final List<String> sourcePaths = anchoredSourcePaths(doc);
         final int anchorCount = sourcePaths.size();
-        if (lastReviewed == null
-                || !Patterns.ISO_DATE.matcher(lastReviewed.strip()).matches()) {
-            // No usable freshness marker — always route to review.
-            return new WorklistEntry(
-                    key, path, lastReviewed, WorklistEntry.Status.REVIEW, null, List.of(), anchorCount, null);
-        }
         if (sourcePaths.isEmpty()) {
+            // Anchors no code — no freshness signal exists, whatever the marker says.
             return unknown(key, path, lastReviewed, "no anchored sources", anchorCount);
         }
         if (!git.available()) {
             return unknown(key, path, lastReviewed, "git unavailable", anchorCount);
         }
 
-        final String reviewedDate = lastReviewed.strip();
-        final List<String> changed = new ArrayList<>();
+        // Scan each anchored source's last-commit date once. The newest is the reviewed-state date the
+        // marker records (via --mark-reviewed) — computed for every anchored document, even one still
+        // marked TBD — while the individual dates decide freshness against an existing marker below.
+        final Map<String, String> datedSources = new LinkedHashMap<>();
         String newest = null;
-        boolean anyDateKnown = false;
         for (final String src : sourcePaths) {
             final String commitDate = git.lastCommitDate(src);
             if (commitDate != null) {
-                anyDateKnown = true;
+                datedSources.put(src, commitDate);
                 if (newest == null || commitDate.compareTo(newest) > 0) {
                     newest = commitDate;
                 }
-                // Inclusive boundary: commit dates are day-granular, so a source last committed on the
-                // last_reviewed day itself counts as changed — a change merged later that same day is
-                // never skipped.
-                if (commitDate.compareTo(reviewedDate) >= 0) {
-                    changed.add(src);
-                }
             }
         }
-        if (!anyDateKnown) {
+        if (newest == null) {
             return unknown(key, path, lastReviewed, "no commit dates for anchored sources", anchorCount);
+        }
+        if (lastReviewed == null
+                || !Patterns.ISO_DATE.matcher(lastReviewed.strip()).matches()) {
+            // Anchored, but no usable freshness marker — route to review (newest known for --mark-reviewed).
+            return new WorklistEntry(
+                    key, path, lastReviewed, WorklistEntry.Status.REVIEW, null, List.of(), anchorCount, newest);
+        }
+        final String reviewedDate = lastReviewed.strip();
+        final List<String> changed = new ArrayList<>();
+        for (final Map.Entry<String, String> src : datedSources.entrySet()) {
+            // Inclusive boundary: commit dates are day-granular, so a source last committed on the
+            // last_reviewed day itself counts as changed — a change merged later that same day is never
+            // skipped.
+            if (src.getValue().compareTo(reviewedDate) >= 0) {
+                changed.add(src.getKey());
+            }
         }
         changed.sort(Comparator.naturalOrder());
         final WorklistEntry.Status status =

--- a/platform-sdk/consensus-kb-freshness/src/test/java/org/hiero/consensus/kbfreshness/EngineFixtureTest.java
+++ b/platform-sdk/consensus-kb-freshness/src/test/java/org/hiero/consensus/kbfreshness/EngineFixtureTest.java
@@ -289,6 +289,29 @@ class EngineFixtureTest {
     }
 
     @Test
+    void everyDocumentTypeEntersTheWorklist() {
+        // The worklist is no longer topic/interface-only: decisions, invariants, rules, and concepts are
+        // all evaluated now. Each anchors code, so it is present (not dropped by a type gate).
+        assertThat(result.worklist())
+                .anySatisfy(e -> assertThat(e.entryPath()).endsWith("decisions/ADR-001-fixture.md"))
+                .anySatisfy(e -> assertThat(e.entryPath()).endsWith("invariants/INV-001-fixture.md"))
+                .anySatisfy(e -> assertThat(e.entryPath()).endsWith("rules/RUL-001-fixture.md"))
+                .anySatisfy(e -> assertThat(e.entryPath()).endsWith("concepts/external-cites.md"));
+    }
+
+    @Test
+    void anchorlessDocIsUnknownRegardlessOfMarker() {
+        // ADR-003-fixture anchors no code and carries a non-ISO `TBD` marker. The no-anchored-sources
+        // check must win over the marker check, so it is `unknown`, not routed to `review`.
+        final WorklistEntry e = result.worklist().stream()
+                .filter(x -> x.entryPath().endsWith("decisions/ADR-003-fixture.md"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(e.status()).isEqualTo(WorklistEntry.Status.UNKNOWN);
+        assertThat(e.note()).isEqualTo("no anchored sources");
+    }
+
+    @Test
     void movedSourceStillFeedsTheWorklist() {
         // moved-anchored.md cites MovedClass at its stale module-a path; the worklist must track it at
         // its unique new location instead of dropping the topic to "no anchored sources".

--- a/platform-sdk/consensus-kb-freshness/src/test/java/org/hiero/consensus/kbfreshness/git/GitTest.java
+++ b/platform-sdk/consensus-kb-freshness/src/test/java/org/hiero/consensus/kbfreshness/git/GitTest.java
@@ -39,6 +39,22 @@ class GitTest {
         assertThat(git.findDeletion("*/NeverExisted.java")).isNull();
     }
 
+    @Test
+    void headCommitDateReportsTheCheckoutTipDate() throws Exception {
+        assumeTrue(runGit("init"), "git unavailable");
+        Files.createDirectories(tmp.resolve("m/src/main/java"));
+        Files.writeString(tmp.resolve("m/src/main/java/Present.java"), "class Present {}");
+        assumeTrue(runGit("add", "."), "git add failed");
+        assumeTrue(runGit("commit", "-m", "add Present"), "git commit failed");
+
+        final Git git = new Git(tmp);
+        assumeTrue(git.available(), "git probe failed");
+        final String head = git.headCommitDate();
+        assertThat(head).matches("\\d{4}-\\d{2}-\\d{2}");
+        // The tip commit touched Present.java, so its per-file date equals HEAD's date.
+        assertThat(git.lastCommitDate("m/src/main/java/Present.java")).isEqualTo(head);
+    }
+
     /**
      * Runs a git command in the temp repository with a hermetic identity, reporting success.
      *

--- a/platform-sdk/consensus-kb-freshness/src/test/resources/fixtures/repo/platform-sdk/docs/consensus-layer/decisions/ADR-003-fixture.md
+++ b/platform-sdk/consensus-kb-freshness/src/test/resources/fixtures/repo/platform-sdk/docs/consensus-layer/decisions/ADR-003-fixture.md
@@ -1,0 +1,13 @@
+---
+type: decision
+id: ADR-003
+title: Anchorless decision fixture
+status: accepted
+last_reviewed: TBD
+---
+
+# Anchorless decision fixture
+
+This decision cites no source file at all — pure prose, no `.java` paths, no fully-qualified type
+spans. With a non-ISO `TBD` marker and no anchored source, it must resolve to
+`unknown (no anchored sources)`: the no-sources check wins over the marker check.

--- a/platform-sdk/docs/consensus-layer/CLAUDE.md
+++ b/platform-sdk/docs/consensus-layer/CLAUDE.md
@@ -109,31 +109,35 @@ Behavioral claims tie to the specific code that makes them true. Match that bar
 - **Verify before you write; refresh on touch.** Confirm every class, method,
   path, and commit exists before citing it — never invent line numbers or
   commit hashes. When you change a claim, re-check that its anchors still
-  resolve, then refresh the file's currency marker (see
+  resolve, then have the freshness checker advance its currency marker —
+  never by hand (see
   [When to bump the freshness marker](#when-to-bump-the-freshness-marker)).
   **A stale-but-present anchor is more dangerous than none** — it reads as
   verified. If you cannot verify an anchor, say so rather than guessing.
 
 ## When to bump the freshness marker
 
-`last_reviewed` (a date) is the freshness marker on narrative and
-single-file-catalog docs (`concepts/`, `architecture/**`, `glossary.md`,
-`symptoms.md`, `tunables.md`). It asserts one thing: the file's code-anchored
-claims were checked against current code on that date. Bump it only when that
-is true. ID-catalog entries (`rules/`, `invariants/`, …) carry no date marker —
-their currency is `status`, kept honest under
-[Keep load-bearing frontmatter in sync](#keep-load-bearing-frontmatter-in-sync).
+`last_reviewed` (a date) is the freshness marker carried by **every** entry document — the narrative
+and single-file-catalog docs (`concepts/`, `architecture/**`, `glossary.md`, `symptoms.md`,
+`tunables.md`) and the ID-catalog entries (`decisions/`, `invariants/`, `rules/`, `scenarios/`,
+`heuristics/`). It asserts one thing: the file's code-anchored claims were checked against the code as
+of that commit date. A document that anchors no code (`glossary.md`, `symptoms.md`, an ADR that cites
+no source) still carries the field as a record of its last review, but the freshness checker reports it
+`unknown` — there is nothing to verify its prose against.
 
-- **Bump when** you add, change, or re-confirm a code-anchored claim: you
-  re-anchor to moved code, confirm existing anchors still resolve against
-  current code, or revise what a claim asserts.
-- **Do not bump** for edits that touch no claim and no anchor: typo fixes,
-  formatting, link repair, reordering, wording changes that leave every claim
-  intact.
-- **Never bump without verifying.** Advancing the date is itself a claim —
-  that you re-checked the anchors. If you edit a claim but cannot re-verify it,
-  leave the date and flag the gap in the entry. A falsely-fresh marker is the
-  stale-anchor failure one level up.
+**The date is written only by the KB freshness checker — never by hand.** It is advanced exclusively by
+the checker's `--mark-reviewed`, which derives the reviewed-state date from git: the newest
+anchored-source commit for an anchored doc, or the reviewed checkout's `HEAD` commit for an unanchored
+one. Do not hand-edit the date, and do not let any other tool set it. The only manual touch is creating
+the field once, as `last_reviewed: TBD`, on a new entry; the checker only ever bumps an existing line.
+
+- **Advance it (run `--mark-reviewed`) when** you have re-read the entry's prose against current code:
+  re-anchored to moved code, confirmed existing anchors still resolve, or revised what a claim asserts.
+- **Do not advance it** for edits that touch no claim and no anchor: typo fixes, formatting, link
+  repair, reordering, wording that leaves every claim intact.
+- **Never advance it without re-reviewing.** The date is a claim that you re-checked the entry against
+  code. If you edit a claim but cannot re-verify it, leave the marker and flag the gap. A falsely-fresh
+  marker is the stale-anchor failure one level up.
 
 ## Keep load-bearing frontmatter in sync
 

--- a/platform-sdk/docs/consensus-layer/LAYOUT.md
+++ b/platform-sdk/docs/consensus-layer/LAYOUT.md
@@ -206,7 +206,7 @@ and fixed per document class.
 Two header orderings apply:
 
 - **Catalog entries** (`decisions/`, `invariants/`, `rules/`, `scenarios/`, `heuristics/`):
-  `type` / `id` / `title` / … (all other existing fields unchanged)
+  `type` / `id` / `title` / … / `last_reviewed` (the trailing key)
 - **Narrative and single-file catalog files** (`concepts/`, `architecture/**`, `glossary.md`,
   `symptoms.md`, `tunables.md`): `type` / `title` / `description` (catalog files only) /
   `last_reviewed`

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-001-pces-state-snapshot-coordination.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-001-pces-state-snapshot-coordination.md
@@ -18,6 +18,7 @@ deciders:
   - Kelly Greco (@poulok)
   - Maximiliano Tartaglia (@mxtartaglia-sl)
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # ADR-001 — No Coordination Between PCES Writer and Signed State Writer for Snapshot PCES Copy

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-002-execution-freeze-signature-handoff.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-002-execution-freeze-signature-handoff.md
@@ -15,6 +15,7 @@ deciders:
   - Kelly Greco (@poulok)
   - Michael Tinker (@tinker-michaelj)
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # ADR-002 — Block `onSealConsensusRound` to Hand Off Freeze Block Signatures from Execution to Consensus

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
@@ -15,6 +15,7 @@ deciders:
   - Kelly Greco (@poulok)
   - Lazar Petrovic (@lpetrovic05)
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # ADR-003 — Remove `SwirldsPlatform.performPcesRecovery()` and Drive ISS Recovery On the Spot

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-004-retain-observing-status-for-self-event-recovery.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-004-retain-observing-status-for-self-event-recovery.md
@@ -15,6 +15,7 @@ deciders:
   - Kelly Greco (@poulok)
   - Lazar Petrovic (@lpetrovic05)
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # ADR-004 — Retain the OBSERVING Platform Status for Self-Event Recovery After Disk Loss

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-005-embedded-future-event-buffers.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-005-embedded-future-event-buffers.md
@@ -15,6 +15,7 @@ deciders:
   - Kelly Greco (@poulok)
   - Lazar Petrovic (@lpetrovic05)
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # ADR-005 — Embed a future-event buffer inside each consuming component instead of one standalone buffering component

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-006-coordinated-network-wide-upgrade.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-006-coordinated-network-wide-upgrade.md
@@ -13,6 +13,7 @@ status: accepted
 date: 2026-06-04
 deciders: []   # foundational design decision; individual authors not recorded — see Notes
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # ADR-006 — Upgrade Software via a Coordinated Network-Wide Freeze Rather Than Rolling Upgrades

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-007-save-reconnect-state-before-resuming-event-creation.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-007-save-reconnect-state-before-resuming-event-creation.md
@@ -15,6 +15,7 @@ deciders:
   - Cody Littley (@cody-littley)
   - Austin Littley (@litt3)
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # ADR-007 — Save the Reconnect State to Disk Before Resuming Event Creation

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-008-replace-ngen-with-sequence-number.md
@@ -17,6 +17,7 @@ deciders:
   - Lazar Petrovic (@lpetrovic05)
 curated_by: Michael Heinrichs (@netopyr)
 provenance: hiero-consensus-node#24618
+last_reviewed: TBD
 ---
 
 # ADR-008 — Adopt a monotonic event sequence number as the local ordering key, replacing nGen

--- a/platform-sdk/docs/consensus-layer/decisions/FORMAT.md
+++ b/platform-sdk/docs/consensus-layer/decisions/FORMAT.md
@@ -35,6 +35,7 @@ deciders:                              # people responsible for the decision
   - Full Name (@github-handle)
 curated_by: Full Name (@github-handle) # who maintains this entry
 provenance: design-session-2026-05-xx  # optional; source discussion if recorded
+last_reviewed: TBD
 ---
 ```
 
@@ -64,6 +65,10 @@ Field discipline:
   fixed vocabulary; the `topics:` axis gives the useful slice.
 - **no `confidence` field** — once accepted, the team has committed. Strength
   of belief is not the right axis for a decision.
+- **`last_reviewed`** — the trailing key. `TBD` until the entry's
+  code-anchored claims have been reviewed against current code, then the date
+  of that review. Written only by the KB freshness checker's
+  `--mark-reviewed` — never by hand.
 
 ## Body
 
@@ -169,6 +174,7 @@ date: YYYY-MM-DD
 deciders:
   - Full Name (@handle)
 curated_by: Full Name (@handle)
+last_reviewed: TBD
 ---
 
 # ADR-NNN — Title

--- a/platform-sdk/docs/consensus-layer/heuristics/FORMAT.md
+++ b/platform-sdk/docs/consensus-layer/heuristics/FORMAT.md
@@ -27,6 +27,7 @@ status: unvalidated                    # unvalidated | validated | retired
 confidence: medium                     # low | medium | high
 provenance: elicitation-2026-05-xx     # where this entry came from
 curated_by: Full Name (@github-handle) # the person responsible for this entry
+last_reviewed: TBD
 ---
 ```
 
@@ -46,6 +47,10 @@ Field discipline:
 - **`curated_by`** — the person responsible for this entry now. See
   [LAYOUT.md](../LAYOUT.md#curator-and-decider-conventions) for the canonical
   format and the distinction from `provenance`.
+- **`last_reviewed`** — the trailing key. `TBD` until the entry's
+  code-anchored claims have been reviewed against current code, then the date
+  of that review. Written only by the KB freshness checker's
+  `--mark-reviewed` — never by hand.
 
 ## Body
 
@@ -91,6 +96,7 @@ status: unvalidated
 confidence: medium
 provenance: ...
 curated_by: ...
+last_reviewed: TBD
 ---
 
 # HEU-NNN — Title

--- a/platform-sdk/docs/consensus-layer/invariants/FORMAT.md
+++ b/platform-sdk/docs/consensus-layer/invariants/FORMAT.md
@@ -31,6 +31,7 @@ source: paper §IV, Theorem 1           # the authority that makes this permanen
 verification: ConsensusEndToEndTest::testTotalOrder   # optional; how adherence is checked
 provenance: elicitation-2026-05-xx     # where this entry came from
 curated_by: Full Name (@github-handle) # the person responsible for this entry
+last_reviewed: TBD
 ---
 ```
 
@@ -65,6 +66,10 @@ Field discipline:
   believed with a strength. If there is genuine uncertainty about whether a
   property is permanent, that uncertainty itself means it belongs in
   `rules/` with a `confidence`, not here.
+- **`last_reviewed`** — the trailing key. `TBD` until the entry's
+  code-anchored claims have been reviewed against current code, then the date
+  of that review. Written only by the KB freshness checker's
+  `--mark-reviewed` — never by hand.
 
 ## Body
 
@@ -114,6 +119,7 @@ source: ...
 verification: ...
 provenance: ...
 curated_by: ...
+last_reviewed: TBD
 ---
 
 # INV-NNN — Title

--- a/platform-sdk/docs/consensus-layer/invariants/INV-001-voting-round-monotonic-along-ancestry.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-001-voting-round-monotonic-along-ancestry.md
@@ -19,6 +19,7 @@ source: >
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java — `recalculateAndVote` (the per-round metadata-clearing step that preserves the property across roster changes)
 provenance: entry originally added by prior elicitation; revised 2026-06-08 (terminology updated to "voting round")
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # INV-001 — Voting round is monotonic along ancestry — a parent's round never exceeds its child's

--- a/platform-sdk/docs/consensus-layer/invariants/INV-002-consensus-order-agreed-by-all-nodes.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-002-consensus-order-agreed-by-all-nodes.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java — `setConsensusOrder` / `findConsensusEvents` (deterministic order assignment over `ConsensusSorter`-sorted events)
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-002 — Consensus order is agreed by all nodes

--- a/platform-sdk/docs/consensus-layer/invariants/INV-003-consensus-timestamp-agreed-by-all-nodes.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-003-consensus-timestamp-agreed-by-all-nodes.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java — `setIsConsensusTrue` (median of judge/ancestor receipt times)
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-003 — Consensus timestamp is agreed by all nodes

--- a/platform-sdk/docs/consensus-layer/invariants/INV-004-staleness-is-network-wide.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-004-staleness-is-network-wide.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java — `ancient(x)` (`birthRound < ancientThreshold`); stale-event emission in `DefaultConsensusEngine`
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-004 — Staleness is network-wide

--- a/platform-sdk/docs/consensus-layer/invariants/INV-005-honest-event-eventually-reaches-consensus-or-stale.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-005-honest-event-eventually-reaches-consensus-or-stale.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java — election pipeline (`voteInAllElections`, `firstVote`, `coinVote`) and ancient eviction
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-005 — Every honest event eventually reaches a final fate

--- a/platform-sdk/docs/consensus-layer/invariants/INV-006-every-round-eventually-has-a-judge.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-006-every-round-eventually-has-a-judge.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/RoundElections.java — `isDecided` / `findAllJudges`; coin rounds in `ConsensusImpl`
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-006 — Every round eventually has at least one judge

--- a/platform-sdk/docs/consensus-layer/invariants/INV-007-judge-set-agreed-across-deciders.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-007-judge-set-agreed-across-deciders.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/RoundElections.java — `findAllJudges`; judge set frozen in `ConsensusSnapshot.judgeIds`
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-007 — All deciders of a round agree on its judge set

--- a/platform-sdk/docs/consensus-layer/invariants/INV-008-consensus-once-reached-is-permanent.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-008-consensus-once-reached-is-permanent.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/EventImpl.java — `setConsensus(true)` is one-way; finalized `ConsensusRound` is immutable
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-008 — Consensus, once reached, is permanent

--- a/platform-sdk/docs/consensus-layer/invariants/INV-009-decided-election-never-flips.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-009-decided-election-never-flips.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/EventImpl.java — `isFameDecided`; `CandidateWitness.isDecided`
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-009 — A decided election never flips

--- a/platform-sdk/docs/consensus-layer/invariants/INV-010-consensus-events-have-verified-signatures.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-010-consensus-events-have-verified-signatures.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-event-intake-concurrent/src/main/java/org/hiero/consensus/event/intake/concurrent/ConcurrentEventIntakeProcessor.java — `isSignatureValid` verifies against the creator's key and rejects failures
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-010 — Every consensus event has a verified creator signature

--- a/platform-sdk/docs/consensus-layer/invariants/INV-011-birth-round-monotonic-along-ancestry.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-011-birth-round-monotonic-along-ancestry.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-utility/src/main/java/org/hiero/consensus/event/validation/DefaultEventFieldValidator.java — `isEventBirthRoundValid` rejects an event whose birth round is below a parent's
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-011 — Birth round is monotonic along ancestry

--- a/platform-sdk/docs/consensus-layer/invariants/INV-012-min-non-ancient-round-monotonic.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-012-min-non-ancient-round-monotonic.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusRounds.java — `updateAncientThreshold`; `RoundCalculationUtils.getOldestNonAncientRound`
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-012 — The minimum non-ancient round never decreases

--- a/platform-sdk/docs/consensus-layer/invariants/INV-013-honest-event-coin-is-unpredictable.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-013-honest-event-coin-is-unpredictable.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreator.java — coin drawn per event from a cryptographically secure `SecureRandom`; consumed in `ConsensusUtils.coin`
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-013 — An honest event's coin value is unpredictable

--- a/platform-sdk/docs/consensus-layer/invariants/INV-014-consensus-order-is-a-strict-total-order.md
+++ b/platform-sdk/docs/consensus-layer/invariants/INV-014-consensus-order-is-a-strict-total-order.md
@@ -14,6 +14,7 @@ source: The hashgraph consensus algorithm (protocol definition).
 verification: consensus-hashgraph-impl/src/main/java/org/hiero/consensus/hashgraph/impl/consensus/ConsensusImpl.java — `setConsensusOrder` assigns a strictly-incrementing order over `ConsensusSorter`-sorted events
 provenance: 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # INV-014 — Consensus order is a strict total order with unique ranks

--- a/platform-sdk/docs/consensus-layer/rules/FORMAT.md
+++ b/platform-sdk/docs/consensus-layer/rules/FORMAT.md
@@ -32,6 +32,7 @@ status: holds                          # holds | divergent | retired
 confidence: medium                     # low | medium | high
 provenance: extraction-2026-05-xx      # where this entry came from
 curated_by: Full Name (@github-handle) # the person responsible for this entry
+last_reviewed: TBD
 ---
 ```
 
@@ -63,6 +64,10 @@ Field discipline:
 - **no `source` field** — a rule has no external authority; that absence is
   precisely what separates it from an invariant. Its justification lives in
   the `## Why it holds now` body section, not in a citation.
+- **`last_reviewed`** — the trailing key. `TBD` until the entry's
+  code-anchored claims have been reviewed against current code, then the date
+  of that review. Written only by the KB freshness checker's
+  `--mark-reviewed` — never by hand.
 
 ## Body
 
@@ -129,6 +134,7 @@ status: holds
 confidence: medium
 provenance: ...
 curated_by: ...
+last_reviewed: TBD
 ---
 
 # RUL-NNN — Title

--- a/platform-sdk/docs/consensus-layer/rules/RUL-001-signed-state-reservations.md
+++ b/platform-sdk/docs/consensus-layer/rules/RUL-001-signed-state-reservations.md
@@ -24,6 +24,7 @@ status: holds
 confidence: high
 provenance: extracted from architecture/topics/signed-state-management.md, 2026-05-27
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # RUL-001 — A SignedState must remain reserved while any consumer can still access it

--- a/platform-sdk/docs/consensus-layer/rules/RUL-002-intake-flush-ordering.md
+++ b/platform-sdk/docs/consensus-layer/rules/RUL-002-intake-flush-ordering.md
@@ -19,6 +19,7 @@ status: holds
 confidence: high
 provenance: elicitation-2026-06-03
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # RUL-002 — The intake pipeline is flushed component-by-component in topological order so every event advances as far as it can

--- a/platform-sdk/docs/consensus-layer/rules/RUL-003-consensus-contributors-independently-restartable.md
+++ b/platform-sdk/docs/consensus-layer/rules/RUL-003-consensus-contributors-independently-restartable.md
@@ -22,6 +22,7 @@ status: holds
 confidence: high
 provenance: extraction-2026-06-09
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # RUL-003 — Every node contributing to consensus is independently restartable

--- a/platform-sdk/docs/consensus-layer/rules/RUL-004-consensus-intake-admits-valid-parent-links.md
+++ b/platform-sdk/docs/consensus-layer/rules/RUL-004-consensus-intake-admits-valid-parent-links.md
@@ -15,6 +15,7 @@ status: holds
 confidence: high
 provenance: originally 2026-06-08 extraction run
 curated_by: Michael Heinrichs (@netopyr)
+last_reviewed: TBD
 ---
 
 # RUL-004 — Consensus intake admits only non-ancient parent links whose claimed birth round matches the actual parent

--- a/platform-sdk/docs/consensus-layer/rules/RUL-005-events-below-decided-round-skip-witness-calc.md
+++ b/platform-sdk/docs/consensus-layer/rules/RUL-005-events-below-decided-round-skip-witness-calc.md
@@ -17,6 +17,7 @@ status: holds
 confidence: high
 provenance: elicitation-2026-06-23; revised from #26319 (sequence-number threshold reverted to nGen); re-diagnosed 2026-07-27 (SCN-002 root cause is #26529, not the key; frontier safety rests on INV-015)
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # RUL-005 — Events below the latest decided round's judges are excluded from witness calculation

--- a/platform-sdk/docs/consensus-layer/scenarios/FORMAT.md
+++ b/platform-sdk/docs/consensus-layer/scenarios/FORMAT.md
@@ -32,6 +32,7 @@ related:
 status: draft                         # draft | reviewed | verified
 provenance: war-story-interview-2026-05-xx
 curated_by: Full Name (@github-handle) # the person responsible for this entry
+last_reviewed: TBD
 ---
 ```
 
@@ -64,6 +65,10 @@ Field discipline:
 - **`curated_by`** — the person responsible for this entry now. See
   [LAYOUT.md](../LAYOUT.md#curator-and-decider-conventions) for the canonical
   format and the distinction from `provenance`.
+- **`last_reviewed`** — the trailing key. `TBD` until the entry's
+  code-anchored claims have been reviewed against current code, then the date
+  of that review. Written only by the KB freshness checker's
+  `--mark-reviewed` — never by hand.
 
 ## Body
 
@@ -149,6 +154,7 @@ related:
 status: draft
 provenance: ...
 curated_by: ...
+last_reviewed: TBD
 ---
 
 # SCN-NNN — Title

--- a/platform-sdk/docs/consensus-layer/scenarios/SCN-001-same-round-judge-ancestry-stalls-consensus.md
+++ b/platform-sdk/docs/consensus-layer/scenarios/SCN-001-same-round-judge-ancestry-stalls-consensus.md
@@ -15,6 +15,7 @@ related:
 status: verified
 provenance: caught by a JRS address-book/roster-change integration test that halted on this stall; JRS test framework subsequently retired
 curated_by: Kelly Greco (@poulok)
+last_reviewed: TBD
 ---
 
 # SCN-001 — A round's judge exempted from clearing has another same-round judge in its ancestry — consensus stalls after roster change


### PR DESCRIPTION
**Description:**

This PR expands the KB freshness checker to validate all documents in the knowledge base. Previously most documents were ignored during the semantic check.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>