### PR TITLE
feat: Cap the block buffer by the total number of bytes consumed (cherry-pick)

### DIFF
--- a/hedera-node/docs/design/app/blocks/BlockBufferService.md
+++ b/hedera-node/docs/design/app/blocks/BlockBufferService.md
@@ -20,8 +20,8 @@ produced by a given consensus node in an ordered manner.
 - Tracks which blocks are currently being produced and what the latest (or highest) block acknowledged by the block node.
 - Provides an interface for access any block that is held in the buffer.
 - Regularly prunes the buffer to reclaim memory by removing acknowledged blocks once they fall outside the soft
-  retention floor (`blockStream.buffer.minAckedBlocksToBuffer`), with the hard `blockStream.buffer.maxBlocks`
-  ceiling always taking precedence when unacknowledged blocks push the buffer toward capacity.
+  retention floor (`blockStream.buffer.ackedBlocksToRetain`), with the hard `blockStream.buffer.maxBlocks` and
+  `blockStream.buffer.maxBytes` ceilings always taking precedence when unacknowledged blocks push the buffer toward capacity.
 - Monitors the buffer for saturation (i.e. too many blocks unacknowledged) and applies back pressure if necessary.
 - Persists the buffer to disk for recovery purposes (only when `streamMode` is `BLOCKS`).
 
@@ -44,8 +44,9 @@ produced by a given consensus node in an ordered manner.
 ## Backpressure Mechanism
 
 The block stream system implements a backpressure mechanism to ensure that block nodes keep pace with the incoming block stream.
-If block acknowledgments are delayed beyond a configurable threshold, this mechanism activates to halt further block production and transaction handling on the consensus node.
-This ensures system stability and prevents the accumulation of unacknowledged blocks in the stream buffer.
+If block acknowledgments are delayed beyond a configurable threshold, this mechanism activates to halt further block production
+and transaction handling on the consensus node. This ensures system stability and prevents the accumulation of
+unacknowledged blocks in the stream buffer.
 
 ### Buffer Management
 
@@ -53,16 +54,22 @@ The system maintains a buffer of block states in `BlockBufferService` with the f
 
 - Each block state contains the block items for a specific block number.
 - The buffer tracks acknowledgment status as a single high watermark.
-- Entries remain in the buffer until acknowledged and expired, according to a configurable TTL (Time To Live).
-- A periodic pruning mechanism removes acknowledged and expired entries.
-- When backpressure is enabled, pruning also enforces a soft retention floor configured by
-  `blockStream.buffer.minAckedBlocksToBuffer` (default `10`): at least this many of the most recent acknowledged
-  blocks are retained (those above `highestBlockAcked - minAckedBlocksToBuffer`); older acknowledged blocks are
-  dropped even while the buffer is below `maxBlocks`. This keeps steady-state memory low when the block node is
-  healthy while still preserving a small window of acknowledged blocks in case the block node re-requests one.
-  The soft limit is overridden by `maxBlocks` when the buffer is dominated by unacknowledged blocks — under that
-  pressure, acknowledged blocks within the floor may still be evicted to make room.
-- The buffer size is monitored to apply backpressure when needed.
+- Entries remain in the buffer until acknowledged.
+- A periodic pruning mechanism removes acknowledged entries.
+
+Within the block buffer, there are two capacity limits that are enforced:
+- Max number of unacknowledged blocks - governed by `blockStream.buffer.maxBlocks`.
+- Max number of bytes consumed by the buffer for unacknowledge blocks - governed by `blockStream.buffer.maxBytes`.
+
+When the pruner runs, it will first check if there are any acknowledged blocks that can be pruned. Once this is complete,
+the number of unacknowledged blocks and the total bytes consumed by unacknowledged blocks is calculated. (Note: in-progress
+blocks - i.e. blocks that haven't been closed yet - are not considered unacknowledged and thus don't count towards the
+calculations.) If either of these exceeds the maximum permitted, then back pressure will be engaged. The effective
+buffer saturation is the maximum of the two dimensions.
+
+If the buffer is not saturated with unacknowledged blocks, then the buffer may retain acknowledged blocks. The number of
+acknowledged blocks to retain is determined by the `blockStream.buffer.ackedBlocksToRetain` configuration. However, this
+is overruled if the buffer starts to be become saturated with unacknowledged blocks. This feature is only a best-effort.
 
 ### Buffer State
 
@@ -102,7 +109,6 @@ The backpressure mechanism operates at two levels:
 1. **Block State Buffer Level**
    - An asynchronous thread is continuously running in the background to prune the buffer.
    - Pruning occurs on a configurable interval defined in `blockStream.buffer.pruneInterval` (if set to `0`, the pruning is disabled)
-   - Acknowledged states older than `blockStream.buffer.blockTtl` are removed
    - If buffer size exceeds safe thresholds after pruning, backpressure is applied
 2. **HandleWorkflow Level**
    - `HandleWorkflow` checks for backpressure signals before processing each round of transactions

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
@@ -25,7 +25,9 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.NavigableMap;
+import java.util.SortedSet;
 import java.util.TreeMap;
+import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -55,6 +57,8 @@ public class BlockBufferService {
     private static final Logger logger = LogManager.getLogger(BlockBufferService.class);
     private static final Duration DEFAULT_WORKER_INTERVAL = Duration.ofSeconds(1);
     private static final int DEFAULT_BUFFER_SIZE = 150;
+    private static final long DEFAULT_BUFFER_BYTES = 15L * BlockStreamingUtils.GB_TO_BYTES; // 15 GB
+    private static final long MIN_BUFFER_BYTES = 10L * BlockStreamingUtils.MB_TO_BYTES; // 10 MB
 
     /**
      * Buffer that stores recent blocks. This buffer is unbounded, however it is technically capped because back
@@ -141,6 +145,11 @@ public class BlockBufferService {
      * data to a block node or persisting on disk.
      */
     private final LongAdder bufferSizeInBytes = new LongAdder();
+    /**
+     * The most recent parsed value for the {@link BlockBufferConfig#maxBytes()} configuration.
+     */
+    private final AtomicReference<BufferMaxBytes> bufferMaxBytesRef =
+            new AtomicReference<>(new BufferMaxBytes("*", DEFAULT_BUFFER_BYTES));
 
     /**
      * Creates a new BlockBufferService with the given configuration.
@@ -190,9 +199,10 @@ public class BlockBufferService {
         if (latestResult == null) {
             return null;
         }
-
-        final boolean isActionStage = latestResult.saturationPercent >= actionStageThreshold();
-        return new BlockBufferStatus(latestResult.timestamp, latestResult.saturationPercent, isActionStage);
+        return new BlockBufferStatus(
+                latestResult.timestamp,
+                latestResult.saturationInfo.maxSaturationPercent(),
+                latestResult.saturationInfo.isAtActionStage);
     }
 
     /**
@@ -263,6 +273,43 @@ public class BlockBufferService {
     private int maxBufferedBlocks() {
         final int maxBufferedBlocks = bufferConfig().maxBlocks();
         return maxBufferedBlocks <= 0 ? DEFAULT_BUFFER_SIZE : maxBufferedBlocks;
+    }
+
+    private long maxBufferedBytes() {
+        final String rawMaxBytes = bufferConfig().maxBytes();
+        final BufferMaxBytes maxBytes = bufferMaxBytesRef.get();
+
+        if (maxBytes.raw.equals(rawMaxBytes)) {
+            // config is unchanged, no need to parse the config value again
+            return maxBytes.bytes;
+        }
+
+        if (rawMaxBytes == null || rawMaxBytes.isBlank()) {
+            return DEFAULT_BUFFER_BYTES;
+        }
+
+        final long bytes = BlockStreamingUtils.parseToBytes(rawMaxBytes);
+
+        if (bytes == -1) {
+            logger.warn(
+                    "Configured max buffer size in bytes (input: '{}') is not valid; defaulting to max size of {} bytes",
+                    rawMaxBytes,
+                    DEFAULT_BUFFER_BYTES);
+            bufferMaxBytesRef.compareAndSet(maxBytes, new BufferMaxBytes(rawMaxBytes, DEFAULT_BUFFER_BYTES));
+        } else if (bytes < MIN_BUFFER_BYTES) {
+            logger.warn(
+                    "Configured max buffer size in bytes (input: '{}' -> {} bytes) is below minimum size (min: {} bytes); defaulting to {} bytes",
+                    rawMaxBytes,
+                    bytes,
+                    MIN_BUFFER_BYTES,
+                    MIN_BUFFER_BYTES);
+            bufferMaxBytesRef.compareAndSet(maxBytes, new BufferMaxBytes(rawMaxBytes, MIN_BUFFER_BYTES));
+        } else {
+            bufferMaxBytesRef.compareAndSet(maxBytes, new BufferMaxBytes(rawMaxBytes, bytes));
+            logger.debug("Successfully parsed max buffer size (input: '{}', result: {} bytes)", rawMaxBytes, bytes);
+        }
+
+        return bufferMaxBytesRef.get().bytes();
     }
 
     /**
@@ -666,88 +713,103 @@ public class BlockBufferService {
      * until the buffer size is within the configured limit. Also computes saturation based on the number of
      * unacknowledged blocks.
      *
-     * <p>When backpressure is enabled, pruning also enforces a soft retention floor configured via
-     * {@code blockStream.buffer.minAckedBlocksToBuffer}: at least this many of the most recent
-     * acknowledged blocks are retained; older acknowledged blocks are dropped even when the buffer is
-     * below {@code maxBlocks}. This keeps steady-state memory low when the block node is healthy while
-     * still preserving a recent window of acked blocks in case one is re-requested. The hard
-     * {@code maxBlocks} ceiling still wins when the buffer is dominated by unacknowledged blocks.
+     * <p> During the pruning process a soft retention policy is enforced for acknowledged blocks. Based on
+     * {@link BlockBufferConfig#ackedBlocksToRetain()}, a certain number of acknowledged blocks may be retained in the
+     * buffer. Acknowledged blocks that fall outside of this retention policy are aggressively pruned. However, this
+     * retention policy is overruled when the amount of unacknowledged blocks (either as a count of blocks or as the
+     * total bytes those blocks consume) exceeds the configured limits. When this happens the number of acknowledged
+     * blocks to retain may be less than what is configured - potentially zero.
      */
-    private @NonNull PruneResult pruneBuffer() {
+    private PruneResult pruneBuffer() {
         final long highestBlockAcked = highestAckedBlockNumber.get();
-        final int maxBufferSize = maxBufferedBlocks();
+        final int maxBlocksAllowed = maxBufferedBlocks();
+        final long maxBytesAllowed = maxBufferedBytes();
         final boolean backpressureEnabled = isBackpressureEnabled();
+        final int maxAckedBlocksToRetain = bufferConfig().ackedBlocksToRetain();
+        final List<Long> orderedBlocks = new ArrayList<>(blockBuffer.keySet());
+        Collections.sort(orderedBlocks);
 
-        // Create a sorted snapshot of keys so the pruning order is oldest-first
-        final List<Long> orderedBuffer = new ArrayList<>(blockBuffer.keySet());
-        Collections.sort(orderedBuffer); // ascending (oldest first)
+        final long ackedBlockRetentionThreshold;
 
-        // Soft-limit threshold: acknowledged blocks strictly below this number are eligible for
-        // aggressive pruning, leaving exactly `minAckedBlocksToBuffer` of the most recent acked blocks
-        // in the buffer. Anchor the retention window on the most recent acked block that is actually
-        // present in the buffer: `highestBlockAcked` is a high-water mark that can run ahead of the
-        // highest buffered block (e.g. an ack for a block that was never buffered), and anchoring on
-        // the raw watermark in that case would prune one genuinely-retained block. The retained window
-        // is then `[anchor - N + 1, anchor]`, which spans N block numbers; the `+ 1` makes the lower
-        // bound exclusive so the count matches the configured value (e.g. N=0 retains no acked blocks,
-        // N=3 retains 3). When no blocks have been acknowledged yet, or the buffer is empty, leave the
-        // threshold at Long.MIN_VALUE so the branch is inert (and the subtraction cannot underflow).
-        // Only read the config when backpressure is enabled.
-        final long pruneBlockNumberThreshold;
-        if (backpressureEnabled && highestBlockAcked != Long.MIN_VALUE && !orderedBuffer.isEmpty()) {
-            final long highestAckedInBuffer = Math.min(highestBlockAcked, orderedBuffer.get(orderedBuffer.size() - 1));
-            pruneBlockNumberThreshold = highestAckedInBuffer - bufferConfig().minAckedBlocksToBuffer() + 1;
+        if (orderedBlocks.isEmpty() || highestBlockAcked < 0) {
+            ackedBlockRetentionThreshold = -1L;
         } else {
-            pruneBlockNumberThreshold = Long.MIN_VALUE;
+            final long highestBufferedBlock = orderedBlocks.getLast();
+
+            if (highestBufferedBlock < highestBlockAcked) {
+                ackedBlockRetentionThreshold = highestBufferedBlock - maxAckedBlocksToRetain + 1;
+            } else {
+                ackedBlockRetentionThreshold = highestBlockAcked - maxAckedBlocksToRetain + 1;
+            }
         }
 
         int numPruned = 0;
         int numChecked = 0;
-        int numPendingAck = 0;
         int numInProgress = 0;
         long newEarliestBlock = Long.MAX_VALUE;
         long newLatestBlock = Long.MIN_VALUE;
+        long bytesPruned = 0;
+        final SortedSet<Long> blocksPruned = new TreeSet<>();
 
-        int size = blockBuffer.size();
-        for (final long blockNumber : orderedBuffer) {
+        for (final long blockNumber : orderedBlocks) {
             final BlockState block = blockBuffer.get(blockNumber);
             ++numChecked;
 
-            if (block.closedTimestamp() == null) {
+            if (!block.isClosed()) {
+                // this block is not closed, and therefore not eligible to be pruned
                 ++numInProgress;
                 newEarliestBlock = Math.min(newEarliestBlock, blockNumber);
                 newLatestBlock = Math.max(newLatestBlock, blockNumber);
-                continue; // the block is not finished yet, so skip checking it
+                continue;
             }
 
-            final boolean shouldPrune;
-            if (!backpressureEnabled) {
-                // If backpressure is disabled, remove blocks based solely on the maximum buffer size
-                shouldPrune = (size > maxBufferSize);
-            } else {
-                // If backpressure is enabled, prune an acknowledged block when either the buffer
-                // exceeds the hard ceiling, or the block is older than the soft retention floor.
-                shouldPrune = (blockNumber <= highestBlockAcked)
-                        && ((size > maxBufferSize) || (blockNumber < pruneBlockNumberThreshold));
-            }
+            final boolean isAcked = blockNumber <= highestBlockAcked;
+            final boolean maxBlocksExceeded = blockBuffer.size() > maxBlocksAllowed;
+            final boolean maxBytesExceeded = bufferSizeInBytes.sum() > maxBytesAllowed;
+            final boolean blockOlderThanRetentionThreshold = blockNumber < ackedBlockRetentionThreshold;
 
-            if (shouldPrune) {
+            if (isAcked && (maxBlocksExceeded || maxBytesExceeded || blockOlderThanRetentionThreshold)) {
+                /*
+                The block is acknowledged, and at least one of the following is true: 1) the buffer is too large in
+                terms of number of blocks, 2) the buffer is too large in terms of bytes, or 3) the block is older than
+                the threshold used to retain acknowledged blocks
+                 */
+                logger.trace(
+                        "Acknowledged block ({}) is being pruned (reason: maxBlocksExceeded({}), maxBytesExceeded({}), blockOlderThanRetentionThreshold({}))",
+                        blockNumber,
+                        maxBlocksExceeded,
+                        maxBytesExceeded,
+                        blockOlderThanRetentionThreshold);
                 blockBuffer.remove(blockNumber);
                 ++numPruned;
-                --size;
-                bufferSizeInBytes.add(-block.sizeBytes()); // subtract the size of the block
+                final long blockSizeInBytes = block.sizeBytes();
+                bytesPruned += blockSizeInBytes;
+                bufferSizeInBytes.add(-blockSizeInBytes);
+                blocksPruned.add(blockNumber);
+            } else if (!isAcked && !backpressureEnabled && (maxBlocksExceeded || maxBytesExceeded)) {
+                /*
+                The block is not yet acknowledged, but back pressure is not enabled. Additionally, the buffer is too
+                large (either in terms of number of blocks or number of bytes). Based on this, the block can safely be
+                pruned.
+                 */
+                logger.trace(
+                        "Unacknowledged block ({}) is being pruned (reason: backPressureEnabled(false), maxBlocksExceeded({}), maxBytesExceeded({}))",
+                        blockNumber,
+                        maxBlocksExceeded,
+                        maxBytesExceeded);
+                blockBuffer.remove(blockNumber);
+                ++numPruned;
+                final long blockSizeInBytes = block.sizeBytes();
+                bytesPruned += blockSizeInBytes;
+                bufferSizeInBytes.add(-blockSizeInBytes);
+                blocksPruned.add(blockNumber);
             } else {
-                // Track all unacknowledged blocks
-                if (blockNumber > highestBlockAcked) {
-                    ++numPendingAck;
-                }
-                // Keep track of the earliest and the latest remaining blocks
+                // The block is not a candidate to prune
                 newEarliestBlock = Math.min(newEarliestBlock, blockNumber);
                 newLatestBlock = Math.max(newLatestBlock, blockNumber);
             }
         }
 
-        // update the earliest block number after pruning
         newEarliestBlock = newEarliestBlock == Long.MAX_VALUE ? Long.MIN_VALUE : newEarliestBlock;
         newLatestBlock = newLatestBlock == Long.MIN_VALUE ? -1 : newLatestBlock;
         earliestBlockNumber.set(newEarliestBlock);
@@ -756,76 +818,104 @@ public class BlockBufferService {
         blockStreamMetrics.recordBufferOldestBlock(newEarliestBlock == Long.MIN_VALUE ? -1 : newEarliestBlock);
         blockStreamMetrics.recordBufferNewestBlock(newLatestBlock);
 
-        return new PruneResult(
-                Instant.now(),
-                maxBufferSize,
-                numChecked,
-                numInProgress,
-                numPendingAck,
-                numPruned,
-                newEarliestBlock,
-                newLatestBlock);
-    }
+        final long finalHighestAckedBlock = highestAckedBlockNumber.get();
+        int finalUnackedBlockCount = 0;
+        long finalUnackedBlockBytes = 0;
 
-    /**
-     * Simple class that contains information related to the outcome of the buffer pruning.
-     */
-    static class PruneResult {
-        static final PruneResult NIL = new PruneResult(Instant.MIN, 0, 0, 0, 0, 0, 0, 0);
-
-        final Instant timestamp;
-        final long idealMaxBufferSize;
-        final int numBlocksInProgress;
-        final int numBlocksChecked;
-        final int numBlocksPendingAck;
-        final int numBlocksPruned;
-        final long oldestBlockNumber;
-        final long newestBlockNumber;
-        final double saturationPercent;
-        final boolean isSaturated;
-
-        PruneResult(
-                final Instant timestamp,
-                final long idealMaxBufferSize,
-                final int numBlocksChecked,
-                final int numBlocksInProgress,
-                final int numBlocksPendingAck,
-                final int numBlocksPruned,
-                final long oldestBlockNumber,
-                final long newestBlockNumber) {
-            this.timestamp = timestamp;
-            this.idealMaxBufferSize = idealMaxBufferSize;
-            this.numBlocksChecked = numBlocksChecked;
-            this.numBlocksInProgress = numBlocksInProgress;
-            this.numBlocksPendingAck = numBlocksPendingAck;
-            this.numBlocksPruned = numBlocksPruned;
-            this.oldestBlockNumber = oldestBlockNumber;
-            this.newestBlockNumber = newestBlockNumber;
-
-            isSaturated = idealMaxBufferSize != 0 && numBlocksPendingAck >= idealMaxBufferSize;
-
-            if (idealMaxBufferSize == 0) {
-                saturationPercent = 0D;
-            } else {
-                final BigDecimal size = BigDecimal.valueOf(idealMaxBufferSize);
-                final BigDecimal pending = BigDecimal.valueOf(numBlocksPendingAck);
-                saturationPercent = pending.divide(size, 6, RoundingMode.HALF_EVEN)
-                        .multiply(BigDecimal.valueOf(100))
-                        .doubleValue();
+        for (final BlockState block : blockBuffer.values()) {
+            if (block.isClosed() && (finalHighestAckedBlock < 0 || block.blockNumber() > finalHighestAckedBlock)) {
+                // we only care about unacknowledged, closed blocks; don't count in-progress blocks
+                finalUnackedBlockCount++;
+                finalUnackedBlockBytes += block.sizeBytes();
             }
         }
 
-        @Override
-        public String toString() {
-            return "PruneResult{" + "timestamp=" + timestamp + ", idealMaxBufferSize="
-                    + idealMaxBufferSize + ", numBlocksChecked="
-                    + numBlocksChecked + ", numBlocksPendingAck="
-                    + numBlocksPendingAck + ", numBlocksInProgress="
-                    + numBlocksInProgress + ", numBlocksPruned="
-                    + numBlocksPruned + ", saturationPercent="
-                    + saturationPercent + ", isSaturated="
-                    + isSaturated + '}';
+        final BigDecimal bufferCountSaturationPercent = BigDecimal.valueOf(finalUnackedBlockCount)
+                .divide(BigDecimal.valueOf(maxBlocksAllowed), 4, RoundingMode.HALF_EVEN)
+                .multiply(BigDecimal.valueOf(100));
+        final BigDecimal bufferBytesSaturationPercent = BigDecimal.valueOf(finalUnackedBlockBytes)
+                .divide(BigDecimal.valueOf(maxBytesAllowed), 4, RoundingMode.HALF_EVEN)
+                .multiply(BigDecimal.valueOf(100));
+        final BigDecimal maxSaturation = bufferCountSaturationPercent.max(bufferBytesSaturationPercent);
+        final double actionStage = actionStageThreshold();
+        final boolean isAtActionStage = maxSaturation.compareTo(BigDecimal.valueOf(actionStage)) >= 0;
+        final boolean isSaturated = maxSaturation.compareTo(BigDecimal.valueOf(100)) >= 0;
+        final int liveBlockCount = blockBuffer.size();
+        final long liveByteCount = bufferSizeInBytes.sum();
+
+        blockStreamMetrics.recordBufferedBlocks(liveBlockCount);
+        blockStreamMetrics.recordBufferedBlocksPendingAck(finalUnackedBlockCount);
+        blockStreamMetrics.recordBufferSizeInBytes(liveByteCount);
+        blockStreamMetrics.recordBufferSaturation(maxSaturation.doubleValue());
+
+        if (logger.isDebugEnabled()) {
+            logger.debug(
+                    "Block Buffer Status - Config(MaxBlocks: {}, MaxBytes: {}, MaxAckedBlocksToRetain: {}) CheckInfo(Checked: {}, InProgress: {}, PendingAck: {}) PruneInfo(Blocks: {}, Bytes: {}) LiveInfo(Blocks: {}, Bytes: {}, HighestBlockAcked: {}) SaturationInfo(ByBlockCount: {}%, ByTotalBytes: {}%)",
+                    maxBlocksAllowed,
+                    maxBytesAllowed,
+                    maxAckedBlocksToRetain,
+                    numChecked,
+                    numInProgress,
+                    finalUnackedBlockCount,
+                    numPruned,
+                    bytesPruned,
+                    getContiguousRangesAsString(new ArrayList<>(blockBuffer.keySet())),
+                    liveByteCount,
+                    finalHighestAckedBlock,
+                    bufferCountSaturationPercent.toPlainString(),
+                    bufferBytesSaturationPercent.toPlainString());
         }
+
+        return new PruneResult(
+                Instant.now(),
+                new PruneConfig(maxBlocksAllowed, maxBytesAllowed, maxAckedBlocksToRetain),
+                new CheckInfo(numChecked, numInProgress, finalUnackedBlockCount),
+                new PruneInfo(numPruned, bytesPruned, blocksPruned),
+                new LiveBufferInfo(liveBlockCount, liveByteCount, finalHighestAckedBlock),
+                new SaturationInfo(
+                        bufferCountSaturationPercent.doubleValue(),
+                        bufferBytesSaturationPercent.doubleValue(),
+                        isSaturated,
+                        isAtActionStage));
+    }
+
+    record PruneConfig(int maxBlocks, long maxBytes, int maxAckedBlocksToRetain) {
+        static final PruneConfig NIL = new PruneConfig(-1, -1, -1);
+    }
+
+    record CheckInfo(int blocksChecked, int blocksInProgress, int blocksPendingAck) {
+        static final CheckInfo NIL = new CheckInfo(0, 0, 0);
+    }
+
+    record PruneInfo(int prunedBlockCount, long prunedByteCount, SortedSet<Long> blocksPruned) {
+        static final PruneInfo NIL = new PruneInfo(0, 0, Collections.unmodifiableSortedSet(new TreeSet<>()));
+    }
+
+    record LiveBufferInfo(int liveBlockCount, long liveByteCount, long highestAckedBlockNumber) {
+        static final LiveBufferInfo NIL = new LiveBufferInfo(0, 0, -1);
+    }
+
+    record SaturationInfo(
+            double blockCountSaturationPercent,
+            double bytesSaturationPercent,
+            boolean isSaturated,
+            boolean isAtActionStage) {
+        static final SaturationInfo NIL = new SaturationInfo(0.0D, 0.0D, false, false);
+
+        double maxSaturationPercent() {
+            return Double.max(blockCountSaturationPercent, bytesSaturationPercent);
+        }
+    }
+
+    record PruneResult(
+            Instant timestamp,
+            PruneConfig config,
+            CheckInfo checkInfo,
+            PruneInfo pruneInfo,
+            LiveBufferInfo liveBufferInfo,
+            SaturationInfo saturationInfo) {
+        static final PruneResult NIL = new PruneResult(
+                Instant.MIN, PruneConfig.NIL, CheckInfo.NIL, PruneInfo.NIL, LiveBufferInfo.NIL, SaturationInfo.NIL);
     }
 
     /**
@@ -839,40 +929,19 @@ public class BlockBufferService {
             return;
         }
 
-        final PruneResult pruningResult = pruneBuffer();
-        final PruneResult previousPruneResult = lastPruningResultRef.getAndSet(pruningResult);
-        final long bufferTotalBytes = bufferSizeInBytes.sum();
-
-        // create a list of ranges of contiguous blocks in the buffer
-        if (logger.isDebugEnabled()) {
-            logger.debug(
-                    "Block buffer status: idealMaxBufferSize: {}, blocksChecked: {}, blocksInProgress: {}, blocksPruned: {}, blocksPendingAck: {}, blockRange: {}, saturation: {}%, bufferSizeBytes: {}",
-                    pruningResult.idealMaxBufferSize,
-                    pruningResult.numBlocksChecked,
-                    pruningResult.numBlocksInProgress,
-                    pruningResult.numBlocksPruned,
-                    pruningResult.numBlocksPendingAck,
-                    getContiguousRangesAsString(new ArrayList<>(blockBuffer.keySet())),
-                    pruningResult.saturationPercent,
-                    bufferTotalBytes);
-        }
-
-        blockStreamMetrics.recordBufferedBlocks(blockBuffer.size());
-        blockStreamMetrics.recordBufferedBlocksPendingAck(pruningResult.numBlocksPendingAck);
-        blockStreamMetrics.recordBufferSizeInBytes(bufferTotalBytes);
-        blockStreamMetrics.recordBufferSaturation(pruningResult.saturationPercent);
-
+        final PruneResult latestResult = pruneBuffer();
+        final PruneResult previousResult = lastPruningResultRef.getAndSet(latestResult);
         final double actionStageThreshold = actionStageThreshold();
 
-        if (previousPruneResult.saturationPercent < actionStageThreshold) {
-            if (pruningResult.isSaturated) {
+        if (previousResult.saturationInfo.maxSaturationPercent() < actionStageThreshold) {
+            if (latestResult.saturationInfo.isSaturated) {
                 /*
                 Zero -> Full
                 The buffer has transitioned from zero/low saturation levels to fully saturated. We need to ensure back
                 pressure is engaged and potentially change which Block Node we are connected to.
                  */
-                enableBackPressure(pruningResult);
-            } else if (pruningResult.saturationPercent >= actionStageThreshold) {
+                enableBackPressure(latestResult);
+            } else if (latestResult.saturationInfo.maxSaturationPercent() >= actionStageThreshold) {
                 /*
                 Zero -> Action Stage
                 The buffer has transitioned from zero/low saturation levels to exceeding the action stage threshold. We
@@ -888,15 +957,16 @@ public class BlockBufferService {
                  */
                 blockStreamMetrics.recordBackPressureDisabled();
             }
-        } else if (!previousPruneResult.isSaturated && previousPruneResult.saturationPercent >= actionStageThreshold) {
-            if (pruningResult.isSaturated) {
+        } else if (!previousResult.saturationInfo.isSaturated
+                && previousResult.saturationInfo.maxSaturationPercent() >= actionStageThreshold) {
+            if (latestResult.saturationInfo.isSaturated) {
                 /*
                 Action Stage -> Full
                 The buffer has transitioned from the action stage saturation level to being completely full/saturated.
                 Back pressure needs to be applied and possibly switch to a different Block Node.
                  */
-                enableBackPressure(pruningResult);
-            } else if (pruningResult.saturationPercent >= actionStageThreshold) {
+                enableBackPressure(latestResult);
+            } else if (latestResult.saturationInfo.maxSaturationPercent() >= actionStageThreshold) {
                 /*
                 Action Stage -> Action Stage
                 Before and after the pruning, the buffer saturation remained at the action stage level. Back pressure
@@ -912,15 +982,15 @@ public class BlockBufferService {
                  */
                 blockStreamMetrics.recordBackPressureDisabled();
             }
-        } else if (previousPruneResult.isSaturated) {
-            if (pruningResult.isSaturated) {
+        } else if (previousResult.saturationInfo.isSaturated) {
+            if (latestResult.saturationInfo.isSaturated) {
                 /*
                 Full -> Full
                 Before and after pruning, the buffer remained fully saturated. Back pressure should be enabled - if not
                 already - and we should maybe swap to a different Block Node.
                  */
-                enableBackPressure(pruningResult);
-            } else if (pruningResult.saturationPercent >= actionStageThreshold) {
+                enableBackPressure(latestResult);
+            } else if (latestResult.saturationInfo.maxSaturationPercent() >= actionStageThreshold) {
                 /*
                 Full -> Action Stage
                 Before the pruning, the buffer was fully saturated, but after pruning the buffer is no longer fully
@@ -928,7 +998,7 @@ public class BlockBufferService {
                 there has been enough buffer recovery. Since the buffer appears to be recovering, avoid trying to
                 connect to a different Block Node.
                  */
-                disableBackPressureIfRecovered(pruningResult);
+                disableBackPressureIfRecovered(latestResult);
                 if (awaitingRecovery) {
                     blockStreamMetrics.recordBackPressureRecovering();
                 } else {
@@ -941,7 +1011,7 @@ public class BlockBufferService {
                 below the action stage threshold. If back pressure is still engaged, it should be removed. Furthermore,
                 since the buffer fully recovered we should avoid trying to connect to a different Block Node.
                  */
-                disableBackPressureIfRecovered(pruningResult);
+                disableBackPressureIfRecovered(latestResult);
                 if (awaitingRecovery) {
                     blockStreamMetrics.recordBackPressureRecovering();
                 } else {
@@ -950,8 +1020,8 @@ public class BlockBufferService {
             }
         }
 
-        if (awaitingRecovery && !pruningResult.isSaturated) {
-            disableBackPressureIfRecovered(pruningResult);
+        if (awaitingRecovery && !latestResult.saturationInfo.isSaturated) {
+            disableBackPressureIfRecovered(latestResult);
         }
     }
 
@@ -969,19 +1039,19 @@ public class BlockBufferService {
         }
         final double recoveryThreshold = recoveryThreshold();
 
-        if (latestPruneResult.saturationPercent > recoveryThreshold) {
+        if (latestPruneResult.saturationInfo.maxSaturationPercent() > recoveryThreshold) {
             // there is not enough of the buffer reclaimed/available yet... do not disable back pressure
             awaitingRecovery = true;
             logger.debug(
                     "Attempted to disable back pressure, but buffer saturation is not less than or equal to recovery threshold (saturation: {}%, recoveryThreshold: {}%)",
-                    latestPruneResult.saturationPercent, recoveryThreshold);
+                    latestPruneResult.saturationInfo.maxSaturationPercent(), recoveryThreshold);
             return;
         }
 
         awaitingRecovery = false;
         logger.debug(
-                "Buffer saturation is below or equal to the recovery threshold; back pressure will be disabled. (saturation: {}%, recoveryThreshold: {}%)",
-                latestPruneResult.saturationPercent, recoveryThreshold);
+                "Buffer saturation is below or equal to the recovery threshold; back pressure will be disabled (saturation: {}%, recoveryThreshold: {}%)",
+                latestPruneResult.saturationInfo.maxSaturationPercent(), recoveryThreshold);
 
         disableBackPressure();
     }
@@ -1020,13 +1090,9 @@ public class BlockBufferService {
                 blockStreamMetrics.recordBackPressureActive();
 
                 logger.warn(
-                        "Block buffer is saturated; backpressure is being enabled "
-                                + "(idealMaxBufferSize: {}, blocksChecked: {}, blocksPruned: {}, blocksPendingAck: {}, saturation: {}%)",
-                        latestPruneResult.idealMaxBufferSize,
-                        latestPruneResult.numBlocksChecked,
-                        latestPruneResult.numBlocksPruned,
-                        latestPruneResult.numBlocksPendingAck,
-                        latestPruneResult.saturationPercent);
+                        "Block buffer is saturated; backpressure is being enabled (blockCountSaturation: {}%, bytesSaturation: {}%)",
+                        latestPruneResult.saturationInfo.blockCountSaturationPercent,
+                        latestPruneResult.saturationInfo.bytesSaturationPercent);
             } else {
                 // If the existing future is not null and not completed, re-use it
                 newCf = oldCf;
@@ -1117,4 +1183,6 @@ public class BlockBufferService {
     private static String formatRange(final long start, final long end) {
         return start == end ? "(" + start + ")" : "(" + start + "-" + end + ")";
     }
+
+    private record BufferMaxBytes(String raw, long bytes) {}
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockStreamingUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockStreamingUtils.java
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl.streaming;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+
+public final class BlockStreamingUtils {
+
+    static final long KB_TO_BYTES = 1024;
+    static final long MB_TO_BYTES = KB_TO_BYTES * 1024;
+    static final long GB_TO_BYTES = MB_TO_BYTES * 1024;
+
+    private BlockStreamingUtils() {
+        throw new UnsupportedOperationException();
+    }
+
+    /**
+     * Converts a size string into a byte value. Accepted units are gigabyte (G|g), megabyte (M|m), kilobyte (K|k), or
+     * unspecified which is interpreted as simple bytes.
+     *
+     * @param string the string to parse
+     * @return the input string as bytes, or -1 if parsing failed for any reason including negative values
+     */
+    public static long parseToBytes(@Nullable final String string) {
+        if (string == null || string.isBlank()) {
+            return -1;
+        }
+
+        final String str = string.trim();
+        final char unit = str.charAt(str.length() - 1);
+        final long bytes;
+
+        if ('G' == unit || 'g' == unit) {
+            // parse gigabytes
+            final long parsedGigabytes = parseLong(str.substring(0, str.length() - 1));
+            final long parsedBytes = multiply(GB_TO_BYTES, parsedGigabytes);
+            bytes = Math.max(-1L, parsedBytes);
+        } else if ('M' == unit || 'm' == unit) {
+            // parse megabytes
+            final long parsedMegabytes = parseLong(str.substring(0, str.length() - 1));
+            final long parsedBytes = multiply(MB_TO_BYTES, parsedMegabytes);
+            bytes = Math.max(-1L, parsedBytes);
+        } else if ('K' == unit || 'k' == unit) {
+            // parse kilobytes
+            final long parsedKilobytes = parseLong(str.substring(0, str.length() - 1));
+            final long parsedBytes = multiply(KB_TO_BYTES, parsedKilobytes);
+            bytes = Math.max(-1L, parsedBytes);
+        } else if (Character.isDigit(unit)) {
+            // parse bytes
+            final long parsedBytes = parseLong(str);
+            bytes = Math.max(-1L, parsedBytes);
+        } else {
+            bytes = -1;
+        }
+
+        return bytes;
+    }
+
+    private static long multiply(final long a, final long b) {
+        try {
+            return Math.multiplyExact(a, b);
+        } catch (final ArithmeticException _) {
+            return -1;
+        }
+    }
+
+    private static long parseLong(final String string) {
+        try {
+            return Long.parseLong(string);
+        } catch (final NumberFormatException _) {
+            return -1;
+        }
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferServiceTest.java
@@ -10,6 +10,8 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.doubleThat;
+import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
@@ -21,6 +23,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.block.stream.BlockItem;
+import com.hedera.hapi.block.stream.BlockItem.ItemOneOfType;
 import com.hedera.hapi.block.stream.output.BlockHeader;
 import com.hedera.node.app.blocks.impl.streaming.BlockBufferService.PruneResult;
 import com.hedera.node.app.blocks.impl.streaming.obs.BlockStreamingObs;
@@ -33,6 +36,7 @@ import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.node.config.types.BlockStreamWriterMode;
 import com.hedera.node.config.types.StreamMode;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import java.io.File;
 import java.io.IOException;
@@ -63,11 +67,13 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -83,25 +89,31 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     private static final VarHandle isStartedHandle;
     private static final MethodHandle checkBufferHandle;
     private static final MethodHandle persistBufferHandle;
+    private static final MethodHandle maxBufferedBytesHandle;
 
     static {
         try {
-            final Lookup lookup = MethodHandles.privateLookupIn(BlockBufferService.class, MethodHandles.lookup());
-            blockBufferHandle = lookup.findVarHandle(BlockBufferService.class, "blockBuffer", ConcurrentMap.class);
-            execSvcHandle = lookup.findVarHandle(BlockBufferService.class, "execSvc", ScheduledExecutorService.class);
-            backPressureFutureRefHandle = lookup.findVarHandle(
-                    BlockBufferService.class, "backpressureCompletableFutureRef", AtomicReference.class);
-            lastPruningResultRefHandle =
-                    lookup.findVarHandle(BlockBufferService.class, "lastPruningResultRef", AtomicReference.class);
-            isStartedHandle = lookup.findVarHandle(BlockBufferService.class, "isStarted", AtomicBoolean.class);
+            final Class<?> cls = BlockBufferService.class;
+            final Lookup lookup = MethodHandles.privateLookupIn(cls, MethodHandles.lookup());
 
-            final Method checkBufferMethod = BlockBufferService.class.getDeclaredMethod("checkBuffer");
+            blockBufferHandle = lookup.findVarHandle(cls, "blockBuffer", ConcurrentMap.class);
+            execSvcHandle = lookup.findVarHandle(cls, "execSvc", ScheduledExecutorService.class);
+            backPressureFutureRefHandle =
+                    lookup.findVarHandle(cls, "backpressureCompletableFutureRef", AtomicReference.class);
+            lastPruningResultRefHandle = lookup.findVarHandle(cls, "lastPruningResultRef", AtomicReference.class);
+            isStartedHandle = lookup.findVarHandle(cls, "isStarted", AtomicBoolean.class);
+
+            final Method checkBufferMethod = cls.getDeclaredMethod("checkBuffer");
             checkBufferMethod.setAccessible(true);
             checkBufferHandle = lookup.unreflect(checkBufferMethod);
 
-            final Method persisBufferMethod = BlockBufferService.class.getDeclaredMethod("persistBuffer");
+            final Method persisBufferMethod = cls.getDeclaredMethod("persistBuffer");
             persisBufferMethod.setAccessible(true);
             persistBufferHandle = lookup.unreflect(persisBufferMethod);
+
+            final Method maxBufferedBytesMethod = cls.getDeclaredMethod("maxBufferedBytes");
+            maxBufferedBytesMethod.setAccessible(true);
+            maxBufferedBytesHandle = lookup.unreflect(maxBufferedBytesMethod);
         } catch (final Exception e) {
             throw new RuntimeException(e);
         }
@@ -160,6 +172,11 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         }
 
         cleanupDirectory();
+    }
+
+    @AfterAll
+    static void afterAll() {
+        Mockito.clearAllCaches();
     }
 
     @Test
@@ -520,7 +537,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         PruneResult lastPruningResult = lastPruningResultRef(blockBufferService).get();
         assertThat(lastPruningResult).isNotNull();
 
-        assertThat(lastPruningResult.isSaturated).isFalse();
+        assertThat(lastPruningResult.saturationInfo().isSaturated()).isFalse();
         verify(blockStreamMetrics).recordBufferSaturation(80.0); // the buffer is 80% saturated
         verify(blockStreamMetrics).recordLatestBlockOpened(1L);
         verify(blockStreamMetrics).recordLatestBlockOpened(2L);
@@ -549,7 +566,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         // the buffer is now marked as saturated because multiple blocks have not been acked yet and they are expired
         lastPruningResult = lastPruningResultRef(blockBufferService).get();
         assertThat(lastPruningResult).isNotNull();
-        assertThat(lastPruningResult.isSaturated).isTrue();
+        assertThat(lastPruningResult.saturationInfo().isSaturated()).isTrue();
 
         verify(blockStreamMetrics).recordLatestBlockOpened(5L);
         verify(blockStreamMetrics).recordBlockOpened();
@@ -576,7 +593,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         checkBufferHandle.invoke(blockBufferService);
         lastPruningResult = lastPruningResultRef(blockBufferService).get();
         assertThat(lastPruningResult).isNotNull();
-        assertThat(lastPruningResult.isSaturated).isTrue();
+        assertThat(lastPruningResult.saturationInfo().isSaturated()).isTrue();
         verify(blockStreamMetrics).recordBufferSaturation(120.0); // the buffer is 120% saturated
         verify(blockStreamMetrics).recordLatestBlockOpened(6L);
         verify(blockStreamMetrics).recordBlockOpened();
@@ -607,7 +624,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         checkBufferHandle.invoke(blockBufferService);
         lastPruningResult = lastPruningResultRef(blockBufferService).get();
         assertThat(lastPruningResult).isNotNull();
-        assertThat(lastPruningResult.isSaturated).isFalse();
+        assertThat(lastPruningResult.saturationInfo().isSaturated()).isFalse();
         verify(blockStreamMetrics).recordBufferSaturation(60.0); // the buffer is 60% saturated
         verify(blockStreamMetrics).recordLatestBlockAcked(3L);
         verify(blockStreamMetrics).recordNumberOfBlocksPruned(1);
@@ -629,7 +646,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         checkBufferHandle.invoke(blockBufferService);
         lastPruningResult = lastPruningResultRef(blockBufferService).get();
         assertThat(lastPruningResult).isNotNull();
-        assertThat(lastPruningResult.isSaturated).isFalse();
+        assertThat(lastPruningResult.saturationInfo().isSaturated()).isFalse();
         verify(blockStreamMetrics).recordBufferSaturation(0.0); // the buffer is 0% saturated
         verify(blockStreamMetrics).recordLatestBlockAcked(6L);
         verify(blockStreamMetrics).recordNumberOfBlocksPruned(0);
@@ -653,7 +670,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         checkBufferHandle.invoke(blockBufferService);
         lastPruningResult = lastPruningResultRef(blockBufferService).get();
         assertThat(lastPruningResult).isNotNull();
-        assertThat(lastPruningResult.isSaturated).isFalse();
+        assertThat(lastPruningResult.saturationInfo().isSaturated()).isFalse();
         verify(blockStreamMetrics).recordLatestBlockOpened(7L);
         verify(blockStreamMetrics).recordBlockOpened();
         verify(blockStreamMetrics).recordBlockClosed();
@@ -695,7 +712,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         }
         checkBufferHandle.invoke(blockBufferService);
         verify(blockStreamMetrics).recordBufferedBlocksPendingAck(6);
-        assertThat(lastPruningResultRef(blockBufferService).get().numBlocksPendingAck)
+        assertThat(lastPruningResultRef(blockBufferService).get().checkInfo().blocksPendingAck())
                 .isEqualTo(6);
         reset(blockStreamMetrics);
 
@@ -742,7 +759,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         blockBufferService.setLatestAcknowledgedBlock(15L);
         checkBufferHandle.invoke(blockBufferService);
         verify(blockStreamMetrics).recordBufferedBlocksPendingAck(0);
-        assertThat(lastPruningResultRef(blockBufferService).get().numBlocksPendingAck)
+        assertThat(lastPruningResultRef(blockBufferService).get().checkInfo().blocksPendingAck())
                 .isZero();
     }
 
@@ -992,9 +1009,9 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         final PruneResult initialPruningResult =
                 lastPruningResultRef(blockBufferService).get();
         assertThat(initialPruningResult).isNotNull();
-        assertThat(initialPruningResult.isSaturated).isTrue();
-        assertThat(initialPruningResult.numBlocksPruned).isZero();
-        assertThat(initialPruningResult.numBlocksPendingAck).isEqualTo(10);
+        assertThat(initialPruningResult.saturationInfo().isSaturated()).isTrue();
+        assertThat(initialPruningResult.pruneInfo().prunedBlockCount()).isZero();
+        assertThat(initialPruningResult.checkInfo().blocksPendingAck()).isEqualTo(10);
 
         // back pressure should NOT be enabled
         final AtomicReference<CompletableFuture<Boolean>> backPressureFutureRef =
@@ -1116,8 +1133,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(2);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(2);
 
         // 2 blocks are unacked, add 8 more to fill the buffer
         for (int i = 3; i <= 10; ++i) {
@@ -1134,8 +1151,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isTrue();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(10);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isTrue();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(10);
 
         // back pressure should be enabled
         final AtomicReference<CompletableFuture<Boolean>> backPressureFutureRef =
@@ -1169,8 +1186,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(2);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(2);
 
         BlockBufferStatus bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1188,9 +1205,9 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(7);
-        assertThat(pruneResult.saturationPercent).isEqualTo(70.0D);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(7);
+        assertThat(pruneResult.saturationInfo().maxSaturationPercent()).isEqualTo(70.0D);
 
         bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1204,7 +1221,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         verify(blockStreamMetrics, times(5)).recordBlockOpened();
         verify(blockStreamMetrics, times(5)).recordBlockClosed();
-        verify(blockStreamMetrics).recordBufferSaturation(pruneResult.saturationPercent);
+        verify(blockStreamMetrics)
+                .recordBufferSaturation(pruneResult.saturationInfo().maxSaturationPercent());
         verify(blockStreamMetrics).recordBackPressureDisabled();
         verify(blockStreamMetrics).recordBackPressureActionStage();
         verify(blockStreamMetrics, times(2)).recordBufferSaturation(anyDouble());
@@ -1227,8 +1245,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(2);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(2);
 
         BlockBufferStatus bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1245,8 +1263,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(4);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(4);
 
         bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1283,8 +1301,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(7);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(7);
 
         BlockBufferStatus bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1303,8 +1321,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isTrue();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(10);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isTrue();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(10);
 
         bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1344,8 +1362,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(7);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(7);
 
         BlockBufferStatus bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1360,8 +1378,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(8);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(8);
 
         bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1398,8 +1416,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(7);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(7);
 
         BlockBufferStatus bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1413,8 +1431,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(2);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(2);
 
         bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1447,8 +1465,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isTrue();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(10);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isTrue();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(10);
 
         BlockBufferStatus bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1459,8 +1477,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isTrue();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(10);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isTrue();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(10);
 
         bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1491,8 +1509,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isTrue();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(10);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isTrue();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(10);
 
         BlockBufferStatus bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1506,8 +1524,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(6);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(6);
 
         bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1542,8 +1560,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isTrue();
-        assertThat(pruneResult.numBlocksPendingAck).isEqualTo(10);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isTrue();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(10);
 
         BlockBufferStatus bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1557,8 +1575,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
 
         pruneResult = lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult).isNotNull();
-        assertThat(pruneResult.isSaturated).isFalse();
-        assertThat(pruneResult.numBlocksPendingAck).isZero();
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isZero();
 
         bufferStatus = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus).isNotNull();
@@ -1613,8 +1631,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         final PruneResult pruneResult1 =
                 lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult1).isNotNull();
-        assertThat(pruneResult1.isSaturated).isTrue();
-        assertThat(pruneResult1.saturationPercent).isEqualTo(100.0);
+        assertThat(pruneResult1.saturationInfo().isSaturated()).isTrue();
+        assertThat(pruneResult1.saturationInfo().maxSaturationPercent()).isEqualTo(100.0);
 
         final BlockBufferStatus bufferStatus1 = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus1).isNotNull();
@@ -1649,8 +1667,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         final PruneResult pruneResult2 =
                 lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult2).isNotNull();
-        assertThat(pruneResult2.isSaturated).isFalse();
-        assertThat(pruneResult2.saturationPercent).isEqualTo(80.0);
+        assertThat(pruneResult2.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult2.saturationInfo().maxSaturationPercent()).isEqualTo(80.0);
 
         final BlockBufferStatus bufferStatus2 = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus2).isNotNull();
@@ -1682,8 +1700,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         final PruneResult pruneResult3 =
                 lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult3).isNotNull();
-        assertThat(pruneResult3.isSaturated).isFalse();
-        assertThat(pruneResult3.saturationPercent).isEqualTo(70.0);
+        assertThat(pruneResult3.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult3.saturationInfo().maxSaturationPercent()).isEqualTo(70.0);
 
         final BlockBufferStatus bufferStatus3 = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus3).isNotNull();
@@ -1715,8 +1733,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         final PruneResult pruneResult4 =
                 lastPruningResultRef(blockBufferService).get();
         assertThat(pruneResult4).isNotNull();
-        assertThat(pruneResult4.isSaturated).isFalse();
-        assertThat(pruneResult4.saturationPercent).isEqualTo(0.0);
+        assertThat(pruneResult4.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult4.saturationInfo().maxSaturationPercent()).isEqualTo(0.0);
 
         final BlockBufferStatus bufferStatus4 = blockBufferService.latestBufferStatus();
         assertThat(bufferStatus4).isNotNull();
@@ -2097,14 +2115,14 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testMinAckedBlocksToBuffer_aggressivePruneWhenAllAcked() throws Throwable {
+    void testAckedBlocksToRetain_aggressivePruneWhenAllAcked() throws Throwable {
         final Configuration config = HederaTestConfigBuilder.create()
                 .withConfigDataType(BlockStreamConfig.class)
                 .withConfigDataType(BlockBufferConfig.class)
                 .withValue("blockStream.writerMode", "GRPC")
                 .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("blockStream.buffer.maxBlocks", 20)
-                .withValue("blockStream.buffer.minAckedBlocksToBuffer", 3)
+                .withValue("blockStream.buffer.ackedBlocksToRetain", 3)
                 .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
                 .getOrCreateConfig();
         when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
@@ -2121,16 +2139,16 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         checkBufferHandle.invoke(blockBufferService);
 
         // Threshold = 10 - 3 + 1 = 8; acked blocks strictly below 8 are pruned, leaving blocks 8..10,
-        // i.e. exactly `minAckedBlocksToBuffer` of the most recent acked blocks.
+        // i.e. exactly `ackedBlocksToRetain` of the most recent acked blocks.
         assertThat(buffer.keySet()).containsExactlyInAnyOrder(8L, 9L, 10L);
 
         final PruneResult result = lastPruningResultRef(blockBufferService).get();
         assertThat(result).isNotNull();
-        // pruning acked blocks does not affect numBlocksPendingAck, saturation stays at 0
-        assertThat(result.numBlocksPendingAck).isZero();
-        assertThat(result.saturationPercent).isZero();
-        assertThat(result.isSaturated).isFalse();
-        assertThat(result.numBlocksPruned).isEqualTo(7);
+        // pruning acked blocks does not affect checkInfo().blocksPendingAck(), saturation stays at 0
+        assertThat(result.checkInfo().blocksPendingAck()).isZero();
+        assertThat(result.saturationInfo().maxSaturationPercent()).isZero();
+        assertThat(result.saturationInfo().isSaturated()).isFalse();
+        assertThat(result.pruneInfo().prunedBlockCount()).isEqualTo(7);
 
         verify(blockStreamMetrics, times(10)).recordLatestBlockOpened(anyLong());
         verify(blockStreamMetrics, times(10)).recordBlockOpened();
@@ -2149,7 +2167,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testMinAckedBlocksToBuffer_softLimitOverriddenByMaxBlocks() throws Throwable {
+    void testAckedBlocksToRetain_softLimitOverriddenByMaxBlocks() throws Throwable {
         // maxBlocks=5, minAcked=10. The soft floor wants to keep 10 acked blocks, but the buffer is
         // dominated by unacked blocks and over the hard ceiling. Acked blocks within the soft floor
         // must be evicted to make room.
@@ -2159,7 +2177,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
                 .withValue("blockStream.writerMode", "GRPC")
                 .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("blockStream.buffer.maxBlocks", 5)
-                .withValue("blockStream.buffer.minAckedBlocksToBuffer", 10)
+                .withValue("blockStream.buffer.ackedBlocksToRetain", 10)
                 .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
                 .getOrCreateConfig();
         when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
@@ -2182,8 +2200,8 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         assertThat(buffer.keySet()).containsExactlyInAnyOrder(3L, 4L, 5L, 6L, 7L);
         final PruneResult result = lastPruningResultRef(blockBufferService).get();
         assertThat(result).isNotNull();
-        assertThat(result.numBlocksPruned).isEqualTo(2);
-        assertThat(result.numBlocksPendingAck).isEqualTo(4);
+        assertThat(result.pruneInfo().prunedBlockCount()).isEqualTo(2);
+        assertThat(result.checkInfo().blocksPendingAck()).isEqualTo(4);
 
         verify(blockStreamMetrics, times(7)).recordLatestBlockOpened(anyLong());
         verify(blockStreamMetrics, times(7)).recordBlockOpened();
@@ -2202,14 +2220,14 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testMinAckedBlocksToBuffer_zeroRetainsNoAckedBlocks() throws Throwable {
+    void testAckedBlocksToRetain_zeroRetainsNoAckedBlocks() throws Throwable {
         final Configuration config = HederaTestConfigBuilder.create()
                 .withConfigDataType(BlockStreamConfig.class)
                 .withConfigDataType(BlockBufferConfig.class)
                 .withValue("blockStream.writerMode", "GRPC")
                 .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("blockStream.buffer.maxBlocks", 20)
-                .withValue("blockStream.buffer.minAckedBlocksToBuffer", 0)
+                .withValue("blockStream.buffer.ackedBlocksToRetain", 0)
                 .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
                 .getOrCreateConfig();
         when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
@@ -2231,7 +2249,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         assertThat(buffer.keySet()).containsExactlyInAnyOrder(5L);
         final PruneResult result = lastPruningResultRef(blockBufferService).get();
         assertThat(result).isNotNull();
-        assertThat(result.numBlocksPruned).isEqualTo(4);
+        assertThat(result.pruneInfo().prunedBlockCount()).isEqualTo(4);
 
         verify(blockStreamMetrics, times(5)).recordLatestBlockOpened(anyLong());
         verify(blockStreamMetrics, times(5)).recordBlockOpened();
@@ -2250,7 +2268,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testMinAckedBlocksToBuffer_noPruningWhenNoAcksReceived() throws Throwable {
+    void testAckedBlocksToRetain_noPruningWhenNoAcksReceived() throws Throwable {
         // With no acks received yet, the soft-limit branch must be inert (and the threshold
         // subtraction must not underflow). Pruning should do nothing while the buffer is below the
         // hard ceiling.
@@ -2260,7 +2278,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
                 .withValue("blockStream.writerMode", "GRPC")
                 .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("blockStream.buffer.maxBlocks", 10)
-                .withValue("blockStream.buffer.minAckedBlocksToBuffer", 3)
+                .withValue("blockStream.buffer.ackedBlocksToRetain", 3)
                 .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
                 .getOrCreateConfig();
         when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
@@ -2279,7 +2297,7 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         assertThat(buffer).hasSize(4);
         final PruneResult result = lastPruningResultRef(blockBufferService).get();
         assertThat(result).isNotNull();
-        assertThat(result.numBlocksPruned).isZero();
+        assertThat(result.pruneInfo().prunedBlockCount()).isZero();
 
         verify(blockStreamMetrics, times(4)).recordLatestBlockOpened(anyLong());
         verify(blockStreamMetrics, times(4)).recordBlockOpened();
@@ -2297,49 +2315,521 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     }
 
     @Test
-    void testMinAckedBlocksToBuffer_backpressureDisabledIgnoresSoftLimit() throws Throwable {
-        // Backpressure is disabled when streamMode is not BLOCKS. In that mode pruning falls back to
-        // the hard ceiling and the soft retention floor must not kick in. Use FILE_AND_GRPC writerMode
-        // so the buffer still accepts blocks via the GRPC path.
+    void testMaxBufferedBytes_invalidConfig() throws Throwable {
         final Configuration config = HederaTestConfigBuilder.create()
                 .withConfigDataType(BlockStreamConfig.class)
                 .withConfigDataType(BlockBufferConfig.class)
-                .withValue("blockStream.writerMode", "FILE_AND_GRPC")
-                .withValue("blockStream.streamMode", "BOTH")
-                .withValue("blockStream.buffer.maxBlocks", 20)
-                .withValue("blockStream.buffer.minAckedBlocksToBuffer", 2)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
                 .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "10GB")
                 .getOrCreateConfig();
         when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
 
         blockBufferService = initBufferService(configProvider);
-        final ConcurrentMap<Long, BlockState> buffer = blockBuffer(blockBufferService);
 
-        for (long b = 1L; b <= 5L; b++) {
-            blockBufferService.openBlock(b);
-            blockBufferService.closeBlock(b);
+        final long actualMaxBytes = maxBufferedBytes(blockBufferService);
+        final long expectedMaxBytes = BlockStreamingUtils.GB_TO_BYTES * 15L; // default is 15 GB
+
+        assertThat(actualMaxBytes).isEqualTo(expectedMaxBytes);
+    }
+
+    @Test
+    void testMaxBufferedBytes_cached() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "10M")
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+
+        final long actualMaxBytes1 = maxBufferedBytes(blockBufferService);
+        final long actualMaxBytes2 = maxBufferedBytes(blockBufferService);
+
+        final long expectedMaxBytes = BlockStreamingUtils.MB_TO_BYTES * 10L; // 10 MB
+
+        assertThat(actualMaxBytes1).isEqualTo(expectedMaxBytes);
+        assertThat(actualMaxBytes2).isEqualTo(expectedMaxBytes);
+    }
+
+    @Test
+    void testMaxBufferedBytes_emptyConfig() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "")
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+
+        final long actualMaxBytes = maxBufferedBytes(blockBufferService);
+        final long expectedMaxBytes = BlockStreamingUtils.GB_TO_BYTES * 15L; // default is 15 GB
+
+        assertThat(actualMaxBytes).isEqualTo(expectedMaxBytes);
+    }
+
+    @Test
+    void testMaxBufferedBytes_minSize() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "100k")
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+
+        final long actualMaxBytes = maxBufferedBytes(blockBufferService);
+        final long expectedMaxBytes = BlockStreamingUtils.MB_TO_BYTES * 10L; // default min is 10 MB
+
+        assertThat(actualMaxBytes).isEqualTo(expectedMaxBytes);
+    }
+
+    @Test
+    void testMaxBufferedBytes_updated() throws Throwable {
+        final Configuration config1 = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "100m")
+                .getOrCreateConfig();
+        final Configuration config2 = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "250m")
+                .getOrCreateConfig();
+        /*
+        Attention: This test may be flakey as changes are made it to the buffer service. This test depends on knowing
+        the number of times the configuration is accessed, since we want to change the configuration at a certain time
+        such that the first time the max bytes is parsed it resolved to 100 MB and then the subsequent call resolves to
+        250 MB. If changes are made and this test fails, it is likely due to the configuration ordering. Update the
+        lines below to add/remove return values.
+         */
+        when(configProvider.getConfiguration())
+                .thenReturn(
+                        new VersionedConfigImpl(config1, 1), // first config read should be 100 MB
+                        new VersionedConfigImpl(config1, 1),
+                        new VersionedConfigImpl(config1, 1),
+                        new VersionedConfigImpl(config2, 2) // second config read should be 250 MB
+                        );
+
+        blockBufferService = initBufferService(configProvider);
+
+        final long actualMaxBytesPreUpdate = maxBufferedBytes(blockBufferService);
+        final long expectedMaxBytesPreUpdate = BlockStreamingUtils.MB_TO_BYTES * 100L; // 100 MB
+
+        assertThat(actualMaxBytesPreUpdate).isEqualTo(expectedMaxBytesPreUpdate);
+
+        final long actualMaxBytesPostUpdate = maxBufferedBytes(blockBufferService);
+        final long expectedMaxBytesPostUpdate = BlockStreamingUtils.MB_TO_BYTES * 250L; // 250 MB
+
+        assertThat(actualMaxBytesPostUpdate).isEqualTo(expectedMaxBytesPostUpdate);
+    }
+
+    @Test
+    void testCheckBuffer_maxBufferedBytes_allClosedBlocks_withBackPressureEnabled() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS") // enable back pressure
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "100M")
+                .withValue("blockStream.buffer.maxBlocks", "100")
+                .withValue("blockStream.buffer.ackedBlocksToRetain", "20")
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+
+        // create 12 blocks that are 10 MB each, this should create a buffer that is 120 MB, 20 MB over the max 100 MB
+        // don't acknowledge the blocks
+        final long tenMB = BlockStreamingUtils.MB_TO_BYTES * 10L;
+        for (int i = 0; i < 12; ++i) {
+            blockBufferService.openBlock(i);
+            final Bytes bytes = BlockItem.PROTOBUF.toBytes(newBlockTxItem((int) tenMB));
+            blockBufferService.addItem(i, bytes, ItemOneOfType.SIGNED_TRANSACTION);
+            blockBufferService.closeBlock(i);
         }
-        blockBufferService.setLatestAcknowledgedBlock(5L);
 
         checkBufferHandle.invoke(blockBufferService);
 
-        // all 5 blocks retained because size <= maxBlocks; the soft limit must be ignored when
-        // backpressure is disabled
-        assertThat(buffer).hasSize(5);
+        final PruneResult pruneResultA =
+                lastPruningResultRef(blockBufferService).get();
 
-        verify(blockStreamMetrics, times(5)).recordLatestBlockOpened(anyLong());
-        verify(blockStreamMetrics, times(5)).recordBlockOpened();
-        verify(blockStreamMetrics, times(5)).recordBlockClosed();
-        verify(blockStreamMetrics).recordLatestBlockAcked(5L);
-        verify(blockStreamMetrics).recordBufferSaturation(0.0);
+        assertThat(pruneResultA).isNotNull();
+        assertThat(pruneResultA.config().maxBytes()).isEqualTo(BlockStreamingUtils.MB_TO_BYTES * 100L);
+        assertThat(pruneResultA.checkInfo().blocksPendingAck()).isEqualTo(12);
+        assertThat(pruneResultA.pruneInfo().prunedBlockCount()).isZero();
+        assertThat(pruneResultA.pruneInfo().prunedByteCount()).isZero();
+        assertThat(pruneResultA.liveBufferInfo().liveBlockCount()).isEqualTo(12);
+        assertThat(pruneResultA.liveBufferInfo().liveByteCount()).isGreaterThanOrEqualTo(tenMB * 12L);
+        assertThat(pruneResultA.saturationInfo().blockCountSaturationPercent()).isEqualTo(12.0D); // 12.0%
+        assertThat(pruneResultA.saturationInfo().bytesSaturationPercent()).isEqualTo(120.0D); // 120.0%
+        assertThat(pruneResultA.saturationInfo().maxSaturationPercent()).isEqualTo(120.0D); // 120.0%
+        assertThat(pruneResultA.saturationInfo().isSaturated()).isTrue();
+
+        final AtomicReference<CompletableFuture<Boolean>> backPressureFutureRef =
+                backpressureCompletableFutureRef(blockBufferService);
+        assertThat(backPressureFutureRef).doesNotHaveNullValue();
+        assertThat(backPressureFutureRef.get()).isNotCompleted();
+
+        // now acknowledge all the blocks... saturation should drop and back pressure should disengage
+        blockBufferService.setLatestAcknowledgedBlock(11L);
+
+        /*
+        Given a transaction payload of 10 MB, the serialized size of a block is 10485765 bytes.
+        This means the buffer has around 125829180 bytes total, with the max allowed being 104857600 bytes.
+        In order to get under the max size, we will need to reclaim 3 blocks
+         */
+        checkBufferHandle.invoke(blockBufferService);
+
+        final PruneResult pruneResultB =
+                lastPruningResultRef(blockBufferService).get();
+
+        assertThat(pruneResultB).isNotNull();
+        assertThat(pruneResultB.config().maxBytes()).isEqualTo(BlockStreamingUtils.MB_TO_BYTES * 100L);
+        assertThat(pruneResultB.checkInfo().blocksPendingAck()).isZero();
+        assertThat(pruneResultB.pruneInfo().prunedBlockCount()).isEqualTo(3);
+        assertThat(pruneResultB.pruneInfo().blocksPruned()).containsExactly(0L, 1L, 2L);
+        // the total amount pruned will be a little over 30 MB (10 MB for each block's transaction data plus overhead)
+        assertThat(pruneResultB.pruneInfo().prunedByteCount())
+                .isGreaterThanOrEqualTo(BlockStreamingUtils.MB_TO_BYTES * 10L * 3L);
+        assertThat(pruneResultB.liveBufferInfo().liveBlockCount()).isEqualTo(9);
+        assertThat(pruneResultB.liveBufferInfo().liveByteCount()).isGreaterThanOrEqualTo(tenMB * 9L);
+        assertThat(pruneResultB.saturationInfo().blockCountSaturationPercent()).isZero();
+        assertThat(pruneResultB.saturationInfo().bytesSaturationPercent()).isZero();
+        assertThat(pruneResultB.saturationInfo().maxSaturationPercent()).isZero();
+        assertThat(pruneResultB.saturationInfo().isSaturated()).isFalse();
+
+        assertThat(backPressureFutureRef).doesNotHaveNullValue();
+        assertThat(backPressureFutureRef.get()).isCompleted();
+
+        verify(blockStreamMetrics, times(12)).recordLatestBlockOpened(anyLong());
+        verify(blockStreamMetrics, times(12)).recordBlockOpened();
+        verify(blockStreamMetrics, times(12)).recordBlockClosed();
+        verify(blockStreamMetrics, times(12)).recordBlockItemsPerBlock(1);
+        verify(blockStreamMetrics, times(12)).recordBlockBytes(anyLong());
+        verify(blockStreamMetrics, times(12)).recordBlockItemBytes(anyLong());
+        verify(blockStreamMetrics).recordLatestBlockAcked(11L);
+        verify(blockStreamMetrics).recordBufferSaturation(120.0D);
+        verify(blockStreamMetrics).recordBufferSaturation(0.0D);
         verify(blockStreamMetrics).recordNumberOfBlocksPruned(0);
-        verify(blockStreamMetrics).recordBufferOldestBlock(1L);
-        verify(blockStreamMetrics).recordBufferNewestBlock(5L);
-        verify(blockStreamMetrics).recordBackPressureDisabled();
-        verify(blockStreamMetrics).recordBufferedBlocks(5);
+        verify(blockStreamMetrics).recordNumberOfBlocksPruned(3);
+        verify(blockStreamMetrics).recordBufferOldestBlock(0L);
+        verify(blockStreamMetrics).recordBufferOldestBlock(3L);
+        verify(blockStreamMetrics, times(2)).recordBufferNewestBlock(11L);
+        verify(blockStreamMetrics).recordBufferedBlocks(12);
+        verify(blockStreamMetrics).recordBufferedBlocks(9);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(12);
         verify(blockStreamMetrics).recordBufferedBlocksPendingAck(0);
-        verify(blockStreamMetrics).recordBufferSizeInBytes(anyLong());
-        verifyBlockSizingMetrics();
+        verify(blockStreamMetrics)
+                .recordBufferSizeInBytes(longThat(val -> val > BlockStreamingUtils.MB_TO_BYTES * 100L));
+        verify(blockStreamMetrics)
+                .recordBufferSizeInBytes(longThat(val -> val < BlockStreamingUtils.MB_TO_BYTES * 100L));
+        verify(blockStreamMetrics).recordBackPressureActive();
+        verify(blockStreamMetrics).recordBackPressureDisabled();
+        verifyNoMoreInteractions(blockStreamMetrics);
+    }
+
+    @Test
+    void testCheckBuffer_maxBufferedBytes_allClosedBlocks_withBackPressureDisabled() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BOTH") // disable back pressure
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "100M")
+                .withValue("blockStream.buffer.maxBlocks", "100")
+                .withValue("blockStream.buffer.ackedBlocksToRetain", "20")
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+
+        // create 12 blocks that are 10 MB each, this should create a buffer that is 120 MB, 20 MB over the max 100 MB
+        // don't acknowledge the blocks
+        final long tenMB = BlockStreamingUtils.MB_TO_BYTES * 10L;
+        for (int i = 0; i < 12; ++i) {
+            blockBufferService.openBlock(i);
+            final Bytes bytes = BlockItem.PROTOBUF.toBytes(newBlockTxItem((int) tenMB));
+            blockBufferService.addItem(i, bytes, ItemOneOfType.SIGNED_TRANSACTION);
+            blockBufferService.closeBlock(i);
+        }
+
+        checkBufferHandle.invoke(blockBufferService);
+
+        final PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
+
+        assertThat(pruneResult).isNotNull();
+        assertThat(pruneResult.config().maxBytes()).isEqualTo(BlockStreamingUtils.MB_TO_BYTES * 100L);
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(9);
+        assertThat(pruneResult.pruneInfo().prunedBlockCount()).isEqualTo(3);
+        assertThat(pruneResult.pruneInfo().blocksPruned()).containsExactly(0L, 1L, 2L);
+        // the total amount pruned will be a little over 30 MB (10 MB for each block's transaction data plus overhead)
+        assertThat(pruneResult.pruneInfo().prunedByteCount())
+                .isGreaterThanOrEqualTo(BlockStreamingUtils.MB_TO_BYTES * 10L * 3L);
+        assertThat(pruneResult.liveBufferInfo().liveBlockCount()).isEqualTo(9);
+        assertThat(pruneResult.liveBufferInfo().liveByteCount()).isGreaterThanOrEqualTo(tenMB * 9L);
+        // there are 9 unacked blocks out of a max of 100 blocks
+        assertThat(pruneResult.saturationInfo().blockCountSaturationPercent()).isEqualTo(9.0D); // 9.0%
+        // there are 9 unacked blocks, each around 10 MB, so a total of ~90 MB out of a max allowed of 100 MB
+        // this should mean the bytes saturation is around 90%... use > 85% for verification since it may not be exact
+        assertThat(pruneResult.saturationInfo().bytesSaturationPercent()).isGreaterThan(85.0D);
+        assertThat(pruneResult.saturationInfo().maxSaturationPercent()).isGreaterThan(85.0D);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.saturationInfo().isAtActionStage()).isTrue();
+
+        final AtomicReference<CompletableFuture<Boolean>> backPressureFutureRef =
+                backpressureCompletableFutureRef(blockBufferService);
+        assertThat(backPressureFutureRef).hasNullValue();
+
+        verify(blockStreamMetrics, times(12)).recordLatestBlockOpened(anyLong());
+        verify(blockStreamMetrics, times(12)).recordBlockOpened();
+        verify(blockStreamMetrics, times(12)).recordBlockClosed();
+        verify(blockStreamMetrics, times(12)).recordBlockItemsPerBlock(1);
+        verify(blockStreamMetrics, times(12)).recordBlockBytes(anyLong());
+        verify(blockStreamMetrics, times(12)).recordBlockItemBytes(anyLong());
+        verify(blockStreamMetrics).recordBufferSaturation(doubleThat(val -> val > 85.0D));
+        verify(blockStreamMetrics).recordNumberOfBlocksPruned(3);
+        verify(blockStreamMetrics).recordBufferOldestBlock(3L);
+        verify(blockStreamMetrics).recordBufferNewestBlock(11L);
+        verify(blockStreamMetrics).recordBufferedBlocks(9);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(9);
+        verify(blockStreamMetrics)
+                .recordBufferSizeInBytes(longThat(val -> val < BlockStreamingUtils.MB_TO_BYTES * 100L));
+        verify(blockStreamMetrics).recordBackPressureActionStage();
+        verifyNoMoreInteractions(blockStreamMetrics);
+    }
+
+    @Test
+    void testCheckBuffer_maxBufferedBytes_inProgressBlockExceedsLimit() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BOTH") // disable back pressure... easier test
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "100M")
+                .withValue("blockStream.buffer.maxBlocks", "100")
+                .withValue("blockStream.buffer.ackedBlocksToRetain", "20")
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+
+        // create 5 blocks that are 10 MB each, this should create a buffer that is ~50 MB, under the max allowed
+        // don't acknowledge the blocks
+        final long tenMB = BlockStreamingUtils.MB_TO_BYTES * 10L;
+        for (int i = 0; i < 5; ++i) {
+            blockBufferService.openBlock(i);
+            final Bytes bytes = BlockItem.PROTOBUF.toBytes(newBlockTxItem((int) tenMB));
+            blockBufferService.addItem(i, bytes, ItemOneOfType.SIGNED_TRANSACTION);
+            blockBufferService.closeBlock(i);
+        }
+
+        // create another block that has a 70 MB payload that will push the buffer over the limit
+        // don't close or acknowledge the block to ensure that it is marked "in progress"
+        {
+            blockBufferService.openBlock(5);
+            final Bytes bytes = BlockItem.PROTOBUF.toBytes(newBlockTxItem((int) (tenMB * 7)));
+            blockBufferService.addItem(5, bytes, ItemOneOfType.SIGNED_TRANSACTION);
+        }
+
+        checkBufferHandle.invoke(blockBufferService);
+
+        final PruneResult pruneResult = lastPruningResultRef(blockBufferService).get();
+
+        assertThat(pruneResult).isNotNull();
+        assertThat(pruneResult.config().maxBytes()).isEqualTo(BlockStreamingUtils.MB_TO_BYTES * 100L);
+        // pending blocks should be 5 since we don't count the in progress block as pending acknowledgment
+        assertThat(pruneResult.checkInfo().blocksPendingAck()).isEqualTo(2);
+        assertThat(pruneResult.pruneInfo().prunedBlockCount()).isEqualTo(3);
+        assertThat(pruneResult.pruneInfo().blocksPruned()).containsExactly(0L, 1L, 2L);
+        // the total amount pruned will be a little over 30 MB (10 MB for each block's transaction data plus overhead)
+        assertThat(pruneResult.pruneInfo().prunedByteCount())
+                .isGreaterThanOrEqualTo(BlockStreamingUtils.MB_TO_BYTES * 10L * 3L);
+        assertThat(pruneResult.liveBufferInfo().liveBlockCount()).isEqualTo(3);
+        assertThat(pruneResult.liveBufferInfo().liveByteCount()).isGreaterThanOrEqualTo((tenMB * 2L) + (tenMB * 7L));
+        // there are 2 unacked blocks out of a max of 100 blocks
+        assertThat(pruneResult.saturationInfo().blockCountSaturationPercent()).isEqualTo(2.0D); // 2.0%
+        // there are 2 unacked blocks, each around 10 MB, so a total of ~20 MB out of a max allowed of 100 MB
+        // this should mean the bytes saturation is around 20%... use > 15% for verification since it may not be exact
+        assertThat(pruneResult.saturationInfo().bytesSaturationPercent())
+                .isGreaterThan(15.0D)
+                .isLessThan(25.0D);
+        assertThat(pruneResult.saturationInfo().maxSaturationPercent())
+                .isGreaterThan(15.0D)
+                .isLessThan(25.0D);
+        assertThat(pruneResult.saturationInfo().isSaturated()).isFalse();
+        assertThat(pruneResult.saturationInfo().isAtActionStage()).isFalse();
+
+        final AtomicReference<CompletableFuture<Boolean>> backPressureFutureRef =
+                backpressureCompletableFutureRef(blockBufferService);
+        assertThat(backPressureFutureRef).hasNullValue();
+
+        verify(blockStreamMetrics, times(6)).recordLatestBlockOpened(anyLong());
+        verify(blockStreamMetrics, times(6)).recordBlockOpened();
+        verify(blockStreamMetrics, times(5)).recordBlockClosed();
+        verify(blockStreamMetrics, times(5)).recordBlockItemsPerBlock(1);
+        verify(blockStreamMetrics, times(5)).recordBlockBytes(anyLong());
+        verify(blockStreamMetrics, times(6)).recordBlockItemBytes(anyLong());
+        verify(blockStreamMetrics).recordBufferSaturation(doubleThat(val -> val > 15.0D && val < 25.0D));
+        verify(blockStreamMetrics).recordNumberOfBlocksPruned(3);
+        verify(blockStreamMetrics).recordBufferOldestBlock(3L);
+        verify(blockStreamMetrics).recordBufferNewestBlock(5L);
+        verify(blockStreamMetrics).recordBufferedBlocks(3);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(2);
+        verify(blockStreamMetrics)
+                .recordBufferSizeInBytes(longThat(val -> val < BlockStreamingUtils.MB_TO_BYTES * 100L));
+        verify(blockStreamMetrics).recordBackPressureDisabled();
+        verifyNoMoreInteractions(blockStreamMetrics);
+    }
+
+    @Test
+    void testCheckBuffer_maxBufferedBytes_inProgressBlockExceedsLimit_singleBlock() throws Throwable {
+        final Configuration config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withConfigDataType(BlockBufferConfig.class)
+                .withValue("blockStream.writerMode", "GRPC")
+                .withValue("blockStream.streamMode", "BLOCKS")
+                .withValue("blockStream.buffer.isBufferPersistenceEnabled", false)
+                .withValue("blockStream.buffer.maxBytes", "100M")
+                .withValue("blockStream.buffer.maxBlocks", "100")
+                .withValue("blockStream.buffer.ackedBlocksToRetain", "20")
+                .getOrCreateConfig();
+        when(configProvider.getConfiguration()).thenReturn(new VersionedConfigImpl(config, 1));
+
+        blockBufferService = initBufferService(configProvider);
+
+        // open a block (the only block to be buffered) that exceeds the max bytes
+        // this should cause the pruner to attempt to clear blocks, but since no blocks are available to prune
+        // the buffer remains saturated until the block is acked and can be pruned
+
+        final long tenMB = BlockStreamingUtils.MB_TO_BYTES * 10L;
+        blockBufferService.openBlock(0);
+
+        // create 15 block items at 10 MB each... this should create a block that is ~150 MB
+        for (int i = 0; i < 15; ++i) {
+            final Bytes bytes = BlockItem.PROTOBUF.toBytes(newBlockTxItem((int) tenMB));
+            blockBufferService.addItem(0, bytes, ItemOneOfType.SIGNED_TRANSACTION);
+        }
+
+        checkBufferHandle.invoke(blockBufferService);
+
+        final PruneResult pruneResultA =
+                lastPruningResultRef(blockBufferService).get();
+
+        assertThat(pruneResultA).isNotNull();
+        assertThat(pruneResultA.config().maxBytes()).isEqualTo(BlockStreamingUtils.MB_TO_BYTES * 100L);
+        // the block isn't closed and thus isn't yet considered pending an acknowledgement
+        assertThat(pruneResultA.checkInfo().blocksPendingAck()).isZero();
+        assertThat(pruneResultA.pruneInfo().prunedBlockCount()).isZero();
+        assertThat(pruneResultA.pruneInfo().blocksPruned()).isEmpty();
+        assertThat(pruneResultA.pruneInfo().prunedByteCount()).isZero();
+        assertThat(pruneResultA.liveBufferInfo().liveBlockCount()).isOne();
+        assertThat(pruneResultA.liveBufferInfo().liveByteCount()).isGreaterThanOrEqualTo(tenMB * 15L);
+        assertThat(pruneResultA.saturationInfo().blockCountSaturationPercent()).isZero();
+        assertThat(pruneResultA.saturationInfo().bytesSaturationPercent()).isZero();
+        assertThat(pruneResultA.saturationInfo().maxSaturationPercent()).isZero();
+        assertThat(pruneResultA.saturationInfo().isAtActionStage()).isFalse();
+        assertThat(pruneResultA.saturationInfo().isSaturated()).isFalse();
+
+        final AtomicReference<CompletableFuture<Boolean>> backPressureFutureRef =
+                backpressureCompletableFutureRef(blockBufferService);
+        assertThat(backPressureFutureRef).hasNullValue();
+
+        // now close the block and check the buffer again... back pressure should now engage since the block is too big
+        blockBufferService.closeBlock(0);
+
+        checkBufferHandle.invoke(blockBufferService);
+
+        final PruneResult pruneResultB =
+                lastPruningResultRef(blockBufferService).get();
+
+        assertThat(pruneResultB).isNotNull();
+        assertThat(pruneResultB.config().maxBytes()).isEqualTo(BlockStreamingUtils.MB_TO_BYTES * 100L);
+        assertThat(pruneResultB.checkInfo().blocksPendingAck()).isOne();
+        assertThat(pruneResultB.pruneInfo().prunedBlockCount()).isZero();
+        assertThat(pruneResultB.pruneInfo().blocksPruned()).isEmpty();
+        assertThat(pruneResultB.pruneInfo().prunedByteCount()).isZero();
+        assertThat(pruneResultB.liveBufferInfo().liveBlockCount()).isOne();
+        assertThat(pruneResultB.liveBufferInfo().liveByteCount()).isGreaterThanOrEqualTo(tenMB * 15L);
+        // there is just one block, and given a max block size of 100, we are now at 1% block count saturation
+        assertThat(pruneResultB.saturationInfo().blockCountSaturationPercent()).isEqualTo(1.0D);
+        // we are now around 150 MB out of the max 100 MB... so there should now be around 150% bytes saturation
+        assertThat(pruneResultB.saturationInfo().bytesSaturationPercent()).isGreaterThanOrEqualTo(150.0D);
+        assertThat(pruneResultB.saturationInfo().maxSaturationPercent()).isGreaterThanOrEqualTo(150.0D);
+        assertThat(pruneResultB.saturationInfo().isAtActionStage()).isTrue();
+        assertThat(pruneResultB.saturationInfo().isSaturated()).isTrue();
+        assertThat(backPressureFutureRef).doesNotHaveNullValue();
+        assertThat(backPressureFutureRef.get()).isNotCompleted();
+
+        // acknowledge the block and check the buffer again
+        // now the block should be pruned immediately
+        blockBufferService.setLatestAcknowledgedBlock(0L);
+        checkBufferHandle.invoke(blockBufferService);
+
+        final PruneResult pruneResultC =
+                lastPruningResultRef(blockBufferService).get();
+
+        assertThat(pruneResultC).isNotNull();
+        assertThat(pruneResultC.config().maxBytes()).isEqualTo(BlockStreamingUtils.MB_TO_BYTES * 100L);
+        assertThat(pruneResultC.checkInfo().blocksPendingAck()).isZero();
+        assertThat(pruneResultC.pruneInfo().prunedBlockCount()).isOne();
+        assertThat(pruneResultC.pruneInfo().blocksPruned()).containsExactly(0L);
+        assertThat(pruneResultC.pruneInfo().prunedByteCount()).isGreaterThanOrEqualTo(tenMB * 15L);
+        assertThat(pruneResultC.liveBufferInfo().liveBlockCount()).isZero();
+        assertThat(pruneResultC.liveBufferInfo().liveByteCount()).isZero();
+        assertThat(pruneResultC.saturationInfo().blockCountSaturationPercent()).isZero();
+        assertThat(pruneResultC.saturationInfo().bytesSaturationPercent()).isZero();
+        assertThat(pruneResultC.saturationInfo().maxSaturationPercent()).isZero();
+        assertThat(pruneResultC.saturationInfo().isAtActionStage()).isFalse();
+        assertThat(pruneResultC.saturationInfo().isSaturated()).isFalse();
+        assertThat(backPressureFutureRef).doesNotHaveNullValue();
+        assertThat(backPressureFutureRef.get()).isCompleted();
+
+        verify(blockStreamMetrics).recordLatestBlockOpened(anyLong());
+        verify(blockStreamMetrics).recordBlockOpened();
+        verify(blockStreamMetrics).recordBlockClosed();
+        verify(blockStreamMetrics).recordBlockItemsPerBlock(15);
+        verify(blockStreamMetrics).recordBlockBytes(longThat(val -> val >= tenMB));
+        verify(blockStreamMetrics, times(15)).recordBlockItemBytes(anyLong());
+        verify(blockStreamMetrics, times(2)).recordBufferSaturation(0.0D);
+        verify(blockStreamMetrics).recordBufferSaturation(150.0D);
+        verify(blockStreamMetrics, times(2)).recordNumberOfBlocksPruned(0);
+        verify(blockStreamMetrics).recordNumberOfBlocksPruned(1);
+        verify(blockStreamMetrics, times(2)).recordBufferOldestBlock(0L);
+        verify(blockStreamMetrics, times(2)).recordBufferNewestBlock(0L);
+        verify(blockStreamMetrics).recordBufferOldestBlock(-1L);
+        verify(blockStreamMetrics).recordBufferNewestBlock(-1L);
+        verify(blockStreamMetrics, times(2)).recordBufferedBlocks(1);
+        verify(blockStreamMetrics).recordBufferedBlocks(0);
+        verify(blockStreamMetrics).recordBufferedBlocksPendingAck(1);
+        verify(blockStreamMetrics, times(2)).recordBufferedBlocksPendingAck(0);
+        verify(blockStreamMetrics, times(2)).recordBufferSizeInBytes(longThat(val -> val >= tenMB * 15L));
+        verify(blockStreamMetrics).recordBufferSizeInBytes(0);
+        verify(blockStreamMetrics).recordBackPressureActive();
+        verify(blockStreamMetrics, times(2)).recordBackPressureDisabled();
+        verify(blockStreamMetrics).recordLatestBlockAcked(0L);
         verifyNoMoreInteractions(blockStreamMetrics);
     }
 
@@ -2374,9 +2864,9 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
         final PruneResult initialPruningResult =
                 lastPruningResultRef(blockBufferService).get();
         assertThat(initialPruningResult).isNotNull();
-        assertThat(initialPruningResult.isSaturated).isEqualTo(expectedSaturated);
-        assertThat(initialPruningResult.numBlocksPruned).isZero();
-        assertThat(initialPruningResult.numBlocksPendingAck).isEqualTo(numBlockUnacked);
+        assertThat(initialPruningResult.saturationInfo().isSaturated()).isEqualTo(expectedSaturated);
+        assertThat(initialPruningResult.pruneInfo().prunedBlockCount()).isZero();
+        assertThat(initialPruningResult.checkInfo().blocksPendingAck()).isEqualTo(numBlockUnacked);
 
         // back pressure should NOT be enabled
         final AtomicReference<CompletableFuture<Boolean>> backPressureFutureRef =
@@ -2405,6 +2895,10 @@ class BlockBufferServiceTest extends BlockNodeCommunicationTestBase {
     @SuppressWarnings("unchecked")
     private ConcurrentMap<Long, BlockState> blockBuffer(final BlockBufferService bufferService) {
         return (ConcurrentMap<Long, BlockState>) blockBufferHandle.get(bufferService);
+    }
+
+    private long maxBufferedBytes(final BlockBufferService bufferService) throws Throwable {
+        return (long) maxBufferedBytesHandle.invoke(bufferService);
     }
 
     private AtomicBoolean isStarted(final BlockBufferService bufferService) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockStreamingUtilsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockStreamingUtilsTest.java
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl.streaming;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class BlockStreamingUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("parseToBytesArgs")
+    void testParseToBytes(final String input, final long expectedValue) {
+        final long actualValue = BlockStreamingUtils.parseToBytes(input);
+        assertThat(actualValue).isEqualTo(expectedValue);
+    }
+
+    static Stream<Arguments> parseToBytesArgs() {
+        return Stream.of(
+                Arguments.of(null, -1L),
+                Arguments.of("", -1L),
+                Arguments.of("        ", -1L),
+                Arguments.of(" 10000  ", 10_000L),
+                Arguments.of(" 100k", 102_400L),
+                Arguments.of("500K ", 512_000L),
+                Arguments.of("10m", 10_485_760L),
+                Arguments.of("25M  ", 26_214_400L),
+                Arguments.of("  1g", 1_073_741_824L),
+                Arguments.of(" 18G ", 19_327_352_832L),
+                Arguments.of("1T", -1),
+                Arguments.of("100 K", -1),
+                Arguments.of("100   K", -1),
+                Arguments.of("-1K", -1),
+                Arguments.of("1KB", -1),
+                Arguments.of(".G", -1),
+                Arguments.of("M100", -1),
+                Arguments.of("10MM", -1),
+                Arguments.of("sdfkj dkj 39dk 1", -1),
+                Arguments.of("-10029381", -1));
+    }
+}

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockBufferConfig.java
@@ -12,6 +12,10 @@ import java.time.Duration;
  * Configuration settings related to the block buffer.
  *
  * @param maxBlocks the maximum number of blocks that can be buffered before the buffer is considered full
+ * @param maxBytes the maximum number of bytes that can be buffered before the buffer is considered full. This value can
+ *                 be specified either in bytes (no postfix), kilobytes (k|K), megabytes (m|M), or gigabytes (g|G) by
+ *                 appending the appropriate postfix to the value. For example, a 1 GB value may be represented as one
+ *                 of the following: 1G, 1024M, 1048576K, 1073741824. The minimum allowed size is 10 MB.
  * @param workerInterval interval to perform periodic tasks related to the block buffer (e.g. pruning and persisting
  *                       buffer to disk)
  * @param actionStageThreshold the threshold (as a percentage from 0.0 to 100.0) at which proactive measures are
@@ -29,22 +33,23 @@ import java.time.Duration;
  *                          the buffer is considered recovered.)
  * @param isBufferPersistenceEnabled true if periodic persistence to disk of the block buffer is permitted, else false
  * @param bufferDirectory the root directory that the block buffer will be persisted into, if enabled
- * @param minAckedBlocksToBuffer the minimum number of acknowledged blocks to retain in the buffer at any given time.
- *                               This is a "soft" limit: when the buffer is under pressure from unacknowledged blocks
- *                               and pushing against {@code maxBlocks}, acknowledged blocks below this floor may still
- *                               be pruned to make room. When the block node is healthy, this floor allows the buffer
- *                               to remain small while still preserving a recent window of acknowledged blocks in case
- *                               the block node re-requests one. Only applies when backpressure is enabled.
+ * @param ackedBlocksToRetain the number of acknowledged blocks to retain in the buffer at any given time.
+ *                            This is a "soft" limit: when the buffer is under pressure from unacknowledged blocks
+ *                            and pushing against {@code maxBlocks} or {@code maxBytes}, acknowledged blocks below this
+ *                            floor may still be pruned to make room. When the block node is healthy, this floor allows
+ *                            the buffer to remain small while still preserving a recent window of acknowledged blocks
+ *                            in case the block node re-requests one.
  */
 // spotless:off
 @ConfigData("blockStream.buffer")
 public record BlockBufferConfig(
         @ConfigProperty(defaultValue = "30") @Min(0) @NetworkProperty int maxBlocks,
+        @ConfigProperty(defaultValue = "15g") @NetworkProperty String maxBytes,
         @ConfigProperty(defaultValue = "1s") @Min(1) @NetworkProperty Duration workerInterval,
         @ConfigProperty(defaultValue = "50.0") @Min(0) @NetworkProperty double actionStageThreshold,
         @ConfigProperty(defaultValue = "20s") @Min(0) @NetworkProperty Duration actionGracePeriod,
         @ConfigProperty(defaultValue = "85.0") @Min(0) @NetworkProperty double recoveryThreshold,
         @ConfigProperty(defaultValue = "false") @NodeProperty boolean isBufferPersistenceEnabled,
         @ConfigProperty(defaultValue = "/opt/hgcapp/blockStreams/buffer") @NodeProperty String bufferDirectory,
-        @ConfigProperty(defaultValue = "10") @Min(0) @NetworkProperty int minAckedBlocksToBuffer) {}
+        @ConfigProperty(defaultValue = "10") @Min(0) @NetworkProperty int ackedBlocksToRetain) {}
 // spotless:on

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
@@ -257,7 +257,7 @@ public class BlockNodeBackPressureSuite {
                                 time::get,
                                 Duration.ofMinutes(2),
                                 Duration.ofMinutes(2),
-                                "Buffer saturation is below or equal to the recovery threshold; back pressure will be disabled.")),
+                                "Buffer saturation is below or equal to the recovery threshold; back pressure will be disabled")),
                 waitForAny(byNodeId(0), Duration.ofSeconds(60), PlatformStatus.ACTIVE),
                 doingContextual(
                         spec -> LockSupport.parkNanos(Duration.ofSeconds(30).toNanos())),
@@ -273,7 +273,7 @@ public class BlockNodeBackPressureSuite {
 
     /**
      * Smoke test: a healthy block node combined with a low
-     * {@code blockStream.buffer.minAckedBlocksToBuffer} value should never engage backpressure and
+     * {@code blockStream.buffer.ackedBlocksToRetain} value should never engage backpressure and
      * the node should remain ACTIVE throughout. Verifies the new property wires through end-to-end
      * without regressing the happy path. The unit tests in {@code BlockBufferServiceTest} verify the
      * pruning algorithm itself.
@@ -290,7 +290,7 @@ public class BlockNodeBackPressureSuite {
                         applicationPropertiesOverrides = {
                             "blockStream.buffer.maxBlocks",
                             "50",
-                            "blockStream.buffer.minAckedBlocksToBuffer",
+                            "blockStream.buffer.ackedBlocksToRetain",
                             "3",
                             "blockStream.streamMode",
                             "BLOCKS",

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSimSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeSimSuite.java
@@ -60,7 +60,8 @@ public class BlockNodeSimSuite {
                         blockNodePriorities = {0, 1, 2, 3},
                         applicationPropertiesOverrides = {
                             "blockStream.streamMode", "BOTH",
-                            "blockStream.writerMode", "FILE_AND_GRPC"
+                            "blockStream.writerMode", "FILE_AND_GRPC",
+                            "blockStream.buffer.ackedBlocksToRetain", "25"
                         })
             })
     @Order(1)
@@ -190,7 +191,7 @@ public class BlockNodeSimSuite {
                         Duration.ofMinutes(2),
                         Duration.ofMinutes(2),
                         // look for the saturation reaching the action stage (50%)
-                        "saturation: 50.0%",
+                        "ByBlockCount: 50.0000%",
                         // look for the log that shows the monitor detected buffer saturation
                         "Streaming connection update requested",
                         "buffer-unhealthy",
@@ -205,7 +206,7 @@ public class BlockNodeSimSuite {
                         Duration.ofMinutes(2),
                         Duration.ofMinutes(2),
                         // saturation should fall back to low levels after switching to node 1
-                        "saturation: 0.0%")));
+                        "ByBlockCount: 0.0000%")));
     }
 
     @HapiTest
@@ -268,7 +269,11 @@ public class BlockNodeSimSuite {
                 doingContextual(spec -> timeRef.set(Instant.now())),
                 // saturation should drop as the block node acknowledges the buffered blocks
                 sourcingContextual(spec -> assertBlockNodeCommsLogContainsTimeframe(
-                        byNodeId(0), timeRef::get, Duration.ofMinutes(3), Duration.ofMinutes(3), "saturation: 0.0%")));
+                        byNodeId(0),
+                        timeRef::get,
+                        Duration.ofMinutes(3),
+                        Duration.ofMinutes(3),
+                        "ByBlockCount: 0.0000%")));
     }
 
     /**


### PR DESCRIPTION
**Description**:
Cherry-pick new block buffer capacity check by bytes: https://github.com/hiero-ledger/hiero-consensus-node/pull/26701

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
