### PR TITLE
feat: 26786 Stop MerkleDb compaction during freeze

### DIFF
--- a/platform-sdk/consensus-state/build.gradle.kts
+++ b/platform-sdk/consensus-state/build.gradle.kts
@@ -11,6 +11,7 @@ mainModuleInfo { annotationProcessor("com.swirlds.config.processor") }
 
 testModuleInfo {
     requires("com.swirlds.config.extensions.test.fixtures")
+    requires("com.swirlds.merkledb")
     requires("com.swirlds.merkledb.test.fixtures")
     requires("com.swirlds.state.impl.test.fixtures")
     requires("org.hiero.base.crypto.test.fixtures")

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java
@@ -181,6 +181,13 @@ public final class SignedStateFileWriter {
         final long pcesLowerBound = ancientThresholdOf(signedState.getState());
         final long round = signedState.getRound();
 
+        if (signedState.isFreezeState()) {
+            // The node halts after a freeze and is restarted for the upgrade, so any further
+            // compaction is wasted work and file/fd churn. Stop it before the snapshot so the
+            // snapshot's pause/resume doesn't roll compactors to fresh output files either.
+            signedState.getState().getRoot().getDataSource().stopAndDisableBackgroundCompaction();
+        }
+
         Future<Void> snapshotFuture = null;
         try {
             writeSnapshotSupplementalFiles(selfId, directory, signedState, configuration);

--- a/platform-sdk/consensus-state/src/test/java/org/hiero/consensus/state/SignedStateFileWriterTest.java
+++ b/platform-sdk/consensus-state/src/test/java/org/hiero/consensus/state/SignedStateFileWriterTest.java
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.state;
+
+import static org.hiero.consensus.state.SignedStateFileWriter.writeSignedStateToDisk;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import com.swirlds.base.time.Time;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.merkledb.MerkleDbDataSource;
+import com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils;
+import com.swirlds.state.StateLifecycleManager;
+import com.swirlds.state.merkle.VirtualMapState;
+import com.swirlds.state.merkle.VirtualMapStateLifecycleManager;
+import com.swirlds.state.test.fixtures.merkle.TestStateUtils;
+import com.swirlds.virtualmap.VirtualMap;
+import com.swirlds.virtualmap.datasource.VirtualDataSource;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.nio.file.Path;
+import org.hiero.base.constructable.ConstructableRegistryException;
+import org.hiero.base.file.FileSystemManager;
+import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
+import org.hiero.consensus.constructable.ConstructableRegistration;
+import org.hiero.consensus.fakes.noop.NoOpMetrics;
+import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.state.signed.SignedState;
+import org.hiero.consensus.state.snapshot.StateToDiskReason;
+import org.hiero.consensus.state.test.fixtures.RandomSignedStateGenerator;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests that writing a freeze state to disk stops background compaction on the data source
+ * before creating the snapshot, and that writing a non-freeze state leaves compaction alone.
+ */
+@DisplayName("SignedStateFileWriter Compaction Tests")
+class SignedStateFileWriterTest {
+
+    @TempDir
+    Path testDirectory;
+
+    private Configuration configuration;
+    private FileSystemManager fileSystemManager;
+    private StateLifecycleManager<VirtualMapState, VirtualMap> stateLifecycleManager;
+
+    @BeforeAll
+    static void beforeAll() throws ConstructableRegistryException {
+        ConstructableRegistration.registerCoreConstructables();
+    }
+
+    @BeforeEach
+    void beforeEach() {
+        configuration = new TestConfigBuilder().getOrCreateConfig();
+        fileSystemManager = new TestFileSystemManager(testDirectory);
+        stateLifecycleManager = new VirtualMapStateLifecycleManager(
+                new NoOpMetrics(), Time.getCurrent(), configuration, fileSystemManager);
+    }
+
+    @AfterEach
+    void tearDown() {
+        TestStateUtils.destroyStateLifecycleManager(stateLifecycleManager);
+        RandomSignedStateGenerator.releaseAllBuiltSignedStates();
+        MerkleDbTestUtils.assertAllDatabasesClosed();
+    }
+
+    @Test
+    @DisplayName("Freeze state: compaction is stopped before snapshot")
+    void freezeStateStopsCompaction() throws IOException {
+        final SignedState signedState =
+                new RandomSignedStateGenerator().setFreezeState(true).build();
+        signedState.markAsStateToSave(StateToDiskReason.FREEZE_STATE);
+
+        final VirtualDataSource dataSourceSpy = installDataSourceSpy(signedState);
+
+        stateLifecycleManager.initWithState(signedState.getState());
+        // The async snapshot path needs the immutable reference released so the copy can be flushed;
+        // the sync path (used for freeze) doesn't, but releasing is safe either way.
+        stateLifecycleManager.getLatestImmutableState().release();
+
+        writeSignedStateToDisk(
+                configuration,
+                fileSystemManager,
+                NodeId.of(0),
+                testDirectory.resolve("freeze-state"),
+                StateToDiskReason.FREEZE_STATE,
+                signedState.reserve("test"),
+                stateLifecycleManager);
+
+        verify(dataSourceSpy).stopAndDisableBackgroundCompaction();
+
+        // Also verify the observable effect: compaction is actually disabled on the real data source
+        final MerkleDbDataSource realDs =
+                (MerkleDbDataSource) signedState.getState().getRoot().getDataSource();
+        assertFalse(realDs.isCompactionEnabled(), "Compaction should be disabled after writing a freeze state");
+
+        stateLifecycleManager.getMutableState().release();
+    }
+
+    @Test
+    @DisplayName("Non-freeze state: compaction is not stopped")
+    void nonFreezeStateDoesNotStopCompaction() throws IOException {
+        final SignedState signedState =
+                new RandomSignedStateGenerator().setFreezeState(false).build();
+
+        final VirtualDataSource dataSourceSpy = installDataSourceSpy(signedState);
+
+        stateLifecycleManager.initWithState(signedState.getState());
+        stateLifecycleManager.getLatestImmutableState().release();
+
+        writeSignedStateToDisk(
+                configuration,
+                fileSystemManager,
+                NodeId.of(0),
+                testDirectory.resolve("periodic-state"),
+                StateToDiskReason.PERIODIC_SNAPSHOT,
+                signedState.reserve("test"),
+                stateLifecycleManager);
+
+        verify(dataSourceSpy, never()).stopAndDisableBackgroundCompaction();
+
+        // Compaction should still be enabled
+        final MerkleDbDataSource realDs =
+                (MerkleDbDataSource) signedState.getState().getRoot().getDataSource();
+        assertTrue(realDs.isCompactionEnabled(), "Compaction should remain enabled after writing a non-freeze state");
+
+        stateLifecycleManager.getMutableState().release();
+    }
+
+    /**
+     * Installs a Mockito spy on the data source of the signed state's VirtualMap so that
+     * calls to {@code stopAndDisableBackgroundCompaction()} can be verified.
+     *
+     * <p>The spy delegates all calls to the real data source, so the full MerkleDb
+     * infrastructure remains functional. The spy is installed by reflectively replacing the
+     * {@code dataSource} field on the VirtualMap — the same technique used elsewhere in this
+     * codebase for cross-package test access to private fields.
+     *
+     * @return the spy, for use in {@code verify()} assertions
+     */
+    private static VirtualDataSource installDataSourceSpy(final SignedState signedState) {
+        final VirtualMap virtualMap = signedState.getState().getRoot();
+        final VirtualDataSource realDataSource = virtualMap.getDataSource();
+        final VirtualDataSource dataSourceSpy = spy(realDataSource);
+        try {
+            final Field dataSourceField = VirtualMap.class.getDeclaredField("dataSource");
+            dataSourceField.setAccessible(true);
+            dataSourceField.set(virtualMap, dataSourceSpy);
+        } catch (final ReflectiveOperationException e) {
+            throw new RuntimeException("Failed to install data source spy", e);
+        }
+        return dataSourceSpy;
+    }
+}

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -960,8 +960,7 @@ public final class MerkleDbDataSource implements VirtualDataSource {
         return initialCapacity;
     }
 
-    // For testing purpose
-    boolean isCompactionEnabled() {
+    public boolean isCompactionEnabled() {
         return compactionCoordinator.isCompactionEnabled();
     }
 

--- a/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/VirtualMapStateTestUtils.java
+++ b/platform-sdk/swirlds-state-impl/src/testFixtures/java/com/swirlds/state/test/fixtures/merkle/VirtualMapStateTestUtils.java
@@ -47,7 +47,11 @@ public final class VirtualMapStateTestUtils {
                         final Path root = Files.createTempDirectory("VirtualMapStateTestUtils");
                         Runtime.getRuntime()
                                 .addShutdownHook(
-                                        new Thread(() -> FileUtils.rethrowIO(() -> FileUtils.deleteDirectory(root))));
+                                        new Thread(() -> FileUtils.rethrowIO(() -> {
+                                            if(root.toFile().exists()) {
+                                                FileUtils.deleteDirectory(root);
+                                            }
+                                        })));
                         fsm = new TestFileSystemManager(root);
                         fallbackFileSystemManager = fsm;
                     } catch (final IOException e) {


### PR DESCRIPTION
When a node is frozen for upgrade, background compaction tasks continue running until the process is killed. This wastes CPU and disk I/O during the freeze → shutdown window and can contribute to file-descriptor growth.

**Change:** In `SignedStateFileWriter.writeSignedStateFilesToDirectory`, call `stopAndDisableBackgroundCompaction()` on the data source before creating the snapshot when the state is a freeze state. This interrupts any in-flight compactors, prevents post-flush compaction submissions, and avoids the snapshot's pause/resume from rolling compactors to fresh output files.

Re-enabling is unnecessary — after `FREEZE_COMPLETE` the process is killed and restarted for the upgrade, which constructs a fresh data source with compaction enabled.

**Verified**: No more compaction at shutdown: https://perf.analytics.eng.hashgraph.io/ephemeral/test_runs/ZDT_report_6/network-node5/asprof_wall_down.html
After `FREEZE_COMPLETE` point, the downtime took 6 secs instead of 16 sec (in comparison with already optimized branch `26503-NOMERGE-poc-shrink-startup-shutdown` branch)

**Related issue(s)**:

Fixes #26786 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
