### PR TITLE
fix: return CONFIG_FILE_PART_UPLOADED for unparseable 0.0.121/0.0.122 contents

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1975,4 +1975,18 @@ enum ResponseCodeEnum {
      * The number of associated registered nodes exceeds the maximum allowed limit.
      */
     MAX_REGISTERED_NODES_EXCEEDED = 535;
+
+    /**
+     * The contents of a configuration system file (the network properties file or the
+     * HAPI permissions file) could not be parsed as a `ServicesConfigurationList`.<br/>
+     * The submitted bytes were committed to the file, but no configuration change was
+     * applied.
+     * <p>
+     * These files may be uploaded across a `fileUpdate` followed by one or more
+     * `fileAppend` transactions; this status is expected for every part before the
+     * last, because the partially assembled content is not yet parseable. On the final
+     * part it indicates that the fully assembled content is invalid and the network
+     * configuration was left unchanged.
+     */
+    CONFIG_FILE_PART_UPLOADED = 536;
 }

--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/response_code.proto
@@ -1977,16 +1977,10 @@ enum ResponseCodeEnum {
     MAX_REGISTERED_NODES_EXCEEDED = 535;
 
     /**
-     * The contents of a configuration system file (the network properties file or the
-     * HAPI permissions file) could not be parsed as a `ServicesConfigurationList`.<br/>
-     * The submitted bytes were committed to the file, but no configuration change was
-     * applied.
-     * <p>
-     * These files may be uploaded across a `fileUpdate` followed by one or more
-     * `fileAppend` transactions; this status is expected for every part before the
-     * last, because the partially assembled content is not yet parseable. On the final
-     * part it indicates that the fully assembled content is invalid and the network
-     * configuration was left unchanged.
+     * The contents of a configuration system file (network properties or HAPI permissions)
+     * could not be parsed as a `ServicesConfigurationList`.<br/>
+     * The bytes were committed, but no configuration change was applied. This is expected
+     * for every part but the last of a multi-part upload.
      */
     CONFIG_FILE_PART_UPLOADED = 536;
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/AbstractSavepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/AbstractSavepoint.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.workflows.handle.stack.savepoints;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.CONFIG_FILE_PART_UPLOADED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.FEE_SCHEDULE_FILE_PART_UPLOADED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.REVERTED_SUCCESS;
@@ -34,8 +35,12 @@ import java.util.List;
  * that determine how each type of savepoint constructs state change block items.
  */
 public abstract class AbstractSavepoint extends BuilderSinkImpl implements Savepoint {
-    public static final EnumSet<ResponseCodeEnum> SUCCESSES =
-            EnumSet.of(OK, SUCCESS, FEE_SCHEDULE_FILE_PART_UPLOADED, SUCCESS_BUT_MISSING_EXPECTED_OPERATION);
+    public static final EnumSet<ResponseCodeEnum> SUCCESSES = EnumSet.of(
+            OK,
+            SUCCESS,
+            FEE_SCHEDULE_FILE_PART_UPLOADED,
+            CONFIG_FILE_PART_UPLOADED,
+            SUCCESS_BUT_MISSING_EXPECTED_OPERATION);
 
     protected final BuilderSink parent;
     protected final WrappedState state;

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdates.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdates.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.workflows.handle.steps;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.CONFIG_FILE_PART_UPLOADED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.util.FileUtilities.observePropertiesAndPermissions;
 import static java.util.Objects.requireNonNull;
@@ -25,6 +26,7 @@ import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.state.State;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.nio.BufferUnderflowException;
 import java.util.concurrent.CompletableFuture;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -36,6 +38,26 @@ import org.apache.logging.log4j.Logger;
  *
  * <p>This is a temporary solution. In the future we want to have specific transactions
  * to update the data that is currently transmitted in these files.
+ *
+ * <p>Several of these files must hold a specific serialization, and they do not all react the same way to
+ * contents that cannot be parsed into it. The difference tracks how each file is uploaded:
+ *
+ * <ul>
+ *   <li>Files large enough to be uploaded across a {@code FileUpdate} and one or more {@code FileAppend}s
+ *       have legitimately unparseable intermediate states, so they commit the bytes and report an
+ *       informative non-{@code SUCCESS} status rather than failing. These are the fee schedules
+ *       ({@code FEE_SCHEDULE_FILE_PART_UPLOADED}) and the two configuration files handled here, the network
+ *       properties and HAPI permissions ({@code CONFIG_FILE_PART_UPLOADED}).</li>
+ *   <li>Files small enough to be replaced in a single transaction reject unparseable contents outright by
+ *       throwing, which rolls the write back. These are the exchange rates
+ *       ({@code INVALID_EXCHANGE_RATE_FILE}) and the throttle definitions
+ *       ({@code UNPARSEABLE_THROTTLE_DEFINITIONS}).</li>
+ * </ul>
+ *
+ * <p>Note the status returned from here is set on the stream builder <i>after</i> the file contents have
+ * already been committed by the file service handler; only a thrown
+ * {@link com.hedera.node.app.spi.workflows.HandleException} rolls that write back. So the two behaviors
+ * above are not interchangeable styles, they differ in whether the submitted bytes survive.
  */
 @Singleton
 public class SystemFileUpdates {
@@ -105,17 +127,39 @@ public class SystemFileUpdates {
         } else if (fileNum == filesConfig.exchangeRates()) {
             exchangeRateManager.update(FileUtilities.getFileContent(state, fileID), payer);
         } else if (fileNum == filesConfig.networkProperties()) {
+            final var status = configListParseStatus(FileUtilities.getFileContent(state, fileID));
             BlockStreamWriterMode currentWriterMode =
                     configuration.getConfigData(BlockStreamConfig.class).writerMode();
             updateConfig(configuration, ConfigType.NETWORK_PROPERTIES, state);
             checkForBlockNodeStreamingChange(currentWriterMode, configProvider);
             throttleServiceManager.refreshThrottleConfiguration();
+            return status;
         } else if (fileNum == filesConfig.hapiPermissions()) {
+            final var status = configListParseStatus(FileUtilities.getFileContent(state, fileID));
             updateConfig(configuration, ConfigType.API_PERMISSIONS, state);
+            return status;
         } else if (fileNum == filesConfig.throttleDefinitions()) {
             return throttleServiceManager.recreateThrottles(FileUtilities.getFileContent(state, fileID));
         }
         return SUCCESS;
+    }
+
+    /**
+     * Returns {@link ResponseCodeEnum#SUCCESS} if the given contents parse as a
+     * {@link ServicesConfigurationList}, and {@link ResponseCodeEnum#CONFIG_FILE_PART_UPLOADED} if not,
+     * in which case no configuration change was applied.
+     *
+     * @param contents the assembled contents of the file
+     * @return the status to report
+     */
+    private ResponseCodeEnum configListParseStatus(@NonNull final Bytes contents) {
+        try {
+            ServicesConfigurationList.PROTOBUF.parseStrict(contents.toReadableSequentialData());
+            return SUCCESS;
+        } catch (ParseException | BufferUnderflowException | NullPointerException ignore) {
+            // Exactly the failures that make ConfigProviderImpl.addByteSource() drop this source
+            return CONFIG_FILE_PART_UPLOADED;
+        }
     }
 
     private void checkForBlockNodeStreamingChange(

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdates.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdates.java
@@ -39,25 +39,9 @@ import org.apache.logging.log4j.Logger;
  * <p>This is a temporary solution. In the future we want to have specific transactions
  * to update the data that is currently transmitted in these files.
  *
- * <p>Several of these files must hold a specific serialization, and they do not all react the same way to
- * contents that cannot be parsed into it. The difference tracks how each file is uploaded:
- *
- * <ul>
- *   <li>Files large enough to be uploaded across a {@code FileUpdate} and one or more {@code FileAppend}s
- *       have legitimately unparseable intermediate states, so they commit the bytes and report an
- *       informative non-{@code SUCCESS} status rather than failing. These are the fee schedules
- *       ({@code FEE_SCHEDULE_FILE_PART_UPLOADED}) and the two configuration files handled here, the network
- *       properties and HAPI permissions ({@code CONFIG_FILE_PART_UPLOADED}).</li>
- *   <li>Files small enough to be replaced in a single transaction reject unparseable contents outright by
- *       throwing, which rolls the write back. These are the exchange rates
- *       ({@code INVALID_EXCHANGE_RATE_FILE}) and the throttle definitions
- *       ({@code UNPARSEABLE_THROTTLE_DEFINITIONS}).</li>
- * </ul>
- *
- * <p>Note the status returned from here is set on the stream builder <i>after</i> the file contents have
- * already been committed by the file service handler; only a thrown
- * {@link com.hedera.node.app.spi.workflows.HandleException} rolls that write back. So the two behaviors
- * above are not interchangeable styles, they differ in whether the submitted bytes survive.
+ * <p>On unparseable contents, chunk-uploaded files return a status (fee schedules, network properties, HAPI
+ * permissions) while single-transaction files throw (exchange rates, throttles). Only throwing rolls the
+ * committed bytes back.
  */
 @Singleton
 public class SystemFileUpdates {
@@ -145,9 +129,8 @@ public class SystemFileUpdates {
     }
 
     /**
-     * Returns {@link ResponseCodeEnum#SUCCESS} if the given contents parse as a
-     * {@link ServicesConfigurationList}, and {@link ResponseCodeEnum#CONFIG_FILE_PART_UPLOADED} if not,
-     * in which case no configuration change was applied.
+     * Returns whether the given contents parse as a {@link ServicesConfigurationList}; if not, no
+     * configuration change was applied.
      *
      * @param contents the assembled contents of the file
      * @return the status to report
@@ -157,7 +140,7 @@ public class SystemFileUpdates {
             ServicesConfigurationList.PROTOBUF.parseStrict(contents.toReadableSequentialData());
             return SUCCESS;
         } catch (ParseException | BufferUnderflowException | NullPointerException ignore) {
-            // Exactly the failures that make ConfigProviderImpl.addByteSource() drop this source
+            // The failures that make ConfigProviderImpl.addByteSource() drop this source
             return CONFIG_FILE_PART_UPLOADED;
         }
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
@@ -268,8 +268,7 @@ class SystemFileUpdatesTest implements TransactionFactory {
 
         // then
         assertThat(status).isEqualTo(CONFIG_FILE_PART_UPLOADED);
-        // The config must still be rebuilt, or a restarted node would derive a different configuration
-        // from the same state than a node that stayed up; see FacilityInitModule.initFacilities()
+        // Must still rebuild config, else a restarted node diverges; see FacilityInitModule
         verify(configProvider).update(eq(UNPARSEABLE_BYTES), eq(CONFIG_LIST_BYTES));
     }
 
@@ -351,7 +350,7 @@ class SystemFileUpdatesTest implements TransactionFactory {
 
     @Test
     void truncatedNetworkPropertiesContentsIsNotSuccess() {
-        // given the state left behind by every part but the last of a multi-part upload
+        // given a partial upload's intermediate state
         final var truncated = CONFIG_LIST_BYTES.slice(0, CONFIG_LIST_BYTES.length() - 1);
         final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
         final var fileID = idFactory.newFileId(config.networkProperties());
@@ -369,7 +368,7 @@ class SystemFileUpdatesTest implements TransactionFactory {
 
     @Test
     void emptyNetworkPropertiesContentsIsSuccess() {
-        // given clearing the override file leaves it empty, which is a valid empty ServicesConfigurationList
+        // given empty contents, as when clearing the override file
         final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
         final var fileID = idFactory.newFileId(config.networkProperties());
         files.put(fileID, File.newBuilder().contents(Bytes.EMPTY).build());
@@ -386,7 +385,7 @@ class SystemFileUpdatesTest implements TransactionFactory {
 
     @Test
     void onlyTheTargetedFileDeterminesTheStatus() {
-        // given a pre-existing unparseable permissions file, an unrelated valid properties update still succeeds
+        // given a pre-existing unparseable permissions file
         final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
         final var fileID = idFactory.newFileId(config.networkProperties());
         files.put(fileID, File.newBuilder().contents(CONFIG_LIST_BYTES).build());

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/steps/SystemFileUpdatesTest.java
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.workflows.handle.steps;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.CONFIG_FILE_PART_UPLOADED;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.node.app.service.file.impl.schemas.V0490FileSchema.FILES_STATE_ID;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,6 +15,8 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.ServicesConfigurationList;
+import com.hedera.hapi.node.base.Setting;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.file.FileAppendTransactionBody;
 import com.hedera.hapi.node.file.FileUpdateTransactionBody;
@@ -40,6 +45,7 @@ import com.hedera.node.config.types.BlockStreamWriterMode;
 import com.hedera.node.config.types.LongPair;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
@@ -57,6 +63,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class SystemFileUpdatesTest implements TransactionFactory {
 
     private static final Bytes FILE_BYTES = Bytes.wrap("Hello World");
+    private static final Bytes UNPARSEABLE_BYTES = Bytes.wrap("NOT_A_SERVICES_CONFIGURATION_LIST");
+    private static final Bytes CONFIG_LIST_BYTES =
+            ServicesConfigurationList.PROTOBUF.toBytes(ServicesConfigurationList.newBuilder()
+                    .nameValue(Setting.newBuilder()
+                            .name("tokens.maxPerAccount")
+                            .value("1000")
+                            .build())
+                    .build());
     private static final Instant CONSENSUS_NOW = Instant.parse("2000-01-01T00:00:00Z");
     private long SHARD;
     private long REALM;
@@ -237,6 +251,163 @@ class SystemFileUpdatesTest implements TransactionFactory {
 
         // then
         verify(configProvider).update(eq(networkPropertiesContent), eq(FILE_BYTES));
+    }
+
+    @Test
+    void unparseableNetworkPropertiesUpdateIsNotSuccess() {
+        // given
+        final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileID = idFactory.newFileId(config.networkProperties());
+        files.put(fileID, File.newBuilder().contents(UNPARSEABLE_BYTES).build());
+        files.put(
+                idFactory.newFileId(config.hapiPermissions()),
+                File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+
+        // when
+        final var status = subject.handleTxBody(state, updateOf(fileID));
+
+        // then
+        assertThat(status).isEqualTo(CONFIG_FILE_PART_UPLOADED);
+        // The config must still be rebuilt, or a restarted node would derive a different configuration
+        // from the same state than a node that stayed up; see FacilityInitModule.initFacilities()
+        verify(configProvider).update(eq(UNPARSEABLE_BYTES), eq(CONFIG_LIST_BYTES));
+    }
+
+    @Test
+    void parseableNetworkPropertiesUpdateIsSuccess() {
+        // given
+        final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileID = idFactory.newFileId(config.networkProperties());
+        files.put(fileID, File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+        files.put(
+                idFactory.newFileId(config.hapiPermissions()),
+                File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+
+        // when
+        final var status = subject.handleTxBody(state, updateOf(fileID));
+
+        // then
+        assertThat(status).isEqualTo(SUCCESS);
+        verify(configProvider).update(eq(CONFIG_LIST_BYTES), eq(CONFIG_LIST_BYTES));
+    }
+
+    @Test
+    void unparseableHapiPermissionsUpdateIsNotSuccess() {
+        // given
+        final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileID = idFactory.newFileId(config.hapiPermissions());
+        files.put(fileID, File.newBuilder().contents(UNPARSEABLE_BYTES).build());
+        files.put(
+                idFactory.newFileId(config.networkProperties()),
+                File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+
+        // when
+        final var status = subject.handleTxBody(state, updateOf(fileID));
+
+        // then
+        assertThat(status).isEqualTo(CONFIG_FILE_PART_UPLOADED);
+        verify(configProvider).update(eq(CONFIG_LIST_BYTES), eq(UNPARSEABLE_BYTES));
+    }
+
+    @Test
+    void parseableHapiPermissionsUpdateIsSuccess() {
+        // given
+        final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileID = idFactory.newFileId(config.hapiPermissions());
+        files.put(fileID, File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+        files.put(
+                idFactory.newFileId(config.networkProperties()),
+                File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+
+        // when
+        final var status = subject.handleTxBody(state, updateOf(fileID));
+
+        // then
+        assertThat(status).isEqualTo(SUCCESS);
+    }
+
+    @Test
+    void unparseableAppendToNetworkPropertiesIsNotSuccess() {
+        // given
+        final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileID = idFactory.newFileId(config.networkProperties());
+        files.put(fileID, File.newBuilder().contents(UNPARSEABLE_BYTES).build());
+        files.put(
+                idFactory.newFileId(config.hapiPermissions()),
+                File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+        final var txBody = TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder()
+                        .accountID(idFactory.newAccountId(50L))
+                        .build())
+                .fileAppend(FileAppendTransactionBody.newBuilder().fileID(fileID))
+                .build();
+
+        // when
+        final var status = subject.handleTxBody(state, txBody);
+
+        // then
+        assertThat(status).isEqualTo(CONFIG_FILE_PART_UPLOADED);
+    }
+
+    @Test
+    void truncatedNetworkPropertiesContentsIsNotSuccess() {
+        // given the state left behind by every part but the last of a multi-part upload
+        final var truncated = CONFIG_LIST_BYTES.slice(0, CONFIG_LIST_BYTES.length() - 1);
+        final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileID = idFactory.newFileId(config.networkProperties());
+        files.put(fileID, File.newBuilder().contents(truncated).build());
+        files.put(
+                idFactory.newFileId(config.hapiPermissions()),
+                File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+
+        // when
+        final var status = subject.handleTxBody(state, updateOf(fileID));
+
+        // then
+        assertThat(status).isEqualTo(CONFIG_FILE_PART_UPLOADED);
+    }
+
+    @Test
+    void emptyNetworkPropertiesContentsIsSuccess() {
+        // given clearing the override file leaves it empty, which is a valid empty ServicesConfigurationList
+        final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileID = idFactory.newFileId(config.networkProperties());
+        files.put(fileID, File.newBuilder().contents(Bytes.EMPTY).build());
+        files.put(
+                idFactory.newFileId(config.hapiPermissions()),
+                File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+
+        // when
+        final var status = subject.handleTxBody(state, updateOf(fileID));
+
+        // then
+        assertThat(status).isEqualTo(SUCCESS);
+    }
+
+    @Test
+    void onlyTheTargetedFileDeterminesTheStatus() {
+        // given a pre-existing unparseable permissions file, an unrelated valid properties update still succeeds
+        final var config = configProvider.getConfiguration().getConfigData(FilesConfig.class);
+        final var fileID = idFactory.newFileId(config.networkProperties());
+        files.put(fileID, File.newBuilder().contents(CONFIG_LIST_BYTES).build());
+        files.put(
+                idFactory.newFileId(config.hapiPermissions()),
+                File.newBuilder().contents(UNPARSEABLE_BYTES).build());
+
+        // when
+        final var status = subject.handleTxBody(state, updateOf(fileID));
+
+        // then
+        assertThat(status).isEqualTo(SUCCESS);
+    }
+
+    private TransactionBody updateOf(@NonNull final FileID fileID) {
+        return TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder()
+                        .accountID(idFactory.newAccountId(50L))
+                        .build())
+                .fileUpdate(FileUpdateTransactionBody.newBuilder().fileID(fileID))
+                .build();
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/UtilVerbs.java
@@ -68,6 +68,7 @@ import static com.hederahashgraph.api.proto.java.FreezeType.FREEZE_UPGRADE;
 import static com.hederahashgraph.api.proto.java.FreezeType.PREPARE_UPGRADE;
 import static com.hederahashgraph.api.proto.java.FreezeType.TELEMETRY_UPGRADE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONFIG_FILE_PART_UPLOADED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FEE_SCHEDULE_FILE_PART_UPLOADED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
@@ -2190,7 +2191,10 @@ public class UtilVerbs {
             HapiFileUpdate updateSubOp = fileUpdate(fileName)
                     .contents(byteString.substring(0, position))
                     .hasKnownStatusFrom(
-                            SUCCESS, FEE_SCHEDULE_FILE_PART_UPLOADED, SUCCESS_BUT_MISSING_EXPECTED_OPERATION)
+                            SUCCESS,
+                            FEE_SCHEDULE_FILE_PART_UPLOADED,
+                            CONFIG_FILE_PART_UPLOADED,
+                            SUCCESS_BUT_MISSING_EXPECTED_OPERATION)
                     .noLogging()
                     .payingWith(payer);
             updateCustomizer.accept(updateSubOp);
@@ -2209,7 +2213,7 @@ public class UtilVerbs {
                 int newPosition = Math.min(fileSize, position + BYTES_4K);
                 var appendSubOp = fileAppend(fileName)
                         .content(byteString.substring(position, newPosition).toByteArray())
-                        .hasKnownStatusFrom(SUCCESS, FEE_SCHEDULE_FILE_PART_UPLOADED)
+                        .hasKnownStatusFrom(SUCCESS, FEE_SCHEDULE_FILE_PART_UPLOADED, CONFIG_FILE_PART_UPLOADED)
                         .noLogging()
                         .payingWith(payer);
                 appendCustomizer.accept(appendSubOp, totalAppendsRequired - numAppends);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/ParsedItem.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/domain/ParsedItem.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.utilops.domain;
 
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONFIG_FILE_PART_UPLOADED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.FEE_SCHEDULE_FILE_PART_UPLOADED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
@@ -53,7 +54,7 @@ public record ParsedItem(TransactionBody itemBody, TransactionRecord itemRecord)
         }
 
         final var status = itemRecord.getReceipt().getStatus();
-        return (status == SUCCESS || status == FEE_SCHEDULE_FILE_PART_UPLOADED)
+        return (status == SUCCESS || status == FEE_SCHEDULE_FILE_PART_UPLOADED || status == CONFIG_FILE_PART_UPLOADED)
                 && (isFileUpdate || isFileAppend)
                 && PROPERTIES_FILE_ID.equals(fileID);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/SystemFileContentValidationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/SystemFileContentValidationTest.java
@@ -32,14 +32,9 @@ import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 
 /**
- * Asserts that an update to a system file whose contents must be a serialized
- * {@code ServicesConfigurationList} reports a non-{@code SUCCESS} status when those contents cannot be
- * parsed, instead of silently reporting {@code SUCCESS} while dropping the configuration change.
- *
- * <p>Every spec here snapshots the file it touches and restores it at the end. This matters more than the
- * usual test hygiene: the configuration is rebuilt from scratch from the network properties and HAPI
- * permissions files together, so leaving unparseable contents in either one drops <i>every</i> active
- * property override for every spec that follows on a shared network.
+ * Asserts that updates to 0.0.121 and 0.0.122 report a non-{@code SUCCESS} status when their contents
+ * cannot be parsed. Each spec restores the file it touches, since unparseable contents in either one drop
+ * every active property override for the specs that follow.
  */
 public class SystemFileContentValidationTest {
     private static final String PROPERTIES_SNAPSHOT = "networkPropertiesSnapshot";
@@ -87,7 +82,7 @@ public class SystemFileContentValidationTest {
                         .payingWith(GENESIS)
                         .signedBy(GENESIS)
                         .hasKnownStatus(SUCCESS),
-                // The override is in effect, not merely written to the file
+                // The override is in effect, not just written to the file
                 cryptoTransfer(tinyBarsFromTo(CIVILIAN, RECEIVER_A, 1L), tinyBarsFromTo(CIVILIAN, RECEIVER_B, 1L))
                         .payingWith(CIVILIAN)
                         .hasKnownStatus(TRANSFER_LIST_SIZE_LIMIT_EXCEEDED),
@@ -104,16 +99,11 @@ public class SystemFileContentValidationTest {
                         .payingWith(GENESIS)
                         .signedBy(GENESIS)
                         .hasKnownStatus(SUCCESS),
-                // The permission change is in effect, not merely written to the file
+                // The permission change is in effect, not just written to the file
                 fileCreate("denied").contents("x").payingWith(CIVILIAN).hasKnownStatus(UNAUTHORIZED),
                 updateLargeFile(GENESIS, API_PERMISSIONS, PERMISSIONS_SNAPSHOT));
     }
 
-    /**
-     * Covers a multi-part upload, where every part but the last leaves the file in a legitimately
-     * unparseable state. Those parts must report {@code CONFIG_FILE_PART_UPLOADED} without being rejected,
-     * and the final part must both report {@code SUCCESS} and apply the assembled configuration.
-     */
     @LeakyHapiTest(requirement = PROPERTY_OVERRIDES)
     final Stream<DynamicTest> multiPartNetworkPropertiesUploadIsNotRejectedMidSequence() {
         final AtomicReference<byte[]> payload = new AtomicReference<>();
@@ -123,7 +113,7 @@ public class SystemFileContentValidationTest {
                 cryptoCreate(RECEIVER_A).balance(0L),
                 cryptoCreate(RECEIVER_B).balance(0L),
                 withOpContext((spec, opLog) -> payload.set(getUpdated121(spec, Map.of(TRANSFERS_MAX_LEN, "2")))),
-                // Split so the first part ends mid-field, which is what makes a partial upload unparseable
+                // Ending mid-field is what makes a partial upload unparseable
                 sourcing(() -> fileUpdate(APP_PROPERTIES)
                         .contents(Arrays.copyOfRange(payload.get(), 0, payload.get().length - 1))
                         .payingWith(GENESIS)
@@ -134,7 +124,6 @@ public class SystemFileContentValidationTest {
                         .payingWith(GENESIS)
                         .signedBy(GENESIS)
                         .hasKnownStatus(SUCCESS)),
-                // The assembled configuration took effect on the final part
                 cryptoTransfer(tinyBarsFromTo(CIVILIAN, RECEIVER_A, 1L), tinyBarsFromTo(CIVILIAN, RECEIVER_B, 1L))
                         .payingWith(CIVILIAN)
                         .hasKnownStatus(TRANSFER_LIST_SIZE_LIMIT_EXCEEDED),
@@ -145,7 +134,7 @@ public class SystemFileContentValidationTest {
     final Stream<DynamicTest> clearingNetworkPropertiesWithEmptyContentsIsSuccess() {
         return hapiTest(
                 getFileContents(APP_PROPERTIES).saveToRegistry(PROPERTIES_SNAPSHOT),
-                // Empty contents clear the override file, and parse as an empty ServicesConfigurationList
+                // Empty contents clear the file and parse as an empty list
                 fileUpdate(APP_PROPERTIES)
                         .contents(new byte[0])
                         .payingWith(GENESIS)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/SystemFileContentValidationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/SystemFileContentValidationTest.java
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.file;
+
+import static com.hedera.services.bdd.junit.ContextRequirement.PERMISSION_OVERRIDES;
+import static com.hedera.services.bdd.junit.ContextRequirement.PROPERTY_OVERRIDES;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getFileContents;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileAppend;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.transactions.file.HapiFileUpdate.getUpdated121;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateLargeFile;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.API_PERMISSIONS;
+import static com.hedera.services.bdd.suites.HapiSuite.APP_PROPERTIES;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONFIG_FILE_PART_UPLOADED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSFER_LIST_SIZE_LIMIT_EXCEEDED;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.UNAUTHORIZED;
+
+import com.hedera.services.bdd.junit.LeakyHapiTest;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+
+/**
+ * Asserts that an update to a system file whose contents must be a serialized
+ * {@code ServicesConfigurationList} reports a non-{@code SUCCESS} status when those contents cannot be
+ * parsed, instead of silently reporting {@code SUCCESS} while dropping the configuration change.
+ *
+ * <p>Every spec here snapshots the file it touches and restores it at the end. This matters more than the
+ * usual test hygiene: the configuration is rebuilt from scratch from the network properties and HAPI
+ * permissions files together, so leaving unparseable contents in either one drops <i>every</i> active
+ * property override for every spec that follows on a shared network.
+ */
+public class SystemFileContentValidationTest {
+    private static final String PROPERTIES_SNAPSHOT = "networkPropertiesSnapshot";
+    private static final String PERMISSIONS_SNAPSHOT = "hapiPermissionsSnapshot";
+    private static final String UNPARSEABLE_CONTENTS = "NOT_A_SERVICES_CONFIGURATION_LIST";
+
+    private static final String TRANSFERS_MAX_LEN = "ledger.transfers.maxLen";
+    private static final String CIVILIAN = "civilian";
+    private static final String RECEIVER_A = "receiverA";
+    private static final String RECEIVER_B = "receiverB";
+
+    @LeakyHapiTest(requirement = PROPERTY_OVERRIDES)
+    final Stream<DynamicTest> unparseableNetworkPropertiesUpdateIsNotSuccess() {
+        return hapiTest(
+                getFileContents(APP_PROPERTIES).saveToRegistry(PROPERTIES_SNAPSHOT),
+                fileUpdate(APP_PROPERTIES)
+                        .contents(UNPARSEABLE_CONTENTS)
+                        .payingWith(GENESIS)
+                        .signedBy(GENESIS)
+                        .hasKnownStatus(CONFIG_FILE_PART_UPLOADED),
+                updateLargeFile(GENESIS, APP_PROPERTIES, PROPERTIES_SNAPSHOT));
+    }
+
+    @LeakyHapiTest(requirement = PERMISSION_OVERRIDES)
+    final Stream<DynamicTest> unparseableHapiPermissionsUpdateIsNotSuccess() {
+        return hapiTest(
+                getFileContents(API_PERMISSIONS).saveToRegistry(PERMISSIONS_SNAPSHOT),
+                fileUpdate(API_PERMISSIONS)
+                        .contents(UNPARSEABLE_CONTENTS)
+                        .payingWith(GENESIS)
+                        .signedBy(GENESIS)
+                        .hasKnownStatus(CONFIG_FILE_PART_UPLOADED),
+                updateLargeFile(GENESIS, API_PERMISSIONS, PERMISSIONS_SNAPSHOT));
+    }
+
+    @LeakyHapiTest(requirement = PROPERTY_OVERRIDES)
+    final Stream<DynamicTest> validNetworkPropertiesUpdateSucceedsAndApplies() {
+        return hapiTest(
+                getFileContents(APP_PROPERTIES).saveToRegistry(PROPERTIES_SNAPSHOT),
+                cryptoCreate(CIVILIAN).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER_A).balance(0L),
+                cryptoCreate(RECEIVER_B).balance(0L),
+                fileUpdate(APP_PROPERTIES)
+                        .overridingProps(Map.of(TRANSFERS_MAX_LEN, "2"))
+                        .payingWith(GENESIS)
+                        .signedBy(GENESIS)
+                        .hasKnownStatus(SUCCESS),
+                // The override is in effect, not merely written to the file
+                cryptoTransfer(tinyBarsFromTo(CIVILIAN, RECEIVER_A, 1L), tinyBarsFromTo(CIVILIAN, RECEIVER_B, 1L))
+                        .payingWith(CIVILIAN)
+                        .hasKnownStatus(TRANSFER_LIST_SIZE_LIMIT_EXCEEDED),
+                updateLargeFile(GENESIS, APP_PROPERTIES, PROPERTIES_SNAPSHOT));
+    }
+
+    @LeakyHapiTest(requirement = PERMISSION_OVERRIDES)
+    final Stream<DynamicTest> validHapiPermissionsUpdateSucceedsAndApplies() {
+        return hapiTest(
+                getFileContents(API_PERMISSIONS).saveToRegistry(PERMISSIONS_SNAPSHOT),
+                cryptoCreate(CIVILIAN).balance(ONE_HUNDRED_HBARS),
+                fileUpdate(API_PERMISSIONS)
+                        .overridingProps(Map.of("createFile", "0-100"))
+                        .payingWith(GENESIS)
+                        .signedBy(GENESIS)
+                        .hasKnownStatus(SUCCESS),
+                // The permission change is in effect, not merely written to the file
+                fileCreate("denied").contents("x").payingWith(CIVILIAN).hasKnownStatus(UNAUTHORIZED),
+                updateLargeFile(GENESIS, API_PERMISSIONS, PERMISSIONS_SNAPSHOT));
+    }
+
+    /**
+     * Covers a multi-part upload, where every part but the last leaves the file in a legitimately
+     * unparseable state. Those parts must report {@code CONFIG_FILE_PART_UPLOADED} without being rejected,
+     * and the final part must both report {@code SUCCESS} and apply the assembled configuration.
+     */
+    @LeakyHapiTest(requirement = PROPERTY_OVERRIDES)
+    final Stream<DynamicTest> multiPartNetworkPropertiesUploadIsNotRejectedMidSequence() {
+        final AtomicReference<byte[]> payload = new AtomicReference<>();
+        return hapiTest(
+                getFileContents(APP_PROPERTIES).saveToRegistry(PROPERTIES_SNAPSHOT),
+                cryptoCreate(CIVILIAN).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(RECEIVER_A).balance(0L),
+                cryptoCreate(RECEIVER_B).balance(0L),
+                withOpContext((spec, opLog) -> payload.set(getUpdated121(spec, Map.of(TRANSFERS_MAX_LEN, "2")))),
+                // Split so the first part ends mid-field, which is what makes a partial upload unparseable
+                sourcing(() -> fileUpdate(APP_PROPERTIES)
+                        .contents(Arrays.copyOfRange(payload.get(), 0, payload.get().length - 1))
+                        .payingWith(GENESIS)
+                        .signedBy(GENESIS)
+                        .hasKnownStatus(CONFIG_FILE_PART_UPLOADED)),
+                sourcing(() -> fileAppend(APP_PROPERTIES)
+                        .content(Arrays.copyOfRange(payload.get(), payload.get().length - 1, payload.get().length))
+                        .payingWith(GENESIS)
+                        .signedBy(GENESIS)
+                        .hasKnownStatus(SUCCESS)),
+                // The assembled configuration took effect on the final part
+                cryptoTransfer(tinyBarsFromTo(CIVILIAN, RECEIVER_A, 1L), tinyBarsFromTo(CIVILIAN, RECEIVER_B, 1L))
+                        .payingWith(CIVILIAN)
+                        .hasKnownStatus(TRANSFER_LIST_SIZE_LIMIT_EXCEEDED),
+                updateLargeFile(GENESIS, APP_PROPERTIES, PROPERTIES_SNAPSHOT));
+    }
+
+    @LeakyHapiTest(requirement = PROPERTY_OVERRIDES)
+    final Stream<DynamicTest> clearingNetworkPropertiesWithEmptyContentsIsSuccess() {
+        return hapiTest(
+                getFileContents(APP_PROPERTIES).saveToRegistry(PROPERTIES_SNAPSHOT),
+                // Empty contents clear the override file, and parse as an empty ServicesConfigurationList
+                fileUpdate(APP_PROPERTIES)
+                        .contents(new byte[0])
+                        .payingWith(GENESIS)
+                        .signedBy(GENESIS)
+                        .hasKnownStatus(SUCCESS),
+                updateLargeFile(GENESIS, APP_PROPERTIES, PROPERTIES_SNAPSHOT));
+    }
+}


### PR DESCRIPTION
Updating the network properties file (0.0.121) or the permissions file (0.0.122) with content that can't be parsed used to save the bytes, report SUCCESS, and apply nothing. A bad 0.0.121 also wiped every property override. Those updates now return CONFIG_FILE_PART_UPLOADED.

It returns a status instead of failing the transaction because these files upload in 4KB chunks and every chunk but the last is incomplete on purpose, so failing would break every chunked upload.

Closes #26863
