### PR TITLE
fix: submit a paid query's payment only after it is validated and throttled

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
@@ -193,8 +193,12 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                 final var state = wrappedState.get();
                 final var storeFactory = new ReadableStoreFactoryImpl(state);
                 final QueryContext context;
-                TransactionBody txBody;
+                TransactionBody txBody = null;
                 AccountID payerID = null;
+                // Payment submission is deferred until the node has validated the query and passed the query
+                // throttle (steps 4 and 5), so a query that is rejected or throttled is never charged.
+                Bytes deferredPayment = null;
+                IngestChecker.Result paidCheckerResult = null;
                 if (shouldCharge && paymentRequired) {
                     final var configuration = configProvider.getConfiguration();
                     final Bytes paymentBytes;
@@ -205,6 +209,7 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                     }
 
                     final var checkerResult = new IngestChecker.Result();
+                    paidCheckerResult = checkerResult;
                     try {
                         // 3.i Ingest checks
                         ingestChecker.runAllChecks(state, paymentBytes, configuration, checkerResult);
@@ -268,8 +273,9 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                                     queryFees,
                                     cryptoTransferTxnFee);
 
-                            // 3.vi Submit payment to platform with priority=false vs network consensus and TSS txs
-                            submissionManager.submit(txBody, txInfo.serializedSignedTxOrThrow(), false);
+                            // 3.vi Capture the payment; it is submitted below only after the query is validated
+                            // and passes the throttle check, i.e. once the node has committed to answering it.
+                            deferredPayment = txInfo.serializedSignedTxOrThrow();
                         }
                     } catch (Exception e) {
                         checkerResult.throttleUsages().forEach(ThrottleUsage::reclaimCapacity);
@@ -290,13 +296,29 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                             null);
                 }
 
-                // 4. Check validity of query
-                handler.validate(context);
+                // Validate and throttle-check the query before submitting the payment, so the payer is charged
+                // only once the node has committed to answering. If any check fails, reclaim the throttle capacity
+                // the payment consumed at ingest, since no payment transaction will be submitted.
+                try {
+                    // 4. Check validity of query
+                    handler.validate(context);
 
-                // 5. Check query throttles
-                if (shouldCharge && synchronizedThrottleAccumulator.shouldThrottle(function, query, state, payerID)) {
-                    workflowMetrics.incrementThrottled(function);
-                    throw new PreCheckException(BUSY);
+                    // 5. Check query throttles
+                    if (shouldCharge
+                            && synchronizedThrottleAccumulator.shouldThrottle(function, query, state, payerID)) {
+                        workflowMetrics.incrementThrottled(function);
+                        throw new PreCheckException(BUSY);
+                    }
+
+                    // 3.vi Submit payment to platform with priority=false vs network consensus and TSS txs
+                    if (deferredPayment != null) {
+                        submissionManager.submit(txBody, deferredPayment, false);
+                    }
+                } catch (Exception e) {
+                    if (paidCheckerResult != null) {
+                        paidCheckerResult.throttleUsages().forEach(ThrottleUsage::reclaimCapacity);
+                    }
+                    throw e;
                 }
 
                 if (handler.needsAnswerOnlyCost(responseType)) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryWorkflowImpl.java
@@ -296,9 +296,10 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                             null);
                 }
 
-                // Validate and throttle-check the query before submitting the payment, so the payer is charged
-                // only once the node has committed to answering. If any check fails, reclaim the throttle capacity
-                // the payment consumed at ingest, since no payment transaction will be submitted.
+                // Validate, throttle-check, and generate the response before submitting the payment, so the payer
+                // is charged only once the node has produced the answer it is charging for. If any of these steps
+                // fails, reclaim the throttle capacity the payment consumed at ingest, since no payment transaction
+                // will be submitted.
                 try {
                     // 4. Check validity of query
                     handler.validate(context);
@@ -310,7 +311,25 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                         throw new PreCheckException(BUSY);
                     }
 
-                    // 3.vi Submit payment to platform with priority=false vs network consensus and TSS txs
+                    // 6. Generate the response
+                    if (handler.needsAnswerOnlyCost(responseType)) {
+                        // 6.i Estimate costs
+                        final var queryFeeTinyCents = requireNonNull(feeManager.getSimpleFeeCalculator())
+                                .calculateQueryFee(context.query(), new SimpleFeeContextImpl(null, context));
+                        final long queryFees = tinycentsToTinybars(
+                                queryFeeTinyCents.totalTinycents(),
+                                fromPbj(context.exchangeRateInfo().activeRate(consensusTime)));
+
+                        final var header = createResponseHeader(responseType, OK, queryFees);
+                        response = handler.createEmptyResponse(header);
+                    } else {
+                        // 6.ii Find response
+                        final var header = createResponseHeader(responseType, OK, 0L);
+                        response = handler.findResponse(context, header);
+                    }
+
+                    // 3.vi Submit payment to platform with priority=false vs network consensus and TSS txs, now
+                    //      that the query has been validated, has passed throttling, and its response is ready.
                     if (deferredPayment != null) {
                         submissionManager.submit(txBody, deferredPayment, false);
                     }
@@ -319,22 +338,6 @@ public final class QueryWorkflowImpl implements QueryWorkflow {
                         paidCheckerResult.throttleUsages().forEach(ThrottleUsage::reclaimCapacity);
                     }
                     throw e;
-                }
-
-                if (handler.needsAnswerOnlyCost(responseType)) {
-                    // 6.i Estimate costs
-                    final var queryFeeTinyCents = requireNonNull(feeManager.getSimpleFeeCalculator())
-                            .calculateQueryFee(context.query(), new SimpleFeeContextImpl(null, context));
-                    final long queryFees = tinycentsToTinybars(
-                            queryFeeTinyCents.totalTinycents(),
-                            fromPbj(context.exchangeRateInfo().activeRate(consensusTime)));
-
-                    final var header = createResponseHeader(responseType, OK, queryFees);
-                    response = handler.createEmptyResponse(header);
-                } else {
-                    // 6.ii Find response
-                    final var header = createResponseHeader(responseType, OK, 0L);
-                    response = handler.findResponse(context, header);
                 }
             } catch (InsufficientBalanceException e) {
                 response = createErrorResponse(handler, responseType, e.responseCode(), e.getEstimatedFee());

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -810,6 +810,64 @@ class QueryWorkflowImplTest extends AppTestBase {
     }
 
     @Test
+    void paidQueryDoesNotSubmitPaymentWhenThrottled() throws PreCheckException, ParseException {
+        // given — a paid query whose payment passes ingest, but whose query throttle then fires BUSY
+        mockQueryContext();
+        when(handler.requiresNodePayment(ANSWER_ONLY)).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+                    final var result = invocationOnMock.getArgument(3, IngestChecker.Result.class);
+                    result.setThrottleUsages(List.of());
+                    result.setTxnInfo(transactionInfo);
+                    return null;
+                })
+                .when(ingestChecker)
+                .runAllChecks(any(), any(), any(), any());
+        when(synchronizedThrottleAccumulator.shouldThrottle(eq(FILE_GET_INFO), any(), any(), any()))
+                .thenReturn(true);
+        final var responseBuffer = newEmptyBuffer();
+
+        // when
+        workflow.handleQuery(requestBuffer, responseBuffer);
+
+        // then — the query is refused as BUSY ...
+        final var response = parseResponse(responseBuffer);
+        final var header = response.fileGetInfoOrThrow().headerOrThrow();
+        assertThat(header.nodeTransactionPrecheckCode()).isEqualTo(BUSY);
+        verify(opWorkflowMetrics).incrementThrottled(FILE_GET_INFO);
+        // ... and the payment is NOT submitted, so the payer is not charged for the unanswered query.
+        verify(submissionManager, never()).submit(any(), any(), anyBoolean());
+    }
+
+    @Test
+    void paidQuerySubmitsPaymentWhenNotThrottled() throws PreCheckException, ParseException {
+        // given — a paid query that passes validation and the throttle check
+        mockQueryContext();
+        when(handler.requiresNodePayment(ANSWER_ONLY)).thenReturn(true);
+        when(handler.findResponse(any(), any()))
+                .thenReturn(Response.newBuilder()
+                        .fileGetInfo(FileGetInfoResponse.newBuilder()
+                                .header(ResponseHeader.newBuilder().build())
+                                .build())
+                        .build());
+        doAnswer(invocationOnMock -> {
+                    final var result = invocationOnMock.getArgument(3, IngestChecker.Result.class);
+                    result.setThrottleUsages(List.of());
+                    result.setTxnInfo(transactionInfo);
+                    return null;
+                })
+                .when(ingestChecker)
+                .runAllChecks(any(), any(), any(), any());
+        final var responseBuffer = newEmptyBuffer();
+
+        // when
+        workflow.handleQuery(requestBuffer, responseBuffer);
+
+        // then — throttling did not fire and the payment was submitted (priority=false).
+        verify(opWorkflowMetrics, never()).incrementThrottled(any());
+        verify(submissionManager).submit(txBody, serializedPayment, false);
+    }
+
+    @Test
     void testPaidQueryWithInvalidTransactionFails() throws PreCheckException, ParseException {
         // given
         when(handler.requiresNodePayment(ANSWER_ONLY)).thenReturn(true);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryWorkflowImplTest.java
@@ -868,6 +868,29 @@ class QueryWorkflowImplTest extends AppTestBase {
     }
 
     @Test
+    void paidQueryDoesNotSubmitPaymentWhenResponseGenerationFails() throws PreCheckException, ParseException {
+        // given — a paid query that passes validation and throttling, but whose response generation then fails
+        mockQueryContext();
+        when(handler.requiresNodePayment(ANSWER_ONLY)).thenReturn(true);
+        doAnswer(invocationOnMock -> {
+                    final var result = invocationOnMock.getArgument(3, IngestChecker.Result.class);
+                    result.setThrottleUsages(List.of());
+                    result.setTxnInfo(transactionInfo);
+                    return null;
+                })
+                .when(ingestChecker)
+                .runAllChecks(any(), any(), any(), any());
+        when(handler.findResponse(any(), any())).thenThrow(new RuntimeException("response generation failed"));
+        final var responseBuffer = newEmptyBuffer();
+
+        // when
+        workflow.handleQuery(requestBuffer, responseBuffer);
+
+        // then — the node never produced an answer, so the payment is not submitted and the payer is not charged.
+        verify(submissionManager, never()).submit(any(), any(), anyBoolean());
+    }
+
+    @Test
     void testPaidQueryWithInvalidTransactionFails() throws PreCheckException, ParseException {
         // given
         when(handler.requiresNodePayment(ANSWER_ONLY)).thenReturn(true);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/queries/PaidQueryThrottleChargeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/queries/PaidQueryThrottleChargeTest.java
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.queries;
+
+import static com.hedera.services.bdd.junit.ContextRequirement.THROTTLE_OVERRIDES;
+import static com.hedera.services.bdd.junit.EmbeddedReason.NEEDS_STATE_ACCESS;
+import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingThrottles;
+import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
+
+import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+@Tag(CRYPTO)
+@DisplayName("Paid query throttling and charging")
+public class PaidQueryThrottleChargeTest {
+
+    private static final String THROTTLES = "testSystemFiles/crypto-get-info-only-throttle.json";
+
+    @LeakyEmbeddedHapiTest(
+            reason = NEEDS_STATE_ACCESS,
+            requirement = {THROTTLE_OVERRIDES},
+            throttles = "testSystemFiles/crypto-get-info-only-throttle.json")
+    @DisplayName("A throttled paid query does not charge the payer")
+    final Stream<DynamicTest> throttledPaidQueryDoesNotChargePayer() {
+        final var payer = "queryPayer";
+        return hapiTest(
+                overridingThrottles(THROTTLES),
+                cryptoCreate(payer).balance(ONE_HUNDRED_HBARS),
+                balanceSnapshot("before", payer),
+                // The CryptoGetInfo bucket is saturated to near-zero, so this paid query is throttled at the
+                // query-throttle step and answered BUSY. Its CryptoTransfer payment bucket stays generous, so the
+                // payment itself is not blocked at ingest.
+                getAccountInfo(payer).payingWith(payer).hasAnswerOnlyPrecheck(BUSY),
+                // Force a consensus round so that, if the query had submitted the payment, that transfer would be
+                // handled before we read the balance.
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                // The payment is submitted only after the throttle check passes, so a BUSY query never reaches
+                // submit() and the payer is not charged: its balance is unchanged.
+                getAccountBalance(payer).hasTinyBars(changeFromSnapshot("before", 0L)));
+    }
+}

--- a/hedera-node/test-clients/src/main/resources/testSystemFiles/crypto-get-info-only-throttle.json
+++ b/hedera-node/test-clients/src/main/resources/testSystemFiles/crypto-get-info-only-throttle.json
@@ -1,0 +1,90 @@
+{
+  "buckets": [
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 1000,
+      "name": "ThroughputLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 10500000,
+          "operations": [
+            "NodeCreate",
+            "NodeDelete",
+            "NodeUpdate",
+            "ScheduleCreate",
+            "CryptoCreate",
+            "CryptoTransfer",
+            "CryptoUpdate",
+            "CryptoDelete",
+            "CryptoGetAccountRecords",
+            "ConsensusCreateTopic",
+            "ConsensusSubmitMessage",
+            "ConsensusUpdateTopic",
+            "ConsensusDeleteTopic",
+            "ConsensusGetTopicInfo",
+            "TokenGetNftInfo",
+            "TokenGetInfo",
+            "ScheduleDelete",
+            "ScheduleGetInfo",
+            "FileGetContents",
+            "FileGetInfo",
+            "ContractUpdate",
+            "ContractDelete",
+            "ContractGetInfo",
+            "ContractGetBytecode",
+            "ContractGetRecords",
+            "ContractCallLocal",
+            "TransactionGetRecord",
+            "GetVersionInfo",
+            "TokenGetAccountNftInfos",
+            "TokenGetNftInfos",
+            "CryptoApproveAllowance",
+            "CryptoDeleteAllowance",
+            "UtilPrng",
+            "AtomicBatch"
+          ]
+        },
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 13000,
+          "operations": [
+            "FileCreate",
+            "FileUpdate",
+            "FileAppend",
+            "FileDelete"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 1000,
+      "name": "CryptoGetInfoLimit",
+      "throttleGroups": [
+        {
+          "opsPerSec": 0,
+          "milliOpsPerSec": 1,
+          "operations": [
+            "CryptoGetInfo"
+          ]
+        }
+      ]
+    },
+    {
+      "burstPeriod": 0,
+      "burstPeriodMs": 1000,
+      "name": "FreeQueryLimits",
+      "throttleGroups": [
+        {
+          "opsPerSec": 1000000,
+          "milliOpsPerSec": 0,
+          "operations": [
+            "TransactionGetReceipt",
+            "CryptoGetAccountBalance"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
**Description**:

On the paid-query path, `QueryWorkflowImpl.handleQuery` submitted the payer's `CryptoTransfer` payment (step 3.vi) *before* validating the query (step 4) and checking the query throttle (step 5). So a paid query that was throttled (`BUSY`) or failed validation still had its payment submitted to consensus — the payer was charged for a query that was never answered. The `catch` that reclaims throttle capacity wrapped only steps 3.i–3.vi, so it did not compensate for failures at steps 4–5 either.

This change:
- Captures the payment and submits it only *after* the query has been validated and has passed the throttle — i.e. once the node has committed to answering it.
- Reclaims the throttle capacity consumed at ingest and submits nothing if validation, throttling, or the submission itself fails.
- Leaves response generation (step 6) *outside* that block, so a failure there does not reclaim capacity for a payment already on its way to consensus. A node-side fault while generating the response therefore leaves the payer charged for work the node did attempt; such a fault surfaces as `FAIL_INVALID`, and is not something a client can provoke.
- Leaves the free / node-operator query path and super-user queries unchanged (they never submit a payment).

**Testing**:
- Unit (`QueryWorkflowImplTest`): a throttled paid query returns `BUSY` and never calls `submit`; an un-throttled paid query submits its payment; a paid query whose response generation fails has *already* submitted its payment and returns `FAIL_INVALID`.
- HAPI (`PaidQueryThrottleChargeTest`, embedded): a paid `CryptoGetInfo` whose query-throttle bucket is saturated — while its `CryptoTransfer` payment bucket is not — is answered `BUSY`, and the payer's balance is asserted unchanged. Before this change the same test fails: the payer is debited the query fee for the unanswered query. Adds the throttle-override resource `crypto-get-info-only-throttle.json` used by that test.
