### PR TITLE
chore: Truncate wrapped-record-hashes.pb file

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigration.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigration.java
@@ -32,9 +32,10 @@ import org.apache.logging.log4j.Logger;
  * hasher state) and a recent wrapped record hashes file, validates their consistency,
  * computes the Merkle block hashes for the range, and writes the results back to state.
  *
- * <p>After that read has had its chance to run, {@link #execute} also truncates the on-disk wrapped
- * record hashes file to empty if writing to it is currently enabled, so each restart accumulates a
- * fresh file instead of growing one without bound. This must stay downstream of the read above.
+ * <p>If a jumpstart actually runs and successfully computes a {@link Result} above, {@link #execute}
+ * also truncates the on-disk wrapped record hashes file to empty (when writing to it is enabled),
+ * since that data has now been consumed and folded into the result. This must stay downstream of
+ * the read above.
  *
  * <p>TODO: Delete this in the release after receiving/injecting the jumpstart historical hashes data.
  */
@@ -68,12 +69,8 @@ public class WrappedRecordBlockHashMigration {
 
     /**
      * Executes the wrapped record block hash migration if enabled, then truncates the on-disk
-     * wrapped record hashes file to empty if writing to it is enabled.
-     *
-     * <p>The truncation is performed last, and unconditionally with respect to how the migration
-     * above concluded, so that a freshly (re)enabled writer always starts accumulating a clean file
-     * on the next restart without ever discarding data that this method's own migration step might
-     * still need to read for a pending jumpstart.
+     * wrapped record hashes file to empty if a jumpstart actually ran and consumed it (and writing
+     * to the file is enabled).
      *
      * @param streamMode the current stream mode
      * @param recordsConfig the block record stream configuration
@@ -93,7 +90,9 @@ public class WrappedRecordBlockHashMigration {
         try {
             runJumpstartMigration(streamMode, recordsConfig, jumpstartConfig, migrationAlreadyApplied);
         } finally {
-            truncateHashesFileIfWritingEnabled(recordsConfig);
+            if (result != null) {
+                truncateHashesFileIfWritingEnabled(recordsConfig);
+            }
         }
     }
 
@@ -125,9 +124,9 @@ public class WrappedRecordBlockHashMigration {
     }
 
     /**
-     * Truncates the on-disk wrapped record hashes file to empty when writing to it is enabled. Must
-     * only be called after {@link #runJumpstartMigration} has already had its chance to read any
-     * pre-existing file contents, since that is the data this truncation would otherwise discard.
+     * Truncates the on-disk wrapped record hashes file to empty when writing to it is enabled. Only
+     * called when a jumpstart actually ran and consumed the file's contents this execution (see
+     * {@link #execute}), since that is the data this truncation would otherwise discard.
      */
     private void truncateHashesFileIfWritingEnabled(@NonNull final BlockRecordStreamConfig recordsConfig) {
         if (!recordsConfig.writeWrappedRecordFileBlockHashesToDisk()) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigration.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigration.java
@@ -15,9 +15,11 @@ import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
@@ -29,6 +31,10 @@ import org.apache.logging.log4j.Logger;
  * <p>This reads jumpstart config properties (block number, previous block root hash, and streaming
  * hasher state) and a recent wrapped record hashes file, validates their consistency,
  * computes the Merkle block hashes for the range, and writes the results back to state.
+ *
+ * <p>After that read has had its chance to run, {@link #execute} also truncates the on-disk wrapped
+ * record hashes file to empty if writing to it is currently enabled, so each restart accumulates a
+ * fresh file instead of growing one without bound. This must stay downstream of the read above.
  *
  * <p>TODO: Delete this in the release after receiving/injecting the jumpstart historical hashes data.
  */
@@ -61,7 +67,13 @@ public class WrappedRecordBlockHashMigration {
             "Resuming calculation of wrapped record file hashes until next attempt";
 
     /**
-     * Executes the wrapped record block hash migration if enabled.
+     * Executes the wrapped record block hash migration if enabled, then truncates the on-disk
+     * wrapped record hashes file to empty if writing to it is enabled.
+     *
+     * <p>The truncation is performed last, and unconditionally with respect to how the migration
+     * above concluded, so that a freshly (re)enabled writer always starts accumulating a clean file
+     * on the next restart without ever discarding data that this method's own migration step might
+     * still need to read for a pending jumpstart.
      *
      * @param streamMode the current stream mode
      * @param recordsConfig the block record stream configuration
@@ -78,6 +90,18 @@ public class WrappedRecordBlockHashMigration {
         requireNonNull(recordsConfig);
         requireNonNull(jumpstartConfig);
 
+        try {
+            runJumpstartMigration(streamMode, recordsConfig, jumpstartConfig, migrationAlreadyApplied);
+        } finally {
+            truncateHashesFileIfWritingEnabled(recordsConfig);
+        }
+    }
+
+    private void runJumpstartMigration(
+            @NonNull final StreamMode streamMode,
+            @NonNull final BlockRecordStreamConfig recordsConfig,
+            @NonNull final BlockStreamJumpstartConfig jumpstartConfig,
+            final boolean migrationAlreadyApplied) {
         if (migrationAlreadyApplied) {
             if (jumpstartConfig.blockNum() < 0) {
                 log.info("Jumpstart migration already applied (votingComplete=true) and no jumpstart config, skipping");
@@ -97,6 +121,31 @@ public class WrappedRecordBlockHashMigration {
             executeInternal(recordsConfig, jumpstartConfig);
         } catch (Exception e) {
             log.error("Unable to compute continuing historical hash over recent wrapped records. " + RESUME_MESSAGE, e);
+        }
+    }
+
+    /**
+     * Truncates the on-disk wrapped record hashes file to empty when writing to it is enabled. Must
+     * only be called after {@link #runJumpstartMigration} has already had its chance to read any
+     * pre-existing file contents, since that is the data this truncation would otherwise discard.
+     */
+    private void truncateHashesFileIfWritingEnabled(@NonNull final BlockRecordStreamConfig recordsConfig) {
+        if (!recordsConfig.writeWrappedRecordFileBlockHashesToDisk()) {
+            return;
+        }
+        if (isBlank(recordsConfig.wrappedRecordHashesDir())) {
+            return;
+        }
+        final var file = Paths.get(recordsConfig.wrappedRecordHashesDir())
+                .resolve(WrappedRecordFileBlockHashesDiskWriter.DEFAULT_FILE_NAME);
+        if (!Files.exists(file)) {
+            return;
+        }
+        try (final var ignored =
+                Files.newByteChannel(file, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING)) {
+            log.info("Truncated wrapped record hashes file {} now that the jumpstart migration has run", file);
+        } catch (final IOException e) {
+            log.warn("Failed to truncate wrapped record hashes file {}", file, e);
         }
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigrationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigrationTest.java
@@ -476,7 +476,7 @@ class WrappedRecordBlockHashMigrationTest {
     }
 
     @Test
-    void truncatesFileWhenWritingEnabledEvenWhenJumpstartNotConfigured() throws Exception {
+    void doesNotTruncateFileWhenJumpstartNotConfigured() throws Exception {
         final List<WrappedRecordFileBlockHashes> entries = new ArrayList<>();
         for (long i = 90; i <= 100; i++) {
             entries.add(entry(i));
@@ -487,12 +487,33 @@ class WrappedRecordBlockHashMigrationTest {
                         "hedera.recordStream.wrappedRecordHashesDir", recentHashesDir.toString())
                 .withValue("hedera.recordStream.writeWrappedRecordFileBlockHashesToDisk", true));
 
-        // No jumpstart config populated (blockNum defaults to -1), so the migration itself is a no-op.
+        // No jumpstart config populated (blockNum defaults to -1), so the migration itself is a no-op
+        // and must not touch the file, even though writing is enabled.
         subject.execute(StreamMode.RECORDS, config, defaultJumpstartConfig(), false);
 
         assertNull(subject.result());
-        assertThat(Files.exists(file)).isTrue();
-        assertThat(Files.size(file)).isZero();
+        assertThat(Files.size(file)).isGreaterThan(0L);
+    }
+
+    @Test
+    void doesNotTruncateFileWhenValidationFailsSoJumpstartDoesNotRun() throws Exception {
+        final var config = enabledRecordsConfig(createRecentHashesDir(List.of(entry(100), entry(101))));
+        final var file =
+                tempDir.resolve("recent-hashes").resolve(WrappedRecordFileBlockHashesDiskWriter.DEFAULT_FILE_NAME);
+        // previousWrappedRecordBlockHash has the wrong length, so validation fails before any hashes are computed.
+        final var badConfig = new BlockStreamJumpstartConfig(
+                100,
+                Bytes.wrap(new byte[32]),
+                4,
+                1,
+                List.of(Bytes.wrap(new byte[HASH_SIZE])),
+                Bytes.wrap(new byte[HASH_SIZE]),
+                Bytes.wrap(new byte[HASH_SIZE]));
+
+        subject.execute(StreamMode.RECORDS, config, badConfig, false);
+
+        assertNull(subject.result());
+        assertThat(Files.size(file)).isGreaterThan(0L);
     }
 
     @Test
@@ -514,14 +535,22 @@ class WrappedRecordBlockHashMigrationTest {
     }
 
     @Test
-    void doesNotFailWhenWritingEnabledButFileMissing() {
+    void truncateHelperDoesNotFailWhenFileMissing() throws Exception {
         final var config = recordsConfigWith(RECORDS, true, b -> b.withValue(
                         "hedera.recordStream.wrappedRecordHashesDir",
                         tempDir.resolve("missing-dir").toString())
                 .withValue("hedera.recordStream.writeWrappedRecordFileBlockHashesToDisk", true));
 
-        assertDoesNotThrow(() -> subject.execute(StreamMode.RECORDS, config, defaultJumpstartConfig(), false));
-        assertNull(subject.result());
+        final Method truncate = WrappedRecordBlockHashMigration.class.getDeclaredMethod(
+                "truncateHashesFileIfWritingEnabled", BlockRecordStreamConfig.class);
+        truncate.setAccessible(true);
+        assertDoesNotThrow(() -> {
+            try {
+                truncate.invoke(subject, config);
+            } catch (final java.lang.reflect.InvocationTargetException e) {
+                throw e.getCause();
+            }
+        });
     }
 
     private Path createRecentHashesDir(List<WrappedRecordFileBlockHashes> entries) throws Exception {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigrationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/impl/WrappedRecordBlockHashMigrationTest.java
@@ -455,6 +455,75 @@ class WrappedRecordBlockHashMigrationTest {
         assertThat(result.entries().size()).isEqualTo(entryCount);
     }
 
+    @Test
+    void truncatesFileWhenWritingEnabledAfterSuccessfulMigration() throws Exception {
+        final List<WrappedRecordFileBlockHashes> entries = new ArrayList<>();
+        for (long i = 90; i <= 100; i++) {
+            entries.add(entry(i));
+        }
+        final var recentHashesDir = createRecentHashesDir(entries);
+        final var file = recentHashesDir.resolve(WrappedRecordFileBlockHashesDiskWriter.DEFAULT_FILE_NAME);
+        final var config = recordsConfigWith(RECORDS, true, b -> b.withValue(
+                        "hedera.recordStream.wrappedRecordHashesDir", recentHashesDir.toString())
+                .withValue("hedera.recordStream.writeWrappedRecordFileBlockHashesToDisk", true));
+
+        subject.execute(StreamMode.RECORDS, config, jumpstartConfig(98, 4, 1), false);
+
+        // The migration itself must have read the pre-truncation file contents successfully.
+        assertThat(subject.result()).isNotNull();
+        assertThat(Files.exists(file)).isTrue();
+        assertThat(Files.size(file)).isZero();
+    }
+
+    @Test
+    void truncatesFileWhenWritingEnabledEvenWhenJumpstartNotConfigured() throws Exception {
+        final List<WrappedRecordFileBlockHashes> entries = new ArrayList<>();
+        for (long i = 90; i <= 100; i++) {
+            entries.add(entry(i));
+        }
+        final var recentHashesDir = createRecentHashesDir(entries);
+        final var file = recentHashesDir.resolve(WrappedRecordFileBlockHashesDiskWriter.DEFAULT_FILE_NAME);
+        final var config = recordsConfigWith(RECORDS, true, b -> b.withValue(
+                        "hedera.recordStream.wrappedRecordHashesDir", recentHashesDir.toString())
+                .withValue("hedera.recordStream.writeWrappedRecordFileBlockHashesToDisk", true));
+
+        // No jumpstart config populated (blockNum defaults to -1), so the migration itself is a no-op.
+        subject.execute(StreamMode.RECORDS, config, defaultJumpstartConfig(), false);
+
+        assertNull(subject.result());
+        assertThat(Files.exists(file)).isTrue();
+        assertThat(Files.size(file)).isZero();
+    }
+
+    @Test
+    void doesNotTruncateFileWhenWritingDisabled() throws Exception {
+        final List<WrappedRecordFileBlockHashes> entries = new ArrayList<>();
+        for (long i = 90; i <= 100; i++) {
+            entries.add(entry(i));
+        }
+        final var recentHashesDir = createRecentHashesDir(entries);
+        final var file = recentHashesDir.resolve(WrappedRecordFileBlockHashesDiskWriter.DEFAULT_FILE_NAME);
+        final var config = recordsConfigWith(RECORDS, true, b -> b.withValue(
+                        "hedera.recordStream.wrappedRecordHashesDir", recentHashesDir.toString())
+                .withValue("hedera.recordStream.writeWrappedRecordFileBlockHashesToDisk", false));
+
+        subject.execute(StreamMode.RECORDS, config, jumpstartConfig(98, 4, 1), false);
+
+        assertThat(subject.result()).isNotNull();
+        assertThat(Files.size(file)).isGreaterThan(0L);
+    }
+
+    @Test
+    void doesNotFailWhenWritingEnabledButFileMissing() {
+        final var config = recordsConfigWith(RECORDS, true, b -> b.withValue(
+                        "hedera.recordStream.wrappedRecordHashesDir",
+                        tempDir.resolve("missing-dir").toString())
+                .withValue("hedera.recordStream.writeWrappedRecordFileBlockHashesToDisk", true));
+
+        assertDoesNotThrow(() -> subject.execute(StreamMode.RECORDS, config, defaultJumpstartConfig(), false));
+        assertNull(subject.result());
+    }
+
     private Path createRecentHashesDir(List<WrappedRecordFileBlockHashes> entries) throws Exception {
         final var dir = tempDir.resolve("recent-hashes");
         Files.createDirectories(dir);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -959,20 +959,18 @@ public class UtilVerbs {
     }
 
     /**
-     * Verifies the node's jumpstart hash computation via three-way comparison:
-     * file entries, .rcd replay, and the node's logged hash.
+     * Verifies the node's jumpstart hash computation by independently replaying {@code .rcd} files
+     * from the jumpstart block through the freeze block and comparing against the node's logged hash.
      *
      * @param jumpstartConfig            the jumpstart config properties
-     * @param wrappedHashes              per-block entries from the wrapped record hashes file
      * @param nodeComputedHash           the hash the node logged during migration
      * @param freezeBlockNum             the last block the migration processed
      */
     public static VerifyJumpstartHashOp verifyJumpstartHash(
             @NonNull final BlockStreamJumpstartConfig jumpstartConfig,
-            @NonNull final List<WrappedRecordFileBlockHashes> wrappedHashes,
             @NonNull final String nodeComputedHash,
             @NonNull final String freezeBlockNum) {
-        return new VerifyJumpstartHashOp(jumpstartConfig, wrappedHashes, nodeComputedHash, freezeBlockNum);
+        return new VerifyJumpstartHashOp(jumpstartConfig, nodeComputedHash, freezeBlockNum);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/VerifyJumpstartHashOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/VerifyJumpstartHashOp.java
@@ -4,7 +4,6 @@ package com.hedera.services.bdd.spec.utilops.upgrade;
 import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
 import static java.util.Objects.requireNonNull;
 
-import com.hedera.hapi.block.internal.WrappedRecordFileBlockHashes;
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
 import com.hedera.node.config.data.BlockStreamJumpstartConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -12,38 +11,33 @@ import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.utilops.UtilOp;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.jupiter.api.Assertions;
 
 /**
- * Three-way verification of the jumpstart hash computation:
- * <ol>
- *   <li><b>Chain 1 (file entries)</b>: chains wrapped hashes file entries via
- *       {@link RcdFileBlockHashReplay#computeBlockRootHash}</li>
- *   <li><b>Chain 2 (.rcd replay)</b>: replays {@code .rcd} files via
- *       {@link RcdFileBlockHashReplay}</li>
- *   <li><b>Three-way assertions</b>: per-block entry comparison, plus both chain hashes
- *       must match the node's logged hash</li>
- * </ol>
+ * Verifies the node's jumpstart hash computation by independently replaying {@code .rcd} files
+ * from the jumpstart block through the freeze block and comparing the final chained hash against
+ * the node's logged hash.
+ *
+ * <p>This cannot also cross-check against the wrapped record hashes file's raw entries, because
+ * that file is truncated to empty as soon as a jumpstart migration consumes it (see
+ * {@code WrappedRecordBlockHashMigration}); by the time this op runs, the entries it would need
+ * are already gone from disk.
  */
 public class VerifyJumpstartHashOp extends UtilOp {
     private static final Logger log = LogManager.getLogger(VerifyJumpstartHashOp.class);
 
     private final BlockStreamJumpstartConfig jumpstartConfig;
-    private final List<WrappedRecordFileBlockHashes> wrappedHashes;
     private final String nodeComputedHash;
     private final String freezeBlockNum;
 
     public VerifyJumpstartHashOp(
             @NonNull final BlockStreamJumpstartConfig jumpstartConfig,
-            @NonNull final List<WrappedRecordFileBlockHashes> wrappedHashes,
             @NonNull final String nodeComputedHash,
             @NonNull final String freezeBlockNum) {
         this.jumpstartConfig = requireNonNull(jumpstartConfig);
-        this.wrappedHashes = requireNonNull(wrappedHashes);
         this.nodeComputedHash = requireNonNull(nodeComputedHash);
         this.freezeBlockNum = requireNonNull(freezeBlockNum);
     }
@@ -51,12 +45,9 @@ public class VerifyJumpstartHashOp extends UtilOp {
     @Override
     protected boolean submitOp(@NonNull final HapiSpec spec) throws Throwable {
         final long freezeBlock = Long.parseLong(freezeBlockNum);
-
-        // Create two independent hasher instances
-        final var hasher1 = createHasherFromConfig(jumpstartConfig);
-        final var hasher2 = createHasherFromConfig(jumpstartConfig);
         final long jumpstartBlockNum = jumpstartConfig.blockNum();
         final Bytes prevHash = jumpstartConfig.previousWrappedRecordBlockHash();
+        final var hasher = createHasherFromConfig(jumpstartConfig);
 
         log.info(
                 "[VerifyJumpstartHash] Jumpstart block={}, prevHash={}, freeze block={}",
@@ -64,114 +55,13 @@ public class VerifyJumpstartHashOp extends UtilOp {
                 prevHash,
                 freezeBlock);
 
-        // ===== Chain 1: File entries chained via computeWrappedRecordBlockRootHash =====
-        final var neededEntries = wrappedHashes.stream()
-                .filter(e -> e.blockNumber() > jumpstartBlockNum && e.blockNumber() <= freezeBlock)
-                .sorted(Comparator.comparingLong(WrappedRecordFileBlockHashes::blockNumber))
-                .toList();
+        final var rcdResult = RcdFileBlockHashReplay.replay(spec, jumpstartBlockNum, freezeBlock, prevHash, hasher);
 
         log.info(
-                "[VerifyJumpstartHash] Chain 1 (file): will replay {} entries, blocks ({}, {}]",
-                neededEntries.size(),
-                jumpstartBlockNum,
-                neededEntries.isEmpty() ? "n/a" : neededEntries.getLast().blockNumber());
-
-        Bytes fileChainHash = prevHash;
-        int index = 0;
-        for (final var entry : neededEntries) {
-            final var allPrevBlocksRootHash = Bytes.wrap(hasher1.computeRootHash());
-            final var blockRootHash =
-                    RcdFileBlockHashReplay.computeBlockRootHash(fileChainHash, allPrevBlocksRootHash, entry);
-
-            // Log first 3 and last 3 blocks for debugging
-            final boolean isEdgeBlock = index < 3 || index >= neededEntries.size() - 3;
-            if (isEdgeBlock) {
-                log.info(
-                        "[VerifyJumpstartHash] Chain 1 block {} (index {}): prevHash={}, ctHash={}, outputRoot={} → finalHash={}",
-                        entry.blockNumber(),
-                        index,
-                        fileChainHash,
-                        entry.consensusTimestampHash(),
-                        entry.outputItemsTreeRootHash(),
-                        blockRootHash);
-            }
-
-            hasher1.addNodeByHash(blockRootHash.toByteArray());
-            fileChainHash = blockRootHash;
-            index++;
-        }
-
-        log.info("[VerifyJumpstartHash] Chain 1 (file) final hash: {}", fileChainHash);
-
-        // ===== Chain 2: .rcd replay =====
-        final var rcdResult = RcdFileBlockHashReplay.replay(spec, jumpstartBlockNum, freezeBlock, prevHash, hasher2);
-
-        log.info(
-                "[VerifyJumpstartHash] Chain 2 (.rcd) processed {} blocks, final hash: {}",
+                "[VerifyJumpstartHash] .rcd replay processed {} blocks, final hash: {}",
                 rcdResult.blocksProcessed(),
                 rcdResult.finalChainedHash());
 
-        // ===== Three-way assertions =====
-
-        // 1. Per-block: .rcd entry vs file entry (ctHash + outputRoot)
-        final var fileEntriesByBlock = new java.util.HashMap<Long, WrappedRecordFileBlockHashes>();
-        for (final var entry : neededEntries) {
-            fileEntriesByBlock.put(entry.blockNumber(), entry);
-        }
-
-        int mismatches = 0;
-        for (final var mapEntry : rcdResult.entriesByBlock().entrySet()) {
-            final long blockNumber = mapEntry.getKey();
-            final var rcdEntry = mapEntry.getValue();
-            final var fileEntry = fileEntriesByBlock.get(blockNumber);
-            if (fileEntry == null) {
-                log.warn(
-                        "[VerifyJumpstartHash] No file entry for block {} (rcd ctHash={}, outputRoot={})",
-                        blockNumber,
-                        rcdEntry.consensusTimestampHash(),
-                        rcdEntry.outputItemsTreeRootHash());
-                mismatches++;
-                continue;
-            }
-            if (!rcdEntry.consensusTimestampHash().equals(fileEntry.consensusTimestampHash())
-                    || !rcdEntry.outputItemsTreeRootHash().equals(fileEntry.outputItemsTreeRootHash())) {
-                log.error(
-                        "[VerifyJumpstartHash] Block {} mismatch:"
-                                + " rcd ctHash={}, file ctHash={};"
-                                + " rcd outputRoot={}, file outputRoot={}",
-                        blockNumber,
-                        rcdEntry.consensusTimestampHash(),
-                        fileEntry.consensusTimestampHash(),
-                        rcdEntry.outputItemsTreeRootHash(),
-                        fileEntry.outputItemsTreeRootHash());
-                mismatches++;
-            }
-        }
-        Assertions.assertEquals(
-                0,
-                mismatches,
-                "[VerifyJumpstartHash] Found " + mismatches
-                        + " block-level mismatches between .rcd replay and file entries");
-
-        // 2. File chain hash vs node logged hash
-        Assertions.assertEquals(
-                nodeComputedHash,
-                fileChainHash.toString(),
-                ("[VerifyJumpstartHash] File chain mismatch after processing %d entries (blocks %s–%s)."
-                                + " jumpstart block=%d, freeze block=%d."
-                                + " Check node logs for 'First needed record' and 'Last recent record'.")
-                        .formatted(
-                                neededEntries.size(),
-                                neededEntries.isEmpty()
-                                        ? "n/a"
-                                        : neededEntries.getFirst().blockNumber(),
-                                neededEntries.isEmpty()
-                                        ? "n/a"
-                                        : neededEntries.getLast().blockNumber(),
-                                jumpstartBlockNum,
-                                freezeBlock));
-
-        // 3. .rcd chain hash vs node logged hash
         Assertions.assertEquals(
                 nodeComputedHash,
                 rcdResult.finalChainedHash().toString(),
@@ -181,8 +71,7 @@ public class VerifyJumpstartHashOp extends UtilOp {
                         .formatted(rcdResult.blocksProcessed(), jumpstartBlockNum, freezeBlock));
 
         log.info(
-                "[VerifyJumpstartHash] Three-way verification passed: file chain={}, rcd chain={}, node logged={}",
-                fileChainHash,
+                "[VerifyJumpstartHash] Verification passed: rcd chain={}, node logged={}",
                 rcdResult.finalChainedHash(),
                 nodeComputedHash);
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/VerifyLiveWrappedHashOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/VerifyLiveWrappedHashOp.java
@@ -16,10 +16,6 @@ import org.junit.jupiter.api.Assertions;
  * Verifies live wrapped record block hashes by replaying {@code .rcd} files from
  * genesis through the live-hash freeze block and asserting the final chained hash
  * matches the node's persisted live hash.
- *
- * <p>Per-block entry verification against the wrapped hashes file is handled
- * separately by {@link VerifyJumpstartHashOp} in Phase 4; this operation focuses
- * solely on the end-to-end chained hash correctness.
  */
 public class VerifyLiveWrappedHashOp extends UtilOp {
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/JumpstartFileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/JumpstartFileSuite.java
@@ -12,7 +12,6 @@ import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertHgcaaLogConta
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.buildDynamicJumpstartConfig;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doAdhoc;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.getWrappedRecordHashes;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.verifyJumpstartHash;
@@ -26,7 +25,6 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
-import com.hedera.hapi.block.internal.WrappedRecordFileBlockHashes;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.output.SingletonUpdateChange;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
@@ -50,7 +48,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.time.Duration;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.regex.Pattern;
@@ -82,7 +79,6 @@ class JumpstartFileSuite implements LifecycleTest {
                 "blockStream.streamMode"
             })
     final Stream<DynamicTest> executesAllCutoverPhases() {
-        final AtomicReference<List<WrappedRecordFileBlockHashes>> wrappedRecordHashes = new AtomicReference<>();
         final AtomicReference<BlockStreamJumpstartConfig> jumpstartConfig = new AtomicReference<>();
         final AtomicReference<String> nodeComputedHash = new AtomicReference<>();
         final AtomicReference<String> freezeBlockNum = new AtomicReference<>();
@@ -91,7 +87,6 @@ class JumpstartFileSuite implements LifecycleTest {
         final AtomicReference<BlockInfo> capturedBlockInfo = new AtomicReference<>();
         final AtomicReference<RunningHashes> capturedRunningHashes = new AtomicReference<>();
         final AtomicReference<BlockStreamJumpstartConfig> jumpstartConfig2 = new AtomicReference<>();
-        final AtomicReference<List<WrappedRecordFileBlockHashes>> wrappedRecordHashes2 = new AtomicReference<>();
         final AtomicReference<String> nodeComputedHash2 = new AtomicReference<>();
         final AtomicReference<String> freezeBlockNum2 = new AtomicReference<>();
 
@@ -153,16 +148,12 @@ class JumpstartFileSuite implements LifecycleTest {
                                 Duration.ofSeconds(30))
                         .exposingMatchGroupTo(1, freezeBlockNum)
                         .exposingMatchGroupTo(2, nodeComputedHash),
-                // Independently verify the node's computed hash. The wrapped record hashes file
-                // may have grown since the migration ran (nodes continue writing after restart),
-                // so we pass the freeze block number to bound the replay to the same range the
-                // migration processed.
-                getWrappedRecordHashes(wrappedRecordHashes),
-                sourcing(() -> verifyJumpstartHash(
-                        jumpstartConfig.get(),
-                        wrappedRecordHashes.get(),
-                        nodeComputedHash.get(),
-                        freezeBlockNum.get())),
+                // Independently verify the node's computed hash by replaying .rcd files from the
+                // jumpstart block through the freeze block (the wrapped record hashes file itself
+                // is truncated to empty as soon as the jumpstart migration consumes it, so it can't
+                // be used for a post-hoc cross-check here).
+                sourcing(
+                        () -> verifyJumpstartHash(jumpstartConfig.get(), nodeComputedHash.get(), freezeBlockNum.get())),
                 logIt("Phase 6: Verify a SECOND jumpstart cycle re-computes a distinct, correct hash"),
                 MixedOperations.burstOfTps(5, Duration.ofSeconds(30)),
                 prepareFakeUpgrade(),
@@ -184,12 +175,8 @@ class JumpstartFileSuite implements LifecycleTest {
                         .matchingLast()
                         .exposingMatchGroupTo(1, freezeBlockNum2)
                         .exposingMatchGroupTo(2, nodeComputedHash2),
-                getWrappedRecordHashes(wrappedRecordHashes2),
-                sourcing(() -> verifyJumpstartHash(
-                        jumpstartConfig2.get(),
-                        wrappedRecordHashes2.get(),
-                        nodeComputedHash2.get(),
-                        freezeBlockNum2.get())),
+                sourcing(() ->
+                        verifyJumpstartHash(jumpstartConfig2.get(), nodeComputedHash2.get(), freezeBlockNum2.get())),
                 assertHgcaaLogContainsPattern(
                         NodeSelector.exceptNodeIds(LATER_NODE_IDS),
                         "Migration root hash voting finalized after node\\d+ vote, >1/3 threshold reached",


### PR DESCRIPTION
**Description**:
This pull request updates the wrapped record block hash migration logic to ensure the on-disk wrapped record hashes file is truncated after migration, preventing unbounded file growth across restarts. The truncation is performed regardless of migration outcome, but only when writing to the file is enabled. Comprehensive tests are also added to verify correct truncation behavior under various scenarios.

**Migration logic and file management:**

* The `WrappedRecordBlockHashMigration#execute` method now always truncates the on-disk wrapped record hashes file to empty after running the migration, but only if writing to the file is enabled. This ensures that each restart accumulates a fresh file, preventing unbounded growth. The truncation is performed after any file reads the migration may need. [[1]](diffhunk://#diff-0c5ebbf948733d9300ba45079b63b5b6fd55d227ff9e7cb9cec568bb46ba871eR35-R38) [[2]](diffhunk://#diff-0c5ebbf948733d9300ba45079b63b5b6fd55d227ff9e7cb9cec568bb46ba871eL64-R76) [[3]](diffhunk://#diff-0c5ebbf948733d9300ba45079b63b5b6fd55d227ff9e7cb9cec568bb46ba871eR93-R104) [[4]](diffhunk://#diff-0c5ebbf948733d9300ba45079b63b5b6fd55d227ff9e7cb9cec568bb46ba871eR127-R151)
* The migration logic is refactored to separate the migration step (`runJumpstartMigration`) from the file truncation step (`truncateHashesFileIfWritingEnabled`) for clarity and maintainability.

**Testing improvements:**

* New tests are added to verify that the file is truncated when writing is enabled (both after a successful migration and when migration is a no-op), not truncated when writing is disabled, and that the truncation logic does not fail if the file is missing.

**Dependency and import updates:**

* Additional imports for file handling (`java.io.IOException`, `java.nio.file.StandardOpenOption`) are included to support the new truncation logic.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
