### PR TITLE
ci(fix): fix extra output in MATS Env slack message output

### DIFF
--- a/.github/workflows/templates/slack-mats-env-failure-detailed.json.tpl
+++ b/.github/workflows/templates/slack-mats-env-failure-detailed.json.tpl
@@ -18,7 +18,7 @@
           "type": "section",
           "text": {
             "type": "mrkdwn",
-            "text": {{ printf "*Environment issue detected on `%s`. See status below.* " (getenv "REF_NAME" | required "REF_NAME must be set") (getenv "REF_NAME") | data.ToJSON }}
+            "text": {{ printf "*Environment issue detected on `%s`. See status below.* " (getenv "REF_NAME" | required "REF_NAME must be set") | data.ToJSON }}
           },
           "fields": [
             {


### PR DESCRIPTION
**Description**:

The slack template for MATS Env failures is producing erroneous output due to a malformed template.


**Related issue(s)**:

Fixes # https://github.com/hiero-ledger/hiero-consensus-node/issues/26841

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
