### PR TITLE
PBJ optimize branch 

### DIFF
--- a/hapi/hapi/src/test/java/com/hedera/hapi/node/base/codec/KeyProtoCodecTest.java
+++ b/hapi/hapi/src/test/java/com/hedera/hapi/node/base/codec/KeyProtoCodecTest.java
@@ -52,11 +52,7 @@ final class KeyProtoCodecTest {
 
         assertThat(serializedKey.bytes()).hasSizeLessThanOrEqualTo(MAX_TRANSACTION_BYTES);
         assertThatThrownBy(() -> Key.PROTOBUF.parse(
-                        Bytes.wrap(serializedKey.bytes()).toReadableSequentialData(),
-                        false,
-                        false,
-                        DEFAULT_MAX_DEPTH,
-                        MAX_TRANSACTION_BYTES))
+                        serializedKey.bytes(), false, false, DEFAULT_MAX_DEPTH, MAX_TRANSACTION_BYTES))
                 .isInstanceOf(ParseException.class)
                 .hasMessageContaining("Reached maximum allowed depth");
     }
@@ -100,12 +96,7 @@ final class KeyProtoCodecTest {
                 null,
                 () -> {
                     try {
-                        Key.PROTOBUF.parse(
-                                Bytes.wrap(serializedKey).toReadableSequentialData(),
-                                false,
-                                false,
-                                maxDepth,
-                                MAX_TRANSACTION_BYTES);
+                        Key.PROTOBUF.parse(serializedKey, false, false, maxDepth, MAX_TRANSACTION_BYTES);
                     } catch (final Throwable t) {
                         thrown.set(t);
                     }

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/CommonPbjConverters.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/CommonPbjConverters.java
@@ -284,7 +284,7 @@ public class CommonPbjConverters {
             final var bytes = requireNonNull(proto).toByteArray();
             final var codecField = requireNonNull(pbjClass).getDeclaredField("PROTOBUF");
             final var codec = (Codec<R>) codecField.get(null);
-            return codec.parseStrict(BufferedData.wrap(bytes));
+            return codec.parseStrict(bytes);
         } catch (NoSuchFieldException | IllegalAccessException | ParseException e) {
             // Should be impossible, so just propagate an exception
             throw new RuntimeException("Invalid conversion to PBJ for " + pbjClass.getSimpleName(), e);
@@ -419,7 +419,7 @@ public class CommonPbjConverters {
         requireNonNull(keyValue);
         try {
             final var bytes = keyValue.toByteArray();
-            return Key.PROTOBUF.parseStrict(BufferedData.wrap(bytes));
+            return Key.PROTOBUF.parseStrict(bytes);
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }
@@ -446,8 +446,7 @@ public class CommonPbjConverters {
             final var bytes = txBody.toByteArray();
             // parse in strict mode.
             // We can't use the `parseStrict` call because we want to also validate the depth of protob messages.
-            return TransactionBody.PROTOBUF.parse(
-                    BufferedData.wrap(bytes), false, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
+            return TransactionBody.PROTOBUF.parse(bytes, false, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
         } catch (ParseException e) {
             throw new RuntimeException(e);
         }

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/CommonPbjConverters.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/CommonPbjConverters.java
@@ -37,16 +37,16 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.hederahashgraph.api.proto.java.AccountID.AccountCase;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
+import org.hiero.base.utility.PbjUtils;
 
 public class CommonPbjConverters {
     public static final int MAX_PBJ_RECORD_SIZE = 33554432;
@@ -134,12 +134,14 @@ public class CommonPbjConverters {
     public static <T> byte[] asBytes(@NonNull Codec<T> codec, @NonNull T tx) {
         requireNonNull(codec);
         requireNonNull(tx);
+        PbjWriter writer = PbjUtils.takeTlsWriter();
         try {
-            final var bytes = new ByteArrayOutputStream();
-            codec.write(tx, new WritableStreamingData(bytes));
-            return bytes.toByteArray();
-        } catch (IOException e) {
-            throw new RuntimeException("Unable to convert from PBJ to bytes", e);
+            codec.write(tx, writer);
+            byte[] bytes = writer.toByteArray();
+            writer.throwOnError();
+            return bytes;
+        } finally {
+            PbjUtils.returnTlsWriter();
         }
     }
 

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/blocks/BlockStreamAccess.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/blocks/BlockStreamAccess.java
@@ -199,19 +199,11 @@ public enum BlockStreamAccess {
                 try (final GZIPInputStream in = new GZIPInputStream(Files.newInputStream(path))) {
                     // parseStrict shorthand omitted intentionally: maxSize validation requires the multi-arg overload.
                     return Block.PROTOBUF.parse(
-                            Bytes.wrap(in.readAllBytes()).toReadableSequentialData(),
-                            true,
-                            false,
-                            DEFAULT_MAX_DEPTH,
-                            MAX_PBJ_RECORD_SIZE);
+                            Bytes.wrap(in.readAllBytes()), true, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
                 }
             } else {
                 return Block.PROTOBUF.parse(
-                        Bytes.wrap(Files.readAllBytes(path)).toReadableSequentialData(),
-                        true,
-                        false,
-                        DEFAULT_MAX_DEPTH,
-                        MAX_PBJ_RECORD_SIZE);
+                        Bytes.wrap(Files.readAllBytes(path)), true, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
             }
         } catch (IOException | ParseException e) {
             throw new RuntimeException("Failed reading block @ " + path, e);

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/blocks/BlockStreamAccess.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/blocks/BlockStreamAccess.java
@@ -15,7 +15,6 @@ import com.hedera.hapi.block.stream.output.SingletonUpdateChange;
 import com.hedera.hapi.block.stream.output.StateChange;
 import com.hedera.hapi.block.stream.output.StateChanges;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.File;
@@ -198,12 +197,11 @@ public enum BlockStreamAccess {
             if (fileName.endsWith(".gz")) {
                 try (final GZIPInputStream in = new GZIPInputStream(Files.newInputStream(path))) {
                     // parseStrict shorthand omitted intentionally: maxSize validation requires the multi-arg overload.
-                    return Block.PROTOBUF.parse(
-                            Bytes.wrap(in.readAllBytes()), true, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
+                    return Block.PROTOBUF.parse(in.readAllBytes(), true, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
                 }
             } else {
                 return Block.PROTOBUF.parse(
-                        Bytes.wrap(Files.readAllBytes(path)), true, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
+                        Files.readAllBytes(path), true, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
             }
         } catch (IOException | ParseException e) {
             throw new RuntimeException("Failed reading block @ " + path, e);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
@@ -1575,7 +1575,7 @@ public class BlockStreamBuilder
 
     private TransactionBody inProgressBody() {
         try {
-            return TransactionBody.PROTOBUF.parseStrict(signedTx.bodyBytes().toReadableSequentialData());
+            return TransactionBody.PROTOBUF.parseStrict(signedTx.bodyBytes());
         } catch (Exception e) {
             throw new IllegalStateException("Record being built for unparseable transaction", e);
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferIO.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferIO.java
@@ -179,8 +179,7 @@ public class BlockBufferIO {
                 byteBuffer.get(payload);
                 final Bytes bytes = Bytes.wrap(payload);
 
-                return BufferedBlock.PROTOBUF.parse(
-                        bytes.toReadableSequentialData(), false, false, maxReadDepth, length);
+                return BufferedBlock.PROTOBUF.parse(bytes, false, false, maxReadDepth, length);
             }
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
@@ -14,6 +14,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
+import org.hiero.base.utility.PbjUtils;
 
 /**
  * A "block state" is the collection of items contained with a single block and can be streamed to a block node.
@@ -154,7 +155,7 @@ public class BlockState {
         }
         // The leading varint is the protobuf tag: (fieldNumber << 3) | wireType. The field number identifies which
         // oneof field is set, which corresponds 1:1 to the BlockItem item type.
-        final int tag = serializedItem.toReadableSequentialData().readVarInt(false);
+        final int tag = PbjUtils.readVarInt(serializedItem, false);
         return BlockItem.ItemOneOfType.fromProtobufOrdinal(tag >>> PROTOBUF_TAG_TYPE_BITS);
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
@@ -320,8 +320,7 @@ public class FileBlockItemWriter implements BlockItemWriter {
     private static Block parseBlock(final byte[] bytes, final int maxReadDepth, final int maxReadSize)
             throws ParseException {
         // parseStrict shorthand omitted: we also need to validate max depth, requiring the multi-arg overload.
-        return Block.PROTOBUF.parse(
-                Bytes.wrap(bytes).toReadableSequentialData(), false, false, maxReadDepth, maxReadSize);
+        return Block.PROTOBUF.parse(bytes, false, false, maxReadDepth, maxReadSize);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ConfigProviderImpl.java
@@ -138,8 +138,7 @@ public class ConfigProviderImpl extends ConfigProviderBase {
         requireNonNull(builder);
         requireNonNull(propertyFileContent);
         try {
-            final var configurationList =
-                    ServicesConfigurationList.PROTOBUF.parseStrict(propertyFileContent.toReadableSequentialData());
+            final var configurationList = ServicesConfigurationList.PROTOBUF.parseStrict(propertyFileContent);
             final var configSource = new SettingsConfigSource(configurationList.nameValue(), 101);
             builder.withSource(configSource);
         } catch (ParseException | NullPointerException e) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
@@ -101,7 +101,7 @@ public final class ExchangeRateManager {
         // Parse the exchange rate file. If we cannot parse it, we just continue with whatever our previous rate was.
         final ExchangeRateSet proposedRates;
         try {
-            proposedRates = ExchangeRateSet.PROTOBUF.parseStrict(bytes.toReadableSequentialData());
+            proposedRates = ExchangeRateSet.PROTOBUF.parseStrict(bytes);
         } catch (final ParseException e) {
             throw new HandleException(ResponseCodeEnum.INVALID_EXCHANGE_RATE_FILE);
         }
@@ -205,7 +205,7 @@ public final class ExchangeRateManager {
         final var bytes = FileUtilities.getFileContent(state, fileID);
         final ExchangeRateSet exchangeRates;
         try {
-            exchangeRates = ExchangeRateSet.PROTOBUF.parseStrict(bytes.toReadableSequentialData());
+            exchangeRates = ExchangeRateSet.PROTOBUF.parseStrict(bytes);
         } catch (ParseException e) {
             // This should never happen
             throw new IllegalStateException(e);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/FeeManager.java
@@ -125,7 +125,7 @@ public final class FeeManager {
         // Parse the current and next fee schedules
         final CurrentAndNextFeeSchedule schedules;
         try {
-            schedules = CurrentAndNextFeeSchedule.PROTOBUF.parseStrict(bytes.toReadableSequentialData());
+            schedules = CurrentAndNextFeeSchedule.PROTOBUF.parseStrict(bytes);
         } catch (final BufferUnderflowException | ParseException ex) {
             return ResponseCodeEnum.FEE_SCHEDULE_FILE_PART_UPLOADED;
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
@@ -3,6 +3,8 @@ package com.hedera.node.app.grpc.impl;
 
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.metrics.api.Counter;
@@ -39,15 +41,15 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
     private static final String SPEEDOMETER_RECEIVED_DESC_TPL = "number of %s received per second";
 
     /**
-     * Per-thread shared {@link BufferedData} for responses. We store these in a thread local, because we do
+     * Per-thread shared {@link PbjWriter} for responses. We store these in a thread local, because we do
      * not have control over the thread pool used by the underlying gRPC server.
      */
     @SuppressWarnings(
             "java:S5164") // looks like a false positive ("ThreadLocal" variables should be cleaned up when no longer
     // used), but these threads are long-lived and the lifetime of the thread local is the same as
     // the application
-    private static final ThreadLocal<BufferedData> BUFFER_THREAD_LOCAL =
-            ThreadLocal.withInitial(() -> BufferedData.allocate(MAX_RESPONSE_SIZE));
+    private static final ThreadLocal<PbjWriter> BUFFER_THREAD_LOCAL =
+            ThreadLocal.withInitial(() -> new PbjWriter(MAX_RESPONSE_SIZE));
 
     /** The name of the service associated with this method. */
     protected final String serviceName;
@@ -124,8 +126,8 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
             handle(requestBytes, responseBuffer);
 
             // Respond to the client
-            responseBuffer.flip();
-            responseObserver.onNext(responseBuffer);
+            PbjReader pbjReader = responseBuffer.toPbjReader();
+            responseObserver.onNext(BufferedData.wrap(pbjReader.array(), 0, (int) pbjReader.limit()));
             responseObserver.onCompleted();
 
             // Track the number of times we successfully handled a call
@@ -146,9 +148,9 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
      * if a gRPC <b>ERROR</b> is to be returned.
      *
      * @param requestBuffer The {@link Bytes} containing the protobuf bytes for the request
-     * @param responseBuffer A {@link BufferedData} into which the response protobuf bytes may be written
+     * @param responseBuffer A {@link PbjWriter} into which the response protobuf bytes may be written
      */
-    protected abstract void handle(@NonNull final Bytes requestBuffer, @NonNull final BufferedData responseBuffer);
+    protected abstract void handle(@NonNull final Bytes requestBuffer, @NonNull final PbjWriter responseBuffer);
 
     /**
      * Helper method for creating a {@link Counter} metric.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/MethodBase.java
@@ -49,7 +49,7 @@ public abstract class MethodBase implements ServerCalls.UnaryMethod<BufferedData
     // used), but these threads are long-lived and the lifetime of the thread local is the same as
     // the application
     private static final ThreadLocal<PbjWriter> BUFFER_THREAD_LOCAL =
-            ThreadLocal.withInitial(() -> new PbjWriter(MAX_RESPONSE_SIZE));
+            ThreadLocal.withInitial(() -> new PbjWriter(MAX_RESPONSE_SIZE, false));
 
     /** The name of the service associated with this method. */
     protected final String serviceName;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/QueryMethod.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/QueryMethod.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.node.transaction.Query;
 import com.hedera.node.app.workflows.query.QueryWorkflow;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.metrics.api.Counter;
 import com.swirlds.metrics.api.Metrics;
@@ -59,7 +59,7 @@ public final class QueryMethod extends MethodBase {
 
     /** {@inheritDoc} */
     @Override
-    protected void handle(@NonNull final Bytes requestBuffer, @NonNull final BufferedData responseBuffer) {
+    protected void handle(@NonNull final Bytes requestBuffer, @NonNull final PbjWriter responseBuffer) {
         workflow.handleQuery(requestBuffer, responseBuffer);
         queriesAnsweredCounter.increment();
         queriesAnsweredSpeedometer.cycle();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/TransactionMethod.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/grpc/impl/TransactionMethod.java
@@ -3,7 +3,7 @@ package com.hedera.node.app.grpc.impl;
 
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.node.app.workflows.ingest.IngestWorkflow;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -39,7 +39,7 @@ public final class TransactionMethod extends MethodBase {
 
     /** {@inheritDoc} */
     @Override
-    protected void handle(@NonNull final Bytes requestBuffer, @NonNull final BufferedData responseBuffer) {
+    protected void handle(@NonNull final Bytes requestBuffer, @NonNull final PbjWriter responseBuffer) {
         workflow.submitTransaction(requestBuffer, responseBuffer);
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/info/DiskStartupNetworks.java
@@ -14,7 +14,7 @@ import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.NetworkAdminConfig;
 import com.hedera.node.internal.network.Network;
 import com.hedera.node.internal.network.NodeMetadata;
-import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.State;
@@ -40,6 +40,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.hiero.base.utility.PbjUtils;
 import org.hiero.consensus.roster.RosterRetriever;
 
 /**
@@ -380,15 +381,15 @@ public class DiskStartupNetworks implements StartupNetworks {
      */
     public static Optional<Network> loadNetworkFrom(@NonNull final Path path) {
         if (Files.exists(path)) {
+            PbjReader reader = PbjUtils.takeTlsReader();
             try (final var fin = Files.newInputStream(path)) {
+                reader.resetWith(fin);
                 return Optional.of(Network.JSON.parse(
-                        new ReadableStreamingData(fin),
-                        true,
-                        false,
-                        DEFAULT_MAX_DEPTH,
-                        STARTUP_NETWORK_JSON_MAX_FIELD_SIZE));
+                        reader, true, false, DEFAULT_MAX_DEPTH, STARTUP_NETWORK_JSON_MAX_FIELD_SIZE));
             } catch (Exception e) {
                 log.warn("Failed to load {} network info from {}", path.toAbsolutePath(), e);
+            } finally {
+                PbjUtils.returnTlsReader();
             }
         }
         return Optional.empty();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigration.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigration.java
@@ -196,11 +196,7 @@ public class WrappedRecordBlockHashMigration {
     private WrappedRecordFileBlockHashesLog loadRecentHashes(@NonNull final Path recentHashesPath) throws Exception {
         final var loadedBytes = Files.readAllBytes(recentHashesPath);
         final var allRecentWrappedRecordHashes = WrappedRecordFileBlockHashesLog.PROTOBUF.parse(
-                com.hedera.pbj.runtime.io.buffer.Bytes.wrap(loadedBytes).toReadableSequentialData(),
-                true,
-                false,
-                Codec.DEFAULT_MAX_DEPTH,
-                loadedBytes.length + loadedBytes.length / 10);
+                loadedBytes, true, false, Codec.DEFAULT_MAX_DEPTH, loadedBytes.length + loadedBytes.length / 10);
         if (allRecentWrappedRecordHashes.entries().isEmpty()) {
             log.error("Recent wrapped record hashes file contains no entries. {}", RESUME_MESSAGE);
             return null;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesDiskWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesDiskWriter.java
@@ -183,11 +183,7 @@ public class WrappedRecordFileBlockHashesDiskWriter implements AutoCloseable {
             // which is a valid protobuf encoding of the container message.
             // parseStrict shorthand omitted: we also need to validate max length, requiring the multi-arg overload.
             final var log = WrappedRecordFileBlockHashesLog.PROTOBUF.parse(
-                    com.hedera.pbj.runtime.io.buffer.Bytes.wrap(allBytes).toReadableSequentialData(),
-                    true,
-                    false,
-                    Codec.DEFAULT_MAX_DEPTH,
-                    allBytes.length + allBytes.length / 10);
+                    allBytes, true, false, Codec.DEFAULT_MAX_DEPTH, allBytes.length + allBytes.length / 10);
             for (final var entry : log.entries()) {
                 index.add(entry.blockNumber());
             }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/BlockRecordWriterV6.java
@@ -27,10 +27,9 @@ import com.hedera.node.app.records.impl.producers.BlockRecordWriter;
 import com.hedera.node.app.records.impl.producers.SerializedSingleTransactionRecord;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
@@ -121,10 +120,8 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
     private GZIPOutputStream gzipOutputStream = null;
     /** HashingOutputStream for hashing the file contents, wraps {@link #gzipOutputStream} or {@link #fileOutputStream} */
     private HashingOutputStream hashingOutputStream;
-    /** The buffered output stream we are writing to, wraps {@link #hashingOutputStream} */
-    private BufferedOutputStream bufferedOutputStream;
-    /** WritableStreamingData we are writing to, wraps {@link #bufferedOutputStream} */
-    private WritableStreamingData outputStream;
+    /** PbjWriter we are writing to, wraps {@link #hashingOutputStream} */
+    private PbjWriter outputStream;
     /** The state of this writer */
     private State state;
 
@@ -209,8 +206,7 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
             fileOutputStream = Files.newOutputStream(recordFilePath);
             gzipOutputStream = new GZIPOutputStream(fileOutputStream);
             hashingOutputStream = new HashingOutputStream(createWholeFileMessageDigest(), gzipOutputStream);
-            bufferedOutputStream = new BufferedOutputStream(hashingOutputStream);
-            outputStream = new WritableStreamingData(bufferedOutputStream);
+            outputStream = new PbjWriter(hashingOutputStream);
 
             // Write the header
             writeHeader(hapiProtoVersion);
@@ -250,7 +246,7 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
         try {
             // There are a lot of flushes and closes here, but unfortunately it is not guaranteed that a OutputStream
             // will propagate though a chain of streams. So we have to flush and close each one individually.
-            bufferedOutputStream.flush();
+            outputStream.flush();
             if (gzipOutputStream != null) gzipOutputStream.flush();
             fileOutputStream.flush();
 
@@ -258,7 +254,6 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
             writeFooter(endRunningHash);
 
             outputStream.close();
-            bufferedOutputStream.close();
             if (gzipOutputStream != null) gzipOutputStream.close();
             fileOutputStream.close();
 
@@ -286,17 +281,17 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
     // =================================================================================================================
     // Private implementation methods
 
-    private void writeHeader(@NonNull final SemanticVersion hapiProtoVersion) throws UncheckedIOException {
-        try {
-            // Write the record file version int first to start of file
-            outputStream.writeInt(VERSION_6);
-            // [1] - hapi_proto_version
-            writeMessage(outputStream, HAPI_PROTO_VERSION, hapiProtoVersion, SemanticVersion.PROTOBUF);
-            // [2] - start_object_running_hash
-            writeMessage(outputStream, START_OBJECT_RUNNING_HASH, startObjectRunningHash, HashObject.PROTOBUF);
-        } catch (final IOException e) {
+    private void writeHeader(@NonNull final SemanticVersion hapiProtoVersion) {
+        // Write the record file version int first to start of file
+        outputStream.writeInt(VERSION_6);
+        // [1] - hapi_proto_version
+        writeMessage(outputStream, HAPI_PROTO_VERSION, hapiProtoVersion, SemanticVersion.PROTOBUF);
+        // [2] - start_object_running_hash
+        writeMessage(outputStream, START_OBJECT_RUNNING_HASH, startObjectRunningHash, HashObject.PROTOBUF);
+        if (outputStream.error() != 0) {
+            RuntimeException e = outputStream.getCause();
             logger.warn("Error writing header to record file {}", recordFilePath, e);
-            throw new UncheckedIOException(e);
+            throw e;
         }
     }
 
@@ -306,20 +301,20 @@ public final class BlockRecordWriterV6 implements BlockRecordWriter {
      * @param endRunningHash the ending running hash after the last record stream item
      */
     private void writeFooter(@NonNull final HashObject endRunningHash) throws UncheckedIOException {
-        try {
-            // [4] - end_object_running_hash
-            writeMessage(outputStream, END_OBJECT_RUNNING_HASH, endRunningHash, HashObject.PROTOBUF);
-            // [5] - block_number
-            writeLong(outputStream, BLOCK_NUMBER, blockNumber);
-            // [6] - sidecars
-            ProtoWriterTools.writeMessageList(
-                    outputStream,
-                    SIDECARS,
-                    sidecarMetadata == null ? Collections.emptyList() : sidecarMetadata,
-                    SidecarMetadata.PROTOBUF);
-        } catch (IOException e) {
+        // [4] - end_object_running_hash
+        writeMessage(outputStream, END_OBJECT_RUNNING_HASH, endRunningHash, HashObject.PROTOBUF);
+        // [5] - block_number
+        writeLong(outputStream, BLOCK_NUMBER, blockNumber);
+        // [6] - sidecars
+        ProtoWriterTools.writeMessageList(
+                outputStream,
+                SIDECARS,
+                sidecarMetadata == null ? Collections.emptyList() : sidecarMetadata,
+                SidecarMetadata.PROTOBUF);
+        if (outputStream.error() != 0) {
+            RuntimeException e = outputStream.getCause();
             logger.warn("Error writing footer to record file {}", recordFilePath, e);
-            throw new UncheckedIOException(e);
+            throw e;
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/SignatureWriterV6.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v6/SignatureWriterV6.java
@@ -7,8 +7,8 @@ import com.hedera.hapi.streams.HashObject;
 import com.hedera.hapi.streams.SignatureFile;
 import com.hedera.hapi.streams.SignatureObject;
 import com.hedera.hapi.streams.SignatureType;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -24,6 +24,7 @@ import org.hiero.base.crypto.DigestType;
 import org.hiero.base.crypto.HashingOutputStream;
 import org.hiero.base.crypto.Signer;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 
 /**
  * Simple stateless class with static methods to write signature files. It cleanly separates out the code for generating
@@ -65,34 +66,40 @@ final class SignatureWriterV6 {
         // write signature file
         final var sigFilePath = getSigFilePath(recordFilePath);
         try (final var fileOut = Files.newOutputStream(sigFilePath, StandardOpenOption.CREATE_NEW)) {
-            final var streamingData = new WritableStreamingData(fileOut);
-            Bytes metadataHash = null;
-            if (writeMetadataSignature) {
-                // create metadata hash
-                HashingOutputStream hashingOutputStream =
-                        new HashingOutputStream(MessageDigest.getInstance(DigestType.SHA_384.algorithmName()));
-                SerializableDataOutputStream dataOutputStream = new SerializableDataOutputStream(hashingOutputStream);
-                dataOutputStream.writeInt(recordFileVersion);
-                dataOutputStream.writeInt(hapiProtoVersion.major());
-                dataOutputStream.writeInt(hapiProtoVersion.minor());
-                dataOutputStream.writeInt(hapiProtoVersion.patch());
-                startRunningHash.writeTo(dataOutputStream);
-                endRunningHash.writeTo(dataOutputStream);
-                dataOutputStream.writeLong(blockNumber);
-                dataOutputStream.close();
-                metadataHash = Bytes.wrap(hashingOutputStream.getDigest());
+            PbjWriter streamingData = PbjUtils.takeTlsWriter();
+            try {
+                streamingData.resetWith(fileOut);
+                Bytes metadataHash = null;
+                if (writeMetadataSignature) {
+                    // create metadata hash
+                    HashingOutputStream hashingOutputStream =
+                            new HashingOutputStream(MessageDigest.getInstance(DigestType.SHA_384.algorithmName()));
+                    SerializableDataOutputStream dataOutputStream =
+                            new SerializableDataOutputStream(hashingOutputStream);
+                    dataOutputStream.writeInt(recordFileVersion);
+                    dataOutputStream.writeInt(hapiProtoVersion.major());
+                    dataOutputStream.writeInt(hapiProtoVersion.minor());
+                    dataOutputStream.writeInt(hapiProtoVersion.patch());
+                    startRunningHash.writeTo(dataOutputStream);
+                    endRunningHash.writeTo(dataOutputStream);
+                    dataOutputStream.writeLong(blockNumber);
+                    dataOutputStream.close();
+                    metadataHash = Bytes.wrap(hashingOutputStream.getDigest());
+                }
+                // create signature file
+                final var signatureFile = new SignatureFile(
+                        generateSignatureObject(signer, recordFileHash),
+                        writeMetadataSignature ? generateSignatureObject(signer, metadataHash) : null);
+                // write version in signature file. It is only 1 byte, compared to 4 in record files
+                streamingData.writeByte((byte) 6);
+                // write protobuf SignatureFile
+                SignatureFile.PROTOBUF.write(signatureFile, streamingData);
+                logger.debug("signature file saved: {}", sigFilePath);
+                // flush
+                streamingData.flush();
+            } finally {
+                PbjUtils.returnTlsWriter();
             }
-            // create signature file
-            final var signatureFile = new SignatureFile(
-                    generateSignatureObject(signer, recordFileHash),
-                    writeMetadataSignature ? generateSignatureObject(signer, metadataHash) : null);
-            // write version in signature file. It is only 1 byte, compared to 4 in record files
-            streamingData.writeByte((byte) 6);
-            // write protobuf SignatureFile
-            SignatureFile.PROTOBUF.write(signatureFile, streamingData);
-            logger.debug("signature file saved: {}", sigFilePath);
-            // flush
-            fileOut.flush();
         } catch (final FileAlreadyExistsException ignore) {
             // This is part of normal operations, as a reconnected node will very commonly
             // re-create an existing record stream file while REPLAYING_EVENTS

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v7/BlockRecordFormatV7.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v7/BlockRecordFormatV7.java
@@ -187,7 +187,7 @@ public final class BlockRecordFormatV7 implements BlockRecordFormat {
 
         @NonNull
         @Override
-        public RecordStreamItemV7 realParse(
+        public RecordStreamItemV7 parse(
                 @NonNull final PbjReader readableSequentialData,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
@@ -203,7 +203,7 @@ public final class BlockRecordFormatV7 implements BlockRecordFormat {
         }
 
         @Override
-        public void realWrite(@NonNull RecordStreamItemV7 item, @NonNull PbjWriter output) {
+        public void write(@NonNull RecordStreamItemV7 item, @NonNull PbjWriter output) {
             // TBD
         }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v7/BlockRecordFormatV7.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/producers/formats/v7/BlockRecordFormatV7.java
@@ -15,8 +15,9 @@ import com.hedera.node.app.records.impl.producers.SerializedSingleTransactionRec
 import com.hedera.node.app.state.SingleTransactionRecord;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -186,8 +187,8 @@ public final class BlockRecordFormatV7 implements BlockRecordFormat {
 
         @NonNull
         @Override
-        public RecordStreamItemV7 parse(
-                @NonNull final ReadableSequentialData readableSequentialData,
+        public RecordStreamItemV7 realParse(
+                @NonNull final PbjReader readableSequentialData,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
@@ -201,7 +202,8 @@ public final class BlockRecordFormatV7 implements BlockRecordFormat {
             return new RecordStreamItemV7(null, null, null, null, 0, 0);
         }
 
-        public void write(@NonNull RecordStreamItemV7 item, @NonNull WritableSequentialData output) {
+        @Override
+        public void realWrite(@NonNull RecordStreamItemV7 item, @NonNull PbjWriter output) {
             // TBD
         }
 
@@ -213,7 +215,7 @@ public final class BlockRecordFormatV7 implements BlockRecordFormat {
             return 0;
         }
 
-        public boolean fastEquals(@NonNull RecordStreamItemV7 item, @NonNull ReadableSequentialData input) {
+        public boolean fastEquals(@NonNull RecordStreamItemV7 item, @NonNull PbjReader input) {
             return false;
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleParser.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleParser.java
@@ -68,7 +68,7 @@ public class ThrottleParser {
      */
     public ValidatedThrottles parse(@NonNull final Bytes bytes) {
         try {
-            final var throttleDefinitions = ThrottleDefinitions.PROTOBUF.parseStrict(bytes.toReadableSequentialData());
+            final var throttleDefinitions = ThrottleDefinitions.PROTOBUF.parseStrict(bytes);
             validate(throttleDefinitions);
             final var successStatus =
                     allExpectedOperations(throttleDefinitions) ? SUCCESS : SUCCESS_BUT_MISSING_EXPECTED_OPERATION;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/ProtobufUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/ProtobufUtils.java
@@ -11,7 +11,7 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
 import com.hedera.pbj.runtime.ProtoWriterTools;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -30,15 +30,13 @@ public class ProtobufUtils {
 
     @NonNull
     public static Bytes extractPaymentBytes(@NonNull final Bytes serializedQuery) throws IOException, ParseException {
-        final var queryBody = extractQuery(serializedQuery.toReadableSequentialData());
-        final var queryHeader =
-                extractFieldBytes(queryBody.toReadableSequentialData(), TransactionGetReceiptQuerySchema.HEADER);
-        return extractFieldBytes(queryHeader.toReadableSequentialData(), QueryHeaderSchema.PAYMENT);
+        final var queryBody = extractQuery(serializedQuery.toPbjReader());
+        final var queryHeader = extractFieldBytes(queryBody.toPbjReader(), TransactionGetReceiptQuerySchema.HEADER);
+        return extractFieldBytes(queryHeader.toPbjReader(), QueryHeaderSchema.PAYMENT);
     }
 
     @NonNull
-    private static Bytes extractFieldBytes(
-            @NonNull final ReadableSequentialData input, @NonNull final FieldDefinition field)
+    private static Bytes extractFieldBytes(@NonNull final PbjReader input, @NonNull final FieldDefinition field)
             throws IOException, ParseException {
         if (field.repeated()) {
             throw new IllegalArgumentException("Cannot extract field bytes for a repeated field: " + field);
@@ -74,7 +72,7 @@ public class ProtobufUtils {
     }
 
     @NonNull
-    private static Bytes extractQuery(@NonNull final ReadableSequentialData input) throws IOException, ParseException {
+    private static Bytes extractQuery(@NonNull final PbjReader input) throws IOException, ParseException {
         while (input.hasRemaining()) {
             final int tag;
             // hasRemaining() doesn't work very well for streaming data, it returns false only when

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -46,6 +46,7 @@ import com.hedera.node.config.data.JumboTransactionsConfig;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.UnknownFieldException;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.metrics.api.Counter;
@@ -218,7 +219,7 @@ public class TransactionChecker {
      */
     @NonNull
     public SignedTransaction parseSigned(@NonNull final Bytes buffer, final int maxSize) throws PreCheckException {
-        return parseStrict(buffer.toReadableSequentialData(), SignedTransaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
+        return parseStrict(buffer.toPbjReader(), SignedTransaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
     }
 
     /**
@@ -272,10 +273,7 @@ public class TransactionChecker {
         if (tx.signedTransactionBytes().length() > 0) {
             serializedSignedTx = tx.signedTransactionBytes();
             signedTx = parseStrict(
-                    serializedSignedTx.toReadableSequentialData(),
-                    SignedTransaction.PROTOBUF,
-                    INVALID_TRANSACTION,
-                    maxSize);
+                    serializedSignedTx.toPbjReader(), SignedTransaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
             validateFalsePreCheck(
                     signedTx.useSerializedTxMessageHashAlgorithm(), INVALID_SERIALIZED_TX_MESSAGE_HASH_ALGORITHM);
         } else {
@@ -669,6 +667,26 @@ public class TransactionChecker {
         }
     }
 
+    @NonNull
+    private <T> T parseStrict(
+            @NonNull final PbjReader data,
+            @NonNull final Codec<T> codec,
+            @NonNull final ResponseCodeEnum parseErrorCode,
+            final int maxSize)
+            throws PreCheckException {
+        try {
+            return codec.parse(data, true, false, DEFAULT_MAX_DEPTH, maxSize);
+        } catch (ParseException e) {
+            recordParseErrorMetric(e);
+            if (e.getCause() instanceof UnknownFieldException) {
+                // We do not allow newer clients to send transactions to older networks.
+                throw new PreCheckException(TRANSACTION_HAS_UNKNOWN_FIELDS);
+            }
+            logger.debug("ParseException while parsing protobuf: ", e);
+            throw new PreCheckException(parseErrorCode);
+        }
+    }
+
     private void recordParseErrorMetric(@NonNull final ParseException e) {
         final var cause = e.getCause();
         switch (cause) {
@@ -685,10 +703,7 @@ public class TransactionChecker {
         validateTruePreCheck(signedTx.hasSigMap(), INVALID_TRANSACTION_BODY);
         final var signatureMap = signedTx.sigMapOrThrow();
         final var txBody = parseStrict(
-                signedTx.bodyBytes().toReadableSequentialData(),
-                TransactionBody.PROTOBUF,
-                INVALID_TRANSACTION_BODY,
-                maxSize);
+                signedTx.bodyBytes().toPbjReader(), TransactionBody.PROTOBUF, INVALID_TRANSACTION_BODY, maxSize);
         final HederaFunctionality functionality;
         try {
             functionality = HapiUtils.functionOf(txBody);
@@ -749,7 +764,7 @@ public class TransactionChecker {
     @VisibleForTesting
     Transaction parse(@NonNull final Bytes buffer, final int maxSize) throws PreCheckException {
         requireNonNull(buffer);
-        return parseStrict(buffer.toReadableSequentialData(), Transaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
+        return parseStrict(buffer.toPbjReader(), Transaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -219,7 +219,7 @@ public class TransactionChecker {
      */
     @NonNull
     public SignedTransaction parseSigned(@NonNull final Bytes buffer, final int maxSize) throws PreCheckException {
-        return parseStrict(buffer.toPbjReader(), SignedTransaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
+        return parseStrict(buffer, SignedTransaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
     }
 
     /**
@@ -272,8 +272,7 @@ public class TransactionChecker {
         final SignedTransaction signedTx;
         if (tx.signedTransactionBytes().length() > 0) {
             serializedSignedTx = tx.signedTransactionBytes();
-            signedTx = parseStrict(
-                    serializedSignedTx.toPbjReader(), SignedTransaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
+            signedTx = parseStrict(serializedSignedTx, SignedTransaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
             validateFalsePreCheck(
                     signedTx.useSerializedTxMessageHashAlgorithm(), INVALID_SERIALIZED_TX_MESSAGE_HASH_ALGORITHM);
         } else {
@@ -687,6 +686,26 @@ public class TransactionChecker {
         }
     }
 
+    @NonNull
+    private <T> T parseStrict(
+            @NonNull final Bytes data,
+            @NonNull final Codec<T> codec,
+            @NonNull final ResponseCodeEnum parseErrorCode,
+            final int maxSize)
+            throws PreCheckException {
+        try {
+            return codec.parse(data, true, false, DEFAULT_MAX_DEPTH, maxSize);
+        } catch (ParseException e) {
+            recordParseErrorMetric(e);
+            if (e.getCause() instanceof UnknownFieldException) {
+                // We do not allow newer clients to send transactions to older networks.
+                throw new PreCheckException(TRANSACTION_HAS_UNKNOWN_FIELDS);
+            }
+            logger.debug("ParseException while parsing protobuf: ", e);
+            throw new PreCheckException(parseErrorCode);
+        }
+    }
+
     private void recordParseErrorMetric(@NonNull final ParseException e) {
         final var cause = e.getCause();
         switch (cause) {
@@ -702,8 +721,8 @@ public class TransactionChecker {
             throws PreCheckException {
         validateTruePreCheck(signedTx.hasSigMap(), INVALID_TRANSACTION_BODY);
         final var signatureMap = signedTx.sigMapOrThrow();
-        final var txBody = parseStrict(
-                signedTx.bodyBytes().toPbjReader(), TransactionBody.PROTOBUF, INVALID_TRANSACTION_BODY, maxSize);
+        final var txBody =
+                parseStrict(signedTx.bodyBytes(), TransactionBody.PROTOBUF, INVALID_TRANSACTION_BODY, maxSize);
         final HederaFunctionality functionality;
         try {
             functionality = HapiUtils.functionOf(txBody);
@@ -764,7 +783,7 @@ public class TransactionChecker {
     @VisibleForTesting
     Transaction parse(@NonNull final Bytes buffer, final int maxSize) throws PreCheckException {
         requireNonNull(buffer);
-        return parseStrict(buffer.toPbjReader(), Transaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
+        return parseStrict(buffer, Transaction.PROTOBUF, INVALID_TRANSACTION, maxSize);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordStreamBuilder.java
@@ -1410,7 +1410,7 @@ public class RecordStreamBuilder
      */
     private TransactionBody inProgressBody() {
         try {
-            return TransactionBody.PROTOBUF.parseStrict(signedTx.bodyBytes().toReadableSequentialData());
+            return TransactionBody.PROTOBUF.parseStrict(signedTx.bodyBytes());
         } catch (Exception e) {
             throw new IllegalStateException("Record being built for unparseable transaction", e);
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdates.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdates.java
@@ -165,7 +165,7 @@ public class SystemFileUpdates {
 
     private void logContentsOf(@NonNull final String configFileName, @NonNull final Bytes contents) {
         try {
-            final var configList = ServicesConfigurationList.PROTOBUF.parseStrict(contents.toReadableSequentialData());
+            final var configList = ServicesConfigurationList.PROTOBUF.parseStrict(contents);
             final var printableConfigList = configList.nameValue().stream()
                     .map(pair -> pair.name() + "=" + pair.value())
                     .collect(joining("\n\t"));

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflow.java
@@ -3,7 +3,7 @@ package com.hedera.node.app.workflows.ingest;
 
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.transaction.TransactionResponse;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -23,5 +23,5 @@ public interface IngestWorkflow {
      * @param requestBuffer The raw protobuf transaction bytes. Must be a transaction object.
      * @param responseBuffer The raw protobuf response bytes.
      */
-    void submitTransaction(@NonNull Bytes requestBuffer, @NonNull BufferedData responseBuffer);
+    void submitTransaction(@NonNull Bytes requestBuffer, @NonNull PbjWriter responseBuffer);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImpl.java
@@ -13,13 +13,11 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.throttle.ThrottleUsage;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.QuiescenceConfig;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.AutoCloseableWrapper;
 import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.function.Supplier;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -66,7 +64,7 @@ public final class IngestWorkflowImpl implements IngestWorkflow {
     }
 
     @Override
-    public void submitTransaction(@NonNull final Bytes requestBuffer, @NonNull final BufferedData responseBuffer) {
+    public void submitTransaction(@NonNull final Bytes requestBuffer, @NonNull final PbjWriter responseBuffer) {
         requireNonNull(requestBuffer);
         requireNonNull(responseBuffer);
 
@@ -122,13 +120,7 @@ public final class IngestWorkflowImpl implements IngestWorkflow {
                     .cost(estimatedFee)
                     .build();
 
-            try {
-                TransactionResponse.PROTOBUF.write(transactionResponse, responseBuffer);
-            } catch (IOException ex) {
-                // It may be that the response couldn't be written because the response buffer was
-                // too small, which would be an internal server error.
-                throw new UncheckedIOException("Failed to write bytes to response buffer", ex);
-            }
+            TransactionResponse.PROTOBUF.write(transactionResponse, responseBuffer);
         } finally {
             if (quiescenceEnabled) {
                 txPipelineTracker.decrementPreFlight();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/SubmissionManager.java
@@ -142,10 +142,8 @@ public class SubmissionManager {
                     final var transactions = txBody.atomicBatchOrThrow().transactions();
                     for (final Bytes buffer : transactions) {
                         try {
-                            final var signedTransaction =
-                                    SignedTransaction.PROTOBUF.parseStrict(buffer.toReadableSequentialData());
-                            final var body = TransactionBody.PROTOBUF.parseStrict(
-                                    signedTransaction.bodyBytes().toReadableSequentialData());
+                            final var signedTransaction = SignedTransaction.PROTOBUF.parseStrict(buffer);
+                            final var body = TransactionBody.PROTOBUF.parseStrict(signedTransaction.bodyBytes());
                             final var innerTxnId = body.transactionIDOrThrow();
                             submittedTxns.add(innerTxnId);
                         } catch (ParseException e) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflow.java
@@ -2,7 +2,7 @@
 package com.hedera.node.app.workflows.query;
 
 import com.hedera.hapi.node.transaction.Query;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
@@ -15,5 +15,5 @@ public interface QueryWorkflow {
      * @param requestBuffer The raw protobuf query bytes. Must be a {@link Query} object.
      * @param responseBuffer The raw protobuf response bytes.
      */
-    void handleQuery(@NonNull Bytes requestBuffer, @NonNull BufferedData responseBuffer);
+    void handleQuery(@NonNull Bytes requestBuffer, @NonNull PbjWriter responseBuffer);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
@@ -345,7 +345,7 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
 
     private Query parseQuery(Bytes requestBuffer) {
         try {
-            return queryParser.parseStrict(requestBuffer.toReadableSequentialData());
+            return queryParser.parseStrict(requestBuffer);
         } catch (ParseException e) {
             switch (e.getCause()) {
                 case MalformedProtobufException ignored:

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
@@ -50,7 +50,7 @@ import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.MalformedProtobufException;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.UnknownFieldException;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.AutoCloseableWrapper;
 import com.swirlds.state.State;
@@ -154,7 +154,7 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
     }
 
     @Override
-    public void handleQuery(@NonNull final Bytes requestBuffer, @NonNull final BufferedData responseBuffer) {
+    public void handleQuery(@NonNull final Bytes requestBuffer, @NonNull final PbjWriter responseBuffer) {
         final long queryStart = System.nanoTime();
 
         requireNonNull(requestBuffer);
@@ -332,13 +332,8 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
             throw new StatusRuntimeException(Status.INVALID_ARGUMENT);
         }
 
-        try {
-            Response.PROTOBUF.write(response, responseBuffer);
-            logger.debug("Finished handling a query request in Query workflow");
-        } catch (IOException e) {
-            logger.warn("Unexpected IO exception while writing protobuf", e);
-            throw new StatusRuntimeException(Status.INTERNAL);
-        }
+        Response.PROTOBUF.write(response, responseBuffer);
+        logger.debug("Finished handling a query request in Query workflow");
 
         workflowMetrics.updateDuration(function, (int) (System.nanoTime() - queryStart));
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneNetworkInfo.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneNetworkInfo.java
@@ -69,7 +69,7 @@ public class StandaloneNetworkInfo implements NetworkInfo {
         final var filesConfig = config.getConfigData(FilesConfig.class);
         final var nodeDetails = getFileContent(state, createFileID(filesConfig.nodeDetails(), config));
         try {
-            final var nodeAddressBook = NodeAddressBook.PROTOBUF.parseStrict(nodeDetails.toReadableSequentialData());
+            final var nodeAddressBook = NodeAddressBook.PROTOBUF.parseStrict(nodeDetails);
             nodeInfos = nodeAddressBook.nodeAddress().stream()
                     .<NodeInfo>map(address -> new NodeInfoImpl(
                             address.nodeId(),

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
@@ -77,7 +77,7 @@ class ExchangeRateManagerTest {
         assertEquals(centEquiv * 2, next.centEquiv());
         assertEquals(expirationTime.seconds(), curr.expirationTimeOrThrow().seconds());
         assertEquals(expirationTime.seconds(), next.expirationTimeOrThrow().seconds());
-        assertEquals(PROTOBUF.parse(validRateBytes.toReadableSequentialData()), subject.exchangeRates());
+        assertEquals(PROTOBUF.parse(validRateBytes), subject.exchangeRates());
     }
 
     @Test

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesDiskWriterTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordFileBlockHashesDiskWriterTest.java
@@ -60,8 +60,8 @@ class WrappedRecordFileBlockHashesDiskWriterTest extends AppTestBase {
             writer.appendAsync(in0).join();
 
             final var allBytes = Files.readAllBytes(file);
-            final WrappedRecordFileBlockHashesLog log = WrappedRecordFileBlockHashesLog.PROTOBUF.parse(
-                    Bytes.wrap(allBytes).toReadableSequentialData(), false, false, 64, allBytes.length);
+            final WrappedRecordFileBlockHashesLog log =
+                    WrappedRecordFileBlockHashesLog.PROTOBUF.parse(allBytes, false, false, 64, allBytes.length);
             assertEquals(1, log.entries().size(), "Expected corrupt file to be truncated and rewritten");
         }
     }
@@ -116,8 +116,8 @@ class WrappedRecordFileBlockHashesDiskWriterTest extends AppTestBase {
             assertTrue(Files.exists(file), "Expected file to be created");
 
             final var allBytes = Files.readAllBytes(file);
-            final WrappedRecordFileBlockHashesLog log = WrappedRecordFileBlockHashesLog.PROTOBUF.parse(
-                    Bytes.wrap(allBytes).toReadableSequentialData(), false, false, 64, allBytes.length);
+            final WrappedRecordFileBlockHashesLog log =
+                    WrappedRecordFileBlockHashesLog.PROTOBUF.parse(allBytes, false, false, 64, allBytes.length);
 
             assertEquals(List.of(e0, e1), log.entries(), "Expected entries to parse back from the on-disk file");
         }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
@@ -2584,7 +2584,7 @@ public class ThrottleAccumulatorTest {
                     in, com.hedera.node.app.hapi.utils.sysfiles.domain.throttling.ThrottleDefinitions.class);
             final var throttleDefsBytes =
                     Bytes.wrap(throttleDefinitionsObj.toProto().toByteArray());
-            return ThrottleDefinitions.PROTOBUF.parse(throttleDefsBytes.toReadableSequentialData());
+            return ThrottleDefinitions.PROTOBUF.parse(throttleDefsBytes);
         }
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordFormatV6Test.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordFormatV6Test.java
@@ -19,8 +19,8 @@ final class BlockRecordFormatV6Test {
                 // Serialize the record, and then parse the object back in from the protobuf just to make sure we can
                 // round-trip the writing and parsing without losing any data.
                 final var serializedRec = BlockRecordFormatV6.INSTANCE.serialize(rec, BLOCK_NUM, VERSION);
-                final var parsedRecordStreamItem = RecordStreamItem.PROTOBUF.parse(
-                        serializedRec.protobufSerializedRecordStreamItem().toReadableSequentialData());
+                final var parsedRecordStreamItem =
+                        RecordStreamItem.PROTOBUF.parse(serializedRec.protobufSerializedRecordStreamItem());
                 assertThat(rec.transaction()).isEqualTo(parsedRecordStreamItem.transaction());
                 assertThat(rec.transactionRecord()).isEqualTo(parsedRecordStreamItem.record());
                 assertThat(rec.transactionSidecarRecords()).hasSameSizeAs(serializedRec.sideCarItems());

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordReaderV6.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordReaderV6.java
@@ -7,9 +7,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.hedera.hapi.node.base.Transaction;
 import com.hedera.hapi.node.transaction.TransactionRecord;
 import com.hedera.hapi.streams.RecordStreamFile;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayOutputStream;
@@ -26,6 +25,7 @@ import java.util.zip.GZIPInputStream;
 import org.hiero.base.crypto.DigestType;
 import org.hiero.base.crypto.Hash;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 
 /**
  * A Record File Version 6 Reader that can be used in tests to read record files and validate then and return the contents
@@ -81,17 +81,28 @@ public class BlockRecordReaderV6 {
      */
     public static RecordStreamFile read(@NonNull final Path filePath) throws Exception {
         if (filePath.getFileName().toString().endsWith(".rcd.gz")) {
-            try (final ReadableStreamingData in =
-                    new ReadableStreamingData(new GZIPInputStream(Files.newInputStream(filePath)))) {
+            PbjReader in = PbjUtils.takeTlsReaderStream();
+            try {
+                in.resetWith(new GZIPInputStream(Files.newInputStream(filePath)));
                 int version = in.readInt();
                 assertEquals(VERSION, version, "File version does not match, on file " + filePath);
-                return RecordStreamFile.PROTOBUF.parse(in);
+                var res = RecordStreamFile.PROTOBUF.parse(in);
+                in.throwOnError();
+                return res;
+            } finally {
+                PbjUtils.returnTlsReaderStream();
             }
         } else if (filePath.getFileName().toString().endsWith(".rcd")) {
-            try (final ReadableStreamingData in = new ReadableStreamingData(Files.newInputStream(filePath))) {
+            PbjReader in = PbjUtils.takeTlsReaderStream();
+            try {
+                in.resetWith(Files.newInputStream(filePath));
                 int version = in.readInt();
                 assertEquals(VERSION, version);
-                return RecordStreamFile.PROTOBUF.parse(in);
+                var res = RecordStreamFile.PROTOBUF.parse(in);
+                in.throwOnError();
+                return res;
+            } finally {
+                PbjUtils.returnTlsReaderStream();
             }
         } else {
             fail("Unknown file type: " + filePath.getFileName());
@@ -107,10 +118,15 @@ public class BlockRecordReaderV6 {
      * @throws Exception If there is an error reading the file
      */
     public static RecordStreamFile read(byte[] uncompressedData) throws Exception {
-        final BufferedData in = BufferedData.wrap(uncompressedData);
-        int version = in.readInt();
-        assertEquals(VERSION, version, "File version does not match");
-        return RecordStreamFile.PROTOBUF.parse(in);
+        PbjReader in = PbjUtils.takeTlsReaderBytes();
+        try {
+            in.resetWith(uncompressedData);
+            int version = in.readInt();
+            assertEquals(VERSION, version, "File version does not match");
+            return RecordStreamFile.PROTOBUF.parse(in);
+        } finally {
+            PbjUtils.returnTlsReaderBytes();
+        }
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordReaderV6.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/BlockRecordReaderV6.java
@@ -81,7 +81,7 @@ public class BlockRecordReaderV6 {
      */
     public static RecordStreamFile read(@NonNull final Path filePath) throws Exception {
         if (filePath.getFileName().toString().endsWith(".rcd.gz")) {
-            PbjReader in = PbjUtils.takeTlsReaderStream();
+            PbjReader in = PbjUtils.takeTlsReader();
             try {
                 in.resetWith(new GZIPInputStream(Files.newInputStream(filePath)));
                 int version = in.readInt();
@@ -90,10 +90,10 @@ public class BlockRecordReaderV6 {
                 in.throwOnError();
                 return res;
             } finally {
-                PbjUtils.returnTlsReaderStream();
+                PbjUtils.returnTlsReader();
             }
         } else if (filePath.getFileName().toString().endsWith(".rcd")) {
-            PbjReader in = PbjUtils.takeTlsReaderStream();
+            PbjReader in = PbjUtils.takeTlsReader();
             try {
                 in.resetWith(Files.newInputStream(filePath));
                 int version = in.readInt();
@@ -102,7 +102,7 @@ public class BlockRecordReaderV6 {
                 in.throwOnError();
                 return res;
             } finally {
-                PbjUtils.returnTlsReaderStream();
+                PbjUtils.returnTlsReader();
             }
         } else {
             fail("Unknown file type: " + filePath.getFileName());
@@ -118,14 +118,14 @@ public class BlockRecordReaderV6 {
      * @throws Exception If there is an error reading the file
      */
     public static RecordStreamFile read(byte[] uncompressedData) throws Exception {
-        PbjReader in = PbjUtils.takeTlsReaderBytes();
+        PbjReader in = PbjUtils.takeTlsReader();
         try {
             in.resetWith(uncompressedData);
             int version = in.readInt();
             assertEquals(VERSION, version, "File version does not match");
             return RecordStreamFile.PROTOBUF.parse(in);
         } finally {
-            PbjUtils.returnTlsReaderBytes();
+            PbjUtils.returnTlsReader();
         }
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/RecordStreamV6Verifier.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/impl/producers/formats/v6/RecordStreamV6Verifier.java
@@ -17,9 +17,9 @@ import com.hedera.hapi.streams.TransactionSidecarRecord;
 import com.hedera.node.app.state.SingleTransactionRecord;
 import com.hedera.node.config.data.BlockRecordStreamConfig;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
@@ -41,6 +41,7 @@ import org.hiero.base.crypto.DigestType;
 import org.hiero.base.crypto.HashingOutputStream;
 import org.hiero.base.crypto.SignatureType;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 
 @SuppressWarnings({"DataFlowIssue", "removal"})
 public class RecordStreamV6Verifier {
@@ -279,10 +280,14 @@ public class RecordStreamV6Verifier {
             throws Exception {
         // read signature file
         SignatureFile signatureFile;
-        try (ReadableStreamingData in = new ReadableStreamingData(Files.newInputStream(recordFileSigPath))) {
+        PbjReader in = PbjUtils.takeTlsReader();
+        try {
+            in.resetWith(Files.newInputStream(recordFileSigPath));
             int version = in.readByte();
             assertEquals(recordStreamConfig.signatureFileVersion(), version);
             signatureFile = SignatureFile.PROTOBUF.parse(in);
+        } finally {
+            PbjUtils.returnTlsReader();
         }
         // compute hash of record file
         MessageDigest digest = MessageDigest.getInstance(DigestType.SHA_384.algorithmName());

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
@@ -72,7 +72,7 @@ class IngestWorkflowImplTest extends AppTestBase {
     private Bytes requestBuffer;
 
     /** The buffer to write responses into. */
-    private final PbjWriter responseBuffer = new PbjWriter(1024 * 6);
+    private final PbjWriter responseBuffer = new PbjWriter(1024 * 6, false);
 
     /** The request transaction */
     private SignedTransaction signedTx;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestWorkflowImplTest.java
@@ -39,7 +39,7 @@ import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.VersionedConfiguration;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.AutoCloseableWrapper;
 import com.swirlds.state.State;
@@ -72,7 +72,7 @@ class IngestWorkflowImplTest extends AppTestBase {
     private Bytes requestBuffer;
 
     /** The buffer to write responses into. */
-    private final BufferedData responseBuffer = BufferedData.allocate(1024 * 6);
+    private final PbjWriter responseBuffer = new PbjWriter(1024 * 6);
 
     /** The request transaction */
     private SignedTransaction signedTx;
@@ -350,8 +350,7 @@ class IngestWorkflowImplTest extends AppTestBase {
         }
     }
 
-    private static TransactionResponse parseResponse(@NonNull final BufferedData responseBuffer) throws ParseException {
-        responseBuffer.flip();
-        return TransactionResponse.PROTOBUF.parse(responseBuffer);
+    private static TransactionResponse parseResponse(@NonNull final PbjWriter responseBuffer) throws ParseException {
+        return TransactionResponse.PROTOBUF.parse(responseBuffer.toPbjReader());
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -55,7 +55,6 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.fees.FeeManager;
 import com.hedera.node.app.fixtures.AppTestBase;
-import com.hedera.node.app.hapi.utils.CommonPbjConverters;
 import com.hedera.node.app.service.consensus.impl.handlers.ConsensusGetTopicInfoHandler;
 import com.hedera.node.app.service.file.impl.handlers.FileGetInfoHandler;
 import com.hedera.node.app.service.networkadmin.impl.handlers.NetworkGetExecutionTimeHandler;
@@ -78,7 +77,7 @@ import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.UnknownFieldException;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.AutoCloseableWrapper;
 import com.swirlds.config.api.Configuration;
@@ -735,7 +734,7 @@ class QueryWorkflowImplTest extends AppTestBase {
                 .build();
         when(queryParser.parseStrict((Bytes) notNull())).thenReturn(query);
 
-        final var requestBytes = CommonPbjConverters.asBytes(localRequestBuffer);
+        final var requestBytes = localRequestBuffer.toByteArray();
         when(handler.extractHeader(query)).thenReturn(queryHeader);
         when(dispatcher.getHandler(query)).thenReturn(handler);
         final var responseBuffer = newEmptyBuffer();
@@ -975,7 +974,7 @@ class QueryWorkflowImplTest extends AppTestBase {
                         NetworkGetExecutionTimeQuery.newBuilder().header(localQueryHeader))
                 .build();
 
-        final var requestBytes = CommonPbjConverters.asBytes(localRequestBuffer);
+        final var requestBytes = localRequestBuffer.toByteArray();
         when(queryParser.parseStrict((Bytes) notNull())).thenReturn(localQuery);
         when(networkHandler.extractHeader(localQuery)).thenReturn(localQueryHeader);
         when(dispatcher.getHandler(localQuery)).thenReturn(networkHandler);
@@ -1062,15 +1061,12 @@ class QueryWorkflowImplTest extends AppTestBase {
         verify(opWorkflowMetrics).updateDuration(eq(FILE_GET_INFO), anyInt());
     }
 
-    private static Response parseResponse(BufferedData responseBuffer) throws ParseException {
-        final byte[] bytes = new byte[Math.toIntExact(responseBuffer.position())];
-        responseBuffer.resetPosition();
-        responseBuffer.readBytes(bytes);
-        return Response.PROTOBUF.parseStrict(BufferedData.wrap(bytes));
+    private static Response parseResponse(PbjWriter responseBuffer) throws ParseException {
+        return Response.PROTOBUF.parseStrict(responseBuffer.toPbjReader());
     }
 
-    private static BufferedData newEmptyBuffer() {
-        return BufferedData.allocate(BUFFER_SIZE);
+    private static PbjWriter newEmptyBuffer() {
+        return new PbjWriter(BUFFER_SIZE);
     }
 
     private void mockQueryContext() {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -1066,7 +1066,7 @@ class QueryWorkflowImplTest extends AppTestBase {
     }
 
     private static PbjWriter newEmptyBuffer() {
-        return new PbjWriter(BUFFER_SIZE);
+        return new PbjWriter(BUFFER_SIZE, false);
     }
 
     private void mockQueryContext() {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -78,7 +78,6 @@ import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.UnknownFieldException;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.common.utility.AutoCloseableWrapper;
@@ -190,7 +189,7 @@ class QueryWorkflowImplTest extends AppTestBase {
                 .fileGetInfo(FileGetInfoQuery.newBuilder().header(queryHeader))
                 .build();
         requestBuffer = Query.PROTOBUF.toBytes(query);
-        when(queryParser.parseStrict((ReadableSequentialData) notNull())).thenReturn(query);
+        when(queryParser.parseStrict((Bytes) notNull())).thenReturn(query);
 
         configuration = new VersionedConfigImpl(HederaTestConfigBuilder.createConfig(), DEFAULT_CONFIG_VERSION);
         when(configProvider.getConfiguration()).thenReturn(configuration);
@@ -609,7 +608,7 @@ class QueryWorkflowImplTest extends AppTestBase {
         final var query = Query.newBuilder()
                 .fileGetInfo(FileGetInfoQuery.newBuilder().header(queryHeader))
                 .build();
-        when(queryParser.parseStrict((ReadableSequentialData) notNull())).thenReturn(query);
+        when(queryParser.parseStrict((Bytes) notNull())).thenReturn(query);
         when(handler.extractHeader(query)).thenReturn(queryHeader);
         when(dispatcher.getHandler(query)).thenReturn(handler);
         given(handler.requiresNodePayment(any())).willReturn(true);
@@ -646,7 +645,7 @@ class QueryWorkflowImplTest extends AppTestBase {
         final var query = Query.newBuilder()
                 .fileGetInfo(FileGetInfoQuery.newBuilder().header(queryHeader))
                 .build();
-        when(queryParser.parseStrict((ReadableSequentialData) notNull())).thenReturn(query);
+        when(queryParser.parseStrict((Bytes) notNull())).thenReturn(query);
         when(dispatcher.getHandler(query)).thenReturn(handler);
         when(handler.extractHeader(query)).thenReturn(queryHeader);
         when(handler.needsAnswerOnlyCost(COST_ANSWER)).thenReturn(true);
@@ -668,7 +667,7 @@ class QueryWorkflowImplTest extends AppTestBase {
     @Test
     void testParsingFails() throws ParseException {
         // given
-        when(queryParser.parseStrict((ReadableSequentialData) notNull()))
+        when(queryParser.parseStrict((Bytes) notNull()))
                 .thenThrow(new ParseException(new RuntimeException("Expected failure")));
         final var responseBuffer = newEmptyBuffer();
 
@@ -683,7 +682,7 @@ class QueryWorkflowImplTest extends AppTestBase {
     void testUnrecognizableQueryTypeFails() throws ParseException {
         // given
         final var query = Query.newBuilder().build();
-        when(queryParser.parseStrict((ReadableSequentialData) notNull())).thenReturn(query);
+        when(queryParser.parseStrict((Bytes) notNull())).thenReturn(query);
         final var responseBuffer = newEmptyBuffer();
 
         // then
@@ -696,7 +695,7 @@ class QueryWorkflowImplTest extends AppTestBase {
     @Test
     void testUnknownQueryParamFails() throws ParseException {
         // given
-        when(queryParser.parseStrict((ReadableSequentialData) notNull()))
+        when(queryParser.parseStrict((Bytes) notNull()))
                 .thenThrow(new ParseException(new UnknownFieldException("bogus field")));
         final var responseBuffer = newEmptyBuffer();
 
@@ -734,7 +733,7 @@ class QueryWorkflowImplTest extends AppTestBase {
         final var query = Query.newBuilder()
                 .fileGetInfo(FileGetInfoQuery.newBuilder().header(queryHeader).build())
                 .build();
-        when(queryParser.parseStrict((ReadableSequentialData) notNull())).thenReturn(query);
+        when(queryParser.parseStrict((Bytes) notNull())).thenReturn(query);
 
         final var requestBytes = CommonPbjConverters.asBytes(localRequestBuffer);
         when(handler.extractHeader(query)).thenReturn(queryHeader);
@@ -977,7 +976,7 @@ class QueryWorkflowImplTest extends AppTestBase {
                 .build();
 
         final var requestBytes = CommonPbjConverters.asBytes(localRequestBuffer);
-        when(queryParser.parseStrict((ReadableSequentialData) notNull())).thenReturn(localQuery);
+        when(queryParser.parseStrict((Bytes) notNull())).thenReturn(localQuery);
         when(networkHandler.extractHeader(localQuery)).thenReturn(localQueryHeader);
         when(dispatcher.getHandler(localQuery)).thenReturn(networkHandler);
 
@@ -1156,7 +1155,7 @@ class QueryWorkflowImplTest extends AppTestBase {
         serializedPayment = Transaction.PROTOBUF.toBytes(payment);
 
         requestBuffer = Query.PROTOBUF.toBytes(query);
-        when(queryParser.parseStrict((ReadableSequentialData) notNull())).thenReturn(query);
+        when(queryParser.parseStrict((Bytes) notNull())).thenReturn(query);
 
         final var signatureMap = SignatureMap.newBuilder().build();
         transactionInfo = new TransactionInfo(

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/V0490FileSchema.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/schemas/V0490FileSchema.java
@@ -415,8 +415,7 @@ public class V0490FileSchema extends Schema<SemanticVersion> {
             @NonNull final byte[] feeScheduleJsonBytes) {
         try {
             final org.hiero.hapi.support.fees.FeeSchedule feeSchedule =
-                    org.hiero.hapi.support.fees.FeeSchedule.JSON.parseStrict(
-                            Bytes.wrap(feeScheduleJsonBytes).toReadableSequentialData());
+                    org.hiero.hapi.support.fees.FeeSchedule.JSON.parseStrict(feeScheduleJsonBytes);
             return feeSchedule;
         } catch (final Exception e) {
             throw new IllegalArgumentException("Unable to parse simple fee schedule file", e);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/scope/HandleHederaOperations.java
@@ -465,8 +465,7 @@ public class HandleHederaOperations implements HederaOperations {
             @NonNull final ContractID contractID, @NonNull final ContractCreateTransactionBody op) {
         return signedTx -> {
             try {
-                final var dispatchedBody = TransactionBody.PROTOBUF.parseStrict(
-                        signedTx.bodyBytes().toReadableSequentialData());
+                final var dispatchedBody = TransactionBody.PROTOBUF.parseStrict(signedTx.bodyBytes());
                 if (!dispatchedBody.hasCryptoCreateAccount()) {
                     throw new IllegalArgumentException(
                             "Dispatched transaction body was not a crypto create" + dispatchedBody);

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/AliasUtils.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/AliasUtils.java
@@ -145,7 +145,7 @@ public final class AliasUtils {
         // a boolean instead of throwing an exception. Or maybe we can make sure the alias is a valid ECDSA key length
         // or ED25519 key length as a short circuit in case of very long aliases (no point parsing those).
         try {
-            final var key = Key.PROTOBUF.parseStrict(alias.toReadableSequentialData());
+            final var key = Key.PROTOBUF.parseStrict(alias);
             return (key.hasEcdsaSecp256k1() || key.hasEd25519()) /* && isValid(key)*/;
         } catch (final Exception e) {
             // There are many possible exceptions thrown here, both checked (IOException) and unchecked. See the
@@ -219,7 +219,7 @@ public final class AliasUtils {
             return def;
         }
         try {
-            return Key.PROTOBUF.parseStrict(alias.toReadableSequentialData());
+            return Key.PROTOBUF.parseStrict(alias);
         } catch (final Exception e) {
             // There are many possible exceptions, not just IOException. We want to catch all of them.
             return def;

--- a/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/HookDispatchUtils.java
+++ b/hedera-node/hedera-token-service/src/main/java/com/hedera/node/app/service/token/HookDispatchUtils.java
@@ -178,8 +178,7 @@ public class HookDispatchUtils {
         final var hookContractId = entityIdFactory.newContractId(HTS_HOOKS_CONTRACT_NUM);
         final StreamBuilder.SignedTxCustomizer executionCustomizer = signedTx -> {
             try {
-                final var dispatchedBody = TransactionBody.PROTOBUF.parseStrict(
-                        signedTx.bodyBytes().toReadableSequentialData());
+                final var dispatchedBody = TransactionBody.PROTOBUF.parseStrict(signedTx.bodyBytes());
                 final var hookCall = dispatchedBody
                         .hookDispatchOrThrow()
                         .executionOrThrow()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/AbstractLocalNode.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/AbstractLocalNode.java
@@ -12,7 +12,7 @@ import static com.hedera.services.bdd.junit.hedera.utils.WorkingDirUtils.recreat
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.internal.network.Network;
-import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.PbjReader;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -111,7 +111,7 @@ public abstract class AbstractLocalNode<T extends AbstractLocalNode<T>> extends 
     private Optional<Network> getStartupAddressBookAt(@NonNull final Path path) {
         if (Files.exists(path)) {
             try (final var fin = Files.newInputStream(path)) {
-                return Optional.of(Network.JSON.parse(new ReadableStreamingData(fin)));
+                return Optional.of(Network.JSON.parse(new PbjReader(fin)));
             } catch (Exception ignore) {
             }
         }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -24,7 +24,7 @@ import com.hedera.node.app.history.impl.HistoryServiceImpl;
 import com.hedera.node.app.info.DiskStartupNetworks;
 import com.hedera.node.app.tss.DualBlockHashSigner;
 import com.hedera.node.internal.network.Network;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.AbstractFakePlatform;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.FakeHintsService;
@@ -223,7 +223,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
             // It's possible this was intentional, but make a little noise to remind test author this happens
             log.warn("All paid queries get INVALID_NODE_ACCOUNT for non-default nodes in embedded mode");
         }
-        final var responseBuffer = BufferedData.allocate(MAX_QUERY_RESPONSE_SIZE);
+        final var responseBuffer = new PbjWriter(MAX_QUERY_RESPONSE_SIZE);
         if (asNodeOperator) {
             hedera.operatorQueryWorkflow().handleQuery(Bytes.wrap(query.toByteArray()), responseBuffer);
         } else {
@@ -312,7 +312,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
                 .toByteArray();
     }
 
-    protected static TransactionResponse parseTransactionResponse(@NonNull final BufferedData responseBuffer) {
+    protected static TransactionResponse parseTransactionResponse(@NonNull final PbjWriter responseBuffer) {
         try {
             return TransactionResponse.parseFrom(AbstractEmbeddedHedera.usedBytesFrom(responseBuffer));
         } catch (IOException e) {
@@ -320,7 +320,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
         }
     }
 
-    protected static Response parseQueryResponse(@NonNull final BufferedData responseBuffer) {
+    protected static Response parseQueryResponse(@NonNull final PbjWriter responseBuffer) {
         try {
             return Response.parseFrom(AbstractEmbeddedHedera.usedBytesFrom(responseBuffer));
         } catch (IOException e) {
@@ -345,10 +345,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
         return query.hasCryptogetAccountBalance() || query.hasTransactionGetReceipt();
     }
 
-    private static byte[] usedBytesFrom(@NonNull final BufferedData responseBuffer) {
-        final byte[] bytes = new byte[Math.toIntExact(responseBuffer.position())];
-        responseBuffer.resetPosition();
-        responseBuffer.readBytes(bytes);
-        return bytes;
+    private static byte[] usedBytesFrom(@NonNull final PbjWriter responseBuffer) {
+        return responseBuffer.toByteArray();
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -223,7 +223,7 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
             // It's possible this was intentional, but make a little noise to remind test author this happens
             log.warn("All paid queries get INVALID_NODE_ACCOUNT for non-default nodes in embedded mode");
         }
-        final var responseBuffer = new PbjWriter(MAX_QUERY_RESPONSE_SIZE);
+        final var responseBuffer = new PbjWriter(MAX_QUERY_RESPONSE_SIZE, false);
         if (asNodeOperator) {
             hedera.operatorQueryWorkflow().handleQuery(Bytes.wrap(query.toByteArray()), responseBuffer);
         } else {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
@@ -9,7 +9,7 @@ import static org.hiero.consensus.platformstate.PlatformStateUtils.bulkUpdateOf;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.AbstractFakePlatform;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.FakeConsensusEvent;
@@ -103,7 +103,7 @@ class ConcurrentEmbeddedHedera extends AbstractEmbeddedHedera implements Embedde
         requireNonNull(transaction);
         requireNonNull(nodeAccountId);
         if (defaultNodeAccountId.equals(nodeAccountId)) {
-            final var responseBuffer = BufferedData.allocate(MAX_PLATFORM_TXN_SIZE);
+            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE);
             hedera.ingestWorkflow().submitTransaction(Bytes.wrap(transaction.toByteArray()), responseBuffer);
             return parseTransactionResponse(responseBuffer);
         } else {
@@ -126,7 +126,7 @@ class ConcurrentEmbeddedHedera extends AbstractEmbeddedHedera implements Embedde
         requireNonNull(nodeAccountId);
         requireNonNull(semanticVersion);
         if (defaultNodeAccountId.equals(nodeAccountId)) {
-            final var responseBuffer = BufferedData.allocate(MAX_PLATFORM_TXN_SIZE);
+            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE);
             hedera.ingestWorkflow().submitTransaction(Bytes.wrap(transaction.toByteArray()), responseBuffer);
             return parseTransactionResponse(responseBuffer);
         } else {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/ConcurrentEmbeddedHedera.java
@@ -103,7 +103,7 @@ class ConcurrentEmbeddedHedera extends AbstractEmbeddedHedera implements Embedde
         requireNonNull(transaction);
         requireNonNull(nodeAccountId);
         if (defaultNodeAccountId.equals(nodeAccountId)) {
-            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE);
+            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE, false);
             hedera.ingestWorkflow().submitTransaction(Bytes.wrap(transaction.toByteArray()), responseBuffer);
             return parseTransactionResponse(responseBuffer);
         } else {
@@ -126,7 +126,7 @@ class ConcurrentEmbeddedHedera extends AbstractEmbeddedHedera implements Embedde
         requireNonNull(nodeAccountId);
         requireNonNull(semanticVersion);
         if (defaultNodeAccountId.equals(nodeAccountId)) {
-            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE);
+            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE, false);
             hedera.ingestWorkflow().submitTransaction(Bytes.wrap(transaction.toByteArray()), responseBuffer);
             return parseTransactionResponse(responseBuffer);
         } else {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
@@ -104,7 +104,7 @@ public class RepeatableEmbeddedHedera extends AbstractEmbeddedHedera implements 
     public TransactionResponse submit(Transaction transaction, AccountID nodeAccountId, final long eventBirthRound) {
         var response = OK_RESPONSE;
         if (defaultNodeAccountId.equals(nodeAccountId)) {
-            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE);
+            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE, false);
             final var payload = Bytes.wrap(transaction.toByteArray());
             hedera.ingestWorkflow().submitTransaction(payload, responseBuffer);
             response = parseTransactionResponse(responseBuffer);
@@ -129,7 +129,7 @@ public class RepeatableEmbeddedHedera extends AbstractEmbeddedHedera implements 
         requireNonNull(semanticVersion);
         var response = OK_RESPONSE;
         if (defaultNodeAccountId.equals(nodeAccountId)) {
-            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE);
+            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE, false);
             final var payload = Bytes.wrap(transaction.toByteArray());
             hedera.ingestWorkflow().submitTransaction(payload, responseBuffer);
             response = parseTransactionResponse(responseBuffer);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/RepeatableEmbeddedHedera.java
@@ -9,7 +9,7 @@ import static org.hiero.consensus.platformstate.PlatformStateUtils.bulkUpdateOf;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.platform.event.StateSignatureTransaction;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.AbstractFakePlatform;
 import com.hedera.services.bdd.junit.hedera.embedded.fakes.FakeConsensusEvent;
@@ -104,7 +104,7 @@ public class RepeatableEmbeddedHedera extends AbstractEmbeddedHedera implements 
     public TransactionResponse submit(Transaction transaction, AccountID nodeAccountId, final long eventBirthRound) {
         var response = OK_RESPONSE;
         if (defaultNodeAccountId.equals(nodeAccountId)) {
-            final var responseBuffer = BufferedData.allocate(MAX_PLATFORM_TXN_SIZE);
+            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE);
             final var payload = Bytes.wrap(transaction.toByteArray());
             hedera.ingestWorkflow().submitTransaction(payload, responseBuffer);
             response = parseTransactionResponse(responseBuffer);
@@ -129,7 +129,7 @@ public class RepeatableEmbeddedHedera extends AbstractEmbeddedHedera implements 
         requireNonNull(semanticVersion);
         var response = OK_RESPONSE;
         if (defaultNodeAccountId.equals(nodeAccountId)) {
-            final var responseBuffer = BufferedData.allocate(MAX_PLATFORM_TXN_SIZE);
+            final var responseBuffer = new PbjWriter(MAX_PLATFORM_TXN_SIZE);
             final var payload = Bytes.wrap(transaction.toByteArray());
             hedera.ingestWorkflow().submitTransaction(payload, responseBuffer);
             response = parseTransactionResponse(responseBuffer);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/inputs/TransactionParts.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/inputs/TransactionParts.java
@@ -20,7 +20,9 @@ import edu.umd.cs.findbugs.annotations.NonNull;
  * Encapsulates the parts of a transaction we care about for translating a block stream into records.
  */
 public record TransactionParts(
-        @NonNull Transaction wrapper, @NonNull TransactionBody body, @NonNull HederaFunctionality function) {
+        @NonNull Transaction wrapper,
+        @NonNull TransactionBody body,
+        @NonNull HederaFunctionality function) {
     public TransactionParts {
         requireNonNull(wrapper);
         requireNonNull(body);
@@ -44,11 +46,7 @@ public record TransactionParts(
     public static TransactionParts from(@NonNull final Bytes serializedSignedTx) {
         try {
             final var signedTx = SignedTransaction.PROTOBUF.parse(
-                    serializedSignedTx.toReadableSequentialData(),
-                    false,
-                    false,
-                    DEFAULT_MAX_DEPTH,
-                    MAX_PBJ_RECORD_SIZE);
+                    serializedSignedTx, false, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
             final Transaction wrapper;
             if (signedTx.useSerializedTxMessageHashAlgorithm()) {
                 wrapper = Transaction.newBuilder()
@@ -61,11 +59,7 @@ public record TransactionParts(
                         .build();
             }
             final var body = TransactionBody.PROTOBUF.parse(
-                    signedTx.bodyBytes().toReadableSequentialData(),
-                    false,
-                    false,
-                    DEFAULT_MAX_DEPTH,
-                    MAX_PBJ_RECORD_SIZE);
+                    signedTx.bodyBytes(), false, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
             return new TransactionParts(wrapper, body, functionOf(body));
         } catch (ParseException | UnknownHederaFunctionality e) {
             // Fail immediately with invalid transactions that should not be in any production record stream

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BinaryStateChangeParser.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BinaryStateChangeParser.java
@@ -4,12 +4,11 @@ package com.hedera.services.bdd.junit.support.validators.block;
 import com.hedera.hapi.block.stream.output.StateChanges;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.BinaryState;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
-import java.io.IOException;
 
 /**
  * Parses binary protobuf {@link StateChanges} and applies mutations through the {@link BinaryState} API.
@@ -32,7 +31,7 @@ final class BinaryStateChangeParser {
             @NonNull final BinaryState binaryState,
             @NonNull final Bytes stateChangesBytes,
             @Nullable final BinaryStateChangeSummary stateChangesSummary) {
-        final ReadableSequentialData input = stateChangesBytes.toReadableSequentialData();
+        PbjReader input = stateChangesBytes.toPbjReader();
         while (input.hasRemaining()) {
             final int tag = input.readVarInt(false);
             switch (tag) {
@@ -53,7 +52,7 @@ final class BinaryStateChangeParser {
 
     private static void processStateChange(
             @NonNull final BinaryState binaryState,
-            @NonNull final ReadableSequentialData input,
+            @NonNull final PbjReader input,
             final long endPosition,
             @Nullable final BinaryStateChangeSummary stateChangesSummary) {
         int stateId = -1;
@@ -125,7 +124,7 @@ final class BinaryStateChangeParser {
     private static void processSingletonUpdateChange(
             @NonNull final BinaryState binaryState,
             final int stateId,
-            @NonNull final ReadableSequentialData input,
+            @NonNull final PbjReader input,
             final long endPosition) {
         final Bytes rawValue = readOneOfPayload(input, endPosition, "SingletonUpdateChange");
         binaryState.updateSingleton(stateId, rawValue);
@@ -134,7 +133,7 @@ final class BinaryStateChangeParser {
     private static void processMapUpdateChange(
             @NonNull final BinaryState binaryState,
             final int stateId,
-            @NonNull final ReadableSequentialData input,
+            @NonNull final PbjReader input,
             final long endPosition) {
         Bytes rawKey = null;
         Bytes rawValue = null;
@@ -167,7 +166,7 @@ final class BinaryStateChangeParser {
     private static void processMapDeleteChange(
             @NonNull final BinaryState binaryState,
             final int stateId,
-            @NonNull final ReadableSequentialData input,
+            @NonNull final PbjReader input,
             final long endPosition) {
         Bytes rawKey = null;
         while (input.position() < endPosition) {
@@ -192,7 +191,7 @@ final class BinaryStateChangeParser {
     private static void processQueuePushChange(
             @NonNull final BinaryState binaryState,
             final int stateId,
-            @NonNull final ReadableSequentialData input,
+            @NonNull final PbjReader input,
             final long endPosition) {
         final Bytes rawElement = readOneOfPayload(input, endPosition, "QueuePushChange");
         binaryState.pushQueue(stateId, rawElement);
@@ -203,7 +202,7 @@ final class BinaryStateChangeParser {
     }
 
     private static Bytes readOneOfPayload(
-            @NonNull final ReadableSequentialData input, final long endPosition, @NonNull final String description) {
+            @NonNull final PbjReader input, final long endPosition, @NonNull final String description) {
         Bytes payload = null;
         while (input.position() < endPosition) {
             final int tag = input.readVarInt(false);
@@ -226,7 +225,7 @@ final class BinaryStateChangeParser {
      * Token relationship keys are the important exception: block stream uses TokenAssociation while state stores
      * EntityIDPair, whose field ordering is different.
      */
-    private static Bytes readMapKeyPayload(@NonNull final ReadableSequentialData input, final long endPosition) {
+    private static Bytes readMapKeyPayload(@NonNull final PbjReader input, final long endPosition) {
         Bytes payload = null;
         while (input.position() < endPosition) {
             final int tag = input.readVarInt(false);
@@ -251,19 +250,15 @@ final class BinaryStateChangeParser {
         return stateId;
     }
 
-    private static void skipField(@NonNull final ReadableSequentialData input, final int tag) {
+    private static void skipField(@NonNull final PbjReader input, final int tag) {
         skipField(input, ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK));
     }
 
-    private static void skipField(@NonNull final ReadableSequentialData input, @NonNull final ProtoConstants wireType) {
-        try {
-            ProtoParserTools.skipField(input, wireType);
-        } catch (IOException e) {
-            throw new IllegalStateException("Failed to skip protobuf field with wire type " + wireType, e);
-        }
+    private static void skipField(@NonNull final PbjReader input, @NonNull final ProtoConstants wireType) {
+        ProtoParserTools.skipField(input, wireType);
     }
 
-    private static void skipMessage(@NonNull final ReadableSequentialData input) {
+    private static void skipMessage(@NonNull final PbjReader input) {
         final int messageLength = input.readVarInt(false);
         input.skip(messageLength);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockStreamEventBuilder.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/BlockStreamEventBuilder.java
@@ -120,13 +120,9 @@ public class BlockStreamEventBuilder {
             // which carry the ~32 MB uncompressed WRAPS proof; parse with the same raised ceiling
             // used by BlockStreamAccess to read the blocks these transactions come from
             final SignedTransaction signedTransaction = SignedTransaction.PROTOBUF.parse(
-                    transactionBytes.toReadableSequentialData(), false, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
+                    transactionBytes, false, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
             return TransactionBody.PROTOBUF.parse(
-                    signedTransaction.bodyBytes().toReadableSequentialData(),
-                    false,
-                    false,
-                    DEFAULT_MAX_DEPTH,
-                    MAX_PBJ_RECORD_SIZE);
+                    signedTransaction.bodyBytes(), false, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
         } catch (final ParseException e) {
             throw new RuntimeException(
                     "Unable to parse transaction bytes (" + transactionBytes.length() + " bytes, prefix 0x"

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/RedactingEventHashBlockStreamValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/RedactingEventHashBlockStreamValidator.java
@@ -179,11 +179,7 @@ public class RedactingEventHashBlockStreamValidator implements BlockStreamValida
             // Raised ceiling for node-generated history proof votes carrying the ~32 MB
             // uncompressed WRAPS proof, which exceed the default PBJ max message size
             return SignedTransaction.PROTOBUF.parse(
-                    ((Bytes) item.item().as()).toReadableSequentialData(),
-                    false,
-                    false,
-                    DEFAULT_MAX_DEPTH,
-                    MAX_PBJ_RECORD_SIZE);
+                    ((Bytes) item.item().as()), false, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
         }
         return null;
     }
@@ -267,12 +263,8 @@ public class RedactingEventHashBlockStreamValidator implements BlockStreamValida
 
                 // Deserialize using PBJ protobuf codec; parseStrict shorthand omitted because
                 // unredacted node-generated transactions can exceed the default max message size
-                final Block reloadedBlock = Block.PROTOBUF.parse(
-                        Bytes.wrap(fileBytes).toReadableSequentialData(),
-                        true,
-                        false,
-                        DEFAULT_MAX_DEPTH,
-                        MAX_PBJ_RECORD_SIZE);
+                final Block reloadedBlock =
+                        Block.PROTOBUF.parse(fileBytes, true, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
                 reloadedBlocks.add(reloadedBlock);
 
             } catch (final IOException e) {

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/blockstream/BlockStreamRecoveryWorkflow.java
@@ -15,6 +15,7 @@ import com.hedera.node.app.hapi.utils.blocks.BlockStreamAccess;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.statevalidation.util.ProgressReporter;
@@ -337,7 +338,7 @@ public class BlockStreamRecoveryWorkflow {
     private static final class BinaryStateChangeApplier {
         private static void applyStateChanges(
                 @NonNull final BinaryState binaryState, @NonNull final Bytes stateChangesBytes) {
-            final ReadableSequentialData input = stateChangesBytes.toReadableSequentialData();
+            PbjReader input = stateChangesBytes.toPbjReader();
             while (input.hasRemaining()) {
                 final int tag = input.readVarInt(false);
                 switch (tag) {
@@ -360,6 +361,61 @@ public class BlockStreamRecoveryWorkflow {
                 @NonNull final BinaryState binaryState,
                 @NonNull final ReadableSequentialData input,
                 final long endPosition) {
+            int stateId = -1;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                switch (tag) {
+                    // state_id: field 1, uint32 varint => (1 << 3) | 0 = 8
+                    case 8 -> stateId = ProtoParserTools.readUint32(input);
+                    // state_add: field 2, message => (2 << 3) | 2 = 18
+                    // state_remove: field 3, message => (3 << 3) | 2 = 26
+                    case 18, 26 -> skipMessage(input);
+                    // singleton_update: field 4, message => (4 << 3) | 2 = 34
+                    case 34 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            final Bytes rawValue =
+                                    readOneOfPayload(input, input.position() + messageLength, "SingletonUpdateChange");
+                            binaryState.updateSingleton(requireStateId(stateId), rawValue);
+                        }
+                    }
+                    // map_update: field 5, message => (5 << 3) | 2 = 42
+                    case 42 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            processMapUpdate(
+                                    binaryState, requireStateId(stateId), input, input.position() + messageLength);
+                        }
+                    }
+                    // map_delete: field 6, message => (6 << 3) | 2 = 50
+                    case 50 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            processMapDelete(
+                                    binaryState, requireStateId(stateId), input, input.position() + messageLength);
+                        }
+                    }
+                    // queue_push: field 7, message => (7 << 3) | 2 = 58
+                    case 58 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            final Bytes rawElement =
+                                    readOneOfPayload(input, input.position() + messageLength, "QueuePushChange");
+                            binaryState.pushQueue(requireStateId(stateId), rawElement);
+                        }
+                    }
+                    // queue_pop: field 8, message => (8 << 3) | 2 = 66
+                    case 66 -> {
+                        skipMessage(input);
+                        binaryState.popQueue(requireStateId(stateId));
+                    }
+                    default -> skipField(input, tag);
+                }
+            }
+        }
+
+        private static void processStateChange(
+                @NonNull final BinaryState binaryState, @NonNull final PbjReader input, final long endPosition) {
             int stateId = -1;
             while (input.position() < endPosition) {
                 final int tag = input.readVarInt(false);
@@ -446,10 +502,67 @@ public class BlockStreamRecoveryWorkflow {
             binaryState.updateKv(stateId, rawKey, rawValue);
         }
 
+        private static void processMapUpdate(
+                @NonNull final BinaryState binaryState,
+                final int stateId,
+                @NonNull final PbjReader input,
+                final long endPosition) {
+            Bytes rawKey = null;
+            Bytes rawValue = null;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                switch (tag) {
+                    // key: field 1, message => (1 << 3) | 2 = 10K
+                    case 10 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            rawKey = readMapKeyPayload(stateId, input, input.position() + messageLength);
+                        }
+                    }
+                    // value: field 2, message => (2 << 3) | 2 = 18
+                    case 18 -> {
+                        final int messageLength = input.readVarInt(false);
+                        if (messageLength > 0) {
+                            rawValue = readOneOfPayload(input, input.position() + messageLength, "MapChangeValue");
+                        }
+                    }
+                    default -> skipField(input, tag);
+                }
+            }
+            if (rawKey == null || rawValue == null) {
+                throw new IllegalStateException("MapChangeKey or MapChangeValue missing");
+            }
+            binaryState.updateKv(stateId, rawKey, rawValue);
+        }
+
         private static void processMapDelete(
                 @NonNull final BinaryState binaryState,
                 final int stateId,
                 @NonNull final ReadableSequentialData input,
+                final long endPosition) {
+            Bytes rawKey = null;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                // key: field 1, message => (1 << 3) | 2 = 10
+                if (tag == 10) {
+                    final int messageLength = input.readVarInt(false);
+                    if (messageLength > 0) {
+                        rawKey = readMapKeyPayload(stateId, input, input.position() + messageLength);
+                    }
+                } else {
+                    skipField(input, tag);
+                }
+            }
+            if (rawKey == null) {
+                throw new IllegalStateException("MapChangeKey missing in MapDeleteChange");
+            }
+            binaryState.removeKv(stateId, rawKey);
+        }
+
+        private static void processMapDelete(
+                @NonNull final BinaryState binaryState,
+                final int stateId,
+                @NonNull final PbjReader input,
                 final long endPosition) {
             Bytes rawKey = null;
             while (input.position() < endPosition) {
@@ -495,6 +608,25 @@ public class BlockStreamRecoveryWorkflow {
             return payload;
         }
 
+        private static Bytes readOneOfPayload(
+                @NonNull final PbjReader input, final long endPosition, @NonNull final String description) {
+            Bytes payload = null;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                final var wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+                if (payload == null && wireType == ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    final int length = input.readVarInt(false);
+                    payload = input.readBytes(length);
+                } else {
+                    skipField(input, wireType);
+                }
+            }
+            if (payload == null) {
+                throw new IllegalStateException(description + " payload missing");
+            }
+            return payload;
+        }
+
         /**
          * Reads the first delimited field payload from a map key message.
          * Most block-stream key payloads are byte-compatible with the state key bytes stored in the
@@ -503,6 +635,27 @@ public class BlockStreamRecoveryWorkflow {
          */
         private static Bytes readMapKeyPayload(
                 final int stateId, @NonNull final ReadableSequentialData input, final long endPosition) {
+            Bytes payload = null;
+            Integer fieldNumber = null;
+            while (input.position() < endPosition) {
+                final int tag = input.readVarInt(false);
+                final var wireType = ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK);
+                if (payload == null && wireType == ProtoConstants.WIRE_TYPE_DELIMITED) {
+                    fieldNumber = tag >>> ProtoParserTools.TAG_FIELD_OFFSET;
+                    final int length = input.readVarInt(false);
+                    payload = input.readBytes(length);
+                } else {
+                    skipField(input, wireType);
+                }
+            }
+            if (payload == null) {
+                throw new IllegalStateException("MapChangeKey payload missing");
+            }
+            return normalizeMapKeyPayload(stateId, fieldNumber, payload);
+        }
+
+        private static Bytes readMapKeyPayload(
+                final int stateId, @NonNull final PbjReader input, final long endPosition) {
             Bytes payload = null;
             Integer fieldNumber = null;
             while (input.position() < endPosition) {
@@ -566,6 +719,9 @@ public class BlockStreamRecoveryWorkflow {
             skipField(input, ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK));
         }
 
+        private static void skipField(@NonNull final PbjReader input, final int tag) {
+            skipField(input, ProtoConstants.get(tag & ProtoConstants.TAG_WIRE_TYPE_MASK));
+        }
         /**
          * Skips a protobuf field value for the given wire type.
          *
@@ -581,7 +737,16 @@ public class BlockStreamRecoveryWorkflow {
             }
         }
 
+        private static void skipField(@NonNull final PbjReader input, @NonNull final ProtoConstants wireType) {
+            ProtoParserTools.skipField(input, wireType);
+        }
+
         private static void skipMessage(@NonNull final ReadableSequentialData input) {
+            final int messageLength = input.readVarInt(false);
+            input.skip(messageLength);
+        }
+
+        private static void skipMessage(@NonNull final PbjReader input) {
             final int messageLength = input.readVarInt(false);
             input.skip(messageLength);
         }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/DiffExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/DiffExporter.java
@@ -237,11 +237,7 @@ public class DiffExporter {
             throws Exception { // Adjust for ParseException, IOException, etc.
         final StateKey stateKey = StateKey.PROTOBUF.parse(keyBytes);
         final StateValue stateValue = StateValue.PROTOBUF.parse(
-                valueBytes.toReadableSequentialData(),
-                false,
-                false,
-                Codec.DEFAULT_MAX_DEPTH,
-                getVirtualMapValueParseMaxSizeBytes());
+                valueBytes, false, false, Codec.DEFAULT_MAX_DEPTH, getVirtualMapValueParseMaxSizeBytes());
 
         final String record;
         if (stateKey.key().kind().equals(StateKey.KeyOneOfType.SINGLETON)) {

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/JsonExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/JsonExporter.java
@@ -171,11 +171,7 @@ public class JsonExporter {
                     }
                     stateKey = StateKey.PROTOBUF.parse(keyBytes);
                     stateValue = StateValue.PROTOBUF.parse(
-                            valueBytes.toReadableSequentialData(),
-                            false,
-                            false,
-                            Codec.DEFAULT_MAX_DEPTH,
-                            getVirtualMapValueParseMaxSizeBytes());
+                            valueBytes, false, false, Codec.DEFAULT_MAX_DEPTH, getVirtualMapValueParseMaxSizeBytes());
                     if (stateKey.key().kind().equals(StateKey.KeyOneOfType.SINGLETON)) {
                         JsonUtils.write(
                                 writer,

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedJsonExporter.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/exporter/SortedJsonExporter.java
@@ -11,7 +11,7 @@ import com.hedera.hapi.platform.state.StateKey;
 import com.hedera.hapi.platform.state.StateValue;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.statevalidation.util.JsonUtils;
 import com.hedera.statevalidation.util.StateUtils;
@@ -90,16 +90,16 @@ public class SortedJsonExporter {
             final Comparator<Pair<Long, Bytes>> comparator;
             if (stateId < StateKey.KeyOneOfType.RECORDCACHE_I_TRANSACTION_RECEIPTS.protoOrdinal()) {
                 comparator = (key1, key2) -> {
-                    ReadableSequentialData keyData1 = key1.right().toReadableSequentialData();
+                    PbjReader keyData1 = key1.right().toPbjReader();
                     keyData1.readVarInt(false); // read tag
                     keyData1.readVarInt(false); // read value
 
-                    ReadableSequentialData keyData2 = key2.right().toReadableSequentialData();
+                    PbjReader keyData2 = key2.right().toPbjReader();
                     keyData2.readVarInt(false); // read tag
                     keyData2.readVarInt(false); // read value
 
-                    return keyData1.readBytes((int) keyData1.remaining())
-                            .compareTo(keyData2.readBytes((int) keyData2.remaining()));
+                    return keyData1.readBytes((int) (keyData1.limit() - keyData1.position()))
+                            .compareTo(keyData2.readBytes((int) (keyData2.limit() - keyData2.position())));
                 };
             } else {
                 comparator = (key1, key2) -> {
@@ -188,7 +188,7 @@ public class SortedJsonExporter {
                 return;
             }
             final Bytes keyBytes = leafRecord.keyBytes();
-            final ReadableSequentialData keyData = keyBytes.toReadableSequentialData();
+            final PbjReader keyData = keyBytes.toPbjReader();
             final int tag = keyData.readVarInt(false);
             final int actualStateId = tag >> TAG_FIELD_OFFSET;
             if (actualStateId == 1) {
@@ -237,11 +237,7 @@ public class SortedJsonExporter {
                 try {
                     stateKey = StateKey.PROTOBUF.parse(keyBytes);
                     stateValue = StateValue.PROTOBUF.parse(
-                            valueBytes.toReadableSequentialData(),
-                            false,
-                            false,
-                            Codec.DEFAULT_MAX_DEPTH,
-                            getVirtualMapValueParseMaxSizeBytes());
+                            valueBytes, false, false, Codec.DEFAULT_MAX_DEPTH, getVirtualMapValueParseMaxSizeBytes());
                     if (stateKey.key().kind().equals(StateKey.KeyOneOfType.SINGLETON)) {
                         JsonUtils.write(
                                 writer,

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/AccountAndSupplyValidator.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/AccountAndSupplyValidator.java
@@ -99,7 +99,7 @@ public class AccountAndSupplyValidator implements LeafBytesValidator {
             try {
                 final com.hedera.hapi.platform.state.StateValue stateValue =
                         com.hedera.hapi.platform.state.StateValue.PROTOBUF.parse(
-                                valueBytes.toReadableSequentialData(),
+                                valueBytes,
                                 false,
                                 false,
                                 Codec.DEFAULT_MAX_DEPTH,

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/LeafBytesIntegrityValidator.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/LeafBytesIntegrityValidator.java
@@ -232,10 +232,6 @@ public class LeafBytesIntegrityValidator implements LeafBytesValidator {
 
     private static StateValue parseValue(Bytes valueBytes) throws ParseException {
         return StateValue.PROTOBUF.parse(
-                valueBytes.toReadableSequentialData(),
-                false,
-                false,
-                Codec.DEFAULT_MAX_DEPTH,
-                getVirtualMapValueParseMaxSizeBytes());
+                valueBytes, false, false, Codec.DEFAULT_MAX_DEPTH, getVirtualMapValueParseMaxSizeBytes());
     }
 }

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/TokenRelationsIntegrityValidator.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/TokenRelationsIntegrityValidator.java
@@ -101,7 +101,7 @@ public class TokenRelationsIntegrityValidator implements LeafBytesValidator {
 
                 final com.hedera.hapi.platform.state.StateValue stateValue =
                         com.hedera.hapi.platform.state.StateValue.PROTOBUF.parse(
-                                valueBytes.toReadableSequentialData(),
+                                valueBytes,
                                 false,
                                 false,
                                 Codec.DEFAULT_MAX_DEPTH,

--- a/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/pipeline/ProcessorTask.java
+++ b/hedera-state-validator/src/main/java/com/hedera/statevalidation/validator/pipeline/ProcessorTask.java
@@ -169,7 +169,7 @@ public class ProcessorTask implements Callable<Void> {
             dataStats.getP2kv().incrementItemCount();
 
             final VirtualLeafBytes<?> virtualLeafBytes =
-                    VirtualLeafBytes.parseFrom(data.bytes().toReadableSequentialData());
+                    VirtualLeafBytes.parseFrom(data.bytes().toPbjReader());
 
             if (data.location() == pathToDiskLocationLeafNodes.get(virtualLeafBytes.path())) {
                 // Live object, perform ops on it...
@@ -212,7 +212,7 @@ public class ProcessorTask implements Callable<Void> {
             dataStats.getId2c().incrementItemCount();
 
             final VirtualHashChunk virtualHashChunk =
-                    VirtualHashChunk.parseFrom(data.bytes().toReadableSequentialData(), vds.getHashChunkHeight());
+                    VirtualHashChunk.parseFrom(data.bytes().toPbjReader(), vds.getHashChunkHeight());
 
             if (data.location() == idToDiskLocationHashChunks.get(virtualHashChunk.getChunkId())) {
                 // Live object, perform ops on it...
@@ -255,7 +255,7 @@ public class ProcessorTask implements Callable<Void> {
             dataStats.getK2p().incrementItemCount();
 
             try (final ParsedBucket bucket = new ParsedBucket()) {
-                bucket.readFrom(data.bytes().toReadableSequentialData());
+                bucket.readFrom(data.bytes().toPbjReader());
 
                 if (data.location() == bucketIndexToBucketLocation.get(bucket.getBucketIndex())) {
                     // Live object, perform ops on it...

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/Hash.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/Hash.java
@@ -2,7 +2,10 @@
 package org.hiero.base.crypto;
 
 import static java.util.Objects.requireNonNull;
+import static org.hiero.base.io.streams.SerializableStreamConstants.DEFAULT_CHECKSUM;
 
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
@@ -14,6 +17,7 @@ import org.hiero.base.io.exceptions.BadIOException;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
 import org.hiero.base.utility.CommonUtils;
+import org.hiero.base.utility.PbjUtils;
 
 /**
  * A cryptographic hash of some data.
@@ -148,6 +152,15 @@ public class Hash implements Comparable<Hash>, SerializableWithKnownLength, Seri
     }
 
     @Override
+    public void serialize(@NonNull final PbjWriter out) throws IOException {
+        requireNonNull(digestType, "digestType");
+        requireNonNull(bytes, "bytes");
+        out.writeInt(digestType.id());
+        out.writeInt((int) bytes.length());
+        bytes.writeTo(out);
+    }
+
+    @Override
     public int getSerializedLength() {
         return Integer.BYTES // digest type
                 + Integer.BYTES // length of the hash
@@ -166,7 +179,24 @@ public class Hash implements Comparable<Hash>, SerializableWithKnownLength, Seri
         }
 
         this.digestType = digestType;
-        final byte[] value = in.readByteArray(digestType.digestLength());
+        final byte[] value = in.readByteArray(digestType.digestLength(), DEFAULT_CHECKSUM);
+
+        if (value == null) {
+            throw new BadIOException("Invalid hash value read from the stream");
+        }
+        this.bytes = Bytes.wrap(value);
+    }
+
+    @Override
+    public void deserialize(@NonNull final PbjReader in, final int version) throws IOException {
+        final DigestType digestType = DigestType.valueOf(in.readInt());
+
+        if (digestType == null) {
+            throw new BadIOException("Invalid DigestType identifier read from the stream");
+        }
+
+        this.digestType = digestType;
+        final byte[] value = PbjUtils.readByteArray(in, digestType.digestLength(), DEFAULT_CHECKSUM);
 
         if (value == null) {
             throw new BadIOException("Invalid hash value read from the stream");

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/SerializablePublicKey.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/SerializablePublicKey.java
@@ -3,6 +3,8 @@ package org.hiero.base.crypto;
 
 import static org.hiero.base.utility.CommonUtils.hex;
 
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.swirlds.base.utility.ToStringBuilder;
 import com.swirlds.logging.legacy.LogMarker;
 import java.io.IOException;
@@ -15,6 +17,7 @@ import java.security.spec.X509EncodedKeySpec;
 import org.hiero.base.io.SelfSerializable;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 
 public class SerializablePublicKey implements SelfSerializable {
     private static final long CLASS_ID = 0x2554c14f4f61cd9L;
@@ -62,6 +65,12 @@ public class SerializablePublicKey implements SelfSerializable {
         out.writeByteArray(publicKey.getEncoded());
     }
 
+    @Override
+    public void serialize(PbjWriter out) throws IOException {
+        out.writeInt(keyType.getAlgorithmIdentifier());
+        PbjUtils.writeByteArray(out, publicKey.getEncoded());
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -74,6 +83,18 @@ public class SerializablePublicKey implements SelfSerializable {
             keyType = KeyType.getKeyType(in.readInt());
         }
         byte[] keyBytes = in.readByteArray(MAX_KEY_LENGTH);
+        publicKey = bytesToPublicKey(keyBytes, keyType.getAlgorithmName());
+    }
+
+    @Override
+    public void deserialize(PbjReader in, int version) throws IOException {
+        if (version == 1) {
+            String algorithm = PbjUtils.readNormalisedString(in, MAX_ALG_LENGTH);
+            keyType = KeyType.valueOf(algorithm);
+        } else {
+            keyType = KeyType.getKeyType(in.readInt());
+        }
+        byte[] keyBytes = PbjUtils.readByteArray(in, MAX_KEY_LENGTH);
         publicKey = bytesToPublicKey(keyBytes, keyType.getAlgorithmName());
     }
 

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/Signature.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/Signature.java
@@ -3,6 +3,7 @@ package org.hiero.base.crypto;
 
 import static org.hiero.base.crypto.SignatureType.RSA;
 
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.base.utility.ToStringBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -10,6 +11,7 @@ import java.io.IOException;
 import java.util.Objects;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 
 /**
  * Encapsulates a cryptographic signature along with its SignatureType.
@@ -112,6 +114,21 @@ public class Signature {
         out.writeInt(CLASS_VERSION);
         out.writeInt(signatureType.ordinal());
         out.writeByteArray(signatureBytes.toByteArray(), true);
+    }
+
+    /**
+     * Serialize this signature to a {@link PbjWriter}.
+     *
+     * @param out the writer to write to
+     * @param withClassId whether to write the class ID
+     */
+    public void serialize(final PbjWriter out, final boolean withClassId) throws IOException {
+        if (withClassId) {
+            out.writeLong(CLASS_ID);
+        }
+        out.writeInt(CLASS_VERSION);
+        out.writeInt(signatureType.ordinal());
+        PbjUtils.writeByteArray(out, signatureBytes.toByteArray(), true);
     }
 
     /**

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/engine/SerializationDigestProvider.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/engine/SerializationDigestProvider.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.crypto.engine;
 
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.swirlds.logging.legacy.LogMarker;
 import java.io.IOException;
 import java.security.MessageDigest;
@@ -9,7 +10,7 @@ import org.hiero.base.crypto.CryptographyException;
 import org.hiero.base.crypto.DigestType;
 import org.hiero.base.crypto.HashingOutputStream;
 import org.hiero.base.io.SelfSerializable;
-import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 
 /**
  * A {@link CachingOperationProvider} capable of computing hashes for {@link SelfSerializable} objects by hashing the
@@ -36,13 +37,16 @@ public class SerializationDigestProvider
             final SelfSerializable item,
             final Void optionalData) {
         algorithm.resetDigest(); // probably not needed, just to be safe
-        try (SerializableDataOutputStream out = new SerializableDataOutputStream(algorithm)) {
-            out.writeSerializable(item, true);
+        PbjWriter out = PbjUtils.takeTlsWriter();
+        try {
+            out.resetWith(algorithm);
+            PbjUtils.writeSerializable(out, item, true);
             out.flush();
-
             return algorithm.getDigest();
         } catch (IOException ex) {
             throw new CryptographyException(ex, LogMarker.EXCEPTION);
+        } finally {
+            PbjUtils.returnTlsWriter();
         }
     }
 }

--- a/platform-sdk/base-crypto/src/testFixtures/java/org/hiero/base/crypto/test/fixtures/SerializableHashableDummy.java
+++ b/platform-sdk/base-crypto/src/testFixtures/java/org/hiero/base/crypto/test/fixtures/SerializableHashableDummy.java
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.crypto.test.fixtures;
 
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import java.io.IOException;
 import org.hiero.base.crypto.AbstractSerializableHashable;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 
 public class SerializableHashableDummy extends AbstractSerializableHashable {
     private static final long CLASS_ID = 0xeecd8387d5496ba3L;
@@ -39,8 +42,20 @@ public class SerializableHashableDummy extends AbstractSerializableHashable {
     }
 
     @Override
+    public void serialize(PbjWriter out) throws IOException {
+        out.writeInt(number);
+        PbjUtils.writeNormalisedString(out, string);
+    }
+
+    @Override
     public void deserialize(SerializableDataInputStream in, int version) throws IOException {
         number = in.readInt();
         string = in.readNormalisedString(MAX_STRING_LENGTH);
+    }
+
+    @Override
+    public void deserialize(PbjReader in, int version) throws IOException {
+        number = in.readInt();
+        string = PbjUtils.readNormalisedString(in, MAX_STRING_LENGTH);
     }
 }

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/io/FunctionalDeserializePbj.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/io/FunctionalDeserializePbj.java
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.base.io;
+
+import com.hedera.pbj.runtime.io.PbjReader;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+
+@FunctionalInterface
+public interface FunctionalDeserializePbj {
+    /**
+     * Deserializes the object from the given buffer. The class ID and version number will have already
+     * been consumed; only the internal data should be read.
+     *
+     * @param in the buffer to read from
+     * @param version the version of the serialized data
+     * @throws IOException if an IO error occurs
+     */
+    void deserialize(@NonNull PbjReader in, int version) throws IOException;
+}

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/io/FunctionalSerializePbj.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/io/FunctionalSerializePbj.java
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.base.io;
+
+import com.hedera.pbj.runtime.io.PbjWriter;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.io.IOException;
+
+@FunctionalInterface
+public interface FunctionalSerializePbj {
+    /**
+     * Serializes the data in the object in a deterministic manner. The class ID and version number should not be
+     * written by this method, it should only include internal data.
+     *
+     * @param out
+     * 		The stream to write to.
+     * @throws IOException
+     * 		Thrown in case of an IO exception.
+     */
+    void serialize(@NonNull PbjWriter out) throws IOException;
+}

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/io/SelfSerializable.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/io/SelfSerializable.java
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.io;
 
-import com.hedera.pbj.runtime.io.PbjWriter;
+import com.hedera.pbj.runtime.io.PbjReader;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import org.hiero.base.io.streams.SerializableDataInputStream;
@@ -11,13 +11,6 @@ import org.hiero.base.io.streams.SerializableDataOutputStream;
  * A SerializableDet that knows how to serialize and deserialize itself.
  */
 public interface SelfSerializable extends SerializableDet, FunctionalSerialize, FunctionalSerializePbj {
-
-    @Override
-    default void serialize(@NonNull PbjWriter out) throws IOException {
-        throw new UnsupportedOperationException(
-                "Not yet migrated to PBJ serialization: " + getClass().getName());
-    }
-
     /**
      * Deserializes an instance that has been previously serialized by {@link FunctionalSerialize#serialize(SerializableDataOutputStream)}.
      * This method should support all versions of the serialized data.
@@ -31,4 +24,6 @@ public interface SelfSerializable extends SerializableDet, FunctionalSerialize, 
      * 		Thrown in case of an IO exception.
      */
     void deserialize(@NonNull SerializableDataInputStream in, int version) throws IOException;
+
+    void deserialize(@NonNull PbjReader in, int version) throws IOException;
 }

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/io/SelfSerializable.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/io/SelfSerializable.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.io;
 
+import com.hedera.pbj.runtime.io.PbjWriter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import org.hiero.base.io.streams.SerializableDataInputStream;
@@ -9,7 +10,13 @@ import org.hiero.base.io.streams.SerializableDataOutputStream;
 /**
  * A SerializableDet that knows how to serialize and deserialize itself.
  */
-public interface SelfSerializable extends SerializableDet, FunctionalSerialize {
+public interface SelfSerializable extends SerializableDet, FunctionalSerialize, FunctionalSerializePbj {
+
+    @Override
+    default void serialize(@NonNull PbjWriter out) throws IOException {
+        throw new UnsupportedOperationException(
+                "Not yet migrated to PBJ serialization: " + getClass().getName());
+    }
 
     /**
      * Deserializes an instance that has been previously serialized by {@link FunctionalSerialize#serialize(SerializableDataOutputStream)}.

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/io/SerializableLong.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/io/SerializableLong.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.io;
 
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import java.io.IOException;
 import java.util.Objects;
 import org.hiero.base.FastCopyable;
@@ -88,11 +90,21 @@ public class SerializableLong implements Comparable<SerializableLong>, FastCopya
         out.writeLong(this.value);
     }
 
+    @Override
+    public void serialize(PbjWriter out) throws IOException {
+        out.writeLong(this.value);
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     public void deserialize(SerializableDataInputStream in, int version) throws IOException {
+        this.value = in.readLong();
+    }
+
+    @Override
+    public void deserialize(PbjReader in, int version) throws IOException {
         this.value = in.readLong();
     }
 

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/utility/PbjUtils.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/utility/PbjUtils.java
@@ -16,7 +16,6 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
 import java.time.Instant;
@@ -29,13 +28,8 @@ import org.hiero.base.io.exceptions.InvalidVersionException;
 import org.hiero.base.io.streams.SerializableStreamConstants;
 
 public final class PbjUtils {
-    static class ReadCacheBytes {
+    static class ReadCache {
         final PbjReader reader = new PbjReader(Bytes.EMPTY);
-        boolean inUse = false;
-    }
-
-    static class ReadCacheStream {
-        final PbjReader reader = new PbjReader((InputStream) null);
         boolean inUse = false;
     }
 
@@ -44,12 +38,11 @@ public final class PbjUtils {
         boolean inUse = false;
     }
 
-    static ThreadLocal<ReadCacheBytes> tlsReaderBytes = ThreadLocal.withInitial(ReadCacheBytes::new);
-    static ThreadLocal<ReadCacheStream> tlsReaderStream = ThreadLocal.withInitial(ReadCacheStream::new);
+    static ThreadLocal<ReadCache> tlsReader = ThreadLocal.withInitial(ReadCache::new);
     static ThreadLocal<WriteCache> tlsWriter = ThreadLocal.withInitial(WriteCache::new);
 
-    public static PbjReader takeTlsReaderBytes() {
-        ReadCacheBytes cache = tlsReaderBytes.get();
+    public static PbjReader takeTlsReader() {
+        ReadCache cache = tlsReader.get();
         if (cache.inUse) {
             throw new RuntimeException("Trying to get tls byte reader more than once");
         }
@@ -57,27 +50,10 @@ public final class PbjUtils {
         return cache.reader;
     }
 
-    public static void returnTlsReaderBytes() {
-        ReadCacheBytes cache = tlsReaderBytes.get();
+    public static void returnTlsReader() {
+        ReadCache cache = tlsReader.get();
         if (!cache.inUse) {
             throw new RuntimeException("Trying to return tls byte reader more than once");
-        }
-        cache.inUse = false;
-    }
-
-    public static PbjReader takeTlsReaderStream() {
-        ReadCacheStream cache = tlsReaderStream.get();
-        if (cache.inUse) {
-            throw new RuntimeException("Trying to get tls stream reader more than once");
-        }
-        cache.inUse = true;
-        return cache.reader;
-    }
-
-    public static void returnTlsReaderStream() {
-        ReadCacheStream cache = tlsReaderStream.get();
-        if (!cache.inUse) {
-            throw new RuntimeException("Trying to return tls stream reader more than once");
         }
         cache.inUse = false;
     }

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/utility/PbjUtils.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/utility/PbjUtils.java
@@ -1,0 +1,299 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.base.utility;
+
+import static com.hedera.pbj.runtime.Codec.DEFAULT_MAX_DEPTH;
+import static org.hiero.base.io.streams.SerializableStreamConstants.NULL_CLASS_ID;
+import static org.hiero.base.io.streams.SerializableStreamConstants.NULL_INSTANT_EPOCH_SECOND;
+import static org.hiero.base.io.streams.SerializableStreamConstants.NULL_LIST_ARRAY_LENGTH;
+import static org.hiero.base.io.streams.SerializableStreamConstants.NULL_VERSION;
+
+import com.hedera.pbj.runtime.Codec;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.BufferOverflowException;
+import java.nio.BufferUnderflowException;
+import java.time.Instant;
+import java.util.function.Supplier;
+import org.hiero.base.io.FunctionalDeserializePbj;
+import org.hiero.base.io.FunctionalSerializePbj;
+import org.hiero.base.io.SelfSerializable;
+import org.hiero.base.io.SerializableDet;
+import org.hiero.base.io.exceptions.InvalidVersionException;
+import org.hiero.base.io.streams.SerializableStreamConstants;
+
+public final class PbjUtils {
+    static class ReadCacheBytes {
+        final PbjReader reader = new PbjReader(Bytes.EMPTY);
+        boolean inUse = false;
+    }
+
+    static class ReadCacheStream {
+        final PbjReader reader = new PbjReader((InputStream) null);
+        boolean inUse = false;
+    }
+
+    static class WriteCache {
+        final PbjWriter writer = new PbjWriter();
+        boolean inUse = false;
+    }
+
+    static ThreadLocal<ReadCacheBytes> tlsReaderBytes = ThreadLocal.withInitial(ReadCacheBytes::new);
+    static ThreadLocal<ReadCacheStream> tlsReaderStream = ThreadLocal.withInitial(ReadCacheStream::new);
+    static ThreadLocal<WriteCache> tlsWriter = ThreadLocal.withInitial(WriteCache::new);
+
+    public static PbjReader takeTlsReaderBytes() {
+        ReadCacheBytes cache = tlsReaderBytes.get();
+        if (cache.inUse) {
+            throw new RuntimeException("Trying to get tls byte reader more than once");
+        }
+        cache.inUse = true;
+        return cache.reader;
+    }
+
+    public static void returnTlsReaderBytes() {
+        ReadCacheBytes cache = tlsReaderBytes.get();
+        if (!cache.inUse) {
+            throw new RuntimeException("Trying to return tls byte reader more than once");
+        }
+        cache.inUse = false;
+    }
+
+    public static PbjReader takeTlsReaderStream() {
+        ReadCacheStream cache = tlsReaderStream.get();
+        if (cache.inUse) {
+            throw new RuntimeException("Trying to get tls stream reader more than once");
+        }
+        cache.inUse = true;
+        return cache.reader;
+    }
+
+    public static void returnTlsReaderStream() {
+        ReadCacheStream cache = tlsReaderStream.get();
+        if (!cache.inUse) {
+            throw new RuntimeException("Trying to return tls stream reader more than once");
+        }
+        cache.inUse = false;
+    }
+
+    public static PbjWriter takeTlsWriter() {
+        WriteCache cache = tlsWriter.get();
+        if (cache.inUse) {
+            throw new RuntimeException("Trying to get tls writer more than once");
+        }
+        cache.inUse = true;
+        return cache.writer;
+    }
+
+    public static void returnTlsWriter() {
+        WriteCache cache = tlsWriter.get();
+        if (!cache.inUse) {
+            throw new RuntimeException("Trying to return tls writer more than once");
+        }
+        cache.inUse = false;
+        cache.writer.resetWithNull(); // clear stream
+        cache.writer.throwOnError();
+    }
+
+    public static void writeNormalisedString(@NonNull final PbjWriter out, @Nullable final String s)
+            throws IOException {
+        writeByteArray(out, CommonUtils.getNormalisedStringBytes(s));
+    }
+
+    public static String readNormalisedString(PbjReader in, int maxLength) throws IOException {
+        byte[] data = readByteArray(in, maxLength, false);
+        if (data == null) {
+            return null;
+        }
+        return CommonUtils.getNormalisedStringFromBytes(data);
+    }
+
+    public static void writeByteArray(@NonNull final PbjWriter out, @Nullable final byte[] data) {
+        if (data == null) {
+            out.writeInt(NULL_LIST_ARRAY_LENGTH);
+            return;
+        }
+        out.writeInt(data.length);
+        out.writeBytes(data);
+    }
+
+    private static final int MAX_PBJ_RECORD_SIZE = 33554432;
+
+    public static <T> T readPbjRecord(PbjReader in, @NonNull final Codec<T> codec) throws IOException {
+        int size = in.readInt();
+        final long origLimit = in.limit();
+        in.limit(in.position() + size);
+        try {
+            // parse strictly with a default depth and max record size to prevent very large messages.
+            // We can't use `parseStrict` as it doesn't support record size validation.
+            final T parsed = codec.parse(in, true, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
+            if (in.position() != in.limit()) {
+                throw new EOFException("PBJ record was not fully read");
+            }
+            return parsed;
+        } catch (final ParseException e) {
+            if (e.getCause() instanceof BufferOverflowException || e.getCause() instanceof BufferUnderflowException) {
+                // PBJ Codec can throw these exceptions if it does not read enough bytes
+                final EOFException eofException = new EOFException("Buffer underflow while reading PBJ record");
+                eofException.addSuppressed(e);
+                throw eofException;
+            }
+            throw new IOException(e);
+        }
+    }
+
+    public static void writeSerializable(
+            PbjWriter out, @NonNull final SelfSerializable serializable, final boolean writeClassId)
+            throws IOException {
+        writeSerializable(out, serializable, writeClassId, serializable);
+    }
+
+    public static int readVarInt(Bytes bytes, boolean zigZag) {
+        return (int) readVarLong(bytes, zigZag);
+    }
+
+    public static long readVarLong(Bytes bytes, boolean zigZag) {
+        byte[] buf = bytes.array();
+        int arrayOffset = bytes.arrayOffset();
+        long value = 0;
+        for (int i = 0; i < 10; i++) {
+            byte b = buf[arrayOffset + i];
+            value |= (long) (b & 0x7F) << (i * 7);
+            if (b >= 0) {
+                return zigZag ? (value >>> 1) ^ -(value & 1) : value;
+            }
+        }
+        return -1;
+    }
+
+    public static long readLong(Bytes bytes) {
+        byte[] buf = bytes.array();
+        int pos = bytes.arrayOffset();
+        if (bytes.length() < 8) return -1;
+
+        long v = 0;
+        for (int i = 0; i < 8; i++) {
+            v |= (long) (buf[pos + 7 - i] & 255) << (i * 8);
+        }
+        pos += 8;
+        return v;
+    }
+
+    private static void writeSerializable(
+            PbjWriter out,
+            @Nullable final SelfSerializable serializable,
+            final boolean writeClassId,
+            @NonNull final FunctionalSerializePbj serializeMethod)
+            throws IOException {
+        if (serializable == null) {
+            if (writeClassId) {
+                out.writeLong(NULL_CLASS_ID);
+            } else {
+                out.writeInt(NULL_VERSION);
+            }
+            return;
+        }
+        writeClassIdVersion(out, serializable, writeClassId);
+        serializeMethod.serialize(out);
+    }
+
+    static void writeClassIdVersion(
+            PbjWriter out, @NonNull final SerializableDet serializable, final boolean writeClassId) throws IOException {
+        if (writeClassId) {
+            out.writeLong(serializable.getClassId());
+        }
+        out.writeInt(serializable.getVersion());
+    }
+
+    @Nullable
+    public static <T extends SelfSerializable & FunctionalDeserializePbj> T readSerializable(
+            @NonNull final PbjReader in, final boolean readClassId, @NonNull final Supplier<T> serializableConstructor)
+            throws IOException {
+        if (readClassId) {
+            if (in.readLong() == NULL_CLASS_ID) return null;
+        }
+        final int version = in.readInt();
+        if (version == NULL_VERSION) return null;
+        final T obj = serializableConstructor.get();
+        if (version < obj.getMinimumSupportedVersion() || version > obj.getVersion()) {
+            throw new InvalidVersionException(version, obj);
+        }
+        obj.deserialize(in, version);
+        return obj;
+    }
+
+    /**
+     * Writes a length-prefixed PBJ record to the given {@link PbjWriter}.
+     *
+     * @param out the destination writer
+     * @param record the record to write
+     * @param codec the codec to use to write the record
+     * @param <T> the type of the record
+     * @return the total number of bytes written (record size + 4-byte length prefix)
+     * @throws IOException if an IO error occurs
+     */
+    public static <T> long writePbjRecord(
+            @NonNull final PbjWriter out, @NonNull final T record, @NonNull final Codec<T> codec) throws IOException {
+        final int recordSize = codec.measureRecord(record);
+        out.writeInt(recordSize);
+        codec.write(record, out);
+        out.flush();
+        return recordSize + Integer.BYTES;
+    }
+
+    public static void writeInstant(@NonNull PbjWriter out, @Nullable final Instant instant) throws IOException {
+        if (instant == null) {
+            out.writeLong(NULL_INSTANT_EPOCH_SECOND);
+            return;
+        }
+        out.writeLong(instant.getEpochSecond());
+        out.writeLong(instant.getNano());
+    }
+
+    @Nullable
+    public static Instant readInstant(@NonNull PbjReader in) throws IOException {
+        long epochSecond = in.readLong(); // from getEpochSecond()
+        if (epochSecond == NULL_INSTANT_EPOCH_SECOND) {
+            return null;
+        }
+        long nanos = in.readLong();
+        if (nanos < 0 || nanos > 999_999_999) {
+            throw new IOException("Instant.nanosecond is not within the allowed range!");
+        }
+        return Instant.ofEpochSecond(epochSecond, nanos);
+    }
+
+    public static byte[] readByteArray(@NonNull final PbjReader in, final int maxLength) throws IOException {
+        return readByteArray(in, maxLength, SerializableStreamConstants.DEFAULT_CHECKSUM);
+    }
+
+    public static byte[] readByteArray(@NonNull final PbjReader in, final int maxLength, final boolean readChecksum)
+            throws IOException {
+        int len = in.readInt();
+        if (len < 0) {
+            return null;
+        }
+        if (readChecksum) {
+            int checksum = in.readInt();
+            if (checksum != (101 - len)) {
+                throw new IOException("readByteArray tried to create array of length " + len + " with wrong checksum.");
+            }
+        }
+        if (len > maxLength) {
+            throw new IOException(
+                    "readByteArray tried to create array of length " + len + " but max allowed is " + maxLength + ".");
+        }
+        byte[] dst = new byte[len];
+        in.readBytes(dst);
+        if (in.error() > 0) {
+            throw new IOException("readByteArray: unexpected end of stream reading " + len + " bytes.");
+        }
+        return dst;
+    }
+}

--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/utility/PbjUtils.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/utility/PbjUtils.java
@@ -115,11 +115,20 @@ public final class PbjUtils {
     }
 
     public static void writeByteArray(@NonNull final PbjWriter out, @Nullable final byte[] data) {
+        writeByteArray(out, data, false);
+    }
+
+    public static void writeByteArray(
+            @NonNull final PbjWriter out, @Nullable final byte[] data, final boolean writeChecksum) {
         if (data == null) {
             out.writeInt(NULL_LIST_ARRAY_LENGTH);
             return;
         }
         out.writeInt(data.length);
+        if (writeChecksum) {
+            // write a simple checksum to detect if at wrong place in the stream
+            out.writeInt(101 - data.length);
+        }
         out.writeBytes(data);
     }
 

--- a/platform-sdk/base-utility/src/testFixtures/java/org/hiero/base/utility/test/fixtures/io/SelfSerializableExample.java
+++ b/platform-sdk/base-utility/src/testFixtures/java/org/hiero/base/utility/test/fixtures/io/SelfSerializableExample.java
@@ -1,11 +1,14 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.utility.test.fixtures.io;
 
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import java.io.IOException;
 import java.util.Objects;
 import org.hiero.base.io.SelfSerializable;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 
 public class SelfSerializableExample implements SelfSerializable {
     private static final long CLASS_ID = 0x157bddfb3b8a7c75L;
@@ -30,6 +33,12 @@ public class SelfSerializableExample implements SelfSerializable {
     }
 
     @Override
+    public void deserialize(PbjReader in, int version) throws IOException {
+        this.aNumber = in.readInt();
+        this.aString = PbjUtils.readNormalisedString(in, STRING_MAX_BYTES);
+    }
+
+    @Override
     public long getClassId() {
         return CLASS_ID;
     }
@@ -50,6 +59,12 @@ public class SelfSerializableExample implements SelfSerializable {
     public void serialize(SerializableDataOutputStream out) throws IOException {
         out.writeInt(aNumber);
         out.writeNormalisedString(aString);
+    }
+
+    @Override
+    public void serialize(PbjWriter out) throws IOException {
+        out.writeInt(aNumber);
+        PbjUtils.writeNormalisedString(out, aString);
     }
 
     @Override

--- a/platform-sdk/consensus-event-stream/src/main/java/org/hiero/consensus/event/stream/internal/TimestampStreamFileWriter.java
+++ b/platform-sdk/consensus-event-stream/src/main/java/org/hiero/consensus/event/stream/internal/TimestampStreamFileWriter.java
@@ -12,7 +12,7 @@ import static org.hiero.consensus.event.stream.LinkedObjectStreamUtilities.gener
 import static org.hiero.consensus.event.stream.LinkedObjectStreamUtilities.getPeriod;
 import static org.hiero.consensus.model.stream.StreamAligned.NO_ALIGNMENT;
 
-import java.io.BufferedOutputStream;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
@@ -31,7 +31,7 @@ import org.hiero.base.crypto.SerializableHashable;
 import org.hiero.base.crypto.Signature;
 import org.hiero.base.crypto.SignatureType;
 import org.hiero.base.crypto.Signer;
-import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 import org.hiero.consensus.event.stream.LinkedObjectStream;
 import org.hiero.consensus.event.stream.StreamType;
 import org.hiero.consensus.model.stream.StreamAligned;
@@ -104,12 +104,12 @@ public class TimestampStreamFileWriter<T extends StreamAligned & RunningHashable
     /**
      * Data destined for the output file should be written to this stream.
      */
-    private SerializableDataOutputStream out = null;
+    private PbjWriter out = null;
     /**
      * Metadata should be written to this stream. Any data written to this stream is used to generate a running
      * metadata hash.
      */
-    private SerializableDataOutputStream metadataOut = null;
+    private PbjWriter metadataOut = null;
     /**
      * The current file being written.
      */
@@ -198,8 +198,7 @@ public class TimestampStreamFileWriter<T extends StreamAligned & RunningHashable
             final StreamType streamType)
             throws IOException {
 
-        try (final SerializableDataOutputStream output =
-                new SerializableDataOutputStream(new BufferedOutputStream(new FileOutputStream(sigFilePath)))) {
+        try (final PbjWriter output = new PbjWriter(new FileOutputStream(sigFilePath))) {
 
             // write signature file header
             for (final byte num : streamType.getSigFileHeader()) {
@@ -207,9 +206,9 @@ public class TimestampStreamFileWriter<T extends StreamAligned & RunningHashable
             }
 
             output.writeInt(OBJECT_STREAM_SIG_VERSION);
-            output.writeSerializable(entireHash, true);
+            PbjUtils.writeSerializable(output, entireHash, true);
             entireSignature.serialize(output, true);
-            output.writeSerializable(metaHash, true);
+            PbjUtils.writeSerializable(output, metaHash, true);
             metaSignature.serialize(output, true);
 
             logger.info(OBJECT_STREAM_FILE.getMarker(), "signature file saved: {}", sigFilePath);
@@ -221,7 +220,7 @@ public class TimestampStreamFileWriter<T extends StreamAligned & RunningHashable
      */
     private void serialize(final T object) {
         try {
-            out.writeSerializable(object, true);
+            PbjUtils.writeSerializable(out, object, true);
             out.flush();
         } catch (IOException e) {
             logger.warn(EXCEPTION.getMarker(), "IOException when serializing {}", object, e);
@@ -241,9 +240,8 @@ public class TimestampStreamFileWriter<T extends StreamAligned & RunningHashable
                 logger.info(OBJECT_STREAM.getMarker(), "Stream file already exists {}", currentFile::getName);
             } else {
                 fileStream = new FileOutputStream(currentFile, false);
-                out = new SerializableDataOutputStream(
-                        new BufferedOutputStream(new HashingOutputStream(streamDigest, fileStream)));
-                metadataOut = new SerializableDataOutputStream(new HashingOutputStream(metadataStreamDigest));
+                out = new PbjWriter(new HashingOutputStream(streamDigest, fileStream));
+                metadataOut = new PbjWriter(new HashingOutputStream(metadataStreamDigest));
                 logger.info(OBJECT_STREAM_FILE.getMarker(), "Stream file created {}", currentFile::getName);
             }
         } catch (final FileNotFoundException e) {
@@ -270,8 +268,8 @@ public class TimestampStreamFileWriter<T extends StreamAligned & RunningHashable
                     OBJECT_STREAM_FILE.getMarker(), "begin :: write OBJECT_STREAM_VERSION {}", OBJECT_STREAM_VERSION);
             // write startRunningHash
             Hash startRunningHash = runningHash.getFutureHash().getAndRethrow();
-            out.writeSerializable(startRunningHash, true);
-            metadataOut.writeSerializable(startRunningHash, true);
+            PbjUtils.writeSerializable(out, startRunningHash, true);
+            PbjUtils.writeSerializable(metadataOut, startRunningHash, true);
             logger.info(OBJECT_STREAM_FILE.getMarker(), "begin :: write startRunningHash {}", startRunningHash);
         } catch (final IOException e) {
             logger.error(
@@ -297,8 +295,8 @@ public class TimestampStreamFileWriter<T extends StreamAligned & RunningHashable
         if (fileStream != null) {
             try {
                 final Hash finalRunningHash = runningHash.getFutureHash().getAndRethrow();
-                out.writeSerializable(finalRunningHash, true);
-                metadataOut.writeSerializable(finalRunningHash, true);
+                PbjUtils.writeSerializable(out, finalRunningHash, true);
+                PbjUtils.writeSerializable(metadataOut, finalRunningHash, true);
                 logger.info(
                         OBJECT_STREAM_FILE.getMarker(),
                         "closeCurrentAndSign {} :: write endRunningHash {}",

--- a/platform-sdk/consensus-event-stream/src/testFixtures/java/org/hiero/consensus/event/stream/test/fixtures/EventStreamTestUtils.java
+++ b/platform-sdk/consensus-event-stream/src/testFixtures/java/org/hiero/consensus/event/stream/test/fixtures/EventStreamTestUtils.java
@@ -164,7 +164,7 @@ public final class EventStreamTestUtils {
                         return null;
                     })
                     .when(wrappedEvent)
-                    .serialize(any());
+                    .serialize(any(org.hiero.base.io.streams.SerializableDataOutputStream.class));
 
             wrappedEvents.add(wrappedEvent);
         }

--- a/platform-sdk/consensus-event-stream/src/testFixtures/java/org/hiero/consensus/event/stream/test/fixtures/EventStreamTestUtils.java
+++ b/platform-sdk/consensus-event-stream/src/testFixtures/java/org/hiero/consensus/event/stream/test/fixtures/EventStreamTestUtils.java
@@ -164,7 +164,7 @@ public final class EventStreamTestUtils {
                         return null;
                     })
                     .when(wrappedEvent)
-                    .serialize(any(org.hiero.base.io.streams.SerializableDataOutputStream.class));
+                    .serialize(any(com.hedera.pbj.runtime.io.PbjWriter.class));
 
             wrappedEvents.add(wrappedEvent);
         }

--- a/platform-sdk/consensus-event-stream/src/testFixtures/java/org/hiero/consensus/event/stream/test/fixtures/ObjectForTestStream.java
+++ b/platform-sdk/consensus-event-stream/src/testFixtures/java/org/hiero/consensus/event/stream/test/fixtures/ObjectForTestStream.java
@@ -3,6 +3,8 @@ package org.hiero.consensus.event.stream.test.fixtures;
 
 import static org.hiero.base.utility.ByteUtils.intToByteArray;
 
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import java.io.IOException;
 import java.security.SecureRandom;
 import java.time.Instant;
@@ -14,6 +16,7 @@ import org.hiero.base.crypto.RunningHashable;
 import org.hiero.base.crypto.SerializableHashable;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 import org.hiero.consensus.model.stream.StreamAligned;
 import org.hiero.consensus.model.stream.Timestamped;
 
@@ -92,6 +95,12 @@ public class ObjectForTestStream extends AbstractHashable
     }
 
     @Override
+    public void serialize(PbjWriter out) throws IOException {
+        PbjUtils.writeByteArray(out, payload);
+        PbjUtils.writeInstant(out, consensusTimestamp);
+    }
+
+    @Override
     public void deserialize(SerializableDataInputStream in, int version) throws IOException {
         if (version == CLASS_VERSION_PAYLOAD) {
             payload = in.readByteArray(Integer.MAX_VALUE);
@@ -101,6 +110,18 @@ public class ObjectForTestStream extends AbstractHashable
             payload = intToByteArray(number);
         }
         consensusTimestamp = in.readInstant();
+    }
+
+    @Override
+    public void deserialize(PbjReader in, int version) throws IOException {
+        if (version == CLASS_VERSION_PAYLOAD) {
+            payload = PbjUtils.readByteArray(in, Integer.MAX_VALUE);
+        } else {
+            // read a int number
+            int number = in.readInt();
+            payload = intToByteArray(number);
+        }
+        consensusTimestamp = PbjUtils.readInstant(in);
     }
 
     @Override

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/event/CesEvent.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/event/CesEvent.java
@@ -5,6 +5,8 @@ import com.hedera.hapi.platform.event.EventConsensusData;
 import com.hedera.hapi.platform.event.EventCore;
 import com.hedera.hapi.platform.event.GossipEvent;
 import com.hedera.hapi.util.HapiUtils;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.base.utility.ToStringBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -17,6 +19,7 @@ import org.hiero.base.crypto.RunningHash;
 import org.hiero.base.crypto.RunningHashable;
 import org.hiero.base.io.streams.SerializableDataInputStream;
 import org.hiero.base.io.streams.SerializableDataOutputStream;
+import org.hiero.base.utility.PbjUtils;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.stream.StreamAligned;
 import org.hiero.consensus.model.stream.Timestamped;
@@ -87,6 +90,26 @@ public class CesEvent extends AbstractSerializableHashable
     }
 
     @Override
+    public void serialize(@NonNull PbjWriter out) throws IOException {
+        Objects.requireNonNull(out);
+        Objects.requireNonNull(platformEvent);
+
+        PbjUtils.writePbjRecord(out, platformEvent.getGossipEvent(), GossipEvent.PROTOBUF);
+
+        // some fields used to be part of the stream but are no longer used
+        // in order to maintain compatibility with older versions of the stream, we write a constant in their place
+
+        out.writeInt(CONSENSUS_DATA_CLASS_VERSION);
+        out.writeLong(UNDEFINED); // ConsensusData.generation
+        out.writeLong(UNDEFINED); // ConsensusData.roundCreated
+        out.writeBoolean(false); // ConsensusData.stale
+        out.writeBoolean(lastInRoundReceived);
+        PbjUtils.writeInstant(out, platformEvent.getConsensusTimestamp());
+        out.writeLong(roundReceived);
+        out.writeLong(platformEvent.getConsensusOrder());
+    }
+
+    @Override
     public void deserialize(@NonNull final SerializableDataInputStream in, final int version) throws IOException {
         this.platformEvent = switch (version) {
             case CES_EVENT_VERSION_PBJ_EVENT ->
@@ -100,6 +123,30 @@ public class CesEvent extends AbstractSerializableHashable
         in.readBoolean(); // ConsensusData.stale
         lastInRoundReceived = in.readBoolean();
         final Instant consensusTimestamp = in.readInstant();
+        roundReceived = in.readLong();
+        final long consensusOrder = in.readLong();
+
+        final EventConsensusData eventConsensusData = EventConsensusData.newBuilder()
+                .consensusTimestamp(HapiUtils.asTimestamp(consensusTimestamp))
+                .consensusOrder(consensusOrder)
+                .build();
+        platformEvent.setConsensusData(eventConsensusData);
+    }
+
+    @Override
+    public void deserialize(@NonNull final PbjReader in, final int version) throws IOException {
+        this.platformEvent = switch (version) {
+            case CES_EVENT_VERSION_PBJ_EVENT ->
+                new PlatformEvent(PbjUtils.readPbjRecord(in, GossipEvent.PROTOBUF), EventOrigin.GOSSIP);
+            default -> throw new IOException("Unsupported version " + version);
+        };
+
+        in.readInt(); // ConsensusData.version
+        in.readLong(); // ConsensusData.generation
+        in.readLong(); // ConsensusData.roundCreated
+        in.readBoolean(); // ConsensusData.stale
+        lastInRoundReceived = in.readBoolean();
+        final Instant consensusTimestamp = PbjUtils.readInstant(in);
         roundReceived = in.readLong();
         final long consensusOrder = in.readLong();
 

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/node/NodeId.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/node/NodeId.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.model.node;
 
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.util.Objects;
@@ -142,11 +144,21 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
         out.writeLong(id);
     }
 
+    @Override
+    public void serialize(PbjWriter out) throws IOException {
+        out.writeLong(id);
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
     public void deserialize(SerializableDataInputStream in, int version) throws IOException {
+        id = in.readLong();
+    }
+
+    @Override
+    public void deserialize(PbjReader in, int version) throws IOException {
         id = in.readLong();
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/AccountIdProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/AccountIdProtoCodec.java
@@ -72,7 +72,7 @@ public final class AccountIdProtoCodec implements Codec<AccountId> {
      * @return Parsed AccountId model object or null if data input was null or empty
      * @throws ParseException If parsing fails
      */
-    public @NonNull AccountId realParse(
+    public @NonNull AccountId parse(
             @NonNull final PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
@@ -192,7 +192,7 @@ public final class AccountIdProtoCodec implements Codec<AccountId> {
         }
     }
 
-    public void realWrite(@NonNull AccountId data, @NonNull PbjWriter out) {
+    public void write(@NonNull AccountId data, @NonNull PbjWriter out) {
         // [1] - id
         writeLong(out, AccountIdSchema.ID, data.id(), true);
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/AccountIdProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/AccountIdProtoCodec.java
@@ -14,6 +14,8 @@ import com.hedera.pbj.runtime.ProtoArrayWriterTools;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.UnknownField;
 import com.hedera.pbj.runtime.UnknownFieldException;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.stream.EOFException;
@@ -70,8 +72,8 @@ public final class AccountIdProtoCodec implements Codec<AccountId> {
      * @return Parsed AccountId model object or null if data input was null or empty
      * @throws ParseException If parsing fails
      */
-    public @NonNull AccountId parse(
-            @NonNull final ReadableSequentialData input,
+    public @NonNull AccountId realParse(
+            @NonNull final PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
@@ -88,7 +90,7 @@ public final class AccountIdProtoCodec implements Codec<AccountId> {
             // -- PARSE LOOP ---------------------------------------------
             // Continue to parse bytes out of the input stream until we get to the end.
             while (input.hasRemaining()) {
-                // Note: ReadableStreamingData.hasRemaining() won't flip to false
+                // Note: PbjReader.hasRemaining() won't flip to false
                 // until the end of stream is actually hit with a read operation.
                 // So we catch this exception here and **only** here, because an EOFException
                 // anywhere else suggests that we're processing malformed data and so
@@ -190,6 +192,20 @@ public final class AccountIdProtoCodec implements Codec<AccountId> {
         }
     }
 
+    public void realWrite(@NonNull AccountId data, @NonNull PbjWriter out) {
+        // [1] - id
+        writeLong(out, AccountIdSchema.ID, data.id(), true);
+
+        // Check if not-empty to avoid creating a lambda if there's nothing to write.
+        if (!data.getUnknownFields().isEmpty()) {
+            data.getUnknownFields().forEach(uf -> {
+                final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
+                out.writeVarInt(tag, false);
+                uf.bytes().writeTo(out);
+            });
+        }
+    }
+
     /**
      * Writes an item to the given byte array, this is a performance focused method. In non-performance centric use
      * cases there are simpler methods such as toBytes() or writing to a {@link WritableStreamingData}.
@@ -252,8 +268,7 @@ public final class AccountIdProtoCodec implements Codec<AccountId> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public boolean fastEquals(@NonNull AccountId item, @NonNull final ReadableSequentialData input)
-            throws ParseException {
+    public boolean fastEquals(@NonNull AccountId item, @NonNull final PbjReader input) throws ParseException {
         return item.equals(parse(input));
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/AccountProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/AccountProtoCodec.java
@@ -15,6 +15,8 @@ import com.hedera.pbj.runtime.ProtoArrayWriterTools;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.UnknownField;
 import com.hedera.pbj.runtime.UnknownFieldException;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.stream.EOFException;
@@ -74,8 +76,8 @@ public final class AccountProtoCodec implements Codec<Account> {
      * @return Parsed Account model object or null if data input was null or empty
      * @throws ParseException If parsing fails
      */
-    public @NonNull Account parse(
-            @NonNull final ReadableSequentialData input,
+    public @NonNull Account realParse(
+            @NonNull final PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
@@ -229,6 +231,22 @@ public final class AccountProtoCodec implements Codec<Account> {
         }
     }
 
+    public void realWrite(@NonNull Account data, @NonNull PbjWriter out) {
+        // [1] - accountId
+        writeMessage(out, AccountSchema.ACCOUNT_ID, data.accountId(), AccountId.PROTOBUF);
+        // [2] - name
+        writeString(out, AccountSchema.NAME, data.name(), true);
+
+        // Check if not-empty to avoid creating a lambda if there's nothing to write.
+        if (!data.getUnknownFields().isEmpty()) {
+            data.getUnknownFields().forEach(uf -> {
+                final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
+                out.writeVarInt(tag, false);
+                uf.bytes().writeTo(out);
+            });
+        }
+    }
+
     /**
      * Writes an item to the given byte array, this is a performance focused method. In non-performance centric use
      * cases there are simpler methods such as toBytes() or writing to a {@link WritableStreamingData}.
@@ -294,8 +312,7 @@ public final class AccountProtoCodec implements Codec<Account> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public boolean fastEquals(@NonNull Account item, @NonNull final ReadableSequentialData input)
-            throws ParseException {
+    public boolean fastEquals(@NonNull Account item, @NonNull final PbjReader input) throws ParseException {
         return item.equals(parse(input));
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/AccountProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/AccountProtoCodec.java
@@ -76,7 +76,7 @@ public final class AccountProtoCodec implements Codec<Account> {
      * @return Parsed Account model object or null if data input was null or empty
      * @throws ParseException If parsing fails
      */
-    public @NonNull Account realParse(
+    public @NonNull Account parse(
             @NonNull final PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
@@ -231,7 +231,7 @@ public final class AccountProtoCodec implements Codec<Account> {
         }
     }
 
-    public void realWrite(@NonNull Account data, @NonNull PbjWriter out) {
+    public void write(@NonNull Account data, @NonNull PbjWriter out) {
         // [1] - accountId
         writeMessage(out, AccountSchema.ACCOUNT_ID, data.accountId(), AccountId.PROTOBUF);
         // [2] - name

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/ConsistencyStateProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/ConsistencyStateProtoCodec.java
@@ -13,6 +13,8 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.UnknownField;
 import com.hedera.pbj.runtime.UnknownFieldException;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.stream.EOFException;
@@ -58,8 +60,8 @@ public final class ConsistencyStateProtoCodec implements Codec<ConsistencyState>
      * @return Parsed ConsistencyState model object or null if data input was null or empty
      * @throws ParseException If parsing fails
      */
-    public @NonNull ConsistencyState parse(
-            @NonNull final ReadableSequentialData input,
+    public @NonNull ConsistencyState realParse(
+            @NonNull final PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
@@ -185,6 +187,22 @@ public final class ConsistencyStateProtoCodec implements Codec<ConsistencyState>
         }
     }
 
+    public void realWrite(@NonNull ConsistencyState data, @NonNull PbjWriter out) {
+        // [1] - running_checksum
+        writeLong(out, ConsistencyStateSchema.RUNNING_CHECKSUM, data.runningChecksum(), true);
+        // [2] - rounds_handled
+        writeLong(out, ConsistencyStateSchema.ROUNDS_HANDLED, data.roundsHandled(), true);
+
+        // Check if not-empty to avoid creating a lambda if there's nothing to write.
+        if (!data.getUnknownFields().isEmpty()) {
+            data.getUnknownFields().forEach(uf -> {
+                final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
+                out.writeVarInt(tag, false);
+                uf.bytes().writeTo(out);
+            });
+        }
+    }
+
     /**
      * Reads from this data input the length of the data within the input. The implementation may
      * read all the data, or just some special serialized data, as needed to find out the length of
@@ -223,8 +241,7 @@ public final class ConsistencyStateProtoCodec implements Codec<ConsistencyState>
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public boolean fastEquals(@NonNull ConsistencyState item, @NonNull final ReadableSequentialData input)
-            throws ParseException {
+    public boolean fastEquals(@NonNull ConsistencyState item, @NonNull final PbjReader input) throws ParseException {
         return item.equals(parse(input));
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/ConsistencyStateProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/ConsistencyStateProtoCodec.java
@@ -60,7 +60,7 @@ public final class ConsistencyStateProtoCodec implements Codec<ConsistencyState>
      * @return Parsed ConsistencyState model object or null if data input was null or empty
      * @throws ParseException If parsing fails
      */
-    public @NonNull ConsistencyState realParse(
+    public @NonNull ConsistencyState parse(
             @NonNull final PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
@@ -187,7 +187,7 @@ public final class ConsistencyStateProtoCodec implements Codec<ConsistencyState>
         }
     }
 
-    public void realWrite(@NonNull ConsistencyState data, @NonNull PbjWriter out) {
+    public void write(@NonNull ConsistencyState data, @NonNull PbjWriter out) {
         // [1] - running_checksum
         writeLong(out, ConsistencyStateSchema.RUNNING_CHECKSUM, data.runningChecksum(), true);
         // [2] - rounds_handled

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/EntityIdGeneratorProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/EntityIdGeneratorProtoCodec.java
@@ -14,6 +14,8 @@ import com.hedera.pbj.runtime.ProtoArrayWriterTools;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.UnknownField;
 import com.hedera.pbj.runtime.UnknownFieldException;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.stream.EOFException;
@@ -70,8 +72,8 @@ public final class EntityIdGeneratorProtoCodec implements Codec<EntityIdGenerato
      * @return Parsed EntityIdGenerator model object or null if data input was null or empty
      * @throws ParseException If parsing fails
      */
-    public @NonNull EntityIdGenerator parse(
-            @NonNull final ReadableSequentialData input,
+    public @NonNull EntityIdGenerator realParse(
+            @NonNull final PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
@@ -190,6 +192,20 @@ public final class EntityIdGeneratorProtoCodec implements Codec<EntityIdGenerato
         }
     }
 
+    public void realWrite(@NonNull EntityIdGenerator data, @NonNull final PbjWriter out) {
+        // [1] - nextId
+        writeLong(out, EntityIdGeneratorSchema.NEXT_ID, data.nextId(), true);
+
+        // Check if not-empty to avoid creating a lambda if there's nothing to write.
+        if (!data.getUnknownFields().isEmpty()) {
+            data.getUnknownFields().forEach(uf -> {
+                final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
+                out.writeVarInt(tag, false);
+                uf.bytes().writeTo(out);
+            });
+        }
+    }
+
     /**
      * Writes an item to the given byte array, this is a performance focused method. In non-performance centric use
      * cases there are simpler methods such as toBytes() or writing to a {@link WritableStreamingData}.
@@ -253,8 +269,7 @@ public final class EntityIdGeneratorProtoCodec implements Codec<EntityIdGenerato
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public boolean fastEquals(@NonNull EntityIdGenerator item, @NonNull final ReadableSequentialData input)
-            throws ParseException {
+    public boolean fastEquals(@NonNull EntityIdGenerator item, @NonNull final PbjReader input) throws ParseException {
         return item.equals(parse(input));
     }
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/EntityIdGeneratorProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/EntityIdGeneratorProtoCodec.java
@@ -72,7 +72,7 @@ public final class EntityIdGeneratorProtoCodec implements Codec<EntityIdGenerato
      * @return Parsed EntityIdGenerator model object or null if data input was null or empty
      * @throws ParseException If parsing fails
      */
-    public @NonNull EntityIdGenerator realParse(
+    public @NonNull EntityIdGenerator parse(
             @NonNull final PbjReader input,
             final boolean strictMode,
             final boolean parseUnknownFields,
@@ -192,7 +192,7 @@ public final class EntityIdGeneratorProtoCodec implements Codec<EntityIdGenerato
         }
     }
 
-    public void realWrite(@NonNull EntityIdGenerator data, @NonNull final PbjWriter out) {
+    public void write(@NonNull EntityIdGenerator data, @NonNull final PbjWriter out) {
         // [1] - nextId
         writeLong(out, EntityIdGeneratorSchema.NEXT_ID, data.nextId(), true);
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/IssStateProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/IssStateProtoCodec.java
@@ -47,7 +47,7 @@ public final class IssStateProtoCodec implements Codec<IssState> {
     }
 
     @Override
-    public @NonNull IssState realParse(
+    public @NonNull IssState parse(
             @NonNull final PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         return parse(input, strictMode, parseUnknownFields, maxDepth);
@@ -186,7 +186,7 @@ public final class IssStateProtoCodec implements Codec<IssState> {
         }
     }
 
-    public void realWrite(@NonNull IssState data, @NonNull PbjWriter out) {
+    public void write(@NonNull IssState data, @NonNull PbjWriter out) {
         // [1] - issState
         writeLong(out, IssStateSchema.ISS_STATE, data.issState(), true);
 

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/IssStateProtoCodec.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/app/model/codec/IssStateProtoCodec.java
@@ -13,6 +13,8 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.UnknownField;
 import com.hedera.pbj.runtime.UnknownFieldException;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.stream.EOFException;
@@ -45,12 +47,8 @@ public final class IssStateProtoCodec implements Codec<IssState> {
     }
 
     @Override
-    public @NonNull IssState parse(
-            @NonNull final ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
+    public @NonNull IssState realParse(
+            @NonNull final PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         return parse(input, strictMode, parseUnknownFields, maxDepth);
     }
@@ -188,6 +186,20 @@ public final class IssStateProtoCodec implements Codec<IssState> {
         }
     }
 
+    public void realWrite(@NonNull IssState data, @NonNull PbjWriter out) {
+        // [1] - issState
+        writeLong(out, IssStateSchema.ISS_STATE, data.issState(), true);
+
+        // Check if not-empty to avoid creating a lambda if there's nothing to write.
+        if (!data.getUnknownFields().isEmpty()) {
+            data.getUnknownFields().forEach(uf -> {
+                final int tag = (uf.field() << TAG_FIELD_OFFSET) | uf.wireType().ordinal();
+                out.writeVarInt(tag, false);
+                uf.bytes().writeTo(out);
+            });
+        }
+    }
+
     /**
      * Reads from this data input the length of the data within the input. The implementation may
      * read all the data, or just some special serialized data, as needed to find out the length of
@@ -226,8 +238,7 @@ public final class IssStateProtoCodec implements Codec<IssState> {
      * @return true if the bytes represent the item, false otherwise.
      * @throws ParseException If parsing fails
      */
-    public boolean fastEquals(@NonNull IssState item, @NonNull final ReadableSequentialData input)
-            throws ParseException {
+    public boolean fastEquals(@NonNull IssState item, @NonNull final PbjReader input) throws ParseException {
         return item.equals(parse(input));
     }
 

--- a/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/common/PcesFileChannelWriter.java
+++ b/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/common/PcesFileChannelWriter.java
@@ -2,36 +2,23 @@
 package org.hiero.consensus.pces.impl.common;
 
 import com.hedera.hapi.platform.event.GossipEvent;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
-import com.hedera.pbj.runtime.io.buffer.BufferedData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
-import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
 import java.nio.channels.FileChannel;
 import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
-import org.hiero.base.utility.MemoryUtils;
 
 /**
  * Writes preconsensus events to a file using a {@link FileChannel}.
  */
 public class PcesFileChannelWriter implements PcesFileWriter {
-    /**
-     * The initial capacity of the ByteBuffer used to write events.
-     *  Can be expanded throughout the lifespan of the app.
-     **/
-    static final int BUFFER_CAPACITY = 1024 * 1024 * 10;
-    /** The file channel for writing events */
     private final FileChannel channel;
-    /** The buffer used to hold data being written to the file */
-    private ByteBuffer buffer;
-    /** Wraps a ByteBuffer so that the protobuf codec can write to it */
-    private WritableSequentialData writableSequentialData;
-    /** Tracks the size of the file in bytes */
-    private int fileSize;
+    private final PbjWriter pbjWriter;
     /**
      * Create a new writer that writes events to a file using a {@link FileChannel}.
      *
@@ -47,73 +34,35 @@ public class PcesFileChannelWriter implements PcesFileWriter {
      *
      * @param filePath       the path to the file to write to
      * @param extraOpenOptions extra flags to indicate how to open the file
-     * @param bufferCapacity  the size of the buffer
-     * @throws IOException if an error occurs while opening the file
-     */
-    PcesFileChannelWriter(
-            @NonNull final Path filePath, @NonNull final List<OpenOption> extraOpenOptions, final int bufferCapacity)
-            throws IOException {
-        final List<OpenOption> allOpenOptions =
-                new ArrayList<>(List.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE));
-        allOpenOptions.addAll(extraOpenOptions);
-        this.channel = FileChannel.open(filePath, allOpenOptions.toArray(OpenOption[]::new));
-        this.buffer = ByteBuffer.allocateDirect(bufferCapacity);
-        this.writableSequentialData = BufferedData.wrap(buffer);
-    }
-
-    /**
-     * Create a new writer that writes events to a file using a {@link FileChannel}.
-     *
-     * @param filePath       the path to the file to write to
-     * @param extraOpenOptions extra flags to indicate how to open the file
      * @throws IOException if an error occurs while opening the file
      */
     public PcesFileChannelWriter(@NonNull final Path filePath, @NonNull final List<OpenOption> extraOpenOptions)
             throws IOException {
-        this(filePath, extraOpenOptions, BUFFER_CAPACITY);
+        final List<OpenOption> allOpenOptions =
+                new ArrayList<>(List.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE));
+        allOpenOptions.addAll(extraOpenOptions);
+        channel = FileChannel.open(filePath, allOpenOptions.toArray(OpenOption[]::new));
+        pbjWriter = new PbjWriter(Channels.newOutputStream(channel));
     }
 
     @Override
     public void writeVersion(final int version) throws IOException {
-        buffer.putInt(version);
-        flipWriteClear();
+        pbjWriter.writeInt(version);
+        pbjWriter.flush();
     }
 
     @Override
     public long writeEvent(@NonNull final GossipEvent event) throws IOException {
         final int size = GossipEvent.PROTOBUF.measureRecord(event);
-        final boolean expandBuffer = (size + Integer.BYTES) > buffer.capacity();
-        if (expandBuffer) {
-            MemoryUtils.closeDirectByteBuffer(buffer);
-            buffer = ByteBuffer.allocateDirect(size + Integer.BYTES);
-            writableSequentialData = BufferedData.wrap(buffer);
-        }
-        buffer.putInt(size);
-        GossipEvent.PROTOBUF.write(event, writableSequentialData);
-        flipWriteClear();
+        pbjWriter.writeInt(size);
+        GossipEvent.PROTOBUF.write(event, pbjWriter);
+        pbjWriter.flush();
         return size;
-    }
-
-    /**
-     * Writes the data in the buffer to the file. This method expects that the buffer will have data that is written to
-     * it. The buffer will be flipped so that it can be read from, the data will be written to the file, and the buffer
-     * will be cleared so that it can be used again.
-     */
-    private void flipWriteClear() throws IOException {
-
-        buffer.flip();
-        final int bytesWritten = channel.write(buffer);
-        fileSize += bytesWritten;
-        if (bytesWritten != buffer.limit()) {
-            throw new IOException(
-                    "Failed to write data to file. Wrote " + bytesWritten + " bytes out of " + buffer.limit());
-        }
-        buffer.clear();
     }
 
     @Override
     public void flush() throws IOException {
-        // nothing to do here
+        pbjWriter.flush();
     }
 
     @Override
@@ -124,11 +73,15 @@ public class PcesFileChannelWriter implements PcesFileWriter {
 
     @Override
     public void close() throws IOException {
-        channel.close();
+        pbjWriter.close();
     }
 
     @Override
     public long fileSize() {
-        return fileSize;
+        try {
+            return channel.position();
+        } catch (Exception ex) {
+            return 0;
+        }
     }
 }

--- a/platform-sdk/consensus-pces-impl/src/test/java/org/hiero/consensus/pces/impl/common/PcesFileChannelWriterTest.java
+++ b/platform-sdk/consensus-pces-impl/src/test/java/org/hiero/consensus/pces/impl/common/PcesFileChannelWriterTest.java
@@ -64,7 +64,7 @@ class PcesFileChannelWriterTest {
                 eventSize > BUFFER_CAPACITY,
                 "Event size should exceed 10MB buffer capacity. Actual size: " + eventSize);
 
-        writer = new PcesFileChannelWriter(testFile, List.of(), BUFFER_CAPACITY);
+        writer = new PcesFileChannelWriter(testFile, List.of());
         writer.writeVersion(2);
 
         // This should trigger buffer expansion since event exceeds default 10MB buffer

--- a/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStateTeacher.java
+++ b/platform-sdk/consensus-reconnect-impl/src/main/java/org/hiero/consensus/reconnect/impl/ReconnectStateTeacher.java
@@ -7,7 +7,7 @@ import static org.hiero.consensus.platformstate.PlatformStateUtils.getInfoString
 import static org.hiero.consensus.reconnect.impl.ReconnectStateLearner.endReconnectHandshake;
 
 import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.logging.legacy.payload.ReconnectFinishPayload;
 import com.swirlds.logging.legacy.payload.ReconnectStartPayload;
@@ -23,6 +23,7 @@ import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Hash;
+import org.hiero.base.utility.PbjUtils;
 import org.hiero.consensus.concurrent.manager.ThreadManager;
 import org.hiero.consensus.gossip.impl.network.Connection;
 import org.hiero.consensus.model.node.NodeId;
@@ -233,8 +234,14 @@ public class ReconnectStateTeacher {
                 .append(hash);
 
         logger.info(RECONNECT.getMarker(), sb);
-        final WritableStreamingData wsd = new WritableStreamingData(connection.getDos());
-        signatures.serialize(wsd);
+        PbjWriter writer = PbjUtils.takeTlsWriter();
+        try {
+            writer.resetWith(connection.getDos());
+            signatures.serialize(writer);
+            writer.flush();
+        } finally {
+            PbjUtils.returnTlsWriter();
+        }
         connection.getDos().flush();
     }
 }

--- a/platform-sdk/consensus-roster/src/main/java/org/hiero/consensus/roster/internal/PbjRecordHasher.java
+++ b/platform-sdk/consensus-roster/src/main/java/org/hiero/consensus/roster/internal/PbjRecordHasher.java
@@ -2,10 +2,8 @@
 package org.hiero.consensus.roster.internal;
 
 import com.hedera.pbj.runtime.Codec;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.security.MessageDigest;
 import org.hiero.base.crypto.DigestType;
 import org.hiero.base.crypto.Hash;
@@ -25,7 +23,7 @@ public class PbjRecordHasher {
     private static final DigestType DIGEST_TYPE = DigestType.SHA_384;
 
     private final MessageDigest digest = DIGEST_TYPE.buildDigest();
-    private final WritableSequentialData stream = new WritableStreamingData(new HashingOutputStream(digest));
+    private final PbjWriter stream = new PbjWriter(new HashingOutputStream(digest));
 
     /**
      * Computes a Hash object for a given PBJ record and its codec.
@@ -43,11 +41,8 @@ public class PbjRecordHasher {
      */
     @NonNull
     public <T> Hash hash(@NonNull final T record, @NonNull final Codec<T> codec) {
-        try {
-            codec.write(record, stream);
-        } catch (final IOException e) {
-            throw new RuntimeException("An exception occurred while trying to hash a record!", e);
-        }
+        codec.write(record, stream);
+        stream.flush();
         // Reminder, MessageDigest.digest resets the digest, so subsequent writes
         // will calculate an independent hash value.
         return new Hash(digest.digest(), DIGEST_TYPE);

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileReader.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileReader.java
@@ -72,12 +72,12 @@ public final class SignedStateFileReader {
         final File pbjFile = stateDir.resolve(SIGNATURE_SET_FILE_NAME).toFile();
         if (pbjFile.exists()) {
             sigSet = new SigSet();
-            PbjReader in = PbjUtils.takeTlsReaderStream();
+            PbjReader in = PbjUtils.takeTlsReader();
             try {
                 in.resetWith(new FileInputStream(pbjFile));
                 sigSet.deserialize(in);
             } finally {
-                PbjUtils.returnTlsReaderStream();
+                PbjUtils.returnTlsReader();
             }
         } else {
             throw new IOException("No signature set file found at " + pbjFile.getAbsolutePath());

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileReader.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileReader.java
@@ -7,7 +7,7 @@ import static org.hiero.consensus.state.persistence.SignedStateFileUtils.SIGNATU
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.StateLifecycleManager;
 import com.swirlds.state.lifecycle.Schema;
@@ -23,6 +23,7 @@ import java.nio.file.Path;
 import java.util.Comparator;
 import org.hiero.base.crypto.CryptoUtils;
 import org.hiero.base.crypto.Hash;
+import org.hiero.base.utility.PbjUtils;
 import org.hiero.consensus.platformstate.PlatformStateService;
 import org.hiero.consensus.platformstate.V0540PlatformStateSchema;
 import org.hiero.consensus.roster.RosterStateId;
@@ -71,8 +72,12 @@ public final class SignedStateFileReader {
         final File pbjFile = stateDir.resolve(SIGNATURE_SET_FILE_NAME).toFile();
         if (pbjFile.exists()) {
             sigSet = new SigSet();
-            try (final ReadableStreamingData in = new ReadableStreamingData(new FileInputStream(pbjFile))) {
+            PbjReader in = PbjUtils.takeTlsReaderStream();
+            try {
+                in.resetWith(new FileInputStream(pbjFile));
                 sigSet.deserialize(in);
+            } finally {
+                PbjUtils.returnTlsReaderStream();
             }
         } else {
             throw new IOException("No signature set file found at " + pbjFile.getAbsolutePath());

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java
@@ -13,7 +13,7 @@ import static org.hiero.consensus.state.persistence.SignedStateFileUtils.SIGNATU
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.logging.legacy.payload.StateSavedToDiskPayload;
 import com.swirlds.state.StateLifecycleManager;
@@ -41,6 +41,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.Mnemonics;
 import org.hiero.base.file.FileSystemManager;
+import org.hiero.base.utility.PbjUtils;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.pces.PcesModule;
 import org.hiero.consensus.pces.impl.DefaultPcesModule;
@@ -116,9 +117,13 @@ public final class SignedStateFileWriter {
     public static void writeSignatureSetFile(final @NonNull Path directory, final @NonNull SignedState signedState)
             throws IOException {
         final Path sigSetFile = directory.resolve(SIGNATURE_SET_FILE_NAME);
-        try (final FileOutputStream fos = new FileOutputStream(sigSetFile.toFile());
-                final WritableStreamingData out = new WritableStreamingData(fos)) {
+        PbjWriter out = PbjUtils.takeTlsWriter();
+        try (final FileOutputStream fos = new FileOutputStream(sigSetFile.toFile())) {
+            out.resetWith(fos);
             signedState.getSigSet().serialize(out);
+            out.flush();
+        } finally {
+            PbjUtils.returnTlsWriter();
         }
     }
 

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/signed/SigSet.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/signed/SigSet.java
@@ -3,6 +3,7 @@ package org.hiero.consensus.state.signed;
 
 import com.hedera.hapi.platform.state.NodeIdSignaturePair;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
@@ -148,6 +149,22 @@ public class SigSet implements FastCopyable, Iterable<NodeId> {
      * @throws IOException if an I/O error occurs
      */
     public void serialize(@NonNull final WritableStreamingData out) throws IOException {
+        final List<NodeId> sortedIds = getSigningNodes().stream().sorted().toList();
+        final List<NodeIdSignaturePair> signaturePairs = new ArrayList<>(sortedIds.size());
+        for (final NodeId nodeId : sortedIds) {
+            final Signature signature = signatures.get(nodeId);
+            final Bytes signatureBytes = signature.getBytes();
+
+            signaturePairs.add(
+                    new NodeIdSignaturePair(nodeId.id(), signature.getType().ordinal(), signatureBytes));
+        }
+
+        final com.hedera.hapi.platform.state.SigSet sigSet = new com.hedera.hapi.platform.state.SigSet(signaturePairs);
+        out.writeVarInt(com.hedera.hapi.platform.state.SigSet.PROTOBUF.measureRecord(sigSet), false);
+        com.hedera.hapi.platform.state.SigSet.PROTOBUF.write(sigSet, out);
+    }
+
+    public void serialize(@NonNull final PbjWriter out) throws IOException {
         final List<NodeId> sortedIds = getSigningNodes().stream().sorted().toList();
         final List<NodeIdSignaturePair> signaturePairs = new ArrayList<>(sortedIds.size());
         for (final NodeId nodeId : sortedIds) {

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/signed/SigSet.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/signed/SigSet.java
@@ -3,6 +3,7 @@ package org.hiero.consensus.state.signed;
 
 import com.hedera.hapi.platform.state.NodeIdSignaturePair;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.stream.ReadableStreamingData;
@@ -187,6 +188,32 @@ public class SigSet implements FastCopyable, Iterable<NodeId> {
      * @throws ParseException if a parse error occurs
      */
     public void deserialize(@NonNull final ReadableStreamingData in) throws IOException, ParseException {
+        signatures.clear();
+
+        final long length = in.readVarInt(false);
+        final long limitBefore = in.limit();
+        in.limit(in.position() + length);
+
+        final com.hedera.hapi.platform.state.SigSet sigSet =
+                com.hedera.hapi.platform.state.SigSet.PROTOBUF.parseStrict(in);
+        in.limit(limitBefore);
+
+        final List<NodeIdSignaturePair> nodeIdSignaturePairs = sigSet.nodeIdSignaturePairs();
+        if (nodeIdSignaturePairs.size() > MAX_SIGNATURE_COUNT) {
+            throw new IOException(
+                    "Signature count of " + signatures.size() + " exceeds maximum of " + MAX_SIGNATURE_COUNT);
+        }
+
+        for (NodeIdSignaturePair nodeIdSignaturePair : nodeIdSignaturePairs) {
+            signatures.put(
+                    NodeId.of(nodeIdSignaturePair.nodeId()),
+                    new Signature(
+                            SignatureType.from(nodeIdSignaturePair.signatureType(), SignatureType.RSA),
+                            nodeIdSignaturePair.signatureBytes()));
+        }
+    }
+
+    public void deserialize(@NonNull final PbjReader in) throws IOException, ParseException {
         signatures.clear();
 
         final long length = in.readVarInt(false);

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/crypto/PbjStreamHasher.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/crypto/PbjStreamHasher.java
@@ -3,11 +3,9 @@ package org.hiero.consensus.crypto;
 
 import com.hedera.hapi.platform.event.EventCore;
 import com.hedera.hapi.platform.event.EventDescriptor;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.security.MessageDigest;
 import java.util.List;
 import java.util.Objects;
@@ -27,12 +25,11 @@ public class PbjStreamHasher implements EventHasher {
     /** The hashing stream for the event. */
     private final MessageDigest eventDigest = DigestType.SHA_384.buildDigest();
 
-    final WritableSequentialData eventStream = new WritableStreamingData(new HashingOutputStream(eventDigest));
+    final PbjWriter eventStream = new PbjWriter(new HashingOutputStream(eventDigest));
     /** The hashing stream for the transactions. */
     private final MessageDigest transactionDigest = DigestType.SHA_384.buildDigest();
 
-    final WritableSequentialData transactionStream =
-            new WritableStreamingData(new HashingOutputStream(transactionDigest));
+    final PbjWriter transactionStream = new PbjWriter(new HashingOutputStream(transactionDigest));
 
     @Override
     @NonNull
@@ -77,19 +74,21 @@ public class PbjStreamHasher implements EventHasher {
                 processTransactionHash(transaction);
             }
             success = true;
-        } catch (final IOException e) {
-            throw new RuntimeException("An exception occurred while trying to hash an event!", e);
         } finally {
             if (!success) {
-                transactionDigest.reset();
+                eventStream.reset();
                 eventDigest.reset();
+                transactionStream.reset();
+                transactionDigest.reset();
             }
         }
 
+        eventStream.flush();
         return new Hash(eventDigest.digest(), DigestType.SHA_384);
     }
 
     private void processTransactionHash(final TransactionWrapper transaction) {
+        transactionStream.flush();
         final byte[] hash = transactionDigest.digest();
         transaction.setHash(Bytes.wrap(hash));
         eventStream.writeBytes(hash);

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/crypto/PbjStreamHasher.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/crypto/PbjStreamHasher.java
@@ -3,11 +3,9 @@ package org.hiero.consensus.crypto;
 
 import com.hedera.hapi.platform.event.EventCore;
 import com.hedera.hapi.platform.event.EventDescriptor;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.security.MessageDigest;
 import java.util.List;
 import java.util.Objects;
@@ -28,12 +26,11 @@ public class PbjStreamHasher implements EventHasher {
     /** The hashing stream for the event. */
     private final MessageDigest eventDigest = DigestType.SHA_384.buildDigest();
 
-    final WritableSequentialData eventStream = new WritableStreamingData(new HashingOutputStream(eventDigest));
+    final PbjWriter eventStream = new PbjWriter(new HashingOutputStream(eventDigest));
     /** The hashing stream for the transactions. */
     private final MessageDigest transactionDigest = DigestType.SHA_384.buildDigest();
 
-    final WritableSequentialData transactionStream =
-            new WritableStreamingData(new HashingOutputStream(transactionDigest));
+    final PbjWriter transactionStream = new PbjWriter(new HashingOutputStream(transactionDigest));
 
     @Override
     @NonNull
@@ -80,19 +77,21 @@ public class PbjStreamHasher implements EventHasher {
                 processTransactionHash(transaction);
             }
             success = true;
-        } catch (final IOException e) {
-            throw new RuntimeException("An exception occurred while trying to hash an event!", e);
         } finally {
             if (!success) {
-                transactionDigest.reset();
+                eventStream.reset();
                 eventDigest.reset();
+                transactionStream.reset();
+                transactionDigest.reset();
             }
         }
 
+        eventStream.flush();
         return new Hash(eventDigest.digest(), DigestType.SHA_384);
     }
 
     private void processTransactionHash(final TransactionWrapper transaction) {
+        transactionStream.flush();
         final byte[] hash = transactionDigest.digest();
         transaction.setHash(Bytes.wrap(hash));
         eventStream.writeBytes(hash);

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValue.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValue.java
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.benchmark;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import java.util.Arrays;
 import java.util.function.LongUnaryOperator;
@@ -32,7 +33,7 @@ public class BenchmarkValue {
         this(other.valueBytes);
     }
 
-    public BenchmarkValue(final ReadableSequentialData in) {
+    public BenchmarkValue(final PbjReader in) {
         final int len = in.readInt();
         valueBytes = new byte[len];
         in.readBytes(valueBytes);
@@ -55,12 +56,17 @@ public class BenchmarkValue {
         out.writeBytes(valueBytes);
     }
 
+    public void writeTo(final PbjWriter out) {
+        out.writeInt(valueBytes.length);
+        out.writeBytes(valueBytes);
+    }
+
     public void serialize(final WritableSequentialData out) {
         out.writeInt(valueBytes.length);
         out.writeBytes(valueBytes);
     }
 
-    public void deserialize(final ReadableSequentialData in) {
+    public void deserialize(final PbjReader in) {
         int n = in.readInt();
         valueBytes = new byte[n];
         in.readBytes(valueBytes);

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValueCodec.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValueCodec.java
@@ -20,7 +20,7 @@ public class BenchmarkValueCodec implements Codec<BenchmarkValue> {
 
     @NonNull
     @Override
-    public BenchmarkValue realParse(
+    public BenchmarkValue parse(
             @NonNull final PbjReader in,
             final boolean strictMode,
             final boolean parseUnknownFields,
@@ -30,7 +30,7 @@ public class BenchmarkValueCodec implements Codec<BenchmarkValue> {
     }
 
     @Override
-    public void realWrite(@NonNull final BenchmarkValue value, @NonNull final PbjWriter out) {
+    public void write(@NonNull final BenchmarkValue value, @NonNull final PbjWriter out) {
         value.writeTo(out);
     }
 

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValueCodec.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkValueCodec.java
@@ -3,10 +3,10 @@ package com.swirlds.benchmark;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 
 public class BenchmarkValueCodec implements Codec<BenchmarkValue> {
 
@@ -20,8 +20,8 @@ public class BenchmarkValueCodec implements Codec<BenchmarkValue> {
 
     @NonNull
     @Override
-    public BenchmarkValue parse(
-            @NonNull final ReadableSequentialData in,
+    public BenchmarkValue realParse(
+            @NonNull final PbjReader in,
             final boolean strictMode,
             final boolean parseUnknownFields,
             final int maxDepth,
@@ -30,8 +30,7 @@ public class BenchmarkValueCodec implements Codec<BenchmarkValue> {
     }
 
     @Override
-    public void write(@NonNull final BenchmarkValue value, @NonNull final WritableSequentialData out)
-            throws IOException {
+    public void realWrite(@NonNull final BenchmarkValue value, @NonNull final PbjWriter out) {
         value.writeTo(out);
     }
 
@@ -46,8 +45,7 @@ public class BenchmarkValueCodec implements Codec<BenchmarkValue> {
     }
 
     @Override
-    public boolean fastEquals(@NonNull final BenchmarkValue value, @NonNull final ReadableSequentialData in)
-            throws ParseException {
+    public boolean fastEquals(@NonNull final BenchmarkValue value, @NonNull final PbjReader in) throws ParseException {
         // It can be implemented in a more efficient way, but is it really used in benchmarks?
         final BenchmarkValue other = parse(in);
         return other.equals(value);

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/ParsedBucket.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/ParsedBucket.java
@@ -7,6 +7,7 @@ import static com.swirlds.merkledb.files.hashmap.HalfDiskHashMap.INVALID_VALUE;
 
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -187,6 +188,30 @@ public final class ParsedBucket extends Bucket {
         checkLargestBucket();
     }
 
+    public void readFrom(PbjReader in) {
+        // defaults
+        bucketIndex = 0;
+        entries.clear();
+
+        while (in.hasRemaining()) {
+            final int tag = in.readVarInt(false);
+            final int fieldNum = tag >> TAG_FIELD_OFFSET;
+            if (fieldNum == FIELD_BUCKET_INDEX.number()) {
+                bucketIndex = in.readInt();
+            } else if (fieldNum == FIELD_BUCKET_ENTRIES.number()) {
+                final int entryBytesSize = in.readVarInt(false);
+                final long oldLimit = in.limit();
+                in.limit(in.position() + entryBytesSize);
+                entries.add(new BucketEntry(in));
+                in.limit(oldLimit);
+            } else {
+                throw new IllegalArgumentException("Unknown bucket field: " + fieldNum);
+            }
+        }
+
+        checkLargestBucket();
+    }
+
     public void writeTo(final WritableSequentialData out) {
         // Bucket index is not optional, write the value even if default (zero)
         ProtoWriterTools.writeTag(out, FIELD_BUCKET_INDEX);
@@ -259,6 +284,39 @@ public final class ParsedBucket extends Bucket {
 
         /** Creates new bucket entry by reading its fields from the given protobuf buffer */
         public BucketEntry(final ReadableSequentialData entryData) {
+            // defaults
+            int hashCode = 0;
+            long value = 0;
+            Bytes keyBytes = null;
+
+            // read fields
+            while (entryData.hasRemaining()) {
+                final int tag = entryData.readVarInt(false);
+                final int fieldNum = tag >> TAG_FIELD_OFFSET;
+                if (fieldNum == Bucket.FIELD_BUCKETENTRY_HASHCODE.number()) {
+                    hashCode = entryData.readInt();
+                } else if (fieldNum == Bucket.FIELD_BUCKETENTRY_VALUE.number()) {
+                    value = entryData.readLong();
+                } else if (fieldNum == Bucket.FIELD_BUCKETENTRY_KEYBYTES.number()) {
+                    final int bytesSize = entryData.readVarInt(false);
+                    keyBytes = entryData.readBytes(bytesSize);
+                } else {
+                    throw new IllegalArgumentException("Unknown bucket entry field: " + fieldNum);
+                }
+            }
+
+            // check required fields
+            if (keyBytes == null) {
+                throw new IllegalArgumentException("Null key for bucket entry");
+            }
+
+            this.hashCode = hashCode;
+            this.value = value;
+            this.keyBytes = keyBytes;
+        }
+
+        /** Creates new bucket entry by reading its fields from the given protobuf buffer */
+        public BucketEntry(PbjReader entryData) {
             // defaults
             int hashCode = 0;
             long value = 0;

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleFixedValue.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleFixedValue.java
@@ -3,7 +3,8 @@ package com.swirlds.merkledb.test.fixtures;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -44,7 +45,7 @@ public final class ExampleFixedValue extends ExampleByteArrayVirtualValue {
         System.arraycopy(data, 0, this.data, 0, data.length);
     }
 
-    public ExampleFixedValue(final ReadableSequentialData in) {
+    public ExampleFixedValue(final PbjReader in) {
         this.id = in.readInt();
         final int len = in.readInt();
         this.data = new byte[len];
@@ -71,6 +72,12 @@ public final class ExampleFixedValue extends ExampleByteArrayVirtualValue {
         out.writeBytes(data);
     }
 
+    public void writeTo(final PbjWriter out) {
+        out.writeInt(id);
+        out.writeInt(data.length);
+        out.writeBytes(data);
+    }
+
     public static class ExampleFixedValueCodec implements Codec<ExampleFixedValue> {
 
         @Override
@@ -81,12 +88,8 @@ public final class ExampleFixedValue extends ExampleByteArrayVirtualValue {
 
         @NonNull
         @Override
-        public ExampleFixedValue parse(
-                @NonNull ReadableSequentialData in,
-                boolean strictMode,
-                boolean parseUnknownFields,
-                int maxDepth,
-                int maxSize) {
+        public ExampleFixedValue realParse(
+                @NonNull PbjReader in, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
             return new ExampleFixedValue(in);
         }
 
@@ -96,7 +99,12 @@ public final class ExampleFixedValue extends ExampleByteArrayVirtualValue {
         }
 
         @Override
-        public int measure(@NonNull ReadableSequentialData in) {
+        public void realWrite(@NonNull ExampleFixedValue value, @NonNull PbjWriter out) {
+            value.writeTo(out);
+        }
+
+        @Override
+        public int measure(@NonNull PbjReader in) {
             throw new UnsupportedOperationException("ExampleFixedValueCodec.measure() not implemented");
         }
 
@@ -106,8 +114,7 @@ public final class ExampleFixedValue extends ExampleByteArrayVirtualValue {
         }
 
         @Override
-        public boolean fastEquals(@NonNull ExampleFixedValue value, @NonNull ReadableSequentialData in)
-                throws ParseException {
+        public boolean fastEquals(@NonNull ExampleFixedValue value, @NonNull PbjReader in) throws ParseException {
             final ExampleFixedValue other = parse(in);
             return other.equals(value);
         }

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleFixedValue.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleFixedValue.java
@@ -88,7 +88,7 @@ public final class ExampleFixedValue extends ExampleByteArrayVirtualValue {
 
         @NonNull
         @Override
-        public ExampleFixedValue realParse(
+        public ExampleFixedValue parse(
                 @NonNull PbjReader in, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
             return new ExampleFixedValue(in);
         }
@@ -99,7 +99,7 @@ public final class ExampleFixedValue extends ExampleByteArrayVirtualValue {
         }
 
         @Override
-        public void realWrite(@NonNull ExampleFixedValue value, @NonNull PbjWriter out) {
+        public void write(@NonNull ExampleFixedValue value, @NonNull PbjWriter out) {
             value.writeTo(out);
         }
 

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleVariableValue.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleVariableValue.java
@@ -73,13 +73,13 @@ public final class ExampleVariableValue extends ExampleByteArrayVirtualValue {
 
         @NonNull
         @Override
-        public ExampleVariableValue realParse(
+        public ExampleVariableValue parse(
                 @NonNull PbjReader in, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
             return new ExampleVariableValue(in);
         }
 
         @Override
-        public void realWrite(@NonNull ExampleVariableValue value, @NonNull PbjWriter out) {
+        public void write(@NonNull ExampleVariableValue value, @NonNull PbjWriter out) {
             value.writeTo(out);
         }
 

--- a/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleVariableValue.java
+++ b/platform-sdk/swirlds-merkledb/src/testFixtures/java/com/swirlds/merkledb/test/fixtures/ExampleVariableValue.java
@@ -3,8 +3,8 @@ package com.swirlds.merkledb.test.fixtures;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Random;
 
@@ -36,7 +36,7 @@ public final class ExampleVariableValue extends ExampleByteArrayVirtualValue {
         System.arraycopy(RANDOM_DATA, 0, data, 0, data.length);
     }
 
-    public ExampleVariableValue(final ReadableSequentialData in) {
+    public ExampleVariableValue(final PbjReader in) {
         this.id = in.readInt();
         final int len = in.readInt();
         this.data = new byte[len];
@@ -57,7 +57,7 @@ public final class ExampleVariableValue extends ExampleByteArrayVirtualValue {
         return Integer.BYTES + Integer.BYTES + data.length;
     }
 
-    public void writeTo(final WritableSequentialData out) {
+    public void writeTo(final PbjWriter out) {
         out.writeInt(id);
         out.writeInt(data.length);
         out.writeBytes(data);
@@ -73,22 +73,18 @@ public final class ExampleVariableValue extends ExampleByteArrayVirtualValue {
 
         @NonNull
         @Override
-        public ExampleVariableValue parse(
-                @NonNull ReadableSequentialData in,
-                boolean strictMode,
-                boolean parseUnknownFields,
-                int maxDepth,
-                int maxSize) {
+        public ExampleVariableValue realParse(
+                @NonNull PbjReader in, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
             return new ExampleVariableValue(in);
         }
 
         @Override
-        public void write(@NonNull ExampleVariableValue value, @NonNull WritableSequentialData out) {
+        public void realWrite(@NonNull ExampleVariableValue value, @NonNull PbjWriter out) {
             value.writeTo(out);
         }
 
         @Override
-        public int measure(@NonNull ReadableSequentialData in) {
+        public int measure(@NonNull PbjReader in) {
             throw new UnsupportedOperationException("ExampleVariableValueCodec.measure() not implemented");
         }
 
@@ -98,8 +94,7 @@ public final class ExampleVariableValue extends ExampleByteArrayVirtualValue {
         }
 
         @Override
-        public boolean fastEquals(@NonNull ExampleVariableValue value, @NonNull ReadableSequentialData in)
-                throws ParseException {
+        public boolean fastEquals(@NonNull ExampleVariableValue value, @NonNull PbjReader in) throws ParseException {
             final ExampleVariableValue other = parse(in);
             return other.equals(value);
         }

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/binary/QueueState.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/binary/QueueState.java
@@ -8,12 +8,12 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
 import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.swirlds.state.spi.ReadableQueueState;
 import com.swirlds.state.spi.WritableQueueState;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 
 /**
  * A class to work with {@link ReadableQueueState} and {@link WritableQueueState} states. Every
@@ -96,8 +96,7 @@ public record QueueState(long head, long tail) {
         }
 
         @Override
-        public void write(@NonNull final QueueState value, @NonNull final WritableSequentialData out)
-                throws IOException {
+        public void realWrite(@NonNull final QueueState value, @NonNull final PbjWriter out) {
             final long pos = out.position();
             if (value.head() != 0) {
                 ProtoWriterTools.writeTag(out, FIELD_QUEUESTATE_HEAD);
@@ -112,8 +111,8 @@ public record QueueState(long head, long tail) {
 
         @NonNull
         @Override
-        public QueueState parse(
-                @NonNull final ReadableSequentialData in,
+        public QueueState realParse(
+                @NonNull final PbjReader in,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
@@ -147,8 +146,7 @@ public record QueueState(long head, long tail) {
         }
 
         @Override
-        public boolean fastEquals(@NonNull final QueueState value, @NonNull final ReadableSequentialData in)
-                throws ParseException {
+        public boolean fastEquals(@NonNull final QueueState value, @NonNull final PbjReader in) throws ParseException {
             return value.equals(parse(in));
         }
 

--- a/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/binary/QueueState.java
+++ b/platform-sdk/swirlds-state-api/src/main/java/com/swirlds/state/binary/QueueState.java
@@ -96,7 +96,7 @@ public record QueueState(long head, long tail) {
         }
 
         @Override
-        public void realWrite(@NonNull final QueueState value, @NonNull final PbjWriter out) {
+        public void write(@NonNull final QueueState value, @NonNull final PbjWriter out) {
             final long pos = out.position();
             if (value.head() != 0) {
                 ProtoWriterTools.writeTag(out, FIELD_QUEUESTATE_HEAD);
@@ -111,7 +111,7 @@ public record QueueState(long head, long tail) {
 
         @NonNull
         @Override
-        public QueueState realParse(
+        public QueueState parse(
                 @NonNull final PbjReader in,
                 final boolean strictMode,
                 final boolean parseUnknownFields,

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateItem.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateItem.java
@@ -64,7 +64,7 @@ public record StateItem(@NonNull Bytes key, @NonNull Bytes value) {
          * @return Parsed StateItem model object
          * @throws ParseException If parsing fails
          */
-        public @NonNull StateItem realParse(
+        public @NonNull StateItem parse(
                 @NonNull final PbjReader input,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
@@ -132,7 +132,7 @@ public record StateItem(@NonNull Bytes key, @NonNull Bytes value) {
          * @param data The input model data to write
          * @param out  The output stream to write to
          */
-        public void realWrite(@NonNull StateItem data, @NonNull final PbjWriter out) {
+        public void write(@NonNull StateItem data, @NonNull final PbjWriter out) {
             writeDelimited(out, FIELD_KEY, toIntExact(data.key.length()), v -> v.writeBytes(data.key));
             writeDelimited(out, FIELD_VALUE, toIntExact(data.value.length()), v -> v.writeBytes(data.value));
         }

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateItem.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateItem.java
@@ -14,11 +14,10 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
 import com.hedera.pbj.runtime.ProtoWriterTools;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 
 /**
  * A record to store state items.
@@ -53,7 +52,7 @@ public record StateItem(@NonNull Bytes key, @NonNull Bytes value) {
         static final FieldDefinition FIELD_VALUE = new FieldDefinition("valueBytes", FieldType.BYTES, false, 3);
 
         /**
-         * Parses a StateItem object from ProtoBuf bytes in a {@link ReadableSequentialData}. Throws if in strict mode ONLY.
+         * Parses a StateItem object from ProtoBuf bytes in a {@link PbjReader}. Throws if in strict mode ONLY.
          *
          * @param input              The data input to parse data from, it is assumed to be in a state ready to read with position at start
          *                           of data to read and limit set at the end of data to read. The data inputs limit will be changed by this
@@ -65,8 +64,8 @@ public record StateItem(@NonNull Bytes key, @NonNull Bytes value) {
          * @return Parsed StateItem model object
          * @throws ParseException If parsing fails
          */
-        public @NonNull StateItem parse(
-                @NonNull final ReadableSequentialData input,
+        public @NonNull StateItem realParse(
+                @NonNull final PbjReader input,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
@@ -100,7 +99,7 @@ public record StateItem(@NonNull Bytes key, @NonNull Bytes value) {
             return new StateItem(keyBytes, valueBytes);
         }
 
-        private static int extractFieldNum(ReadableSequentialData input) throws ParseException {
+        private static int extractFieldNum(PbjReader input) throws ParseException {
             final int tag = input.readVarInt(false);
             final int wireType = tag & ProtoConstants.TAG_WIRE_TYPE_MASK;
             if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED.ordinal()) {
@@ -110,8 +109,7 @@ public record StateItem(@NonNull Bytes key, @NonNull Bytes value) {
             return tag >> ProtoParserTools.TAG_FIELD_OFFSET;
         }
 
-        private static Bytes readBytes(ReadableSequentialData input, FieldDefinition fieldDefinition)
-                throws ParseException {
+        private static Bytes readBytes(PbjReader input, FieldDefinition fieldDefinition) throws ParseException {
             final ProtoConstants wireType = ProtoWriterTools.wireType(fieldDefinition);
             if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
                 throw new ParseException("StateItem key wire type mismatch: expected="
@@ -133,9 +131,8 @@ public record StateItem(@NonNull Bytes key, @NonNull Bytes value) {
          *
          * @param data The input model data to write
          * @param out  The output stream to write to
-         * @throws IOException If there is a problem writing
          */
-        public void write(@NonNull StateItem data, @NonNull final WritableSequentialData out) throws IOException {
+        public void realWrite(@NonNull StateItem data, @NonNull final PbjWriter out) {
             writeDelimited(out, FIELD_KEY, toIntExact(data.key.length()), v -> v.writeBytes(data.key));
             writeDelimited(out, FIELD_VALUE, toIntExact(data.value.length()), v -> v.writeBytes(data.value));
         }
@@ -143,7 +140,7 @@ public record StateItem(@NonNull Bytes key, @NonNull Bytes value) {
         /**
          * {@inheritDoc}
          */
-        public int measure(@NonNull final ReadableSequentialData input) throws ParseException {
+        public int measure(@NonNull final PbjReader input) throws ParseException {
             final var start = input.position();
             parse(input);
             final var end = input.position();
@@ -176,8 +173,7 @@ public record StateItem(@NonNull Bytes key, @NonNull Bytes value) {
          * {@inheritDoc}
          */
         @Override
-        public boolean fastEquals(@NonNull StateItem item, @NonNull ReadableSequentialData input)
-                throws ParseException {
+        public boolean fastEquals(@NonNull StateItem item, @NonNull PbjReader input) throws ParseException {
             return item.equals(parse(input));
         }
 

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateKeyUtils.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateKeyUtils.java
@@ -8,6 +8,7 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
 import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
@@ -16,6 +17,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Objects;
+import org.hiero.base.utility.PbjUtils;
 
 /**
  * A set of utility methods to work with state keys. These methods are used by readable
@@ -89,8 +91,8 @@ public class StateKeyUtils {
 
     // K/V key: OneOf field number is K/V state ID, field value is the key
     public static <K> Bytes kvKey(final int stateId, final K key, final Codec<K> keyCodec) {
-        try (final ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
-            final WritableSequentialData out = new WritableStreamingData(bout);
+        PbjWriter out = PbjUtils.takeTlsWriter();
+        try {
             // Write tag: field number == state ID, wire type == DELIMITED
             out.writeVarInt(
                     (stateId << ProtoParserTools.TAG_FIELD_OFFSET) | ProtoConstants.WIRE_TYPE_DELIMITED.ordinal(),
@@ -99,16 +101,16 @@ public class StateKeyUtils {
             out.writeVarInt(keyCodec.measureRecord(key), false);
             // Write key
             keyCodec.write(key, out);
-            return Bytes.wrap(bout.toByteArray());
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
+            return out.toByteArrayWrapped();
+        } finally {
+            PbjUtils.returnTlsWriter();
         }
     }
 
     // K/V key: OneOf field number is K/V state ID, field value is the key
     public static Bytes kvKey(final int stateId, final Bytes key) {
-        try (final ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
-            final WritableSequentialData out = new WritableStreamingData(bout);
+        PbjWriter out = PbjUtils.takeTlsWriter();
+        try {
             // Write tag: field number == state ID, wire type == DELIMITED
             out.writeVarInt(
                     (stateId << ProtoParserTools.TAG_FIELD_OFFSET) | ProtoConstants.WIRE_TYPE_DELIMITED.ordinal(),
@@ -117,9 +119,9 @@ public class StateKeyUtils {
             out.writeVarInt(toIntExact(key.length()), false);
             // Write key
             out.writeBytes(key);
-            return Bytes.wrap(bout.toByteArray());
-        } catch (final IOException e) {
-            throw new UncheckedIOException(e);
+            return out.toByteArrayWrapped();
+        } finally {
+            PbjUtils.returnTlsWriter();
         }
     }
 
@@ -145,7 +147,7 @@ public class StateKeyUtils {
             throws ParseException {
         Objects.requireNonNull(stateKey, "Null state key");
         Objects.requireNonNull(keyCodec, "Null key codec");
-        final PbjReader in = stateKey.toPbjReader();
+        PbjReader in = stateKey.toPbjReader();
         final int tag = in.readVarInt(false);
         assert tag >> ProtoParserTools.TAG_FIELD_OFFSET == extractStateIdFromStateKeyOneOf(stateKey);
         assert tag >> ProtoParserTools.TAG_FIELD_OFFSET != FIELD_NUM_SINGLETON; // must not be a singleton key

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateKeyUtils.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateKeyUtils.java
@@ -7,7 +7,7 @@ import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.pbj.runtime.io.stream.WritableStreamingData;
@@ -131,7 +131,7 @@ public class StateKeyUtils {
     public static int extractStateIdFromStateKeyOneOf(@NonNull final Bytes stateKey) {
         Objects.requireNonNull(stateKey, "Null state key");
         // Assumption is the key bytes are a OneOf
-        return ProtoParserTools.readNextFieldNumber(stateKey.toReadableSequentialData());
+        return ProtoParserTools.readNextFieldNumber(stateKey.toPbjReader());
     }
 
     /**
@@ -145,7 +145,7 @@ public class StateKeyUtils {
             throws ParseException {
         Objects.requireNonNull(stateKey, "Null state key");
         Objects.requireNonNull(keyCodec, "Null key codec");
-        final ReadableSequentialData in = stateKey.toReadableSequentialData();
+        final PbjReader in = stateKey.toPbjReader();
         final int tag = in.readVarInt(false);
         assert tag >> ProtoParserTools.TAG_FIELD_OFFSET == extractStateIdFromStateKeyOneOf(stateKey);
         assert tag >> ProtoParserTools.TAG_FIELD_OFFSET != FIELD_NUM_SINGLETON; // must not be a singleton key

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateUtils.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateUtils.java
@@ -7,7 +7,7 @@ import static com.hedera.pbj.runtime.ProtoWriterTools.sizeOfVarInt32;
 import static com.swirlds.state.merkle.StateKeyUtils.kvKey;
 
 import com.hedera.pbj.runtime.Codec;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.state.binary.QueueState;
@@ -144,12 +144,12 @@ public final class StateUtils {
      */
     @NonNull
     public static Bytes unwrap(@NonNull final Bytes stateValueBytes) {
-        ReadableSequentialData sequentialData = stateValueBytes.toReadableSequentialData();
+        PbjReader sequentialData = stateValueBytes.toPbjReader();
         // skipping tag
         sequentialData.readVarInt(false);
         int valueSize = sequentialData.readVarInt(false);
 
-        assert valueSize == sequentialData.remaining() : "Value size mismatch";
+        assert valueSize == sequentialData.limit() - sequentialData.position() : "Value size mismatch";
 
         try (InputStream is = sequentialData.asInputStream()) {
             return Bytes.wrap(is.readAllBytes());

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateValue.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateValue.java
@@ -99,7 +99,7 @@ public record StateValue<V>(int stateId, @NonNull V value) {
          * {@inheritDoc}
          */
         @Override
-        public void realWrite(@NonNull final StateValue<V> value, @NonNull final PbjWriter out) {
+        public void write(@NonNull final StateValue<V> value, @NonNull final PbjWriter out) {
             // Write tag
             final int stateId = value.stateId();
             out.writeVarInt(
@@ -119,7 +119,7 @@ public record StateValue<V>(int stateId, @NonNull V value) {
          */
         @NonNull
         @Override
-        public StateValue<V> realParse(
+        public StateValue<V> parse(
                 @NonNull final PbjReader in,
                 final boolean strictMode,
                 final boolean parseUnknownFields,

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateValue.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateValue.java
@@ -6,11 +6,10 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
 import com.hedera.pbj.runtime.ProtoWriterTools;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.util.Objects;
 
 /**
@@ -100,8 +99,7 @@ public record StateValue<V>(int stateId, @NonNull V value) {
          * {@inheritDoc}
          */
         @Override
-        public void write(@NonNull final StateValue<V> value, @NonNull final WritableSequentialData out)
-                throws IOException {
+        public void realWrite(@NonNull final StateValue<V> value, @NonNull final PbjWriter out) {
             // Write tag
             final int stateId = value.stateId();
             out.writeVarInt(
@@ -121,8 +119,8 @@ public record StateValue<V>(int stateId, @NonNull V value) {
          */
         @NonNull
         @Override
-        public StateValue<V> parse(
-                @NonNull final ReadableSequentialData in,
+        public StateValue<V> realParse(
+                @NonNull final PbjReader in,
                 final boolean strictMode,
                 final boolean parseUnknownFields,
                 final int maxDepth,
@@ -155,8 +153,7 @@ public record StateValue<V>(int stateId, @NonNull V value) {
          * {@inheritDoc}
          */
         @Override
-        public boolean fastEquals(@NonNull StateValue<V> value, @NonNull ReadableSequentialData in)
-                throws ParseException {
+        public boolean fastEquals(@NonNull StateValue<V> value, @NonNull PbjReader in) throws ParseException {
             final int tag = in.readVarInt(false);
             final int fieldNum = tag >> ProtoParserTools.TAG_FIELD_OFFSET;
             if (fieldNum != stateId) {
@@ -183,7 +180,7 @@ public record StateValue<V>(int stateId, @NonNull V value) {
          * {@inheritDoc}
          */
         @Override
-        public int measure(@NonNull final ReadableSequentialData in) throws ParseException {
+        public int measure(@NonNull final PbjReader in) throws ParseException {
             // This implementation can be optimized a bit to avoid V parsing
             final var start = in.position();
             parse(in);

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateValue.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/StateValue.java
@@ -45,7 +45,7 @@ public record StateValue<V>(int stateId, @NonNull V value) {
      */
     public static int extractStateIdFromStateValueOneOf(@NonNull final Bytes stateValue) {
         Objects.requireNonNull(stateValue, "Null state value");
-        return ProtoParserTools.readNextFieldNumber(stateValue.toReadableSequentialData());
+        return ProtoParserTools.readNextFieldNumber(stateValue.toPbjReader());
     }
 
     /**

--- a/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapStateImpl.java
+++ b/platform-sdk/swirlds-state-impl/src/main/java/com/swirlds/state/merkle/VirtualMapStateImpl.java
@@ -813,7 +813,7 @@ public class VirtualMapStateImpl implements VirtualMapState {
                         try {
                             final QueueState queueState = queueStateCodec
                                     .parse(
-                                            leafBytes.valueBytes().toReadableSequentialData(),
+                                            leafBytes.valueBytes(),
                                             false,
                                             false,
                                             Codec.DEFAULT_MAX_DEPTH,

--- a/platform-sdk/swirlds-state-impl/src/test/java/com/swirlds/state/merkle/VirtualMapStateImplTest.java
+++ b/platform-sdk/swirlds-state-impl/src/test/java/com/swirlds/state/merkle/VirtualMapStateImplTest.java
@@ -943,8 +943,7 @@ public class VirtualMapStateImplTest extends MerkleTestBase {
 
             // Get Merkle proof and verify state item content
             final MerkleProof proof = virtualMapState.getMerkleProof(path);
-            final StateItem parsedStateItem =
-                    StateItem.CODEC.parse(proof.stateItem().toReadableSequentialData());
+            final StateItem parsedStateItem = StateItem.CODEC.parse(proof.stateItem());
             assertThat(parsedStateItem.key()).isEqualTo(leaf.keyBytes());
             assertThat(parsedStateItem.value()).isEqualTo(leaf.valueBytes());
 
@@ -1018,8 +1017,7 @@ public class VirtualMapStateImplTest extends MerkleTestBase {
 
             // Get Merkle proof and verify state item content
             final MerkleProof proof = virtualMapState.getMerkleProof(path);
-            final StateItem parsedStateItem =
-                    StateItem.CODEC.parse(proof.stateItem().toReadableSequentialData());
+            final StateItem parsedStateItem = StateItem.CODEC.parse(proof.stateItem());
             assertThat(parsedStateItem.key()).isEqualTo(leaf.keyBytes());
             assertThat(parsedStateItem.value()).isEqualTo(leaf.valueBytes());
 
@@ -1074,8 +1072,7 @@ public class VirtualMapStateImplTest extends MerkleTestBase {
 
             // Get Merkle proof and verify state item content
             final MerkleProof proof = virtualMapState.getMerkleProof(path);
-            final StateItem parsedStateItem =
-                    StateItem.CODEC.parse(proof.stateItem().toReadableSequentialData());
+            final StateItem parsedStateItem = StateItem.CODEC.parse(proof.stateItem());
             assertThat(parsedStateItem.key()).isEqualTo(leaf.keyBytes());
             assertThat(parsedStateItem.value()).isEqualTo(leaf.valueBytes());
 

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/TestLongCodec.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/TestLongCodec.java
@@ -35,7 +35,7 @@ public class TestLongCodec implements Codec<Long> {
 
     @NonNull
     @Override
-    public Long realParse(
+    public Long parse(
             @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         Objects.requireNonNull(input);
@@ -49,7 +49,7 @@ public class TestLongCodec implements Codec<Long> {
         output.writeLong(value);
     }
 
-    public void realWrite(@NonNull Long value, @NonNull PbjWriter output) {
+    public void write(@NonNull Long value, @NonNull PbjWriter output) {
         Objects.requireNonNull(value);
         Objects.requireNonNull(output);
         output.writeLong(value);

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/TestLongCodec.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/TestLongCodec.java
@@ -3,7 +3,8 @@ package com.swirlds.state.test.fixtures.merkle;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -34,20 +35,8 @@ public class TestLongCodec implements Codec<Long> {
 
     @NonNull
     @Override
-    public Long parse(
-            @NonNull ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
-            throws ParseException {
-        Objects.requireNonNull(input);
-        return Long.valueOf(input.readLong());
-    }
-
-    @NonNull
-    @Override
-    public Long parse(@NonNull final ReadableSequentialData input, final boolean strictMode, final int maxDepth)
+    public Long realParse(
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         Objects.requireNonNull(input);
         return Long.valueOf(input.readLong());
@@ -60,8 +49,14 @@ public class TestLongCodec implements Codec<Long> {
         output.writeLong(value);
     }
 
+    public void realWrite(@NonNull Long value, @NonNull PbjWriter output) {
+        Objects.requireNonNull(value);
+        Objects.requireNonNull(output);
+        output.writeLong(value);
+    }
+
     @Override
-    public int measure(@Nullable ReadableSequentialData input) {
+    public int measure(@Nullable PbjReader input) {
         return Long.BYTES;
     }
 
@@ -71,8 +66,7 @@ public class TestLongCodec implements Codec<Long> {
     }
 
     @Override
-    public boolean fastEquals(@NonNull final Long value, @NonNull final ReadableSequentialData input)
-            throws ParseException {
+    public boolean fastEquals(@NonNull final Long value, @NonNull final PbjReader input) throws ParseException {
         Objects.requireNonNull(value);
         Objects.requireNonNull(input);
         return value.equals(parse(input));

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/TestStringCodec.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/TestStringCodec.java
@@ -3,6 +3,8 @@ package com.swirlds.state.test.fixtures.merkle;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -32,12 +34,8 @@ public class TestStringCodec implements Codec<String> {
 
     @NonNull
     @Override
-    public String parse(
-            @NonNull ReadableSequentialData input,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize)
+    public String realParse(
+            @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         Objects.requireNonNull(input);
         final var len = input.readInt();
@@ -61,14 +59,21 @@ public class TestStringCodec implements Codec<String> {
         output.writeBytes(bytes);
     }
 
+    public void realWrite(final @NonNull String value, final @NonNull PbjWriter output) {
+        Objects.requireNonNull(value);
+        Objects.requireNonNull(output);
+        final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        output.writeInt(bytes.length);
+        output.writeBytes(bytes);
+    }
+
     @Override
-    public int measure(final @NonNull ReadableSequentialData input) {
+    public int measure(final @NonNull PbjReader input) {
         return input.readInt() + Integer.BYTES;
     }
 
     @Override
-    public boolean fastEquals(final @NonNull String value, final @NonNull ReadableSequentialData input)
-            throws ParseException {
+    public boolean fastEquals(final @NonNull String value, final @NonNull PbjReader input) throws ParseException {
         Objects.requireNonNull(value);
         Objects.requireNonNull(input);
         return value.equals(parse(input));

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/TestStringCodec.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/TestStringCodec.java
@@ -34,7 +34,7 @@ public class TestStringCodec implements Codec<String> {
 
     @NonNull
     @Override
-    public String realParse(
+    public String parse(
             @NonNull PbjReader input, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize)
             throws ParseException {
         Objects.requireNonNull(input);
@@ -59,7 +59,7 @@ public class TestStringCodec implements Codec<String> {
         output.writeBytes(bytes);
     }
 
-    public void realWrite(final @NonNull String value, final @NonNull PbjWriter output) {
+    public void write(final @NonNull String value, final @NonNull PbjWriter output) {
         Objects.requireNonNull(value);
         Objects.requireNonNull(output);
         final byte[] bytes = value.getBytes(StandardCharsets.UTF_8);

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -725,7 +725,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
             return removedValueBytes == null
                     ? null
                     : valueCodec.parse(
-                            removedValueBytes.toReadableSequentialData(),
+                            removedValueBytes,
                             false,
                             false,
                             DEFAULT_MAX_DEPTH,

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualHashChunk.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualHashChunk.java
@@ -6,6 +6,7 @@ import com.hedera.pbj.runtime.FieldType;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
 import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.swirlds.virtualmap.MerkleHasher;
@@ -136,6 +137,69 @@ public class VirtualHashChunk {
      * @return A deserialized hash chunk
      */
     public static VirtualHashChunk parseFrom(final ReadableSequentialData in, final int height) {
+        if (in == null) {
+            return null;
+        }
+
+        long path = 0;
+        int dataRank = 0;
+        byte[] hashData = null;
+
+        while (in.hasRemaining()) {
+            final int field = in.readVarInt(false);
+            final int tag = field >> ProtoParserTools.TAG_FIELD_OFFSET;
+            if (tag == FIELD_HASHCHUNK_PATH.number()) {
+                if ((field & ProtoConstants.TAG_WIRE_TYPE_MASK) != ProtoConstants.WIRE_TYPE_FIXED_64_BIT.ordinal()) {
+                    throw new IllegalArgumentException("Wrong field type: " + field);
+                }
+                path = in.readLong();
+            } else if (tag == FIELD_HASHCHUNK_HASHDATA.number()) {
+                if ((field & ProtoConstants.TAG_WIRE_TYPE_MASK) != ProtoConstants.WIRE_TYPE_DELIMITED.ordinal()) {
+                    throw new IllegalArgumentException("Wrong field type: " + field);
+                }
+                final int len = in.readVarInt(false);
+                final int singleHashLength = Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+                hashData = new byte[singleHashLength * getChunkSize(height)];
+                if (len == hashData.length) {
+                    dataRank = height;
+                    // Full chunk, read in one call
+                    if (in.readBytes(hashData) != len) {
+                        throw new IllegalArgumentException("Failed to read " + len + " bytes");
+                    }
+                } else {
+                    // Packed chunk, need to read hashes one by one and put them to the right
+                    // offsets in hashData. This process must be in sync with writeTo()
+                    final int numHashes = len / singleHashLength;
+                    // Check the length is a power of two
+                    if ((numHashes & (numHashes - 1)) != 0) {
+                        throw new IllegalArgumentException("Wrong hash data length: " + numHashes);
+                    }
+                    // Check hashData contains no more hashes than 2 ^ height
+                    if (numHashes > 1 << height) {
+                        throw new IllegalArgumentException(
+                                "Wrong hash data length / height: " + numHashes + " / " + height);
+                    }
+                    dataRank = 1;
+                    while ((1 << dataRank) < numHashes) {
+                        dataRank++;
+                    }
+                    final int step = 1 << (height - dataRank);
+                    for (int i = 0; i < numHashes; i++) {
+                        final int dstOffset = i * singleHashLength * step;
+                        if (in.readBytes(hashData, dstOffset, singleHashLength) != singleHashLength) {
+                            throw new IllegalArgumentException("Failed to read hash chunk");
+                        }
+                    }
+                }
+            } else {
+                throw new IllegalArgumentException("Unknown field: " + field);
+            }
+        }
+
+        return new VirtualHashChunk(path, height, hashData, dataRank);
+    }
+
+    public static VirtualHashChunk parseFrom(PbjReader in, final int height) {
         if (in == null) {
             return null;
         }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualLeafBytes.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/datasource/VirtualLeafBytes.java
@@ -8,6 +8,7 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
 import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -141,8 +142,7 @@ public class VirtualLeafBytes<V> {
                 assert this.valueCodec == null || this.valueCodec.equals(valueCodec);
                 this.valueCodec = valueCodec;
                 try {
-                    value = valueCodec.parse(
-                            valueBytes.toReadableSequentialData(), false, false, Codec.DEFAULT_MAX_DEPTH, maxSize);
+                    value = valueCodec.parse(valueBytes, false, false, Codec.DEFAULT_MAX_DEPTH, maxSize);
                 } catch (final ParseException e) {
                     throw new RuntimeException("Failed to deserialize a value from bytes", e);
                 }
@@ -193,6 +193,46 @@ public class VirtualLeafBytes<V> {
      * @return the virtual leaf bytes object
      */
     public static <V> VirtualLeafBytes<V> parseFrom(final ReadableSequentialData in) {
+        if (in == null) {
+            return null;
+        }
+
+        long path = 0;
+        Bytes keyBytes = null;
+        Bytes valueBytes = null;
+
+        while (in.hasRemaining()) {
+            final int field = in.readVarInt(false);
+            final int tag = field >> ProtoParserTools.TAG_FIELD_OFFSET;
+            if (tag == FIELD_LEAFRECORD_PATH.number()) {
+                if ((field & ProtoConstants.TAG_WIRE_TYPE_MASK) != ProtoConstants.WIRE_TYPE_FIXED_64_BIT.ordinal()) {
+                    throw new IllegalArgumentException("Wrong field type: " + field);
+                }
+                path = in.readLong();
+            } else if (tag == FIELD_LEAFRECORD_KEY.number()) {
+                if ((field & ProtoConstants.TAG_WIRE_TYPE_MASK) != ProtoConstants.WIRE_TYPE_DELIMITED.ordinal()) {
+                    throw new IllegalArgumentException("Wrong field type: " + field);
+                }
+                final int len = in.readVarInt(false);
+                keyBytes = in.readBytes(len);
+            } else if (tag == FIELD_LEAFRECORD_VALUE.number()) {
+                if ((field & ProtoConstants.TAG_WIRE_TYPE_MASK) != ProtoConstants.WIRE_TYPE_DELIMITED.ordinal()) {
+                    throw new IllegalArgumentException("Wrong field type: " + field);
+                }
+                final int len = in.readVarInt(false);
+                valueBytes = len == 0 ? Bytes.EMPTY : in.readBytes(len);
+            } else {
+                throw new IllegalArgumentException("Unknown field: " + field);
+            }
+        }
+
+        Objects.requireNonNull(keyBytes, "Missing key bytes in the input");
+
+        // Key hash code is not deserialized
+        return new VirtualLeafBytes<>(path, false, keyBytes, valueBytes);
+    }
+
+    public static <V> VirtualLeafBytes<V> parseFrom(final PbjReader in) {
         if (in == null) {
             return null;
         }

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapIteratorTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapIteratorTest.java
@@ -32,6 +32,7 @@ import com.swirlds.virtualmap.test.fixtures.TestValueCodec;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.NoSuchElementException;
+import org.hiero.base.utility.PbjUtils;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -83,7 +84,7 @@ class VirtualMapIteratorTest extends VirtualTestBase {
         it.setFilter(leaf -> {
             final Bytes keyBytes = leaf.keyBytes();
             // TestKey.longToKey puts a long (8 bytes)
-            final long keyLong = keyBytes.toReadableSequentialData().readLong();
+            final long keyLong = PbjUtils.readLong(keyBytes);
             return keyLong % 2 == 0;
         });
 

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualHashChunkTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/datasource/VirtualHashChunkTest.java
@@ -13,6 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import com.hedera.pbj.runtime.ProtoConstants;
 import com.hedera.pbj.runtime.ProtoParserTools;
 import com.hedera.pbj.runtime.ProtoWriterTools;
+import com.hedera.pbj.runtime.io.PbjReader;
 import com.hedera.pbj.runtime.io.ReadableSequentialData;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
@@ -632,7 +633,7 @@ public class VirtualHashChunkTest {
     @Test
     void parseFromNullInputTest() {
         // Test that parseFrom returns null for null input
-        final VirtualHashChunk result = VirtualHashChunk.parseFrom(null, 3);
+        final VirtualHashChunk result = VirtualHashChunk.parseFrom((PbjReader) null, 3);
         assertNull(result);
     }
 

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/TestValue.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/TestValue.java
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.virtualmap.test.fixtures;
 
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import com.hedera.pbj.runtime.io.WritableSequentialData;
 import com.hedera.pbj.runtime.io.buffer.BufferedData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -20,7 +21,7 @@ public final class TestValue {
         this.s = s;
     }
 
-    public TestValue(final ReadableSequentialData in) {
+    public TestValue(final PbjReader in) {
         final int len = in.readInt();
         final byte[] value = new byte[len];
         in.readBytes(value);
@@ -33,6 +34,12 @@ public final class TestValue {
     }
 
     public void writeTo(final WritableSequentialData out) {
+        final byte[] value = s.getBytes(StandardCharsets.UTF_8);
+        out.writeInt(value.length);
+        out.writeBytes(value);
+    }
+
+    public void writeTo(final PbjWriter out) {
         final byte[] value = s.getBytes(StandardCharsets.UTF_8);
         out.writeInt(value.length);
         out.writeBytes(value);

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/TestValueCodec.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/TestValueCodec.java
@@ -20,13 +20,13 @@ public class TestValueCodec implements Codec<TestValue> {
 
     @NonNull
     @Override
-    public TestValue realParse(
+    public TestValue parse(
             @NonNull PbjReader in, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
         return new TestValue(in);
     }
 
     @Override
-    public void realWrite(@NonNull TestValue value, @NonNull PbjWriter out) {
+    public void write(@NonNull TestValue value, @NonNull PbjWriter out) {
         value.writeTo(out);
     }
 

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/TestValueCodec.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/TestValueCodec.java
@@ -3,8 +3,8 @@ package com.swirlds.virtualmap.test.fixtures;
 
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.ParseException;
-import com.hedera.pbj.runtime.io.ReadableSequentialData;
-import com.hedera.pbj.runtime.io.WritableSequentialData;
+import com.hedera.pbj.runtime.io.PbjReader;
+import com.hedera.pbj.runtime.io.PbjWriter;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
 public class TestValueCodec implements Codec<TestValue> {
@@ -20,22 +20,18 @@ public class TestValueCodec implements Codec<TestValue> {
 
     @NonNull
     @Override
-    public TestValue parse(
-            @NonNull ReadableSequentialData in,
-            boolean strictMode,
-            boolean parseUnknownFields,
-            int maxDepth,
-            int maxSize) {
+    public TestValue realParse(
+            @NonNull PbjReader in, boolean strictMode, boolean parseUnknownFields, int maxDepth, int maxSize) {
         return new TestValue(in);
     }
 
     @Override
-    public void write(@NonNull TestValue value, @NonNull WritableSequentialData out) {
+    public void realWrite(@NonNull TestValue value, @NonNull PbjWriter out) {
         value.writeTo(out);
     }
 
     @Override
-    public int measure(@NonNull ReadableSequentialData in) {
+    public int measure(@NonNull PbjReader in) {
         throw new UnsupportedOperationException("TestValueCodec.measure() not implemented");
     }
 
@@ -45,7 +41,7 @@ public class TestValueCodec implements Codec<TestValue> {
     }
 
     @Override
-    public boolean fastEquals(@NonNull TestValue value, @NonNull ReadableSequentialData in) throws ParseException {
+    public boolean fastEquals(@NonNull TestValue value, @NonNull PbjReader in) throws ParseException {
         final TestValue other = parse(in);
         return other.equals(value);
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,10 +1,22 @@
 // SPDX-License-Identifier: Apache-2.0
-pluginManagement { includeBuild("gradle/besu-native-patch") }
+pluginManagement {
+    includeBuild("gradle/besu-native-patch")
+    repositories {
+        mavenLocal()
+        gradlePluginPortal()
+    }
+}
 
 plugins {
     id("org.hiero.gradle.build") version "0.7.11"
-    id("com.hedera.pbj.pbj-compiler") version "0.15.10" apply false
+    id("com.hedera.pbj.pbj-compiler") version "0.pbj.1" apply false
     id("org.hiero.gradle.feature.besu-native-patch")
+}
+
+dependencyResolutionManagement {
+    repositories {
+        mavenLocal()
+    }
 }
 
 javaModules {


### PR DESCRIPTION
**Description**:
Uses the new PBJ branch https://github.com/hashgraph/pbj/tree/ldintr-cn

- parse and write have overloads that use a thread local storage object, prefer that to creating new `PbjReader`/`PbjWriter`
- `PbjWriter` has a `toPbjReader` method which reuses the buffer. It can be used as long as you don't need to write to the writer object before the reader is done. Otherwise use toByteArray to clone the buffer
- Bytes now has `array()` and `arrayOffset()` so `PbjReader` doesn't need to copy data
- RandomAccessSequenceAdapter has been changed for the same reason (to skip a copy)
- Many exceptions were deleted. `PbjReader`/`PbjWriter` doesn't throw checked exceptions. If you need them you can use throwOnError(), or use `error()` to get an error code 
- Some exceptions look at the error message, prefer using error codes in the future
- Many functions that have `ReadableSequentialData` have either the signature change to `PbjReader` or had the function copied with the parameter changed to `PbjReader`. Same with `WritableSequentialData` and `PbjWriter`
- pbj.ReaderWriter.useStackTrace defaults to true, use false to use premade exceptions/stacktraces which will run faster

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

Performance team hasn't run tests yet, but expecting it soon

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
