### PR TITLE
fix: align bytes to the right in EthTxData.asUnsignedByteArray

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -124,17 +124,26 @@ public record EthTxData(
     }
 
     /// Returns an unsigned byte[] representation of a BigInteger, dropping the leading zero byte
-    /// if present. Adopted from org.bouncycastle.util.BigIntegers.asUnsignedByteArray().
+    /// if present, and aligning remaining bytes to the right.
     public static byte[] asUnsignedByteArray(final BigInteger value) {
         final byte[] bytes = value.toByteArray();
 
-        if (bytes[0] == 0 && bytes.length != 1) {
-            final byte[] tmp = new byte[bytes.length - 1];
-            System.arraycopy(bytes, 1, tmp, 0, tmp.length);
-            return tmp;
+        if (bytes.length == 32) {
+            return bytes;
+        } else {
+            final byte[] tmp = new byte[32];
+
+            if (bytes.length == 33 && bytes[0] == 0) {
+                System.arraycopy(bytes, 1, tmp, 0, 32);
+                return tmp;
+            } else if (bytes.length < 32) {
+                System.arraycopy(bytes, 0, tmp, 32 - bytes.length, bytes.length);
+                return tmp;
+            }
         }
 
-        return bytes;
+        // The byte array is longer than 33 bytes. It's an invalid secp256k1 key.
+        throw new IllegalArgumentException("Invalid BigInteger that is too long. It cannot be a valid private key.");
     }
 
     public EthTxData replaceCallData(final byte[] newCallData) {

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
@@ -52,9 +52,8 @@ public class Secp256k1Utils {
     public static byte[] extractEcdsaPublicKey(final ECPrivateKey key) {
         final Cache cache = CACHE.get();
 
-        if (LIBSECP256K1.secp256k1EcPubkeyCreate(
-                        cache.pubkeySeg, MemorySegment.ofArray(EthTxData.asUnsignedByteArray(key.getS())))
-                != 1) {
+        final byte[] privateKeyBytes = EthTxData.asUnsignedByteArray(key.getS());
+        if (LIBSECP256K1.secp256k1EcPubkeyCreate(cache.pubkeySeg, MemorySegment.ofArray(privateKeyBytes)) != 1) {
             throw new IllegalArgumentException("secp256k1EcPubkeyCreate failed. The private key is probably invalid.");
         }
 


### PR DESCRIPTION
**Description**:
Fixing `exactBytesSettleUnderTheHashOfTheSignedEncoding` and `trailingBytesAreRejectedAndLeaveTheNonceUnspent` from `hapiTestSmartContract`. They use some exotic secp256k1 private keys whose BigIntegers yield an unexpected byte array representations - shorter than 32 bytes.

Apparently, the array needs to be padded with zeros and all the bytes need to be aligned to the right.

So I'm fixing this in `EthTxData.asUnsignedByteArray`.

**Related issue(s)**:

Fixes #26898

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
