### PR TITLE
fix: remove the insecure default for crypto.keystorePassword

### DIFF
--- a/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/config/CryptoConfig.java
+++ b/platform-sdk/base-crypto/src/main/java/org/hiero/base/crypto/config/CryptoConfig.java
@@ -14,4 +14,4 @@ import com.swirlds.config.api.ConfigProperty;
  */
 @ConfigData("crypto")
 public record CryptoConfig(
-        @ConfigProperty(defaultValue = "password") String keystorePassword) {}
+        @ConfigProperty(defaultValue = "") String keystorePassword) {}

--- a/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/config/CryptoConfigTest.java
+++ b/platform-sdk/base-crypto/src/test/java/org/hiero/base/crypto/config/CryptoConfigTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.base.crypto.config;
 
+import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -14,5 +15,22 @@ class CryptoConfigTest {
 
         // then
         Assertions.assertDoesNotThrow(() -> builder.build(), "All default values of CryptoConfig should be valid");
+    }
+
+    @Test
+    public void testNoUsableDefaultKeystorePassword() {
+        // given
+        final Configuration configuration = ConfigurationBuilder.create()
+                .withConfigDataType(CryptoConfig.class)
+                .build();
+
+        // when
+        final CryptoConfig cryptoConfig = configuration.getConfigData(CryptoConfig.class);
+
+        // then
+        Assertions.assertTrue(
+                cryptoConfig.keystorePassword() == null
+                        || cryptoConfig.keystorePassword().isBlank(),
+                "CryptoConfig must not provide a usable default keystore password");
     }
 }

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/modular/PeerCommunicationTests.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/modular/PeerCommunicationTests.java
@@ -58,6 +58,7 @@ public class PeerCommunicationTests {
         configurationBuilder.withValue("socket.timeoutServerAcceptConnect", "100");
         configurationBuilder.withValue("socket.timeoutSyncClientSocket", "100");
         configurationBuilder.withValue("socket.timeoutSyncClientConnect", "100");
+        configurationBuilder.withValue("crypto.keystorePassword", "password");
 
         this.configuration = configurationBuilder.build();
 

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/network/connectivity/ConnectivityTestBase.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/network/connectivity/ConnectivityTestBase.java
@@ -12,6 +12,7 @@ import java.net.Socket;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.base.crypto.config.CryptoConfig_;
 import org.hiero.consensus.gossip.config.SocketConfig;
 import org.hiero.consensus.gossip.config.SocketConfig_;
 
@@ -25,10 +26,14 @@ class ConnectivityTestBase {
     protected static final byte[] TEST_DATA = new byte[] {1, 2, 3};
 
     static {
-        TLS_NO_IP_TOS_CONFIG =
-                new TestConfigBuilder().withValue(SocketConfig_.IP_TOS, "-1").getOrCreateConfig();
-        TLS_IP_TOS_CONFIG =
-                new TestConfigBuilder().withValue(SocketConfig_.IP_TOS, "100").getOrCreateConfig();
+        TLS_NO_IP_TOS_CONFIG = new TestConfigBuilder()
+                .withValue(SocketConfig_.IP_TOS, "-1")
+                .withValue(CryptoConfig_.KEYSTORE_PASSWORD, "password")
+                .getOrCreateConfig();
+        TLS_IP_TOS_CONFIG = new TestConfigBuilder()
+                .withValue(SocketConfig_.IP_TOS, "100")
+                .withValue(CryptoConfig_.KEYSTORE_PASSWORD, "password")
+                .getOrCreateConfig();
 
         final Configuration configurationNoIpTos =
                 new TestConfigBuilder().withValue(SocketConfig_.IP_TOS, "-1").getOrCreateConfig();

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/network/connectivity/SocketFactoryTest.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/network/connectivity/SocketFactoryTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.base.crypto.config.CryptoConfig_;
 import org.hiero.consensus.gossip.config.GossipConfig;
 import org.hiero.consensus.gossip.config.GossipConfig_;
 import org.hiero.consensus.gossip.config.NetworkEndpoint;
@@ -159,6 +160,7 @@ class SocketFactoryTest extends ConnectivityTestBase {
                 .withValues(
                         GossipConfig_.INTERFACE_BINDINGS,
                         List.of("{ \"nodeId\": 0, \"hostname\": \"localhost\", \"port\": 1234 }"))
+                .withValue(CryptoConfig_.KEYSTORE_PASSWORD, "password")
                 .getOrCreateConfig();
         testInterfaceBinding(node0, roster, keysAndCerts, config, port);
     }
@@ -181,7 +183,9 @@ class SocketFactoryTest extends ConnectivityTestBase {
         assertTrue(roster.rosterEntries().size() > 1, "Address book must contain at least 2 nodes");
         final NodeId node0 = NodeId.of(roster.rosterEntries().getFirst().nodeId());
 
-        final Configuration config = new TestConfigBuilder().getOrCreateConfig();
+        final Configuration config = new TestConfigBuilder()
+                .withValue(CryptoConfig_.KEYSTORE_PASSWORD, "password")
+                .getOrCreateConfig();
         testInterfaceBinding(node0, roster, keysAndCerts, config, port);
     }
 
@@ -207,6 +211,7 @@ class SocketFactoryTest extends ConnectivityTestBase {
                 .withValues(
                         GossipConfig_.INTERFACE_BINDINGS,
                         List.of("{ \"nodeId\": 0, \"hostname\": \"10.123.123.123\", \"port\": 1234 }"))
+                .withValue(CryptoConfig_.KEYSTORE_PASSWORD, "password")
                 .getOrCreateConfig();
 
         assertThrows(BindException.class, () -> testInterfaceBinding(node0, roster, keysAndCerts, config, port));

--- a/platform-sdk/docs/consensus-layer/tunables.md
+++ b/platform-sdk/docs/consensus-layer/tunables.md
@@ -137,9 +137,9 @@ Startup-time OS health probes; values exceeded at startup produce warning logs b
 
 Module: `base-crypto`. Source: [CryptoConfig.java](../../base-crypto/src/main/java/org/hiero/base/crypto/config/CryptoConfig.java).
 
-|   ID    |            Key            |  Type  |  Default   |                                         Effect                                         | Range | Fragility |
-|---------|---------------------------|--------|------------|----------------------------------------------------------------------------------------|-------|-----------|
-| TUN-050 | `crypto.keystorePassword` | String | `password` | Password protecting the PKCS12 key stores that hold node RSA public/private key pairs. |       | —         |
+|   ID    |            Key            |  Type  | Default |                                                                                           Effect                                                                                           | Range | Fragility |
+|---------|---------------------------|--------|---------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------|-----------|
+| TUN-050 | `crypto.keystorePassword` | String | `""`    | Password protecting the PKCS12 key stores that hold node RSA public/private key pairs. Intentionally no usable default; node key loading and gossip TLS fail fast if it is not configured. |       | —         |
 
 ## BasicCommonConfig (no prefix)
 


### PR DESCRIPTION
**Description**

`CryptoConfig.keystorePassword` shipped `@ConfigProperty(defaultValue = "password")`. Its consumers (`CryptoUtils.getConfiguredKeystorePassword`, used by node key loading and gossip TLS setup) are written to fail fast when the password is not configured, but the non-blank `"password"` default meant that check never fired: an unconfigured node silently protected its PKCS12 key stores with the well-known string `"password"`.

This removes the default (sets it to `""`) so an unconfigured node fails fast during key loading / gossip TLS setup instead of falling back to `"password"`. It also updates the tunables doc and adds a test asserting there is no usable default.

**Compatibility — breaking change**

Any deployment that relied on the old `"password"` default will fail to start until `crypto.keystorePassword` is set. Existing nodes whose key stores were created with `"password"` must set `crypto.keystorePassword=password` (or re-key the stores) before upgrading; leaving it unset will fail fast. Sequence this with the deploy: set `crypto.keystorePassword` out of band and confirm the existing key stores open with it before this change lands.

**Testing**

- `base-crypto`: added `CryptoConfigTest.testNoUsableDefaultKeystorePassword` (the default is null/blank). The existing "all defaults valid" test still passes because `""` is a valid build-time value. 55 tests pass.
- `consensus-gossip-impl`: `SocketFactoryTest`, `ConnectivityTestBase`, and `PeerCommunicationTests` now set  `crypto.keystorePassword` explicitly (they relied on the old default). 253 tests pass.
- The only other tests that load key stores or set up TLS (`TlsFactoryTest`, `EnhancedKeyStoreLoaderTest`) already set the password and are unaffected.
- `./gradlew :base-crypto:test :consensus-gossip-impl:test` — pass.