### PR TITLE
fix: use long arithmetic for throttle requirement capacity math

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleReqsManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleReqsManager.java
@@ -54,7 +54,9 @@ public class ThrottleReqsManager {
             final var req = allReqs.get(i);
             final var opsRequired = req.getRight();
             final var bucket = req.getLeft();
-            bucket.leakCapacity(nTransactions * opsRequired * BucketThrottle.capacityUnitsPerTxn());
+            // Widen before multiplying: nTransactions * opsRequired is an int*int product that could
+            // wrap before it is widened by the long capacityUnitsPerTxn().
+            bucket.leakCapacity((long) nTransactions * opsRequired * BucketThrottle.capacityUnitsPerTxn());
         }
     }
 
@@ -68,7 +70,11 @@ public class ThrottleReqsManager {
             var req = allReqs.get(i);
             var opsRequired = req.getRight();
             if (scaleFactor != null) {
-                opsRequired = scaleFactor.scaling(nTransactions * opsRequired);
+                // Compute in long and clamp: nTransactions * opsRequired is an int*int product that could
+                // wrap to a small/negative value before scaling(); clamping to Integer.MAX_VALUE keeps
+                // scaling()'s existing large-input cap.
+                opsRequired =
+                        scaleFactor.scaling((int) Math.min((long) nTransactions * opsRequired, Integer.MAX_VALUE));
             }
             passedReq[i] = req.getLeft().allow(opsRequired, now);
             if (throttleUsages != null && passedReq[i]) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleReqsManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleReqsManagerTest.java
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.throttle;
+
+import static com.hedera.node.app.hapi.utils.sysfiles.domain.throttling.ScaleFactor.ONE_TO_ONE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import com.hedera.node.app.hapi.utils.throttles.DeterministicThrottle;
+import java.time.Instant;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ThrottleReqsManagerTest {
+
+    @Mock
+    private DeterministicThrottle throttle;
+
+    /**
+     * The scaled requirement handed to a bucket must reflect the true product of the logical-operation
+     * count and the per-transaction ops requirement. When that product exceeds {@link Integer#MAX_VALUE}
+     * it must be clamped (by {@link com.hedera.node.app.hapi.utils.sysfiles.domain.throttling.ScaleFactor})
+     * rather than wrapping: an int-only multiplication would wrap to a negative value that
+     * {@code scaling(...)} then floors to 1, silently under-counting the requirement.
+     */
+    @Test
+    void scalingUsesLongArithmeticForLargeLogicalOps() {
+        final int opsRequired = 3;
+        // 800_000_000 * 3 = 2_400_000_000, which is greater than Integer.MAX_VALUE (2_147_483_647).
+        final int nTransactions = 800_000_000;
+        final var subject = new ThrottleReqsManager(List.of(Pair.of(throttle, opsRequired)));
+
+        subject.allReqsMetAt(Instant.EPOCH, nTransactions, ONE_TO_ONE, null);
+
+        final var scaledOps = ArgumentCaptor.forClass(Integer.class);
+        verify(throttle).allow(scaledOps.capture(), any());
+        assertThat(scaledOps.getValue()).isEqualTo(Integer.MAX_VALUE);
+    }
+}


### PR DESCRIPTION
## Summary

`ThrottleReqsManager` computed per-bucket capacity requirements as
`nTransactions * opsRequired * capacityUnitsPerTxn()` (`undoClaimedReqsFor`) and
`scaleFactor.scaling(nTransactions * opsRequired)` (`allVerboseReqsMetAt`), where
`nTransactions * opsRequired` is an `int * int` product evaluated **before** it is widened to `long`.
For large operands this product can wrap, yielding an incorrect capacity requirement — in the
scaling path a wrapped-negative product is floored to `1` by `ScaleFactor.scaling`, silently
under-counting the requirement.

## Change

- Widen both multiplications to `long`.
- In the scaling path, compute the product in `long` and clamp to `Integer.MAX_VALUE` before passing
  it to `ScaleFactor.scaling(int)`, which preserves `scaling`'s existing large-input cap.

No behavioral change for existing operand ranges.

## Testing

Adds `ThrottleReqsManagerTest` covering the scaling path with a large logical-op count; it fails on
the previous `int` arithmetic (the scaled requirement floors to `1`) and passes with the widened
arithmetic (clamped to `Integer.MAX_VALUE`).
