### PR TITLE
chore: remove SelfSerializable from NodeId

### DIFF
--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/node/NodeId.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/node/NodeId.java
@@ -2,29 +2,12 @@
 package org.hiero.consensus.model.node;
 
 import edu.umd.cs.findbugs.annotations.NonNull;
-import java.io.IOException;
 import java.util.Objects;
-import org.hiero.base.io.SelfSerializable;
-import org.hiero.base.io.streams.SerializableDataInputStream;
-import org.hiero.base.io.streams.SerializableDataOutputStream;
 
 /**
  * A class that is used to uniquely identify a Swirlds Node.
  */
-public class NodeId implements Comparable<NodeId>, SelfSerializable {
-
-    /** The class identifier for this class. */
-    private static final long CLASS_ID = 0xea520dcf050bcaadL;
-
-    /** The class version for this class. */
-    public static final class ClassVersion {
-        /**
-         * The original version of the class.
-         *
-         * @since 0.39.0
-         */
-        public static final int ORIGINAL = 1;
-    }
+public class NodeId implements Comparable<NodeId> {
 
     /** The undefined NodeId. */
     public static final NodeId UNDEFINED_NODE_ID = null;
@@ -69,30 +52,6 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
     }
 
     /**
-     * {@inheritDoc}
-     */
-    @Override
-    public long getClassId() {
-        return CLASS_ID;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int getVersion() {
-        return ClassVersion.ORIGINAL;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public int getMinimumSupportedVersion() {
-        return ClassVersion.ORIGINAL;
-    }
-
-    /**
      * Gets the long value of the NodeId
      *
      * @return the long value of the NodeId
@@ -132,40 +91,6 @@ public class NodeId implements Comparable<NodeId>, SelfSerializable {
     @Override
     public String toString() {
         return Long.toString(id);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void serialize(SerializableDataOutputStream out) throws IOException {
-        out.writeLong(id);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void deserialize(SerializableDataInputStream in, int version) throws IOException {
-        id = in.readLong();
-    }
-
-    /**
-     * Deserialize a NodeId from a {@link SerializableDataInputStream}.
-     *
-     * @param in the {@link SerializableDataInputStream} to read from
-     * @return the deserialized NodeId
-     * @throws IOException thrown if an exception occurs while reading from the stream or the long value is negative,
-     */
-    public static NodeId deserializeLong(SerializableDataInputStream in, boolean allowNull) throws IOException {
-        final long longValue = in.readLong();
-        if (longValue < LOWEST_NODE_NUMBER) {
-            if (allowNull) {
-                return null;
-            }
-            throw new IOException("id must be non-negative");
-        }
-        return NodeId.of(longValue);
     }
 
     /**

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/constructable/ConstructableRegistration.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/constructable/ConstructableRegistration.java
@@ -37,7 +37,6 @@ public final class ConstructableRegistration {
         registry.registerConstructable(
                 new ClassConstructorPair(SerializablePublicKey.class, SerializablePublicKey::new));
         registry.registerConstructable(new ClassConstructorPair(CesEvent.class, CesEvent::new));
-        registry.registerConstructable(new ClassConstructorPair(NodeId.class, NodeId::new));
     }
 
     /**

--- a/platform-sdk/consensus-utility/src/test/java/org/hiero/consensus/scratchpad/ScratchpadTests.java
+++ b/platform-sdk/consensus-utility/src/test/java/org/hiero/consensus/scratchpad/ScratchpadTests.java
@@ -57,7 +57,6 @@ class ScratchpadTests {
     static void beforeAll() throws ConstructableRegistryException {
         final ConstructableRegistry registry = ConstructableRegistry.getInstance();
         registry.registerConstructable(new ClassConstructorPair(Hash.class, Hash::new));
-        registry.registerConstructable(new ClassConstructorPair(NodeId.class, NodeId::new));
         registry.registerConstructable(new ClassConstructorPair(SerializableLong.class, SerializableLong::new));
     }
 
@@ -98,12 +97,9 @@ class ScratchpadTests {
         assertEquals(long1, scratchpad.get(TestScratchpadType.BAR));
         assertNull(scratchpad.get(TestScratchpadType.BAZ));
 
-        final NodeId nodeId1 = NodeId.of(random.nextInt(0, 1000));
-        assertNull(scratchpad.set(TestScratchpadType.BAZ, nodeId1));
         assertEquals(1, scratchpadDirectory.toFile().listFiles().length);
         assertEquals(hash1, scratchpad.get(TestScratchpadType.FOO));
         assertEquals(long1, scratchpad.get(TestScratchpadType.BAR));
-        assertEquals(nodeId1, scratchpad.get(TestScratchpadType.BAZ));
 
         // Overwrite an existing value
 
@@ -112,21 +108,16 @@ class ScratchpadTests {
         assertEquals(1, scratchpadDirectory.toFile().listFiles().length);
         assertEquals(hash2, scratchpad.get(TestScratchpadType.FOO));
         assertEquals(long1, scratchpad.get(TestScratchpadType.BAR));
-        assertEquals(nodeId1, scratchpad.get(TestScratchpadType.BAZ));
 
         final SerializableLong long2 = new SerializableLong(random.nextLong());
         assertEquals(long1, scratchpad.set(TestScratchpadType.BAR, long2));
         assertEquals(1, scratchpadDirectory.toFile().listFiles().length);
         assertEquals(hash2, scratchpad.get(TestScratchpadType.FOO));
         assertEquals(long2, scratchpad.get(TestScratchpadType.BAR));
-        assertEquals(nodeId1, scratchpad.get(TestScratchpadType.BAZ));
 
-        final NodeId nodeId2 = NodeId.of(random.nextInt(1001, 2000));
-        assertEquals(nodeId1, scratchpad.set(TestScratchpadType.BAZ, nodeId2));
         assertEquals(1, scratchpadDirectory.toFile().listFiles().length);
         assertEquals(hash2, scratchpad.get(TestScratchpadType.FOO));
         assertEquals(long2, scratchpad.get(TestScratchpadType.BAR));
-        assertEquals(nodeId2, scratchpad.get(TestScratchpadType.BAZ));
 
         // Clear the scratchpad
 
@@ -152,12 +143,9 @@ class ScratchpadTests {
         assertEquals(long3, scratchpad.get(TestScratchpadType.BAR));
         assertNull(scratchpad.get(TestScratchpadType.BAZ));
 
-        final NodeId nodeId3 = NodeId.of(random.nextInt(2001, 3000));
-        assertNull(scratchpad.set(TestScratchpadType.BAZ, nodeId3));
         assertEquals(1, scratchpadDirectory.toFile().listFiles().length);
         assertEquals(hash3, scratchpad.get(TestScratchpadType.FOO));
         assertEquals(long3, scratchpad.get(TestScratchpadType.BAR));
-        assertEquals(nodeId3, scratchpad.get(TestScratchpadType.BAZ));
 
         // Simulate a restart
         final Scratchpad<TestScratchpadType> scratcphad2 =
@@ -167,7 +155,6 @@ class ScratchpadTests {
         assertEquals(1, scratchpadDirectory.toFile().listFiles().length);
         assertEquals(hash3, scratcphad2.get(TestScratchpadType.FOO));
         assertEquals(long3, scratcphad2.get(TestScratchpadType.BAR));
-        assertEquals(nodeId3, scratcphad2.get(TestScratchpadType.BAZ));
     }
 
     /**
@@ -247,12 +234,10 @@ class ScratchpadTests {
 
         final Hash hash1 = randomHash(random);
         final SerializableLong long1 = new SerializableLong(random.nextLong());
-        final NodeId nodeId1 = NodeId.of(random.nextInt(0, 1000));
 
         scratchpad.atomicOperation(map -> {
             assertNull(map.put(TestScratchpadType.FOO, hash1));
             assertNull(map.put(TestScratchpadType.BAR, long1));
-            assertNull(map.put(TestScratchpadType.BAZ, nodeId1));
 
             return true;
         });
@@ -264,7 +249,6 @@ class ScratchpadTests {
 
         assertEquals(hash1, scratchpad.get(TestScratchpadType.FOO));
         assertEquals(long1, scratchpad.get(TestScratchpadType.BAR));
-        assertEquals(nodeId1, scratchpad.get(TestScratchpadType.BAZ));
 
         // Overwrite an existing value
 
@@ -275,7 +259,6 @@ class ScratchpadTests {
         scratchpad.atomicOperation(map -> {
             assertEquals(hash1, map.put(TestScratchpadType.FOO, hash2));
             assertEquals(long1, map.put(TestScratchpadType.BAR, long2));
-            assertEquals(nodeId1, map.put(TestScratchpadType.BAZ, nodeId2));
 
             return true;
         });
@@ -318,7 +301,6 @@ class ScratchpadTests {
         scratchpad.atomicOperation(map -> {
             assertNull(map.put(TestScratchpadType.FOO, hash3));
             assertNull(map.put(TestScratchpadType.BAR, long3));
-            assertNull(map.put(TestScratchpadType.BAZ, nodeId3));
 
             return true;
         });

--- a/platform-sdk/consensus-utility/src/test/java/org/hiero/consensus/scratchpad/ScratchpadTests.java
+++ b/platform-sdk/consensus-utility/src/test/java/org/hiero/consensus/scratchpad/ScratchpadTests.java
@@ -294,7 +294,6 @@ class ScratchpadTests {
 
         final Hash hash3 = randomHash(random);
         final SerializableLong long3 = new SerializableLong(random.nextLong());
-        final NodeId nodeId3 = NodeId.of(random.nextInt(2001, 3000));
 
         scratchpad.atomicOperation(map -> {
             assertNull(map.put(TestScratchpadType.FOO, hash3));
@@ -310,7 +309,6 @@ class ScratchpadTests {
 
         assertEquals(hash3, scratchpad.get(TestScratchpadType.FOO));
         assertEquals(long3, scratchpad.get(TestScratchpadType.BAR));
-        assertEquals(nodeId3, scratchpad.get(TestScratchpadType.BAZ));
 
         // Simulate a restart
         final Scratchpad<TestScratchpadType> scratchpad2 =
@@ -322,7 +320,6 @@ class ScratchpadTests {
         scratchpad2.atomicOperation(map -> {
             assertEquals(hash3, map.get(TestScratchpadType.FOO));
             assertEquals(long3, map.get(TestScratchpadType.BAR));
-            assertEquals(nodeId3, map.get(TestScratchpadType.BAZ));
 
             return true;
         });
@@ -332,14 +329,12 @@ class ScratchpadTests {
 
         assertEquals(hash3, scratchpad2.get(TestScratchpadType.FOO));
         assertEquals(long3, scratchpad2.get(TestScratchpadType.BAR));
-        assertEquals(nodeId3, scratchpad2.get(TestScratchpadType.BAZ));
 
         // Should have no effect.
         scratchpad.atomicOperation(map -> false);
 
         assertEquals(hash3, scratchpad2.get(TestScratchpadType.FOO));
         assertEquals(long3, scratchpad2.get(TestScratchpadType.BAR));
-        assertEquals(nodeId3, scratchpad2.get(TestScratchpadType.BAZ));
     }
 
     @Test

--- a/platform-sdk/consensus-utility/src/test/java/org/hiero/consensus/scratchpad/ScratchpadTests.java
+++ b/platform-sdk/consensus-utility/src/test/java/org/hiero/consensus/scratchpad/ScratchpadTests.java
@@ -254,7 +254,6 @@ class ScratchpadTests {
 
         final Hash hash2 = randomHash(random);
         final SerializableLong long2 = new SerializableLong(random.nextLong());
-        final NodeId nodeId2 = NodeId.of(random.nextInt(1001, 2000));
 
         scratchpad.atomicOperation(map -> {
             assertEquals(hash1, map.put(TestScratchpadType.FOO, hash2));
@@ -270,7 +269,6 @@ class ScratchpadTests {
 
         assertEquals(hash2, scratchpad.get(TestScratchpadType.FOO));
         assertEquals(long2, scratchpad.get(TestScratchpadType.BAR));
-        assertEquals(nodeId2, scratchpad.get(TestScratchpadType.BAZ));
 
         // Clear the scratchpad
 


### PR DESCRIPTION
**Description**:
Part of the bigger task of getting rid of SelfSerialiable. NodeId had the issue with slightly wrong deserialization, so removing it early helps with buggy node scans.

**Related issue(s)**:

Fixes #26756 


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
