### PR TITLE
refactor: expose unmodifiable collections from PreHandleResult

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
@@ -147,6 +147,13 @@ public record PreHandleResult(
     public PreHandleResult {
         requireNonNull(status);
         requireNonNull(responseCode);
+        // Defensively wrap the exposed collections so a consumer cannot mutate them after construction.
+        // innerResults is intentionally left mutable: atomic-batch pre-handle appends inner results to it
+        // after construction (see PreHandleWorkflow#preHandleTransaction).
+        requiredKeys = requiredKeys == null ? null : Collections.unmodifiableSet(requiredKeys);
+        optionalKeys = optionalKeys == null ? null : Collections.unmodifiableSet(optionalKeys);
+        hollowAccounts = hollowAccounts == null ? null : Collections.unmodifiableSet(hollowAccounts);
+        verificationResults = verificationResults == null ? null : Collections.unmodifiableMap(verificationResults);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleResult.java
@@ -17,6 +17,8 @@ import com.hedera.node.app.workflows.TransactionInfo;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -147,13 +149,19 @@ public record PreHandleResult(
     public PreHandleResult {
         requireNonNull(status);
         requireNonNull(responseCode);
-        // Defensively wrap the exposed collections so a consumer cannot mutate them after construction.
+        // Defensively snapshot the exposed collections so a consumer cannot mutate them, and so later mutation
+        // of the caller's original collection is not visible through these. LinkedHashSet/LinkedHashMap preserve
+        // insertion order, which is load-bearing: hollowAccounts order drives the order of the synthetic
+        // CryptoUpdate dispatches in HollowAccountCompletions#finalizeHollowAccounts.
         // innerResults is intentionally left mutable: atomic-batch pre-handle appends inner results to it
         // after construction (see PreHandleWorkflow#preHandleTransaction).
-        requiredKeys = requiredKeys == null ? null : Collections.unmodifiableSet(requiredKeys);
-        optionalKeys = optionalKeys == null ? null : Collections.unmodifiableSet(optionalKeys);
-        hollowAccounts = hollowAccounts == null ? null : Collections.unmodifiableSet(hollowAccounts);
-        verificationResults = verificationResults == null ? null : Collections.unmodifiableMap(verificationResults);
+        requiredKeys = requiredKeys == null ? null : Collections.unmodifiableSet(new LinkedHashSet<>(requiredKeys));
+        optionalKeys = optionalKeys == null ? null : Collections.unmodifiableSet(new LinkedHashSet<>(optionalKeys));
+        hollowAccounts =
+                hollowAccounts == null ? null : Collections.unmodifiableSet(new LinkedHashSet<>(hollowAccounts));
+        verificationResults = verificationResults == null
+                ? null
+                : Collections.unmodifiableMap(new LinkedHashMap<>(verificationResults));
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
@@ -43,6 +43,7 @@ import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -149,17 +150,20 @@ class PreHandleContextImplTest implements Scenarios {
         assertThatThrownBy(() -> subject.requiredHollowAccounts().add(account))
                 .isInstanceOf(UnsupportedOperationException.class);
 
-        // A PreHandleResult built from those views (as PreHandleWorkflowImpl does) likewise exposes
-        // collections that reject post-construction mutation.
+        // Feeding raw, mutable sets (not the unmodifiable views above) proves PreHandleResult does the wrapping
+        // itself: the exposed collections still reject mutation...
+        final var rawRequiredKeys = new LinkedHashSet<>(subject.requiredNonPayerKeys());
+        final var rawOptionalKeys = new LinkedHashSet<>(subject.optionalNonPayerKeys());
+        final var rawHollowAccounts = new LinkedHashSet<>(subject.requiredHollowAccounts());
         final var result = new PreHandleResult(
                 PAYER,
                 payerKey,
                 SO_FAR_SO_GOOD,
                 OK,
                 null,
-                subject.requiredNonPayerKeys(),
-                subject.optionalNonPayerKeys(),
-                subject.requiredHollowAccounts(),
+                rawRequiredKeys,
+                rawOptionalKeys,
+                rawHollowAccounts,
                 Map.of(),
                 null,
                 0L);
@@ -169,6 +173,15 @@ class PreHandleContextImplTest implements Scenarios {
                 .isInstanceOf(UnsupportedOperationException.class);
         assertThatThrownBy(() -> result.getHollowAccounts().add(account))
                 .isInstanceOf(UnsupportedOperationException.class);
+
+        // ...and that it snapshots them, so mutating the source sets after construction is not visible through
+        // the exposed collections.
+        rawRequiredKeys.add(payerKey);
+        rawOptionalKeys.add(payerKey);
+        rawHollowAccounts.add(account);
+        assertThat(result.getRequiredKeys()).doesNotContain(payerKey);
+        assertThat(result.getOptionalKeys()).doesNotContain(payerKey);
+        assertThat(result.getHollowAccounts()).doesNotContain(account);
     }
 
     @Nested

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleContextImplTest.java
@@ -6,9 +6,11 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BA
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_CONTRACT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNRESOLVABLE_REQUIRED_SIGNERS;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static com.hedera.node.app.workflows.prehandle.PreHandleContextListUpdatesTest.A_COMPLEX_KEY;
+import static com.hedera.node.app.workflows.prehandle.PreHandleResult.Status.SO_FAR_SO_GOOD;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -41,6 +43,7 @@ import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.config.data.AccountsConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
+import java.util.Map;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -131,6 +134,41 @@ class PreHandleContextImplTest implements Scenarios {
     void creatorInfoWorks() {
         final var result = subject.creatorInfo();
         assertThat(result).isEqualTo(creatorInfo);
+    }
+
+    @Test
+    @DisplayName("Key/account sets exposed to PreHandleResult are unmodifiable")
+    void exposedKeyAndAccountSetsAreUnmodifiable() throws PreCheckException {
+        subject.requireKey(otherKey);
+
+        // PreHandleContextImpl exposes unmodifiable views, so a consumer cannot mutate them.
+        assertThatThrownBy(() -> subject.requiredNonPayerKeys().add(payerKey))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> subject.optionalNonPayerKeys().add(payerKey))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> subject.requiredHollowAccounts().add(account))
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        // A PreHandleResult built from those views (as PreHandleWorkflowImpl does) likewise exposes
+        // collections that reject post-construction mutation.
+        final var result = new PreHandleResult(
+                PAYER,
+                payerKey,
+                SO_FAR_SO_GOOD,
+                OK,
+                null,
+                subject.requiredNonPayerKeys(),
+                subject.optionalNonPayerKeys(),
+                subject.requiredHollowAccounts(),
+                Map.of(),
+                null,
+                0L);
+        assertThatThrownBy(() -> result.getRequiredKeys().add(payerKey))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> result.getOptionalKeys().add(payerKey))
+                .isInstanceOf(UnsupportedOperationException.class);
+        assertThatThrownBy(() -> result.getHollowAccounts().add(account))
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     @Nested

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleResultTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleResultTest.java
@@ -20,6 +20,7 @@ import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.TransactionScenarioBuilder;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -89,6 +90,26 @@ final class PreHandleResultTest implements Scenarios {
         given(context.optionalNonPayerKeys()).willReturn(Set.of(CAROL.account().keyOrThrow()));
         given(context.requiredHollowAccounts()).willReturn(Set.of(ERIN.account()));
         assertThat(DEFAULT_RESULT.hasReusableVerificationResultsFor(context)).isTrue();
+    }
+
+    @Test
+    void getVerificationResultsRejectsMutation() {
+        // SignatureVerifierImpl hands back a mutable HashMap; a PreHandleResult must not let a
+        // consumer mutate the verification results it exposes via getVerificationResults().
+        final var result = new PreHandleResult(
+                ALICE.accountID(),
+                ALICE.account().keyOrThrow(),
+                SO_FAR_SO_GOOD,
+                OK,
+                new TransactionScenarioBuilder().txInfo(),
+                Set.of(BOB.account().keyOrThrow()),
+                Set.of(CAROL.account().keyOrThrow()),
+                Set.of(ERIN.account()),
+                new HashMap<>(),
+                null,
+                1L);
+        assertThatThrownBy(() -> result.getVerificationResults().clear())
+                .isInstanceOf(UnsupportedOperationException.class);
     }
 
     /**


### PR DESCRIPTION
## What

Wrap the collections exposed by `PreHandleResult` — `requiredKeys`, `optionalKeys`, `hollowAccounts`, `verificationResults` — as unmodifiable views in the record's compact constructor, so a consumer cannot mutate them after construction.

`innerResults` is intentionally left mutable: atomic-batch pre-handle appends inner results to it after the `PreHandleResult` is constructed (`PreHandleWorkflow#preHandleTransaction`).

## Why

SpotBugs reports `EI_EXPOSE_REP`/`EI_EXPOSE_REP2` on these fields — the record stored and returned the references directly. In practice the key/account sets already arrive unmodifiable (built via `PreHandleContextImpl`), but `verificationResults` is a plain `HashMap` returned by `SignatureVerifierImpl.verify`, so `getVerificationResults()` handed out a mutable map. Wrapping the fields makes the exposure defensively safe regardless of how the result is constructed.

## Testing

- `PreHandleResultTest.getVerificationResultsRejectsMutation` — new; fails before the change (the `HashMap` accepts a mutation), passes after.
- `PreHandleContextImplTest.exposedKeyAndAccountSetsAreUnmodifiable` — asserts the exposed key/account sets reject mutation.
- `./gradlew :app:test` for `PreHandleResultTest`, `PreHandleContextImplTest`, `PreHandleWorkflowImplTest` (atomic-batch + reuse), `DefaultKeyVerifierTest`, `DispatchValidatorTest` — all green.
