### PR TITLE
build: Capture, promote yahcli images for 'build' tags

### DIFF
--- a/.github/workflows/304-flow-publish-yahcli-image.yaml
+++ b/.github/workflows/304-flow-publish-yahcli-image.yaml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*.*.*"
+      - "build-*"
   workflow_dispatch:
     inputs:
       ref:


### PR DESCRIPTION
**Description**:

Adds a trigger to publish the Yahcli Docker image on `build-*` tags in addition to the existing `v*.*.*` semantic version tags. This supports triggering image publication from build-tagged releases that don't follow the semver format.

Closes #26886