### PR TITLE
fix: Calculate Auto Associations when charging gas for ERC transfers

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/ClassicTransfersCall.java
@@ -162,12 +162,7 @@ public class ClassicTransfersCall extends AbstractCall {
         } else {
             recordBuilder.status(callStatusStandardizer.codeForFailure(recordBuilder.status(), frame, op));
         }
-        if (recordBuilder.getNumAutoAssociations() > 0) {
-            if (configOf(frame).getConfigData(EntitiesConfig.class).unlimitedAutoAssociationsEnabled()) {
-                gasRequirement +=
-                        recordBuilder.getNumAutoAssociations() * gasCalculator.canonicalGasRequirement(ASSOCIATE);
-            }
-        }
+        gasRequirement += autoAssociationGasRequirement(frame, recordBuilder, gasCalculator);
         return completionWith(gasRequirement, recordBuilder, encodedRc(recordBuilder.status()));
     }
 
@@ -212,6 +207,33 @@ public class ClassicTransfersCall extends AbstractCall {
                 baseLazyCreationPrice,
                 extantAccounts);
         return systemContractGasCalculator.gasRequirementWithTinycents(body, payerId, minimumTinycentPrice);
+    }
+
+    /**
+     * Returns the extra gas to charge for any auto-associations created by a dispatched transfer.
+     *
+     * <p>The token service does not charge auto-association fees inline for internal dispatches, precisely because
+     * the contract service is expected to take those costs from the remaining EVM gas here; so every transfer call
+     * that dispatches a synthetic body must apply this top-up. Note it can only be computed after the dispatch,
+     * since the number of auto-associations is not derivable from the synthetic body alone.
+     *
+     * @param frame                       the frame of the transfer call
+     * @param recordBuilder               the stream builder of the dispatched transfer
+     * @param systemContractGasCalculator the gas calculator to use
+     * @return the extra gas to charge, zero if there were no auto-associations
+     */
+    public static long autoAssociationGasRequirement(
+            @NonNull final MessageFrame frame,
+            @NonNull final ContractCallStreamBuilder recordBuilder,
+            @NonNull final SystemContractGasCalculator systemContractGasCalculator) {
+        final var numAutoAssociations = recordBuilder.getNumAutoAssociations();
+        // The "sender pays" fee model only applies when using unlimited auto-associations; note we check the
+        // association count first so that we only need the frame's configuration when there is something to charge
+        if (numAutoAssociations > 0
+                && configOf(frame).getConfigData(EntitiesConfig.class).unlimitedAutoAssociationsEnabled()) {
+            return numAutoAssociations * systemContractGasCalculator.canonicalGasRequirement(ASSOCIATE);
+        }
+        return 0L;
     }
 
     @VisibleForTesting

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc20TransfersCall.java
@@ -7,6 +7,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.revertResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.successResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call.PricedResult.gasOnly;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersCall.autoAssociationGasRequirement;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersCall.transferGasRequirement;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc20TransfersTranslator.ERC_20_TRANSFER;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc20TransfersTranslator.ERC_20_TRANSFER_FROM;
@@ -102,12 +103,14 @@ public class Erc20TransfersCall extends AbstractCall {
     public @NonNull PricedResult execute(@NonNull final MessageFrame frame) {
         // https://eips.ethereum.org/EIPS/eip-20
         final var syntheticTransfer = syntheticTransferOrTransferFrom(senderId);
-        final var gasRequirement = transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId);
+        // When unlimited associations are enabled, will be updated with additional charges for any auto-associations
+        var gasRequirement = transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId);
         if (tokenId == null) {
             return reversionWith(INVALID_TOKEN_ID, gasRequirement);
         }
         final var recordBuilder = systemContractOperations()
                 .dispatch(syntheticTransfer, verificationStrategy, senderId, ContractCallStreamBuilder.class);
+        gasRequirement += autoAssociationGasRequirement(frame, recordBuilder, gasCalculator);
         final var status = recordBuilder.status();
         if (status != SUCCESS) {
             if (status == NOT_SUPPORTED) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromCall.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/hts/transfer/Erc721TransferFromCall.java
@@ -5,6 +5,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.revertResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult.successResult;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.common.Call.PricedResult.gasOnly;
+import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersCall.autoAssociationGasRequirement;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.ClassicTransfersCall.transferGasRequirement;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc721TransferFromTranslator.ERC_721_TRANSFER_FROM;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.TransferEventLoggingUtils.logSuccessfulNftTransfer;
@@ -87,9 +88,11 @@ public class Erc721TransferFromCall extends AbstractCall {
             return reversionWith(INVALID_TOKEN_ID, gasCalculator.canonicalGasRequirement(DispatchType.TRANSFER_NFT));
         }
         final var syntheticTransfer = syntheticTransfer(senderId);
-        final var gasRequirement = transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId);
+        // When unlimited associations are enabled, will be updated with additional charges for any auto-associations
+        var gasRequirement = transferGasRequirement(syntheticTransfer, gasCalculator, enhancement, senderId);
         final var recordBuilder = systemContractOperations()
                 .dispatch(syntheticTransfer, verificationStrategy, senderId, ContractCallStreamBuilder.class);
+        gasRequirement += autoAssociationGasRequirement(frame, recordBuilder, gasCalculator);
         final var status = recordBuilder.status();
         if (status != ResponseCodeEnum.SUCCESS) {
             return gasOnly(revertResult(recordBuilder, gasRequirement), status, false);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/ClassicTransfersCallTest.java
@@ -8,7 +8,9 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SPENDER_DOES_NOT_HAVE_ALLOWANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
+import static com.hedera.node.app.service.contract.impl.exec.gas.DispatchType.ASSOCIATE;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.ReturnTypes.tuweniEncodedRc;
+import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.CONFIG_CONTEXT_VARIABLE;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.ALIASED_RECEIVER;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.A_NEW_ACCOUNT_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_CONFIG;
@@ -51,7 +53,11 @@ import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.commo
 import com.hedera.node.app.service.token.ReadableAccountStore;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -65,6 +71,10 @@ import org.mockito.Mockito;
 
 class ClassicTransfersCallTest extends CallTestBase {
     private static final TupleType<Tuple> INT64_ENCODER = TupleType.parse(ReturnTypes.INT_64);
+    private static final Configuration NO_UNLIMITED_ASSOCIATIONS_CONFIG = HederaTestConfigBuilder.create()
+            .withValue("entities.unlimitedAutoAssociationsEnabled", false)
+            .getOrCreateConfig();
+    private static final long CANONICAL_ASSOCIATE_GAS = 704_000L;
 
     @Mock
     private VerificationStrategy verificationStrategy;
@@ -114,6 +124,53 @@ class ClassicTransfersCallTest extends CallTestBase {
 
         assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.state());
         assertEquals(tuweniEncodedRc(SUCCESS), result.output());
+    }
+
+    @Test
+    void chargesGasForAutoAssociationsCreatedByTransfer() {
+        givenRetryingSubject();
+        givenFrameConfig(DEFAULT_CONFIG);
+        given(systemContractOperations.dispatch(
+                        any(TransactionBody.class),
+                        eq(verificationStrategy),
+                        eq(A_NEW_ACCOUNT_ID),
+                        eq(ContractCallStreamBuilder.class)))
+                .willReturn(recordBuilder);
+        given(recordBuilder.status()).willReturn(SUCCESS);
+        given(recordBuilder.getNumAutoAssociations()).willReturn(2);
+        given(systemContractGasCalculator.canonicalGasRequirement(ASSOCIATE)).willReturn(CANONICAL_ASSOCIATE_GAS);
+        given(systemContractOperations.signatureTestWith(verificationStrategy)).willReturn(signatureTest);
+        given(approvalSwitchHelper.switchToApprovalsAsNeededIn(
+                        CryptoTransferTransactionBody.DEFAULT, signatureTest, nativeOperations, A_NEW_ACCOUNT_ID))
+                .willReturn(CryptoTransferTransactionBody.DEFAULT);
+
+        final var result = subject.execute(frame).fullResult();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.result().state());
+        assertEquals(2 * CANONICAL_ASSOCIATE_GAS, result.gasRequirement());
+    }
+
+    @Test
+    void doesNotChargeAutoAssociationGasIfUnlimitedAssociationsDisabled() {
+        givenRetryingSubject();
+        givenFrameConfig(NO_UNLIMITED_ASSOCIATIONS_CONFIG);
+        given(systemContractOperations.dispatch(
+                        any(TransactionBody.class),
+                        eq(verificationStrategy),
+                        eq(A_NEW_ACCOUNT_ID),
+                        eq(ContractCallStreamBuilder.class)))
+                .willReturn(recordBuilder);
+        given(recordBuilder.status()).willReturn(SUCCESS);
+        given(recordBuilder.getNumAutoAssociations()).willReturn(2);
+        given(systemContractOperations.signatureTestWith(verificationStrategy)).willReturn(signatureTest);
+        given(approvalSwitchHelper.switchToApprovalsAsNeededIn(
+                        CryptoTransferTransactionBody.DEFAULT, signatureTest, nativeOperations, A_NEW_ACCOUNT_ID))
+                .willReturn(CryptoTransferTransactionBody.DEFAULT);
+
+        final var result = subject.execute(frame).fullResult();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.result().state());
+        assertEquals(0L, result.gasRequirement());
     }
 
     @Test
@@ -316,6 +373,13 @@ class ClassicTransfersCallTest extends CallTestBase {
     private static final TransactionBody PRETEND_TRANSFER = TransactionBody.newBuilder()
             .cryptoTransfer(CryptoTransferTransactionBody.DEFAULT)
             .build();
+
+    private void givenFrameConfig(@NonNull final Configuration config) {
+        final Deque<MessageFrame> stack = new ArrayDeque<>();
+        stack.push(frame);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(frame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(config);
+    }
 
     private void givenRetryingSubject() {
         subject = new ClassicTransfersCall(

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc20TransfersCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc20TransfersCallTest.java
@@ -3,6 +3,7 @@ package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TOKEN_ID;
+import static com.hedera.node.app.service.contract.impl.exec.gas.DispatchType.ASSOCIATE;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc20TransfersTranslator.ERC_20_TRANSFER;
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.hts.transfer.Erc20TransfersTranslator.ERC_20_TRANSFER_FROM;
 import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.CONFIG_CONTEXT_VARIABLE;
@@ -58,6 +59,11 @@ class Erc20TransfersCallTest extends CallTestBase {
     private static final Configuration BLOCKS_MODE_CONFIG = HederaTestConfigBuilder.create()
             .withValue("blockStream.streamMode", "BLOCKS")
             .getOrCreateConfig();
+    private static final Configuration NO_UNLIMITED_ASSOCIATIONS_CONFIG = HederaTestConfigBuilder.create()
+            .withValue("blockStream.streamMode", "BOTH")
+            .withValue("entities.unlimitedAutoAssociationsEnabled", false)
+            .getOrCreateConfig();
+    private static final long CANONICAL_ASSOCIATE_GAS = 704_000L;
     private static final Address FROM_ADDRESS = ConversionUtils.asHeadlongAddress(EIP_1014_ADDRESS.toArray());
     private static final Address TO_ADDRESS =
             ConversionUtils.asHeadlongAddress(asEvmAddress(B_NEW_ACCOUNT_ID.accountNumOrThrow()));
@@ -229,6 +235,84 @@ class Erc20TransfersCallTest extends CallTestBase {
 
         assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.state());
         verify(streamBuilder, never()).contractCallResult(any());
+    }
+
+    @Test
+    void chargesGasForAutoAssociationsCreatedByTransfer() {
+        givenSynthIdHelperWithoutFrom();
+        givenFrameConfig();
+        givenSuccessfulDispatch();
+        given(streamBuilder.getNumAutoAssociations()).willReturn(2);
+        given(systemContractGasCalculator.canonicalGasRequirement(ASSOCIATE)).willReturn(CANONICAL_ASSOCIATE_GAS);
+
+        subject = subjectForTransfer(1L);
+
+        final var result = subject.execute(frame).fullResult();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.result().state());
+        assertEquals(2 * CANONICAL_ASSOCIATE_GAS, result.gasRequirement());
+    }
+
+    @Test
+    void chargesGasForAutoAssociationsCreatedByTransferFrom() {
+        givenSynthIdHelperWithFrom();
+        givenFrameConfig();
+        givenSuccessfulDispatch();
+        given(streamBuilder.getNumAutoAssociations()).willReturn(1);
+        given(systemContractGasCalculator.canonicalGasRequirement(ASSOCIATE)).willReturn(CANONICAL_ASSOCIATE_GAS);
+
+        subject = subjectForTransferFrom(1L);
+
+        final var result = subject.execute(frame).fullResult();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.result().state());
+        assertEquals(CANONICAL_ASSOCIATE_GAS, result.gasRequirement());
+    }
+
+    @Test
+    void doesNotChargeAutoAssociationGasIfUnlimitedAssociationsDisabled() {
+        givenSynthIdHelperWithoutFrom();
+        final Deque<MessageFrame> stack = new ArrayDeque<>();
+        stack.push(frame);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(frame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(NO_UNLIMITED_ASSOCIATIONS_CONFIG);
+        givenSuccessfulDispatch();
+        given(streamBuilder.getNumAutoAssociations()).willReturn(2);
+
+        subject = subjectForTransfer(1L);
+
+        final var result = subject.execute(frame).fullResult();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.result().state());
+        assertEquals(0L, result.gasRequirement());
+    }
+
+    @Test
+    void doesNotConsultConfigWithoutAutoAssociations() {
+        givenSynthIdHelperWithoutFrom();
+        givenFrameConfig();
+        givenSuccessfulDispatch();
+
+        subject = subjectForTransfer(1L);
+
+        final var result = subject.execute(frame).fullResult();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.result().state());
+        assertEquals(0L, result.gasRequirement());
+        verify(systemContractGasCalculator, never()).canonicalGasRequirement(ASSOCIATE);
+    }
+
+    private void givenSuccessfulDispatch() {
+        given(systemContractOperations.dispatch(
+                        any(TransactionBody.class),
+                        eq(verificationStrategy),
+                        eq(SENDER_ID),
+                        eq(ContractCallStreamBuilder.class)))
+                .willReturn(streamBuilder);
+        given(streamBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
+        given(streamBuilder.contractCallResult(any())).willReturn(streamBuilder);
+        given(nativeOperations.readableAccountStore()).willReturn(readableAccountStore);
+        given(readableAccountStore.getAliasedAccountById(any())).willReturn(OWNER_ACCOUNT);
     }
 
     private void givenSynthIdHelperWithFrom() {

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc721TransferFromCallTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/hts/transfer/Erc721TransferFromCallTest.java
@@ -2,7 +2,10 @@
 package com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.hts.transfer;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SENDER_DOES_NOT_OWN_NFT_SERIAL_NO;
+import static com.hedera.node.app.service.contract.impl.exec.gas.DispatchType.ASSOCIATE;
+import static com.hedera.node.app.service.contract.impl.exec.utils.FrameUtils.CONFIG_CONTEXT_VARIABLE;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.B_NEW_ACCOUNT_ID;
+import static com.hedera.node.app.service.contract.impl.test.TestHelpers.DEFAULT_CONFIG;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.EIP_1014_ADDRESS;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.NON_FUNGIBLE_TOKEN_ID;
 import static com.hedera.node.app.service.contract.impl.test.TestHelpers.RECEIVER_ID;
@@ -14,6 +17,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
@@ -27,7 +32,12 @@ import com.hedera.node.app.service.contract.impl.records.ContractCallStreamBuild
 import com.hedera.node.app.service.contract.impl.test.exec.systemcontracts.common.CallTestBase;
 import com.hedera.node.app.service.contract.impl.utils.ConversionUtils;
 import com.hedera.node.app.service.token.ReadableAccountStore;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.swirlds.config.api.Configuration;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.List;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.units.bigints.UInt256;
@@ -38,6 +48,10 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 
 class Erc721TransferFromCallTest extends CallTestBase {
+    private static final Configuration NO_UNLIMITED_ASSOCIATIONS_CONFIG = HederaTestConfigBuilder.create()
+            .withValue("entities.unlimitedAutoAssociationsEnabled", false)
+            .getOrCreateConfig();
+    private static final long CANONICAL_ASSOCIATE_GAS = 704_000L;
     private static final Address FROM_ADDRESS = ConversionUtils.asHeadlongAddress(EIP_1014_ADDRESS.toArray());
     private static final Address TO_ADDRESS =
             ConversionUtils.asHeadlongAddress(asEvmAddress(B_NEW_ACCOUNT_ID.accountNumOrThrow()));
@@ -115,6 +129,72 @@ class Erc721TransferFromCallTest extends CallTestBase {
 
         assertEquals(MessageFrame.State.REVERT, result.state());
         assertEquals(readableRevertReason(SENDER_DOES_NOT_OWN_NFT_SERIAL_NO), result.output());
+    }
+
+    @Test
+    void chargesGasForAutoAssociationsCreatedByTransferFrom() {
+        givenSuccessfulTransfer();
+        givenFrameConfig(DEFAULT_CONFIG);
+        given(recordBuilder.getNumAutoAssociations()).willReturn(1);
+        given(gasCalculator.canonicalGasRequirement(ASSOCIATE)).willReturn(CANONICAL_ASSOCIATE_GAS);
+
+        subject = subjectFor(1L);
+
+        final var result = subject.execute(frame).fullResult();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.result().state());
+        assertEquals(CANONICAL_ASSOCIATE_GAS, result.gasRequirement());
+    }
+
+    @Test
+    void doesNotChargeAutoAssociationGasIfUnlimitedAssociationsDisabled() {
+        givenSuccessfulTransfer();
+        givenFrameConfig(NO_UNLIMITED_ASSOCIATIONS_CONFIG);
+        given(recordBuilder.getNumAutoAssociations()).willReturn(1);
+
+        subject = subjectFor(1L);
+
+        final var result = subject.execute(frame).fullResult();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.result().state());
+        assertEquals(0L, result.gasRequirement());
+    }
+
+    @Test
+    void doesNotConsultConfigWithoutAutoAssociations() {
+        givenSuccessfulTransfer();
+
+        subject = subjectFor(1L);
+
+        final var result = subject.execute(frame).fullResult();
+
+        assertEquals(MessageFrame.State.COMPLETED_SUCCESS, result.result().state());
+        assertEquals(0L, result.gasRequirement());
+        verify(gasCalculator, never()).canonicalGasRequirement(ASSOCIATE);
+    }
+
+    private void givenSuccessfulTransfer() {
+        given(nativeOperations.readableAccountStore()).willReturn(accountStore);
+        given(systemContractOperations.dispatch(
+                        any(TransactionBody.class),
+                        eq(verificationStrategy),
+                        eq(SENDER_ID),
+                        eq(ContractCallStreamBuilder.class)))
+                .willReturn(recordBuilder);
+        given(recordBuilder.status()).willReturn(ResponseCodeEnum.SUCCESS);
+        given(addressIdConverter.convert(FROM_ADDRESS)).willReturn(SENDER_ID);
+        given(addressIdConverter.convertCredit(TO_ADDRESS)).willReturn(RECEIVER_ID);
+        given(accountStore.getAliasedAccountById(SENDER_ID))
+                .willReturn(Account.newBuilder().accountId(SENDER_ID).build());
+        given(accountStore.getAliasedAccountById(RECEIVER_ID))
+                .willReturn(Account.newBuilder().accountId(RECEIVER_ID).build());
+    }
+
+    private void givenFrameConfig(@NonNull final Configuration config) {
+        final Deque<MessageFrame> stack = new ArrayDeque<>();
+        stack.push(frame);
+        given(frame.getMessageFrameStack()).willReturn(stack);
+        given(frame.getContextVariable(CONFIG_CONTEXT_VARIABLE)).willReturn(config);
     }
 
     private void givenSynthIdHelperForToAccount() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hips/hip1340/CodeDelegationTests.java
@@ -221,6 +221,7 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
                     /* Trigger an HTS token transfer by sending a transaction from the owner account */
                     HapiEthereumCall.explicitlyTo(delegatingEoa.evmAddressBytes(), 0)
                             .withExplicitParams(() -> HexFormat.of().formatHex(callData))
+                            .gasLimit(2_000_000L)
                             .payingWith(payer.name())
                             .signingWith(delegatingEoa.keyName())
                             .hasKnownStatus(ResponseCodeEnum.SUCCESS),
@@ -230,6 +231,7 @@ public class CodeDelegationTests extends CodeDelegationTestBase {
                     /* Trigger an HTS token transfer by sending a transaction from an unrelated account */
                     HapiEthereumCall.explicitlyTo(delegatingEoa.evmAddressBytes(), 0)
                             .withExplicitParams(() -> HexFormat.of().formatHex(callData))
+                            .gasLimit(2_000_000L)
                             .payingWith(payer.name())
                             .signingWith(caller.keyName())
                             .hasKnownStatus(ResponseCodeEnum.SUCCESS),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/LazyCreateThroughPrecompileSuite.java
@@ -257,7 +257,7 @@ public class LazyCreateThroughPrecompileSuite {
                                             BigInteger.valueOf(2))
                                     .refusingEthConversion()
                                     .via(TRANSFER_TXN)
-                                    .gas(780_000L)
+                                    .gas(2_000_000L)
                                     .hasKnownStatus(SUCCESS),
                             getAliasedAccountInfo(ECDSA_KEY)
                                     .has(AccountInfoAsserts.accountWith()
@@ -365,7 +365,7 @@ public class LazyCreateThroughPrecompileSuite {
                                             HapiParserUtil.asHeadlongAddress(addressBytes),
                                             BigInteger.TWO)
                                     .refusingEthConversion()
-                                    .gas(780_000L)
+                                    .gas(2_000_000L)
                                     .via(TRANSFER_FROM_ACCOUNT_TXN)
                                     .hasKnownStatus(SUCCESS),
                             getAliasedAccountInfo(ECDSA_KEY)
@@ -464,7 +464,7 @@ public class LazyCreateThroughPrecompileSuite {
                                             BigInteger.valueOf(1))
                                     .refusingEthConversion()
                                     .via(TRANSFER_FROM_ACCOUNT_TXN)
-                                    .gas(780_000L)
+                                    .gas(2_000_000L)
                                     .hasKnownStatus(SUCCESS),
                             getAliasedAccountInfo(ECDSA_KEY)
                                     .has(AccountInfoAsserts.accountWith()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/ErcTransferAutoAssociationGasTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/token/ErcTransferAutoAssociationGasTest.java
@@ -1,0 +1,213 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.precompile.token;
+
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertCloseEnough;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.TINY_PARTS_PER_WHOLE;
+import static com.hederahashgraph.api.proto.java.HederaFunctionality.ContractCall;
+import static com.hederahashgraph.api.proto.java.SubType.DEFAULT;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.services.bdd.junit.LeakyHapiTest;
+import com.hedera.services.bdd.spec.SpecOperation;
+import com.hedera.services.bdd.spec.dsl.annotations.Account;
+import com.hedera.services.bdd.spec.dsl.annotations.Contract;
+import com.hedera.services.bdd.spec.dsl.annotations.FungibleToken;
+import com.hedera.services.bdd.spec.dsl.annotations.NonFungibleToken;
+import com.hedera.services.bdd.spec.dsl.entities.SpecAccount;
+import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
+import com.hedera.services.bdd.spec.dsl.entities.SpecFungibleToken;
+import com.hedera.services.bdd.spec.dsl.entities.SpecNonFungibleToken;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.DoubleConsumer;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Asserts the ERC-20 and ERC-721 transfer redirects charge for the auto-associations they create.
+ *
+ * <p>The token service does not charge auto-association fees inline for internal dispatches, on the explicit
+ * assumption that the contract service takes those costs from the remaining EVM gas; so a transfer through an
+ * ERC redirect must cost roughly one association fee more when the receiver has to be auto-associated. This is
+ * the ERC analogue of {@code UnlimitedAutoAssociationSuite#autoAssociationThroughSystemContractChangesGasCost},
+ * which asserts the same thing for the "classic" HTS transfer calls.
+ */
+@Tag(SMART_CONTRACT)
+@DisplayName("ERC transfer auto-association gas")
+public class ErcTransferAutoAssociationGasTest {
+    // Note we have a 20% markup on doing HAPI operations through the EVM
+    private static final double EXPECTED_USD_ASSOCIATION_FEE = 0.05 * 1.2;
+    // Enough to cover the transfer plus an association, which alone is priced at ~705K gas
+    private static final long CALL_GAS = 2_000_000L;
+    private static final String NO_AUTO_ASSOCIATION_TXN = "noAutoAssociation";
+    private static final String AUTO_ASSOCIATION_TXN = "autoAssociation";
+
+    @Contract(contract = "ERC20Contract", creationGas = 4_000_000L)
+    static SpecContract erc20Contract;
+
+    @Contract(contract = "ERC721Contract", creationGas = 4_000_000L)
+    static SpecContract erc721Contract;
+
+    @LeakyHapiTest(overrides = {"contracts.maxRefundPercentOfGasLimit"})
+    @DisplayName("ERC-20 transfer charges for an auto-association")
+    final Stream<DynamicTest> erc20TransferChargesForAutoAssociation(
+            @FungibleToken(initialSupply = 1_000) SpecFungibleToken token,
+            @Account(tinybarBalance = ONE_HUNDRED_HBARS) SpecAccount preAssociated,
+            @Account(tinybarBalance = ONE_HUNDRED_HBARS, maxAutoAssociations = 1) SpecAccount autoAssociated) {
+        return hapiTest(
+                refundAllUnusedGas(),
+                preAssociated.associateTokens(token),
+                erc20Contract.associateTokens(token),
+                token.treasury().transferUnitsTo(erc20Contract, 100L, token),
+                // Make two calls, the first with no auto-association and the second with auto-association
+                erc20Contract
+                        .call("transfer", token, preAssociated, BigInteger.ONE)
+                        .gas(CALL_GAS)
+                        .via(NO_AUTO_ASSOCIATION_TXN),
+                erc20Contract
+                        .call("transfer", token, autoAssociated, BigInteger.ONE)
+                        .gas(CALL_GAS)
+                        .via(AUTO_ASSOCIATION_TXN),
+                assertGasDifferenceIsAnAssociationFee());
+    }
+
+    @LeakyHapiTest(overrides = {"contracts.maxRefundPercentOfGasLimit"})
+    @DisplayName("ERC-20 transferFrom charges for an auto-association")
+    final Stream<DynamicTest> erc20TransferFromChargesForAutoAssociation(
+            @FungibleToken(initialSupply = 1_000) SpecFungibleToken token,
+            @Account(tinybarBalance = ONE_HUNDRED_HBARS) SpecAccount owner,
+            @Account(tinybarBalance = ONE_HUNDRED_HBARS) SpecAccount preAssociated,
+            @Account(tinybarBalance = ONE_HUNDRED_HBARS, maxAutoAssociations = 1) SpecAccount autoAssociated) {
+        return hapiTest(
+                refundAllUnusedGas(),
+                preAssociated.associateTokens(token),
+                owner.associateTokens(token),
+                token.treasury().transferUnitsTo(owner, 100L, token),
+                // Unlike ERC-721, the ERC-20 transferFrom redirect always dispatches with approvals, so the
+                // calling contract needs an explicit allowance even though it never owns the units
+                owner.approveTokenAllowance(token, erc20Contract, 100L),
+                erc20Contract
+                        .call("transferFrom", token, owner, preAssociated, BigInteger.ONE)
+                        .gas(CALL_GAS)
+                        .via(NO_AUTO_ASSOCIATION_TXN),
+                erc20Contract
+                        .call("transferFrom", token, owner, autoAssociated, BigInteger.ONE)
+                        .gas(CALL_GAS)
+                        .via(AUTO_ASSOCIATION_TXN),
+                assertGasDifferenceIsAnAssociationFee());
+    }
+
+    @LeakyHapiTest(overrides = {"contracts.maxRefundPercentOfGasLimit"})
+    @DisplayName("ERC-721 transferFrom charges for an auto-association")
+    final Stream<DynamicTest> erc721TransferFromChargesForAutoAssociation(
+            @NonFungibleToken(numPreMints = 2) SpecNonFungibleToken token,
+            @Account(tinybarBalance = ONE_HUNDRED_HBARS) SpecAccount preAssociated,
+            @Account(tinybarBalance = ONE_HUNDRED_HBARS, maxAutoAssociations = 1) SpecAccount autoAssociated) {
+        return hapiTest(
+                refundAllUnusedGas(),
+                preAssociated.associateTokens(token),
+                erc721Contract.associateTokens(token),
+                // The contract is the owner of both serials, so no allowance is needed; the redirect only sets
+                // isApproval when the sender differs from the owner
+                token.treasury().transferNFTsTo(erc721Contract, token, 1L, 2L),
+                erc721Contract
+                        .call("transferFrom", token, erc721Contract, preAssociated, BigInteger.ONE)
+                        .gas(CALL_GAS)
+                        .via(NO_AUTO_ASSOCIATION_TXN),
+                erc721Contract
+                        .call("transferFrom", token, erc721Contract, autoAssociated, BigInteger.TWO)
+                        .gas(CALL_GAS)
+                        .via(AUTO_ASSOCIATION_TXN),
+                assertGasDifferenceIsAnAssociationFee());
+    }
+
+    @LeakyHapiTest(overrides = {"contracts.maxRefundPercentOfGasLimit", "entities.unlimitedAutoAssociationsEnabled"})
+    @DisplayName("ERC-20 transfer does not charge for an auto-association if the sender-pays model is off")
+    final Stream<DynamicTest> erc20TransferChargesNothingWhenUnlimitedAssociationsDisabled(
+            @FungibleToken(initialSupply = 1_000) SpecFungibleToken token,
+            @Account(tinybarBalance = ONE_HUNDRED_HBARS) SpecAccount preAssociated,
+            @Account(tinybarBalance = ONE_HUNDRED_HBARS, maxAutoAssociations = 1) SpecAccount autoAssociated) {
+        return hapiTest(
+                refundAllUnusedGas(),
+                overriding("entities.unlimitedAutoAssociationsEnabled", "false"),
+                preAssociated.associateTokens(token),
+                erc20Contract.associateTokens(token),
+                token.treasury().transferUnitsTo(erc20Contract, 100L, token),
+                erc20Contract
+                        .call("transfer", token, preAssociated, BigInteger.ONE)
+                        .gas(CALL_GAS)
+                        .via(NO_AUTO_ASSOCIATION_TXN),
+                erc20Contract
+                        .call("transfer", token, autoAssociated, BigInteger.ONE)
+                        .gas(CALL_GAS)
+                        .via(AUTO_ASSOCIATION_TXN),
+                // The auto-association still happens, only the "sender pays" fee model is disabled
+                exposingUsdGasDifferenceTo(usdDiff -> assertTrue(
+                        Math.abs(usdDiff) < EXPECTED_USD_ASSOCIATION_FEE / 10,
+                        "Auto-associating cost " + usdDiff + " USD of extra gas, but the sender-pays fee model"
+                                + " is disabled so it should have cost nothing")));
+    }
+
+    /**
+     * Refunds all unused gas so the gas actually consumed by the two calls is directly comparable; without this
+     * the reported gas used is floored at {@code gasLimit - gasLimit * maxRefundPercentOfGasLimit / 100} and both
+     * calls report the same figure.
+     */
+    private static SpecOperation refundAllUnusedGas() {
+        return overriding("contracts.maxRefundPercentOfGasLimit", "100");
+    }
+
+    private static SpecOperation assertGasDifferenceIsAnAssociationFee() {
+        return exposingUsdGasDifferenceTo(usdDiff -> assertCloseEnough(
+                EXPECTED_USD_ASSOCIATION_FEE,
+                usdDiff,
+                // Allow at most one percent deviation from expected
+                1.0,
+                "USD value of gas difference",
+                "auto-association fee"));
+    }
+
+    /**
+     * Exposes the USD value of the difference in gas used by the {@code autoAssociation} and
+     * {@code noAutoAssociation} transactions to the given assertion.
+     */
+    private static SpecOperation exposingUsdGasDifferenceTo(@NonNull final DoubleConsumer assertion) {
+        final var gasWithoutAutoAssociation = new AtomicLong();
+        final var gasWithAutoAssociation = new AtomicLong();
+        return withOpContext((spec, opLog) -> {
+            allRunFor(
+                    spec,
+                    getTxnRecord(NO_AUTO_ASSOCIATION_TXN)
+                            .exposingTo(txnRecord -> gasWithoutAutoAssociation.set(
+                                    txnRecord.getContractCallResult().getGasUsed())),
+                    getTxnRecord(AUTO_ASSOCIATION_TXN)
+                            .exposingTo(txnRecord -> gasWithAutoAssociation.set(
+                                    txnRecord.getContractCallResult().getGasUsed())));
+            final var gasDiff = gasWithAutoAssociation.get() - gasWithoutAutoAssociation.get();
+            // Convert to USD by multiplying the gas difference by the price in thousandths of a tinycent
+            // from the fee schedule; and then dividing by 1e13 to convert to USD
+            final var approxUsdDiff = (1.0
+                            * gasDiff
+                            * spec.fees()
+                                    .getCurrentOpFeeData()
+                                    .get(ContractCall)
+                                    .get(DEFAULT)
+                                    .getServicedata()
+                                    .getGas()
+                            / 1000
+                            / TINY_PARTS_PER_WHOLE)
+                    / 100.0;
+            assertion.accept(approxUsdDiff);
+        });
+    }
+}


### PR DESCRIPTION
**Description**:
Include the associations fee when charging for ERC20/721 transfers 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
