### PR TITLE
fix: Ethereum Transaction  validation optimisations

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -614,23 +614,30 @@ public record EthTxData(
         }
     }
 
-    /// Returns whether the given envelope item ends exactly at the end of {@code data}, i.e. whether the RLP
-    /// encoding consumed the whole input as EIP-2718 requires and as `ethereum_data` is specified ("the
-    /// complete transaction data").
-    ///
-    /// `RLPDecoder.sequenceIterator` is a *sequence* reader, so anything past the envelope is simply left
-    /// unread rather than reported: `tx || extra` would otherwise parse as `tx`, yielding identical fields but
-    /// a different `keccak256(rawTx)` — the value externalized as a record's `ethereum_hash`. Requiring full
-    /// consumption keeps that hash a function of the transaction rather than of how its bytes were framed.
-    ///
-    /// This governs only bytes *outside* the envelope. It is unrelated to trailing bytes *inside* ABI-encoded
-    /// `callData`, which are part of the signed payload and which HIP-1342 deliberately permits; neither rule
-    /// generalizes to the other layer.
-    ///
-    /// A positional comparison is preferred over `decoder.hasNext()`, which reaches the same two outcomes only
-    /// by way of exception control flow: it returns `true` for a well-formed trailing item but throws
-    /// headlong's `ShortInputException` for a malformed one, relying on that being an
-    /// `IllegalArgumentException` for {@link #populateEthTxData} to map it to `null`.
+    /**
+     * Returns whether the given envelope item ends exactly at the end of {@code data}, i.e. whether the RLP
+     * encoding consumed the whole input as EIP-2718 requires and as {@code ethereum_data} is specified ("the
+     * complete transaction data").
+     *
+     * <p>{@code RLPDecoder.sequenceIterator} is a <em>sequence</em> reader, so anything past the envelope is
+     * simply left unread rather than reported: {@code tx || extra} would otherwise parse as {@code tx}, yielding
+     * identical fields but a different {@code keccak256(rawTx)} — the value externalized as a record's
+     * {@code ethereum_hash}. Requiring full consumption keeps that hash a function of the transaction rather
+     * than of how its bytes were framed.
+     *
+     * <p>This governs only bytes <em>outside</em> the envelope. It is unrelated to trailing bytes <em>inside</em>
+     * ABI-encoded {@code callData}, which are part of the signed payload and which HIP-1342 deliberately
+     * permits; neither rule generalizes to the other layer.
+     *
+     * <p>A positional comparison is preferred over {@code decoder.hasNext()}, which reaches the same two
+     * outcomes only by way of exception control flow: it returns {@code true} for a well-formed trailing item
+     * but throws headlong's {@code ShortInputException} for a malformed one, relying on that being an
+     * {@code IllegalArgumentException} for {@link #populateEthTxData} to map it to {@code null}.
+     *
+     * @param envelope the RLP item parsed from the start of {@code data}
+     * @param data the complete candidate transaction bytes
+     * @return whether the envelope ends exactly at the end of {@code data}
+     */
     private static boolean consumesAllOf(@NonNull final RLPItem envelope, @NonNull final byte[] data) {
         return envelope.endIndex == data.length;
     }

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -601,12 +601,36 @@ public record EthTxData(
         }
     }
 
+    /// Returns whether the given envelope item ends exactly at the end of {@code data}, i.e. whether the RLP
+    /// encoding consumed the whole input as EIP-2718 requires and as `ethereum_data` is specified ("the
+    /// complete transaction data").
+    ///
+    /// `RLPDecoder.sequenceIterator` is a *sequence* reader, so anything past the envelope is simply left
+    /// unread rather than reported: `tx || extra` would otherwise parse as `tx`, yielding identical fields but
+    /// a different `keccak256(rawTx)` — the value externalized as a record's `ethereum_hash`. Requiring full
+    /// consumption keeps that hash a function of the transaction rather than of how its bytes were framed.
+    ///
+    /// This governs only bytes *outside* the envelope. It is unrelated to trailing bytes *inside* ABI-encoded
+    /// `callData`, which are part of the signed payload and which HIP-1342 deliberately permits; neither rule
+    /// generalizes to the other layer.
+    ///
+    /// Note `decoder.hasNext()` cannot serve here: on a malformed trailer it throws headlong's
+    /// `ShortInputException`, which escapes the `IllegalArgumentException | NoSuchElementException` catch in
+    /// {@link #populateEthTxData}.
+    private static boolean consumesAllOf(@NonNull final RLPItem envelope, @NonNull final byte[] data) {
+        return envelope.endIndex == data.length;
+    }
+
     /**
      * Encodes the transaction data into a EthTxData according to legacy RLP format.
      *
      * @return the encoded transaction data
      */
     private static EthTxData populateLegacyEthTxData(final RLPItem rlpItem, final byte[] rawTx) {
+        if (!consumesAllOf(rlpItem, rawTx)) {
+            return null;
+        }
+
         final List<RLPItem> rlpList = rlpItem.asRLPList().elements();
         if (rlpList.size() != 9) {
             return null;
@@ -649,6 +673,9 @@ public record EthTxData(
         if (!rlpItem.isList()) {
             return null;
         }
+        if (!consumesAllOf(rlpItem, rawTx)) {
+            return null;
+        }
 
         final List<RLPItem> rlpList = rlpItem.asRLPList().elements();
         if (rlpList.size() != 12) {
@@ -689,6 +716,9 @@ public record EthTxData(
         if (!rlpItem.isList()) {
             return null;
         }
+        if (!consumesAllOf(rlpItem, rawTx)) {
+            return null;
+        }
 
         final List<RLPItem> rlpList = rlpItem.asRLPList().elements();
         if (rlpList.size() != 11) {
@@ -727,6 +757,9 @@ public record EthTxData(
      */
     private static EthTxData populateEip7702EthTxData(RLPItem rlpItem, byte[] rawTx) {
         if (!rlpItem.isList()) {
+            return null;
+        }
+        if (!consumesAllOf(rlpItem, rawTx)) {
             return null;
         }
 

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -78,16 +78,29 @@ public record EthTxData(
     public static EthTxData populateEthTxData(final byte[] data) {
         try {
             final var decoder = RLPDecoder.RLP_STRICT.sequenceIterator(data);
-            final var rlpItem = decoder.next();
-            if (rlpItem.isList()) {
-                return populateLegacyEthTxData(rlpItem, data);
+            final var firstItem = decoder.next();
+
+            // A legacy transaction is a bare RLP list, so it is its own envelope.
+            if (firstItem.isList()) {
+                return consumesAllOf(firstItem, data) ? populateLegacyEthTxData(firstItem, data) : null;
             }
 
-            return switch (asByte(rlpItem)) {
-                case 1 -> populateEip2390EthTxData(decoder.next(), data);
-                case 2 -> populateEip1559EthTxData(decoder.next(), data);
+            // A typed transaction (EIP-2718) is a one-byte type tag followed by its payload list, so there the
+            // envelope is the second item. Unsupported types fall through to `null` below; decoding their
+            // payload first is wasted work on an already-rejected input, but it keeps the check in one place,
+            // and a malformed payload only raises `IllegalArgumentException`, which this method already maps
+            // to `null`.
+            final var type = asByte(firstItem);
+            final var envelope = decoder.next();
+            if (!consumesAllOf(envelope, data)) {
+                return null;
+            }
+
+            return switch (type) {
+                case 1 -> populateEip2390EthTxData(envelope, data);
+                case 2 -> populateEip1559EthTxData(envelope, data);
                 case 3 -> null; // We don't currently support Cancun "blob" transactions
-                case 4 -> populateEip7702EthTxData(decoder.next(), data);
+                case 4 -> populateEip7702EthTxData(envelope, data);
                 default -> null;
             };
 
@@ -614,9 +627,10 @@ public record EthTxData(
     /// `callData`, which are part of the signed payload and which HIP-1342 deliberately permits; neither rule
     /// generalizes to the other layer.
     ///
-    /// Note `decoder.hasNext()` cannot serve here: on a malformed trailer it throws headlong's
-    /// `ShortInputException`, which escapes the `IllegalArgumentException | NoSuchElementException` catch in
-    /// {@link #populateEthTxData}.
+    /// A positional comparison is preferred over `decoder.hasNext()`, which reaches the same two outcomes only
+    /// by way of exception control flow: it returns `true` for a well-formed trailing item but throws
+    /// headlong's `ShortInputException` for a malformed one, relying on that being an
+    /// `IllegalArgumentException` for {@link #populateEthTxData} to map it to `null`.
     private static boolean consumesAllOf(@NonNull final RLPItem envelope, @NonNull final byte[] data) {
         return envelope.endIndex == data.length;
     }
@@ -627,10 +641,6 @@ public record EthTxData(
      * @return the encoded transaction data
      */
     private static EthTxData populateLegacyEthTxData(final RLPItem rlpItem, final byte[] rawTx) {
-        if (!consumesAllOf(rlpItem, rawTx)) {
-            return null;
-        }
-
         final List<RLPItem> rlpList = rlpItem.asRLPList().elements();
         if (rlpList.size() != 9) {
             return null;
@@ -673,9 +683,6 @@ public record EthTxData(
         if (!rlpItem.isList()) {
             return null;
         }
-        if (!consumesAllOf(rlpItem, rawTx)) {
-            return null;
-        }
 
         final List<RLPItem> rlpList = rlpItem.asRLPList().elements();
         if (rlpList.size() != 12) {
@@ -716,9 +723,6 @@ public record EthTxData(
         if (!rlpItem.isList()) {
             return null;
         }
-        if (!consumesAllOf(rlpItem, rawTx)) {
-            return null;
-        }
 
         final List<RLPItem> rlpList = rlpItem.asRLPList().elements();
         if (rlpList.size() != 11) {
@@ -757,9 +761,6 @@ public record EthTxData(
      */
     private static EthTxData populateEip7702EthTxData(RLPItem rlpItem, byte[] rawTx) {
         if (!rlpItem.isList()) {
-            return null;
-        }
-        if (!consumesAllOf(rlpItem, rawTx)) {
             return null;
         }
 

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -19,6 +19,7 @@ import com.esaulpaugh.headlong.rlp.RLPEncoder;
 import com.esaulpaugh.headlong.rlp.RLPList;
 import com.esaulpaugh.headlong.util.Integers;
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -380,6 +381,67 @@ class EthTxDataTest {
 
         // poorly wrapped typed transaction
         assertNull(EthTxData.populateEthTxData(RLPEncoder.sequence(new byte[] {2}, oneByte, oneByte)));
+
+        // Trailing bytes after a complete envelope - the mirror of "Trimmed End Bytes" above
+        assertNull(EthTxData.populateEthTxData(withSuffix(HexFormat.of().parseHex(RAW_TX_TYPE_0), new byte[] {0})));
+    }
+
+    /// Returns `data || suffix`.
+    private static byte[] withSuffix(final byte[] data, final byte[] suffix) {
+        final var suffixed = Arrays.copyOf(data, data.length + suffix.length);
+        System.arraycopy(suffix, 0, suffixed, data.length, suffix.length);
+        return suffixed;
+    }
+
+    /// Bytes past the end of the RLP envelope must be rejected outright, never left unread.
+    ///
+    /// EIP-2718 requires the envelope to consume its whole input, and `ethereum_data` is specified as the
+    /// complete transaction data. Since a record's `ethereum_hash` is `keccak256` of exactly those bytes,
+    /// tolerating a longer framing would make the recorded hash depend on the framing rather than on the
+    /// transaction: the fields, the signer and the operation would all be unchanged.
+    ///
+    /// `00`, `01`, `80` and `c0` are each well-formed RLP items on their own, so those are the trailers that
+    /// parse cleanly and would slip past a weaker check. `ff` and `deadbeef` are malformed, covering the case
+    /// where the trailer itself provokes a decoder error.
+    @ParameterizedTest(name = "suffix=0x{0}")
+    @ValueSource(strings = {"00", "01", "80", "c0", "ff", "deadbeef", "ffffffffffffffffffffffff"})
+    void rejectsTrailingBytesAfterEnvelope(final String suffixHex) {
+        final var suffix = HexFormat.of().parseHex(suffixHex);
+        for (final var canonicalHex : List.of(
+                RAW_TX_TYPE_0,
+                RAW_TX_TYPE_0_WITH_CHAIN_ID_11155111,
+                RAW_TX_TYPE_1,
+                RAW_TX_TYPE_2,
+                EIP155_DEMO,
+                EIP155_UNPROTECTED)) {
+            final var canonical = HexFormat.of().parseHex(canonicalHex);
+            assertNotNull(EthTxData.populateEthTxData(canonical), () -> canonicalHex + " must still parse");
+            assertNull(
+                    EthTxData.populateEthTxData(withSuffix(canonical, suffix)),
+                    () -> canonicalHex + " with trailing 0x" + suffixHex + " must be rejected");
+        }
+    }
+
+    /// A transaction's `ethereum_hash` must be fixed by the signed envelope alone.
+    @Test
+    void ethereumHashIsKeccakOfTheCanonicalEnvelope() {
+        for (final var canonicalHex :
+                List.of(RAW_TX_TYPE_0, RAW_TX_TYPE_1, RAW_TX_TYPE_2, EIP155_DEMO, EIP155_UNPROTECTED)) {
+            final var canonical = HexFormat.of().parseHex(canonicalHex);
+            final var parsed = requireNonNull(EthTxData.populateEthTxData(canonical));
+            assertArrayEquals(MiscCryptoUtils.keccak256DigestOf(canonical), parsed.getEthereumHash(), canonicalHex);
+        }
+    }
+
+    /// Guards the boundary from the accepting side: a programmatically built type-2 envelope parses, and the
+    /// same bytes plus one trailing zero do not. The other fixtures are hard-coded hex, so this is the only
+    /// case that proves the check tracks the encoded length rather than a fixture's known size.
+    @Test
+    void acceptsBuiltTypedEnvelopeButRejectsItWithOneTrailingByte() {
+        final var canonical = RLPEncoder.sequence(new byte[] {2}, Arrays.asList(normalRlpData()));
+
+        assertNotNull(EthTxData.populateEthTxData(canonical));
+        assertNull(EthTxData.populateEthTxData(Arrays.copyOf(canonical, canonical.length + 1)));
     }
 
     byte[][] normalRlpData() {

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -393,16 +393,20 @@ class EthTxDataTest {
         return suffixed;
     }
 
-    /// Bytes past the end of the RLP envelope must be rejected outright, never left unread.
-    ///
-    /// EIP-2718 requires the envelope to consume its whole input, and `ethereum_data` is specified as the
-    /// complete transaction data. Since a record's `ethereum_hash` is `keccak256` of exactly those bytes,
-    /// tolerating a longer framing would make the recorded hash depend on the framing rather than on the
-    /// transaction: the fields, the signer and the operation would all be unchanged.
-    ///
-    /// `00`, `01`, `80` and `c0` are each well-formed RLP items on their own, so those are the trailers that
-    /// parse cleanly and would slip past a weaker check. `ff` and `deadbeef` are malformed, covering the case
-    /// where the trailer itself provokes a decoder error.
+    /**
+     * Bytes past the end of the RLP envelope must be rejected outright, never left unread.
+     *
+     * <p>EIP-2718 requires the envelope to consume its whole input, and {@code ethereum_data} is specified as
+     * the complete transaction data. Since a record's {@code ethereum_hash} is {@code keccak256} of exactly
+     * those bytes, tolerating a longer framing would make the recorded hash depend on the framing rather than
+     * on the transaction: the fields, the signer and the operation would all be unchanged.
+     *
+     * <p>{@code 00}, {@code 01}, {@code 80} and {@code c0} are each well-formed RLP items on their own, so
+     * those are the trailers that parse cleanly and would slip past a weaker check. {@code ff} and
+     * {@code deadbeef} are malformed, covering the case where the trailer itself provokes a decoder error.
+     *
+     * @param suffixHex the hex-encoded trailer appended to each canonical transaction
+     */
     @ParameterizedTest(name = "suffix=0x{0}")
     @ValueSource(strings = {"00", "01", "80", "c0", "ff", "deadbeef", "ffffffffffffffffffffffff"})
     void rejectsTrailingBytesAfterEnvelope(final String suffixHex) {

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataType4TransactionTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataType4TransactionTest.java
@@ -307,6 +307,43 @@ class EthTxDataType4TransactionTest {
         assertNull(tx);
     }
 
+    /// EIP-2718 requires the envelope to consume its whole input. Bytes past its end would leave every field
+    /// intact while changing `keccak256(rawTx)` - the value externalized as a record's `ethereum_hash` - so
+    /// they must be rejected rather than left unread. See `EthTxDataTest.rejectsTrailingBytesAfterEnvelope`
+    /// for the legacy, type-1 and type-2 equivalents.
+    @Test
+    void populateEip7702EthTxDataReturnsNullWhenTrailingBytesFollowEnvelope() {
+        final byte[] authorizationList = rlpList(
+                rlpBytes(new byte[] {0x01}),
+                rlpBytes(repeat((byte) 0x11, 20)),
+                rlpUInt(5),
+                rlpUInt(1),
+                rlpBytes(repeat((byte) 0x22, 32)),
+                rlpBytes(repeat((byte) 0x33, 32)));
+        final byte[] canonical = buildType4Raw(
+                fillBytes(2, 0x01),
+                1,
+                fillBytes(3, 0x02),
+                fillBytes(3, 0x03),
+                100,
+                fillBytes(20, 0x04),
+                0L,
+                new byte[] {},
+                new Object[] {},
+                authorizationList,
+                27,
+                fillBytes(32, 0x05),
+                fillBytes(32, 0x06));
+
+        assertNotNull(EthTxData.populateEthTxData(canonical));
+
+        for (final byte[] suffix : new byte[][] {{0x00}, {(byte) 0x80}, {(byte) 0xc0}, {(byte) 0xff}}) {
+            final var suffixed = Arrays.copyOf(canonical, canonical.length + suffix.length);
+            System.arraycopy(suffix, 0, suffixed, canonical.length, suffix.length);
+            assertNull(EthTxData.populateEthTxData(suffixed), "trailing byte must be rejected");
+        }
+    }
+
     private static byte[] rlpBytes(byte[] bytes) {
         if (bytes.length == 1 && (bytes[0] & 0xFF) < 0x80) {
             return new byte[] {bytes[0]};

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumTransactionCanonicalRlpTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumTransactionCanonicalRlpTest.java
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.ethereum;
+
+import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.EthTransactionType.EIP1559;
+import static com.hedera.node.app.hapi.utils.ethereum.EthTxData.WEIBARS_IN_A_TINYBAR;
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.changeFromSnapshot;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAliasedAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAutoCreatedAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall.fromSignedBytes;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromAccountToAlias;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.spec.utilops.inventory.SpecKeyFromEcdsaFile.createAndLinkEcdsaKey;
+import static com.hedera.services.bdd.spec.utilops.inventory.SpecKeyFromEcdsaFile.ecdsaFrom;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.flattened;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.esaulpaugh.headlong.util.Integers;
+import com.google.protobuf.ByteString;
+import com.hedera.node.app.hapi.utils.EthSigsUtils;
+import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.spec.SpecOperation;
+import com.hedera.services.bdd.utils.Signing;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.bouncycastle.jcajce.provider.digest.Keccak;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Pins the canonical RLP encoding as the only accepted form of {@code EthereumTransactionBody.ethereum_data}.
+ *
+ * <p>EIP-2718 requires a transaction envelope to consume its entire input, and
+ * {@code ethereum_transaction.proto} specifies {@code ethereum_data} as "the complete transaction data". Since a
+ * record's {@code ethereum_hash} is the keccak256 of exactly those bytes, accepting a longer framing of the same
+ * transaction would make the recorded hash depend on how the bytes were packaged rather than on the transaction
+ * itself - two encodings of one transaction would settle under two different identities. Signer recovery does not
+ * constrain this on its own, because {@code EthTxSigs.calculateSignableMessage()} re-encodes from the parsed
+ * fields and so is indifferent to the surrounding framing.
+ *
+ * <p>These specs cover both directions end to end: a non-canonical encoding is refused at ingest and leaves the
+ * account's nonce untouched, and the canonical encoding of the same transaction then settles normally under the
+ * keccak256 of the bytes that were signed. Nothing is hard-coded - each transaction is built and signed in-spec,
+ * and expected hashes are computed with Keccak directly rather than through the code under test. The two specs
+ * use disjoint keys so they remain independent of ordering when sharing a network.
+ */
+@Tag(SMART_CONTRACT)
+@SuppressWarnings("java:S5960")
+public class EthereumTransactionCanonicalRlpTest {
+    private static final int CHAIN_ID = 298;
+    private static final long GAS_LIMIT = 100_000L;
+    private static final long MAX_PRIORITY_GAS_WEIBAR = 1_000L;
+    private static final long MAX_GAS_WEIBAR = 500_000_000_000L;
+    private static final long TRANSFER_TINYBARS = ONE_HBAR;
+    private static final byte TRAILING_BYTE = 0x42;
+
+    private static final Sender REJECTION_SENDER = new Sender("rejectionSender", "rejectionRecipient", 0x1c0de);
+    private static final Sender CANONICAL_SENDER = new Sender("canonicalSender", "canonicalRecipient", 0x2c0de);
+
+    /**
+     * An encoding carrying bytes past the end of the envelope is refused at ingest, the operation does not run,
+     * and the nonce stays unspent - so the canonical encoding of the same transaction still settles afterwards,
+     * under the keccak256 of the bytes that were signed.
+     *
+     * <p>The refusal is a precheck failure rather than a consensus status because {@code pureChecks} runs inside
+     * {@code IngestChecker}, so a non-canonical encoding never reaches consensus.
+     */
+    @HapiTest
+    final Stream<DynamicTest> trailingBytesAreRejectedAndLeaveTheNonceUnspent() {
+        final var canonical = REJECTION_SENDER.canonicalSignedBytes();
+        final var withTrailingByte = withTrailingByte(canonical);
+        assertEveryOneByteTrailerIsRejected(canonical);
+
+        return hapiTest(flattened(
+                REJECTION_SENDER.setUp(),
+                balanceSnapshot("rejectionRecipientBefore", REJECTION_SENDER.recipientKey())
+                        .accountIsAlias(),
+                fromSignedBytes(withTrailingByte)
+                        .payingWith(REJECTION_SENDER.submitter())
+                        .maxGasAllowance(10 * ONE_HBAR)
+                        .hasPrecheck(INVALID_ETHEREUM_TRANSACTION),
+                // Nothing was transferred and no nonce was consumed
+                getAutoCreatedAccountBalance(REJECTION_SENDER.recipientKey())
+                        .hasTinyBars(changeFromSnapshot("rejectionRecipientBefore", 0L)),
+                getAliasedAccountInfo(REJECTION_SENDER.senderKey())
+                        .has(accountWith().nonce(0L)),
+                // So the canonical encoding remains usable, and records the hash of what was signed
+                fromSignedBytes(canonical)
+                        .payingWith(REJECTION_SENDER.submitter())
+                        .maxGasAllowance(10 * ONE_HBAR)
+                        .via("canonicalAfterRefusal")
+                        .hasKnownStatus(SUCCESS),
+                getTxnRecord("canonicalAfterRefusal")
+                        .hasPriority(
+                                recordWith().status(SUCCESS).ethereumHash(ByteString.copyFrom(keccak256(canonical)))),
+                getAutoCreatedAccountBalance(REJECTION_SENDER.recipientKey())
+                        .hasTinyBars(changeFromSnapshot("rejectionRecipientBefore", TRANSFER_TINYBARS)),
+                getAliasedAccountInfo(REJECTION_SENDER.senderKey())
+                        .has(accountWith().nonce(1L))));
+    }
+
+    /**
+     * The baseline: a transaction submitted as exact bytes settles and is recorded under
+     * {@code keccak256(signedBytes)}. The only thing separating this from the refused case is the byte appended
+     * past the envelope, which isolates the framing as the cause.
+     */
+    @HapiTest
+    final Stream<DynamicTest> exactBytesSettleUnderTheHashOfTheSignedEncoding() {
+        final var canonical = CANONICAL_SENDER.canonicalSignedBytes();
+
+        return hapiTest(flattened(
+                CANONICAL_SENDER.setUp(),
+                balanceSnapshot("canonicalRecipientBefore", CANONICAL_SENDER.recipientKey())
+                        .accountIsAlias(),
+                fromSignedBytes(canonical)
+                        .payingWith(CANONICAL_SENDER.submitter())
+                        .maxGasAllowance(10 * ONE_HBAR)
+                        .via("exactSubmission")
+                        .hasKnownStatus(SUCCESS),
+                getTxnRecord("exactSubmission")
+                        .hasPriority(
+                                recordWith().status(SUCCESS).ethereumHash(ByteString.copyFrom(keccak256(canonical)))),
+                getAutoCreatedAccountBalance(CANONICAL_SENDER.recipientKey())
+                        .hasTinyBars(changeFromSnapshot("canonicalRecipientBefore", TRANSFER_TINYBARS)),
+                getAliasedAccountInfo(CANONICAL_SENDER.senderKey())
+                        .has(accountWith().nonce(1L))));
+    }
+
+    /**
+     * Checks off-network that the canonical bytes parse and that every one of the 256 possible single trailing
+     * bytes is refused. Sweeping all of them matters because some values ({@code 00}, {@code 80}, {@code c0}) are
+     * well-formed RLP items on their own and would be read as a further item, while others are malformed and
+     * instead provoke a decoder error - the check has to cover both.
+     */
+    private static void assertEveryOneByteTrailerIsRejected(final byte[] canonical) {
+        assertNotNull(EthTxData.populateEthTxData(canonical), "canonical bytes must parse");
+        for (int i = 0; i < 256; i++) {
+            final var variant = Arrays.copyOf(canonical, canonical.length + 1);
+            variant[canonical.length] = (byte) i;
+            final var trailer = i;
+            assertNull(EthTxData.populateEthTxData(variant), () -> "a trailing 0x%02x must not be accepted"
+                    .formatted(trailer));
+        }
+    }
+
+    private static byte[] withTrailingByte(final byte[] canonical) {
+        final var extended = Arrays.copyOf(canonical, canonical.length + 1);
+        extended[canonical.length] = TRAILING_BYTE;
+        return extended;
+    }
+
+    private static byte[] keccak256(final byte[] bytes) {
+        return new Keccak.Digest256().digest(bytes);
+    }
+
+    /// Left-pads `value` to a 32-byte secp256k1 private key.
+    private static byte[] as32Bytes(final BigInteger value) {
+        final var magnitude = EthTxData.asUnsignedByteArray(value);
+        final var padded = new byte[32];
+        System.arraycopy(magnitude, 0, padded, 32 - magnitude.length, magnitude.length);
+        return padded;
+    }
+
+    /**
+     * One EOA, the recipient of its transfer, and the ordinary account that pays for the HAPI wrapper. The
+     * {@code seed} gives each spec disjoint EVM addresses, so their nonces are independent.
+     */
+    private record Sender(String senderKey, String recipientKey, int seed) {
+        private BigInteger senderPrivateKey() {
+            return BigInteger.valueOf(seed).shiftLeft(200).add(BigInteger.ONE);
+        }
+
+        private BigInteger recipientPrivateKey() {
+            return BigInteger.valueOf(seed).shiftLeft(200).add(BigInteger.TWO);
+        }
+
+        String submitter() {
+            return senderKey + "Submitter";
+        }
+
+        SpecOperation[] setUp() {
+            return new SpecOperation[] {
+                withOpContext((spec, opLog) -> {
+                    createAndLinkEcdsaKey(
+                            spec, ecdsaFrom(senderPrivateKey()), senderKey, Optional.empty(), Optional.empty(), opLog);
+                    createAndLinkEcdsaKey(
+                            spec,
+                            ecdsaFrom(recipientPrivateKey()),
+                            recipientKey,
+                            Optional.empty(),
+                            Optional.empty(),
+                            opLog);
+                }),
+                cryptoCreate(submitter()).balance(ONE_HUNDRED_HBARS),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, senderKey, ONE_HUNDRED_HBARS)),
+                cryptoTransfer(tinyBarsFromAccountToAlias(GENESIS, recipientKey, 1L)),
+                getAliasedAccountInfo(senderKey).has(accountWith().nonce(0L))
+            };
+        }
+
+        /** Builds and signs this sender's transaction, so the raw bytes are derived rather than hard-coded. */
+        byte[] canonicalSignedBytes() {
+            final var privateKey = as32Bytes(senderPrivateKey());
+            final var to = EthSigsUtils.recoverAddressFromPrivateKey(as32Bytes(recipientPrivateKey()));
+            final var unsigned = new EthTxData(
+                    null, // rawTx - null so encodeTx() yields the canonical encoding
+                    EIP1559,
+                    Integers.toBytes(CHAIN_ID),
+                    0L, // nonce
+                    null, // gasPrice
+                    Integers.toBytes(MAX_PRIORITY_GAS_WEIBAR),
+                    Integers.toBytes(MAX_GAS_WEIBAR),
+                    GAS_LIMIT,
+                    to,
+                    BigInteger.valueOf(TRANSFER_TINYBARS).multiply(WEIBARS_IN_A_TINYBAR),
+                    new byte[0], // callData
+                    new byte[0], // accessList
+                    new Object[0],
+                    null, // authorizationList
+                    null,
+                    0, // recId - replaced by signing
+                    null, // v
+                    new byte[0], // r - replaced by signing
+                    new byte[0]); // s - replaced by signing
+            return Signing.signMessage(unsigned, privateKey).encodeTx();
+        }
+    }
+}


### PR DESCRIPTION
**Description**:
Reject trailing bytes of an ethereum transaction

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
