### PR TITLE
build: Publish yahcli image tag for each main merge

### DIFF
--- a/.github/workflows/304-flow-publish-yahcli-image.yaml
+++ b/.github/workflows/304-flow-publish-yahcli-image.yaml
@@ -2,6 +2,8 @@
 name: "304: [FLOW] Publish Yahcli Image"
 on:
   push:
+    branches:
+      - main
     tags:
       - "v*.*.*"
       - "build-*"
@@ -85,6 +87,10 @@ jobs:
             VERSION="${{ github.ref_name }}"
             echo "version=${VERSION}" >>"${GITHUB_OUTPUT}"
             echo "Resolved version from tag: ${VERSION}"
+          elif [[ "${{ github.ref }}" == refs/heads/main ]]; then
+            VERSION="build-main-$(echo '${{ github.sha }}' | cut -c1-8)"
+            echo "version=${VERSION}" >>"${GITHUB_OUTPUT}"
+            echo "Resolved version from commit SHA: ${VERSION}"
           else
             VERSION="$(./gradlew showVersion --quiet 2>/dev/null | tr -d '[:space:]')"
             echo "version=${VERSION}" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
**Description**:

PR #26887 enabled publishing of yahcli images when `build-*` tags were pushed. We also need to enable the push for any change to `main`. This will allow devops to run tests in our integration environment with the latest yahcli version. 

Part of #26886 