### PR TITLE
fix: Remove RpcOverloadMonitor race condition

### DIFF
--- a/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/RpcOverloadMonitor.java
+++ b/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/RpcOverloadMonitor.java
@@ -14,6 +14,7 @@ import org.hiero.consensus.gossip.impl.gossip.sync.SyncMetrics;
  * callback about being 'overloaded' Please see {@link BroadcastConfig#throttleOutputQueueThreshold()},
  * {@link BroadcastConfig#disablePingThreshold()} and {@link BroadcastConfig#pauseOnLag()} for configuration
  * options
+ * This class is not thread safe, all methods should be called from the same thread.
  */
 public class RpcOverloadMonitor {
 
@@ -24,8 +25,8 @@ public class RpcOverloadMonitor {
     private final Time time;
     private final Consumer<Boolean> communicationOverloadHandler;
 
-    private volatile long disabledBroadcastDueToQueueSizeTime = ENABLED;
-    private volatile long disabledBroadcastDueToLagTime = ENABLED;
+    private long disabledBroadcastDueToQueueSizeTime = ENABLED;
+    private long disabledBroadcastDueToLagTime = ENABLED;
 
     public RpcOverloadMonitor(
             @NonNull final BroadcastConfig syncConfig,

--- a/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/RpcPeerProtocol.java
+++ b/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/RpcPeerProtocol.java
@@ -481,7 +481,10 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
                             final long correlationId = input.readLong();
                             final long pingMillis =
                                     TimeUnit.NANOSECONDS.toMillis(pingHandler.handleIncomingPingReply(correlationId));
-                            overloadMonitor.reportPing(pingMillis);
+                            // we are still reporting delay to receive, not to handle
+                            // we want to measure the network ping, rather than dispatch thread ping
+                            // it is still handled over there, to make overloadMonitor managed from same thread
+                            inputQueue.add(() -> overloadMonitor.reportPing(pingMillis));
                             break;
                     }
                 }

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/RpcOverloadMonitorTest.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/RpcOverloadMonitorTest.java
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-package com.swirlds.platform.gossip;
+package org.hiero.consensus.gossip.impl.gossip;
 
 // this class should be moved to a different package, but modules are WIP as of now and it is not possible to do that
 // without breaking build


### PR DESCRIPTION
**Description**:
Given that RpcOverloadMonitor was updated from two different threads, even in the presence of volatiles, there could be a strange ordering of updates, which would lead to a delayed reaction to overload or going out of overload.

This change simplifies handling, as everything will be done from the same (dispatch) thread.

**Related issue(s)**:

Fixes #26762 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
