### PR TITLE
fix: libsodium rollback

### DIFF
--- a/gradle/modules.properties
+++ b/gradle/modules.properties
@@ -4,8 +4,13 @@
 #   https://github.com/gradlex-org/java-module-dependencies/blob/main/src/main/resources/org/gradlex/javamodule/dependencies/unique_modules.properties
 #   https://github.com/gradlex-org/java-module-dependencies/blob/main/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties
 # Consider contributing the missing entry back to the plugin by creating a PR for the 'modules.properties' linked above.
+com.hedera.cryptography.pairings.api=com.hedera.cryptography:hedera-cryptography-pairings-api
+com.hedera.cryptography.pairings.signatures=com.hedera.cryptography:hedera-cryptography-pairings-signatures
+com.hedera.cryptography.bls=com.hedera.cryptography:hedera-cryptography-bls
+com.hedera.cryptography.tss=com.hedera.cryptography:hedera-cryptography-tss
 com.hedera.cryptography.hints=com.hedera.cryptography:hedera-cryptography-hints
 com.hedera.cryptography.wraps=com.hedera.cryptography:hedera-cryptography-wraps
-com.hedera.cryptography.libsodium=com.hedera.cryptography:libsodium
+com.hedera.cryptography.tss.impl=com.hedera.cryptography:hedera-cryptography-tss:impl
+com.hedera.cryptography.tss.api=com.hedera.cryptography:hedera-cryptography-tss:api
 com.hedera.cryptography.libsecp256k1=com.hedera.cryptography:libsecp256k1
 jmh.core=org.openjdk.jmh:jmh-core

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies.constraints {
     }
     api("jakarta.inject:jakarta.inject-api:2.0.1") { because("jakarta.inject") }
     api("javax.inject:javax.inject:1") { because("javax.inject") }
+    api("com.goterl:lazysodium-java:5.2.0") { because("com.goterl.lazysodium") }
     api("net.i2p.crypto:eddsa:0.3.0") { because("net.i2p.crypto.eddsa") }
     api("org.antlr:antlr4-runtime:4.13.2") { because("org.antlr.antlr4.runtime") }
     api("commons-codec:commons-codec:1.22.0") { because("org.apache.commons.codec") }
@@ -126,9 +127,6 @@ dependencies.constraints {
     }
     api("com.hedera.cryptography:hedera-cryptography-hints:$hederaCryptography") {
         because("com.hedera.cryptography.hints")
-    }
-    api("com.hedera.cryptography:libsodium:$hederaCryptography") {
-        because("com.hedera.cryptography.libsodium")
     }
     api("com.hedera.cryptography:libsecp256k1:$hederaCryptography") {
         because("com.hedera.cryptography.libsecp256k1")

--- a/platform-sdk/base-crypto/src/main/java/module-info.java
+++ b/platform-sdk/base-crypto/src/main/java/module-info.java
@@ -19,12 +19,12 @@ module org.hiero.base.crypto {
             org.hiero.otter.test,
             com.fasterxml.jackson.databind;
 
-    requires transitive com.hedera.cryptography.libsodium;
     requires transitive com.hedera.pbj.runtime;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.logging;
     requires transitive org.hiero.base.concurrent;
     requires transitive org.hiero.base.utility;
+    requires transitive com.goterl.lazysodium;
     requires com.hedera.cryptography.libsecp256k1;
     requires com.swirlds.base;
     requires org.apache.logging.log4j;

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/engine/Ed25519VerificationProvider.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/engine/Ed25519VerificationProvider.java
@@ -4,8 +4,9 @@ package org.hiero.base.crypto.engine;
 import static com.swirlds.logging.legacy.LogMarker.TESTING_EXCEPTIONS;
 import static org.hiero.base.utility.CommonUtils.hex;
 
-import com.hedera.cryptography.libsodium.Libsodium;
-import java.lang.foreign.MemorySegment;
+import com.goterl.lazysodium.LazySodiumJava;
+import com.goterl.lazysodium.SodiumJava;
+import com.goterl.lazysodium.interfaces.Sign;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.crypto.SignatureType;
@@ -16,7 +17,7 @@ import org.hiero.base.crypto.TransactionSignature;
  * Ed25519 signatures and depends on LazySodium (libSodium) for all operations.
  */
 public class Ed25519VerificationProvider
-        extends OperationProvider<TransactionSignature, Void, Boolean, Libsodium, SignatureType> {
+        extends OperationProvider<TransactionSignature, Void, Boolean, Sign.Native, SignatureType> {
 
     private static final Logger logger = LogManager.getLogger(Ed25519VerificationProvider.class);
 
@@ -24,10 +25,11 @@ public class Ed25519VerificationProvider
      * The JNI interface to the underlying native libSodium dynamic library. This variable is initialized when this
      * class is loaded and initialized by the {@link ClassLoader}.
      */
-    private static final Libsodium algorithm;
+    private static final Sign.Native algorithm;
 
     static {
-        algorithm = Libsodium.getInstance();
+        final SodiumJava sodiumJava = new SodiumJava();
+        algorithm = new LazySodiumJava(sodiumJava);
     }
 
     /**
@@ -68,7 +70,7 @@ public class Ed25519VerificationProvider
      */
     protected boolean compute(
             final byte[] message, final byte[] signature, final byte[] publicKey, final SignatureType algorithmType) {
-        final Libsodium loadedAlgorithm = loadAlgorithm(algorithmType);
+        final Sign.Native loadedAlgorithm = loadAlgorithm(algorithmType);
         return compute(loadedAlgorithm, algorithmType, message, signature, publicKey);
     }
 
@@ -76,7 +78,7 @@ public class Ed25519VerificationProvider
      * {@inheritDoc}
      */
     @Override
-    protected Libsodium loadAlgorithm(final SignatureType algorithmType) {
+    protected Sign.Native loadAlgorithm(final SignatureType algorithmType) {
         return algorithm;
     }
 
@@ -85,7 +87,7 @@ public class Ed25519VerificationProvider
      */
     @Override
     protected Boolean handleItem(
-            final Libsodium algorithm,
+            final Sign.Native algorithm,
             final SignatureType algorithmType,
             final TransactionSignature sig,
             final Void optionalData) {
@@ -113,17 +115,12 @@ public class Ed25519VerificationProvider
      * @return true if the provided signature is valid; false otherwise
      */
     private boolean compute(
-            final Libsodium algorithm,
+            final Sign.Native algorithm,
             final SignatureType algorithmType,
             final byte[] message,
             final byte[] signature,
             final byte[] publicKey) {
-        final boolean isValid = algorithm.cryptoSignVerifyDetached(
-                        MemorySegment.ofArray(signature),
-                        MemorySegment.ofArray(message),
-                        message.length,
-                        MemorySegment.ofArray(publicKey))
-                == 0;
+        final boolean isValid = algorithm.cryptoSignVerifyDetached(signature, message, message.length, publicKey);
 
         if (!isValid && logger.isDebugEnabled()) {
             logger.debug(

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/SodiumJni.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/SodiumJni.java
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.base.crypto.internal;
+
+import com.goterl.lazysodium.LazySodiumJava;
+import com.goterl.lazysodium.SodiumJava;
+import com.goterl.lazysodium.interfaces.Sign;
+
+/**
+ * Internal class to hold the JNI interface to the native libSodium library.
+ */
+final class SodiumJni {
+    private SodiumJni() {
+        // Prevent instantiation
+    }
+    /**
+     * The JNI interface to the underlying native libSodium dynamic library. This variable is initialized when this
+     * class is loaded and initialized by the {@link ClassLoader}.
+     */
+    static final Sign.Native SODIUM = new LazySodiumJava(new SodiumJava());
+}

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/SodiumSigner.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/SodiumSigner.java
@@ -1,10 +1,9 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.crypto.internal;
 
-import com.hedera.cryptography.libsodium.Libsodium;
+import com.goterl.lazysodium.interfaces.Sign;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.lang.foreign.MemorySegment;
 import java.security.KeyPair;
 import org.hiero.base.crypto.BytesSigner;
 
@@ -13,7 +12,6 @@ import org.hiero.base.crypto.BytesSigner;
  */
 public class SodiumSigner implements BytesSigner {
     private final byte[] sodiumSecretKey;
-    private final MemorySegment secretKeyMemorySegment;
 
     /**
      * Constructs a SodiumSigner with the given Ed25519 KeyPair.
@@ -29,20 +27,13 @@ public class SodiumSigner implements BytesSigner {
         // Extract 32-byte raw public key from X.509 encoded public key
         final byte[] publicEncoded = keyPair.getPublic().getEncoded();
         System.arraycopy(publicEncoded, publicEncoded.length - 32, sodiumSecretKey, 32, 32);
-        secretKeyMemorySegment = MemorySegment.ofArray(sodiumSecretKey);
     }
 
     @Override
     public @NonNull Bytes sign(@NonNull final Bytes data) {
-        final byte[] signature = new byte[Libsodium.ED25519_BYTES];
-        final boolean signed = Libsodium.getInstance()
-                        .cryptoSignDetached(
-                                MemorySegment.ofArray(signature),
-                                MemorySegment.NULL,
-                                data.toMemorySegment(),
-                                data.length(),
-                                secretKeyMemorySegment)
-                == 0;
+        final byte[] signature = new byte[Sign.BYTES];
+        final boolean signed =
+                SodiumJni.SODIUM.cryptoSignDetached(signature, data.toByteArray(), data.length(), sodiumSecretKey);
         if (!signed) {
             throw new RuntimeException("Failed to sign data using Ed25519 with Sodium");
         }

--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/SodiumVerifier.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/internal/SodiumVerifier.java
@@ -1,10 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.crypto.internal;
 
-import com.hedera.cryptography.libsodium.Libsodium;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.lang.foreign.MemorySegment;
 import java.security.PublicKey;
 import org.hiero.base.crypto.BytesSignatureVerifier;
 
@@ -14,7 +12,6 @@ import org.hiero.base.crypto.BytesSignatureVerifier;
  */
 public class SodiumVerifier implements BytesSignatureVerifier {
     private final byte[] publicKey;
-    private final MemorySegment publicKeyMemorySegment;
 
     /**
      * Constructs a SodiumVerifier with the given Ed25519 PublicKey.
@@ -26,17 +23,11 @@ public class SodiumVerifier implements BytesSignatureVerifier {
         this.publicKey = new byte[32];
         // Extract 32-byte raw public key from X.509 encoded public key
         System.arraycopy(encoded, encoded.length - 32, this.publicKey, 0, 32);
-        this.publicKeyMemorySegment = MemorySegment.ofArray(this.publicKey);
     }
 
     @Override
     public boolean verify(@NonNull final Bytes data, @NonNull final Bytes signature) {
-        return Libsodium.getInstance()
-                        .cryptoSignVerifyDetached(
-                                signature.toMemorySegment(),
-                                data.toMemorySegment(),
-                                Math.toIntExact(data.length()),
-                                publicKeyMemorySegment)
-                == 0;
+        return SodiumJni.SODIUM.cryptoSignVerifyDetached(
+                signature.toByteArray(), data.toByteArray(), Math.toIntExact(data.length()), publicKey);
     }
 }

--- a/platform-sdk/base-crypto/src/testFixtures/java/org/hiero/base/crypto/test/fixtures/ED25519SigningProvider.java
+++ b/platform-sdk/base-crypto/src/testFixtures/java/org/hiero/base/crypto/test/fixtures/ED25519SigningProvider.java
@@ -3,8 +3,9 @@ package org.hiero.base.crypto.test.fixtures;
 
 import static org.hiero.base.utility.CommonUtils.hex;
 
-import com.hedera.cryptography.libsodium.Libsodium;
-import java.lang.foreign.MemorySegment;
+import com.goterl.lazysodium.LazySodiumJava;
+import com.goterl.lazysodium.SodiumJava;
+import com.goterl.lazysodium.interfaces.Sign;
 import java.security.SignatureException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -15,17 +16,17 @@ public class ED25519SigningProvider implements SigningProvider {
     /**
      * the length of signature in bytes
      */
-    public static final int SIGNATURE_LENGTH = Libsodium.ED25519_BYTES;
+    public static final int SIGNATURE_LENGTH = Sign.BYTES;
 
     /**
      * the length of the public key in bytes
      */
-    public static final int PUBLIC_KEY_LENGTH = Libsodium.ED25519_PUBLICKEYBYTES;
+    public static final int PUBLIC_KEY_LENGTH = Sign.PUBLICKEYBYTES;
 
     /**
      * the length of the private key in bytes
      */
-    public static final int PRIVATE_KEY_LENGTH = Libsodium.ED25519_SECRETKEYBYTES;
+    public static final int PRIVATE_KEY_LENGTH = Sign.SECRETKEYBYTES;
 
     /**
      * use this for all logging, as controlled by the optional data/log4j2.xml file
@@ -42,16 +43,15 @@ public class ED25519SigningProvider implements SigningProvider {
      */
     private byte[] privateKey;
 
-    /// Cached MemorySegment for the privateKey.
-    private MemorySegment privateKeyMemorySegment;
-
     /**
      * the public key for each signed transaction
      */
     private byte[] publicKey;
 
-    /// Libsodium signer that calls the native library.
-    private Libsodium signer;
+    /**
+     * the native NaCl signing interface
+     */
+    private Sign.Native signer;
 
     /**
      * indicates whether there is an available algorithm implementation & keypair
@@ -65,13 +65,7 @@ public class ED25519SigningProvider implements SigningProvider {
     @Override
     public byte[] sign(byte[] data) throws SignatureException {
         final byte[] sig = new byte[SIGNATURE_LENGTH];
-        if (signer.cryptoSignDetached(
-                        MemorySegment.ofArray(sig),
-                        MemorySegment.NULL,
-                        MemorySegment.ofArray(data),
-                        data.length,
-                        privateKeyMemorySegment)
-                != 0) {
+        if (!signer.cryptoSignDetached(sig, data, data.length, privateKey)) {
             throw new SignatureException();
         }
 
@@ -102,15 +96,14 @@ public class ED25519SigningProvider implements SigningProvider {
      * Initializes the {@link #signer} instance and creates the public/private keys.
      */
     private void tryAcquireSignature() {
-        signer = Libsodium.getInstance();
+        final SodiumJava sodium = new SodiumJava();
+        signer = new LazySodiumJava(sodium);
 
         publicKey = new byte[PUBLIC_KEY_LENGTH];
         privateKey = new byte[PRIVATE_KEY_LENGTH];
 
-        algorithmAvailable =
-                signer.cryptoSignKeypair(MemorySegment.ofArray(publicKey), MemorySegment.ofArray(privateKey)) == 0;
+        algorithmAvailable = signer.cryptoSignKeypair(publicKey, privateKey);
         logger.trace(LOGM_STARTUP, "Public Key -> hex('{}')", () -> hex(publicKey));
         algorithmAvailable = true;
-        privateKeyMemorySegment = MemorySegment.ofArray(privateKey);
     }
 }

--- a/platform-sdk/base-crypto/src/testFixtures/java/org/hiero/base/crypto/test/fixtures/SignaturePool.java
+++ b/platform-sdk/base-crypto/src/testFixtures/java/org/hiero/base/crypto/test/fixtures/SignaturePool.java
@@ -3,9 +3,10 @@ package org.hiero.base.crypto.test.fixtures;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 
-import com.hedera.cryptography.libsodium.Libsodium;
+import com.goterl.lazysodium.LazySodiumJava;
+import com.goterl.lazysodium.SodiumJava;
+import com.goterl.lazysodium.interfaces.Sign;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
-import java.lang.foreign.MemorySegment;
 import java.security.SignatureException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -26,17 +27,17 @@ public class SignaturePool {
     /**
      * the length of signature in bytes
      */
-    static final int SIGNATURE_LENGTH = Libsodium.ED25519_BYTES;
+    static final int SIGNATURE_LENGTH = Sign.BYTES;
 
     /**
      * the length of the public key in bytes
      */
-    static final int PUBLIC_KEY_LENGTH = Libsodium.ED25519_PUBLICKEYBYTES;
+    static final int PUBLIC_KEY_LENGTH = Sign.PUBLICKEYBYTES;
 
     /**
      * the length of the private key in bytes
      */
-    static final int PRIVATE_KEY_LENGTH = Libsodium.ED25519_SECRETKEYBYTES;
+    static final int PRIVATE_KEY_LENGTH = Sign.SECRETKEYBYTES;
 
     /**
      * the length of the signature and the public key combined
@@ -90,8 +91,10 @@ public class SignaturePool {
      */
     private byte[] publicKey;
 
-    /// Libsodium signer that calls the native library.
-    private Libsodium signer;
+    /**
+     * the native NaCl signing interface
+     */
+    private Sign.Native signer;
 
     private AtomicInteger readPosition;
 
@@ -185,7 +188,7 @@ public class SignaturePool {
      * 		the pre-allocated buffer of at least {@link #transactionSize} long, if {@link #signed} is true then
      * 		length must be at least ({@link #transactionSize} + {@link #SIG_KEY_LENGTH}) long
      * @throws SignatureException
-     * 		if {@link Libsodium#cryptoSignDetached(MemorySegment, MemorySegment, MemorySegment, long, MemorySegment)}
+     * 		if {@link Sign.Native#cryptoSignDetached(byte[], byte[], long, byte[])}
      * 		returns a failure code
      */
     private void sign(final byte[] buffer) {
@@ -202,13 +205,7 @@ public class SignaturePool {
             System.arraycopy(publicKey, 0, buffer, offset, publicKey.length);
             offset += publicKey.length;
 
-            if (signer.cryptoSignDetached(
-                            MemorySegment.ofArray(sig),
-                            MemorySegment.NULL,
-                            MemorySegment.ofArray(data),
-                            (long) data.length,
-                            MemorySegment.ofArray(privateKey))
-                    != 0) {
+            if (!signer.cryptoSignDetached(sig, data, (long) data.length, privateKey)) {
                 throw new SignatureException();
             }
 
@@ -236,13 +233,13 @@ public class SignaturePool {
      */
     private void tryAcquireSignature() {
         try {
-            signer = Libsodium.getInstance();
+            final SodiumJava sodium = new SodiumJava();
+            signer = new LazySodiumJava(sodium);
 
             publicKey = new byte[PUBLIC_KEY_LENGTH];
             privateKey = new byte[PRIVATE_KEY_LENGTH];
 
-            algorithmAvailable =
-                    signer.cryptoSignKeypair(MemorySegment.ofArray(publicKey), MemorySegment.ofArray(privateKey)) == 0;
+            algorithmAvailable = signer.cryptoSignKeypair(publicKey, privateKey);
             logger.trace(LOGM_STARTUP, "StatsSigningDemo: Public Key -> hex('{}')", () -> hex(publicKey));
         } catch (Exception ex) {
             algorithmAvailable = false;


### PR DESCRIPTION
This reverts commit 2d1268a7a0b4ac5c9ed46b6baaac717feb82d624.

**Description**:
Libsodium rollback because of incomparability with `RHEL 8.10` (mainnet OS)


**Related issue(s)**:

Fixes [#26730](https://github.com/hiero-ledger/hiero-consensus-node/issues/26730)

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
