### PR TITLE
fix: 26788: (0.78) 0.77 snapshots cannot be loaded, unknown data source metadata field

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -80,6 +80,11 @@ public final class MerkleDbDataSource implements VirtualDataSource {
     private static final FieldDefinition FIELD_DSMETADATA_INITIALCAPACITY =
             new FieldDefinition("initialCapacity", FieldType.UINT64, false, true, false, 3);
 
+    // FUTURE WORK: this field will be removed completely in 0.79
+    @Deprecated
+    private static final FieldDefinition FIELD_DSMETADATA_HASHESRAMTODISKTHRESHOLD =
+            new FieldDefinition("hashesRamToDiskThreshold", FieldType.UINT64, false, true, false, 4);
+
     private static final FieldDefinition FIELD_DSMETADATA_HASHCHUNKHEIGHT =
             new FieldDefinition("hashChunkHeight", FieldType.UINT32, false, true, false, 7);
 
@@ -1002,6 +1007,9 @@ public final class MerkleDbDataSource implements VirtualDataSource {
                         maxValidKey = in.readVarLong(false);
                     } else if (fieldNum == FIELD_DSMETADATA_INITIALCAPACITY.number()) {
                         initialCapacity = in.readVarLong(false);
+                    } else if (fieldNum == FIELD_DSMETADATA_HASHESRAMTODISKTHRESHOLD.number()) {
+                        // Skip hashesRamToDiskThreshold field, it is no longer used
+                        in.readVarLong(false);
                     } else if (fieldNum == FIELD_DSMETADATA_HASHCHUNKHEIGHT.number()) {
                         final int hashChunkHeight = in.readVarInt(false);
                         if (this.hashChunkHeight != hashChunkHeight) {


### PR DESCRIPTION
Fix summary: this is the same fix as https://github.com/hiero-ledger/hiero-consensus-node/pull/26744, which will never be merged to `main`, as no changes in release 0.79 are needed. That PR will be closed shortly.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/26788
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
