### PR TITLE
ci(fix): use specific TCK & JS SDK versions

### DIFF
--- a/.github/workflows/819-call-tck-regression.yaml
+++ b/.github/workflows/819-call-tck-regression.yaml
@@ -179,7 +179,7 @@ jobs:
           echo "Using proto version: ${PROTO_VERSION}"
 
           # Install with the extracted versions
-          pnpm add @hiero-ledger/sdk@^${SDK_VERSION} long@${LONG_VERSION} @hiero-ledger/proto@${PROTO_VERSION}
+          pnpm add @hiero-ledger/sdk@${SDK_VERSION} long@${LONG_VERSION} @hiero-ledger/proto@${PROTO_VERSION}
           pnpm install
           nohup pnpm start &
           server_pid=$!

--- a/.github/workflows/821-call-block-node-regression.yaml
+++ b/.github/workflows/821-call-block-node-regression.yaml
@@ -238,7 +238,7 @@ jobs:
           # (e.g. protobufjs 8.0.1 in lockfile vs 8.2.0 in manifest, caused by
           # pnpm.overrides being silently ignored in pnpm v11+).
           # --ignore-scripts skips unapproved build scripts (ERR_PNPM_IGNORED_BUILDS).
-          pnpm add "@hiero-ledger/sdk@^${SDK_VERSION}" "long@${LONG_VERSION}" "@hiero-ledger/proto@${PROTO_VERSION}"
+          pnpm add "@hiero-ledger/sdk@${SDK_VERSION}" "long@${LONG_VERSION}" "@hiero-ledger/proto@${PROTO_VERSION}"
           pnpm install --no-frozen-lockfile --ignore-scripts
           nohup pnpm start &
           server_pid=$!


### PR DESCRIPTION
**Description**:

Update the pnpm install to use specific versions instead of allowing ranges.

**Related issue(s)**:

Fixes broken run https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/31612045838/job/94201992247

**Checklist**

- [ ] Tested (unit, integration, etc.)
