### PR TITLE
chore: Platform destroy should call PCES destroy

### DIFF
--- a/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/DefaultPcesModule.java
+++ b/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/DefaultPcesModule.java
@@ -62,6 +62,9 @@ public class DefaultPcesModule implements PcesModule {
     @Nullable
     private PcesCoordinator pcesCoordinator;
 
+    @Nullable
+    private InlinePcesWriter pcesWriter;
+
     /**
      * {@inheritDoc}
      */
@@ -124,8 +127,7 @@ public class DefaultPcesModule implements PcesModule {
             final PcesFileManager fileManager = new PcesFileManager(
                     configuration, metrics, time, initialPcesFiles, databaseDirectory, startingRound);
             commonPcesWriter = new CommonPcesWriter(configuration, fileManager);
-            final InlinePcesWriter pcesWriter =
-                    new DefaultInlinePcesWriter(configuration, metrics, time, commonPcesWriter, selfId);
+            pcesWriter = new DefaultInlinePcesWriter(configuration, metrics, time, commonPcesWriter, selfId);
             pcesWriterWiring.bind(pcesWriter);
         } catch (final IOException e) {
             throw new UncheckedIOException(e);
@@ -248,5 +250,13 @@ public class DefaultPcesModule implements PcesModule {
         requireNonNull(fileSystemManager, "Not initialized");
         BestEffortPcesFileCopy.copyPcesFilesRetryOnFailure(
                 configuration, selfId, destinationDirectory, fileSystemManager, lowerBound, round);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void destroy() {
+        requireNonNull(pcesWriter, "Not initialized").destroy();
     }
 }

--- a/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/writer/DefaultInlinePcesWriter.java
+++ b/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/writer/DefaultInlinePcesWriter.java
@@ -138,11 +138,10 @@ public class DefaultInlinePcesWriter implements InlinePcesWriter {
     }
 
     /**
-     * Cleanup/destroy method which makes sure we are not in the middle of processing the event
-     * when we close PCES file; this instance of PcesWriter is not usable and not possible to recover after using it.
-     * This method will be called from a random thread, take care about memory visibility versus rest of the class
+     * {@inheritDoc}
      */
-    void destroy() {
+    @Override
+    public void destroy() {
         this.beingDestroyed = true;
         while (this.processingEvent) {
             Thread.yield();

--- a/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/writer/InlinePcesWriter.java
+++ b/platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/writer/InlinePcesWriter.java
@@ -54,4 +54,11 @@ public interface InlinePcesWriter {
      */
     @InputWireLabel("minimum identifier to store")
     void setMinimumBirthRoundToStore(@NonNull Long minimumBirthRoundToStore);
+
+    /**
+     * Cleanup/destroy method which makes sure we are not in the middle of processing the event
+     * when we close PCES file; this instance of PcesWriter is not usable and not possible to recover after using it.
+     * This method will be called from a random thread, take care about memory visibility versus rest of the class
+     */
+    void destroy();
 }

--- a/platform-sdk/consensus-pces-noop-impl/src/testFixtures/java/org/hiero/consensus/pces/noop/impl/test/fixtures/NoopPcesModule.java
+++ b/platform-sdk/consensus-pces-noop-impl/src/testFixtures/java/org/hiero/consensus/pces/noop/impl/test/fixtures/NoopPcesModule.java
@@ -192,4 +192,12 @@ public class NoopPcesModule implements PcesModule {
             final long round) {
         // no-op
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void destroy() {
+        // no-op
+    }
 }

--- a/platform-sdk/consensus-pces/src/main/java/org/hiero/consensus/pces/PcesModule.java
+++ b/platform-sdk/consensus-pces/src/main/java/org/hiero/consensus/pces/PcesModule.java
@@ -149,4 +149,9 @@ public interface PcesModule {
             @NonNull Path destinationDirectory,
             long lowerBound,
             long round);
+
+    /**
+     * Destroys the PCES module and releases any resources it holds.
+     */
+    void destroy();
 }

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java
@@ -129,6 +129,7 @@ public class SwirldsPlatform implements Platform {
         notificationEngine.shutdown();
         inputs.recycleBin().stop();
         buildingBlocks.wiringModel().stop();
+        buildingBlocks.pcesModule().destroy();
         getMetricsProvider().removePlatformMetrics(selfId);
     }
 


### PR DESCRIPTION
**Description**:
The `Platform.destroy()` method should invoke the `InlinePcesWriter.destroy()` method, since this is how the Turtle environment kills a node. Adding this call makes the node shutdown more like a real shutdown in which events sent to the OS for writing are durable.

**Related issue(s)**:

Part of #26828
