### PR TITLE
chore: Proper bandwidth handling in Turtle

### DIFF
--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/internal/ConnectionPriorityTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/internal/ConnectionPriorityTest.java
@@ -2,6 +2,7 @@
 package org.hiero.otter.fixtures.internal;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hiero.otter.fixtures.internal.AbstractNetwork.BandwidthControlSupport.BANDWIDTH_CONTROL_SUPPORTED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -274,7 +275,7 @@ class ConnectionPriorityTest {
         private final ControllableTopology controllableTopology;
 
         TestableNetwork() {
-            super(new java.util.Random(42), false);
+            super(new java.util.Random(42), false, BANDWIDTH_CONTROL_SUPPORTED);
             this.controllableTopology = new ControllableTopology(super.topology());
         }
 

--- a/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/internal/UnidirectionalConnectionImplTest.java
+++ b/platform-sdk/consensus-otter-tests/src/test/java/org/hiero/otter/fixtures/internal/UnidirectionalConnectionImplTest.java
@@ -3,6 +3,7 @@ package org.hiero.otter.fixtures.internal;
 
 import static java.time.temporal.ChronoUnit.MILLIS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hiero.otter.fixtures.internal.AbstractNetwork.BandwidthControlSupport.BANDWIDTH_CONTROL_SUPPORTED;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -222,7 +223,7 @@ class UnidirectionalConnectionImplTest {
     private static class TestableNetwork extends AbstractNetwork {
 
         TestableNetwork() {
-            super(new java.util.Random(42), false);
+            super(new java.util.Random(42), false, BANDWIDTH_CONTROL_SUPPORTED);
         }
 
         @Override

--- a/platform-sdk/consensus-otter-tests/src/testChaos/java/org/hiero/otter/chaos/ChaosTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testChaos/java/org/hiero/otter/chaos/ChaosTest.java
@@ -1,10 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.otter.chaos;
 
+import static org.hiero.otter.fixtures.Capability.BANDWIDTH_CONTROL;
+import static org.hiero.otter.fixtures.Capability.RECONNECT;
+
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Duration;
 import org.hiero.consensus.reconnect.config.ReconnectConfig_;
-import org.hiero.otter.fixtures.Capability;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.OtterTest;
 import org.hiero.otter.fixtures.TestEnvironment;
@@ -15,7 +17,7 @@ import org.hiero.otter.fixtures.chaosbot.ChaosBotConfiguration;
  */
 class ChaosTest {
 
-    @OtterTest(requires = Capability.RECONNECT)
+    @OtterTest(requires = {RECONNECT, BANDWIDTH_CONTROL})
     void chaosTest(@NonNull final TestEnvironment env) {
         final Network network = env.network();
         network.addNodes(7);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Capability.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/Capability.java
@@ -23,5 +23,8 @@ public enum Capability {
     USES_REAL_NETWORK,
 
     /** The test requires deterministic execution (e.g. no random delays). */
-    DETERMINISTIC_EXECUTION;
+    DETERMINISTIC_EXECUTION,
+
+    /** The test requires the ability to control the bandwidth of the network. */
+    BANDWIDTH_CONTROL;
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerNetwork.java
@@ -2,6 +2,7 @@
 package org.hiero.otter.fixtures.container;
 
 import static java.util.Objects.requireNonNull;
+import static org.hiero.otter.fixtures.internal.AbstractNetwork.BandwidthControlSupport.BANDWIDTH_CONTROL_SUPPORTED;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -73,7 +74,7 @@ public class ContainerNetwork extends AbstractNetwork {
             final boolean proxyEnabled,
             final boolean gcLoggingEnabled,
             @NonNull final List<String> jvmArgs) {
-        super(new Random(), useRandomNodeIds);
+        super(new Random(), useRandomNodeIds, BANDWIDTH_CONTROL_SUPPORTED);
         this.timeManager = requireNonNull(timeManager);
         this.transactionGenerator = requireNonNull(transactionGenerator);
         this.rootOutputDirectory = requireNonNull(rootOutputDirectory);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerTestEnvironment.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/container/ContainerTestEnvironment.java
@@ -35,7 +35,8 @@ public class ContainerTestEnvironment implements TestEnvironment {
             Capability.RECONNECT,
             Capability.BACK_PRESSURE,
             Capability.SINGLE_NODE_JVM_SHUTDOWN,
-            Capability.USES_REAL_NETWORK));
+            Capability.USES_REAL_NETWORK,
+            Capability.BANDWIDTH_CONTROL));
 
     /** The granularity of time defining how often continuous assertions are checked */
     private static final Duration GRANULARITY = Duration.ofMillis(10);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/AbstractNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/internal/AbstractNetwork.java
@@ -95,6 +95,12 @@ import org.hiero.otter.fixtures.util.OtterSavedStateUtils;
  * environments.
  */
 public abstract class AbstractNetwork implements Network {
+
+    public enum BandwidthControlSupport {
+        BANDWIDTH_CONTROL_SUPPORTED,
+        BANDWIDTH_CONTROL_NOT_SUPPORTED
+    }
+
     /**
      * The fraction of nodes that must consider a node behind for the node to be considered behind by the network.
      */
@@ -133,6 +139,8 @@ public abstract class AbstractNetwork implements Network {
     private Topology currentTopology;
     protected final NetworkConfiguration networkConfiguration;
 
+    private final boolean bandwidthControlNotSupported;
+
     protected Lifecycle lifecycle = Lifecycle.INIT;
 
     protected WeightGenerator weightGenerator = WeightGenerators.REAL_NETWORK_GAUSSIAN;
@@ -144,13 +152,18 @@ public abstract class AbstractNetwork implements Network {
 
     private NodeId nextNodeId = NodeId.FIRST_NODE_ID;
 
-    protected AbstractNetwork(@NonNull final Random random, final boolean useRandomNodeIds) {
+    protected AbstractNetwork(
+            @NonNull final Random random,
+            final boolean useRandomNodeIds,
+            @NonNull final BandwidthControlSupport bandwidthControlSupport) {
         this.random = requireNonNull(random);
         this.useRandomNodeIds = useRandomNodeIds;
         // Initialize with default GeoMeshTopology
         this.currentTopology = new GeoMeshTopologyImpl(
                 GeoMeshTopologyConfiguration.DEFAULT, random, this::createNodes, this::createInstrumentedNode);
         this.networkConfiguration = new NetworkConfiguration();
+        this.bandwidthControlNotSupported =
+                bandwidthControlSupport != BandwidthControlSupport.BANDWIDTH_CONTROL_SUPPORTED;
     }
 
     /**
@@ -600,6 +613,9 @@ public abstract class AbstractNetwork implements Network {
      */
     @Override
     public void setBandwidthForAllConnections(@NonNull final Node node, @NonNull final BandwidthLimit bandwidthLimit) {
+        if (bandwidthControlNotSupported && !bandwidthLimit.isUnlimited()) {
+            throw new UnsupportedOperationException("Bandwidth control is not supported.");
+        }
         log.info("Setting bandwidth for all connections from node {} to {}", node.selfId(), bandwidthLimit);
         for (final Node otherNode : nodes()) {
             if (!node.equals(otherNode)) {
@@ -1330,6 +1346,9 @@ public abstract class AbstractNetwork implements Network {
         @Override
         public void bandwidthLimit(@NonNull final BandwidthLimit bandwidthLimit) {
             requireNonNull(bandwidthLimit);
+            if (bandwidthControlNotSupported && !bandwidthLimit.isUnlimited()) {
+                throw new UnsupportedOperationException("Bandwidth control is not supported.");
+            }
             log.info(
                     "Setting bandwidth limit from node {} to node {} to {}",
                     sender.selfId(),

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/turtle/TurtleNetwork.java
@@ -2,6 +2,7 @@
 package org.hiero.otter.fixtures.turtle;
 
 import static java.util.Objects.requireNonNull;
+import static org.hiero.otter.fixtures.internal.AbstractNetwork.BandwidthControlSupport.BANDWIDTH_CONTROL_NOT_SUPPORTED;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import com.hedera.hapi.node.state.roster.Roster;
@@ -71,7 +72,7 @@ public class TurtleNetwork extends AbstractNetwork implements TimeTickReceiver {
             @NonNull final Path rootOutputDirectory,
             @NonNull final TurtleTransactionGenerator transactionGenerator,
             final boolean useRandomNodeIds) {
-        super(randotron, useRandomNodeIds);
+        super(randotron, useRandomNodeIds, BANDWIDTH_CONTROL_NOT_SUPPORTED);
         this.randotron = requireNonNull(randotron);
         this.timeManager = requireNonNull(timeManager);
         this.logging = requireNonNull(logging);

--- a/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/ReconnectTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/ReconnectTest.java
@@ -8,6 +8,7 @@ import static org.hiero.consensus.model.status.PlatformStatus.OBSERVING;
 import static org.hiero.consensus.model.status.PlatformStatus.RECONNECT_COMPLETE;
 import static org.hiero.consensus.model.status.PlatformStatus.REPLAYING_EVENTS;
 import static org.hiero.consensus.test.fixtures.WeightGenerators.TOTAL_NETWORK_WEIGHT;
+import static org.hiero.otter.fixtures.Capability.*;
 import static org.hiero.otter.fixtures.OtterAssertions.assertContinuouslyThat;
 import static org.hiero.otter.fixtures.OtterAssertions.assertThat;
 import static org.hiero.otter.fixtures.assertions.StatusProgressionStep.target;
@@ -22,7 +23,6 @@ import java.util.stream.IntStream;
 import org.hiero.consensus.hashgraph.config.ConsensusConfig_;
 import org.hiero.consensus.reconnect.config.ReconnectConfig_;
 import org.hiero.consensus.transaction.handling.config.TransactionHandlingWiringConfig_;
-import org.hiero.otter.fixtures.Capability;
 import org.hiero.otter.fixtures.Network;
 import org.hiero.otter.fixtures.Node;
 import org.hiero.otter.fixtures.OtterTest;
@@ -50,7 +50,7 @@ public class ReconnectTest {
      *
      * @param env the test environment
      */
-    @OtterTest(requires = Capability.RECONNECT)
+    @OtterTest(requires = RECONNECT)
     void testNodeDeathReconnect(@NonNull final TestEnvironment env) {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();
@@ -141,7 +141,7 @@ public class ReconnectTest {
      *
      * @param env the test environment
      */
-    @OtterTest(requires = Capability.BACK_PRESSURE)
+    @OtterTest(requires = BACK_PRESSURE)
     void testSyntheticBottleneckReconnect(final TestEnvironment env) {
         final int numReconnectCycles = 2;
         final Network network = env.network();
@@ -247,7 +247,7 @@ public class ReconnectTest {
      *
      * @param env the test environment
      */
-    @OtterTest(requires = Capability.RECONNECT)
+    @OtterTest(requires = {RECONNECT, BANDWIDTH_CONTROL})
     void testReconnectSucceedsAfterFailure(@NonNull final TestEnvironment env) {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();
@@ -307,7 +307,7 @@ public class ReconnectTest {
      *
      * @param env the test environment
      */
-    @OtterTest(requires = {Capability.RECONNECT, Capability.SINGLE_NODE_JVM_SHUTDOWN})
+    @OtterTest(requires = {RECONNECT, SINGLE_NODE_JVM_SHUTDOWN, BANDWIDTH_CONTROL})
     void testNodeShutsDownAfterMaxFailedReconnects(@NonNull final TestEnvironment env) {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();
@@ -352,7 +352,7 @@ public class ReconnectTest {
                 "Node did not shut down within the expected time frame after exceeding the maximum number of failed reconnects.");
     }
 
-    @OtterTest(requires = {Capability.RECONNECT, Capability.SINGLE_NODE_JVM_SHUTDOWN})
+    @OtterTest(requires = {RECONNECT, SINGLE_NODE_JVM_SHUTDOWN, BANDWIDTH_CONTROL})
     void testIsolateNodeWhileReconnectingAndRestore(@NonNull final TestEnvironment env) {
         final Network network = env.network();
         final TimeManager timeManager = env.timeManager();


### PR DESCRIPTION
**Description**:

Turtle does not support configuring connection bandwidth. Any attempt is currently silently ignored. This PR introduces the `BANDWIDTH_CONTROL` capability and throws an `UnsupportedOperationException` when attempting to limit bandwidth.

**Related issue(s)**:

Fixes #26779 