### PR TITLE
chore: Remove mqpt-cluster entry from .citr-env

### DIFF
--- a/.github/workflows/support/citr/.citr-env
+++ b/.github/workflows/support/citr/.citr-env
@@ -3,7 +3,6 @@ adhoc-solo-version=0.79.1
 adhoc-xts-solo-version=0.79.1
 cutover-solo-version=0.84.1
 citr-mirror-node-version=0.161.0
-mqpt-cluster=Dallas_n10
 tck-version=v0.12.3
 js-sdk-version=v2.85.0
 block-node-version=v0.35.1


### PR DESCRIPTION
## Description

This pull request makes a small change to the `.github/workflows/support/citr/.citr-env` file by removing the `mqpt-cluster` configuration line. This simplifies the environment configuration and removes an unused or unnecessary setting.

## Related Issue(s)

- Closes #26838