### PR TITLE
fix: make SequentialContentManager honor its no-overwrite contract

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/SequentialContentManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/tss/SequentialContentManager.java
@@ -223,10 +223,14 @@ public class SequentialContentManager<T> {
      */
     private void assertNoExtantContentFor(final long seqNo) {
         final var p = pathFor(seqNo);
+        boolean exists = false;
         try {
             contentReader.readContent(p);
-            throw new IllegalArgumentException("Content already exists for #" + seqNo + " at " + p.toAbsolutePath());
+            exists = true;
         } catch (Exception ignore) {
+        }
+        if (exists) {
+            throw new IllegalArgumentException("Content already exists for #" + seqNo + " at " + p.toAbsolutePath());
         }
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/SequentialContentManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/tss/SequentialContentManagerTest.java
@@ -86,6 +86,16 @@ class SequentialContentManagerTest {
     }
 
     @Test
+    void createContentForThrowsWhenContentAlreadyExists() {
+        subject.createContentFor(1);
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> subject.createContentFor(1),
+                "createContentFor should reject a seqNo whose content file already exists");
+    }
+
+    @Test
     void purgeKeyPairsForConstructionsBeforeRemovesCorrectDirs() {
         subject.createContentFor(1);
         subject.createContentFor(5);


### PR DESCRIPTION
**Description**

`SequentialContentManager.assertNoExtantContentFor(seqNo)` was dead code: it threw `IllegalArgumentException` from inside its own `try` block, and the immediately-following `catch (Exception ignore)` swallowed that same exception. As a result the method could never throw, and the `@throws IllegalArgumentException` contract documented on the public `createContentFor(seqNo)` was never honored.

This restores the guard: it records whether readable content already exists and throws after the `try/catch` instead of inside it.

**Behavior**

- No change to the normal path. In production `createContentFor` is only reached via `getOrCreateContent`, which calls it solely when `findLatestContentFor` finds no readable content at the target path, so the guard does not fire there.
- The check remains based on `contentReader.readContent` (not `Files.exists`), so a present-but-corrupt file is still treated as "no content" and the recreate-on-corruption recovery path is preserved.
- Effect is limited to restoring the documented contract for direct/future callers of the public `createContentFor`.

**Testing**

- Added `SequentialContentManagerTest.createContentForThrowsWhenContentAlreadyExists`, which asserts `createContentFor` rejects a seq no whose content already exists. It fails against the previous (dead-guard) code and passes with this change.