### PR TITLE
chore: do reduce Bouncy Castle and Besu usages

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/MiscCryptoUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/MiscCryptoUtils.java
@@ -78,9 +78,14 @@ public class MiscCryptoUtils {
             throw new RuntimeException("keccakHashInitialize returned " + ret);
         }
 
-        ret = LIBXKCP.keccakHashUpdate(hashInstanceSeg, msgSegment, msgSegment.byteSize() * 8L);
-        if (ret != Libxkcp.KECCAK_SUCCESS) {
-            throw new RuntimeException("keccakHashUpdate returned " + ret);
+        // Libxkcp currently requires a non-zero length of data to hash.
+        // We'll support this eventually: https://github.com/hiero-ledger/hiero-cryptography/issues/679
+        // But we cannot upgrade hiero-cryptography now due to a set of incompatible changes there.
+        if (msgSegment.byteSize() > 0) {
+            ret = LIBXKCP.keccakHashUpdate(hashInstanceSeg, msgSegment, msgSegment.byteSize() * 8L);
+            if (ret != Libxkcp.KECCAK_SUCCESS) {
+                throw new RuntimeException("keccakHashUpdate returned " + ret);
+            }
         }
 
         final byte[] hash = new byte[Libxkcp.SHA3_256_HASHVAL_LENGTH_BYTES];

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigs.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigs.java
@@ -18,13 +18,17 @@ import java.util.HexFormat;
 import java.util.Optional;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
 
 public record EthTxSigs(byte[] publicKey, byte[] address) {
     private static final ContextualLibsecp256k1 LIBSECP256K1 = ContextualLibsecp256k1.getInstance();
 
     private static final Logger logger = LogManager.getLogger(EthTxSigs.class);
-    private static final BigInteger N = SECNamedCurves.getByName("secp256k1").getN();
+
+    // Per https://www.google.com/search?q=secp256k1+curve+n
+    // N = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+    // or in decimal:
+    private static final BigInteger N =
+            new BigInteger("115792089237316195423570985008687907852837564279074904382605163141518161494337");
     // Lower-half boundary (N >> 1) by EIP-2 standard.
     private static final BigInteger HALF_N = N.shiftRight(1);
 

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
@@ -7,7 +7,6 @@ import static java.util.Objects.requireNonNull;
 import com.hedera.cryptography.libsecp256k1.ContextualLibsecp256k1;
 import com.hedera.cryptography.libsecp256k1.Libsecp256k1;
 import com.hedera.hapi.node.base.ContractID;
-import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hederahashgraph.api.proto.java.Key;
 import edu.umd.cs.findbugs.annotations.NonNull;

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
@@ -53,7 +53,7 @@ public class Secp256k1Utils {
         final Cache cache = CACHE.get();
 
         if (LIBSECP256K1.secp256k1EcPubkeyCreate(
-                        cache.pubkeySeg, MemorySegment.ofArray(EthTxData.asUnsignedByteArray(key.getS())))
+                        cache.pubkeySeg, MemorySegment.ofArray(asPrivateKeyByteArray32(key.getS())))
                 != 1) {
             throw new IllegalArgumentException("secp256k1EcPubkeyCreate failed. The private key is probably invalid.");
         }
@@ -72,6 +72,29 @@ public class Secp256k1Utils {
         }
 
         return serializedPubkey;
+    }
+
+    /// Returns an unsigned byte[] representation of a BigInteger, dropping the leading zero byte
+    /// if present, aligning remaining bytes to the right, and padding with zeros to 32 bytes.
+    public static byte[] asPrivateKeyByteArray32(final BigInteger value) {
+        final byte[] bytes = value.toByteArray();
+
+        if (bytes.length == 32) {
+            return bytes;
+        } else {
+            final byte[] tmp = new byte[32];
+
+            if (bytes.length == 33 && bytes[0] == 0) {
+                System.arraycopy(bytes, 1, tmp, 0, 32);
+                return tmp;
+            } else if (bytes.length < 32) {
+                System.arraycopy(bytes, 0, tmp, 32 - bytes.length, bytes.length);
+                return tmp;
+            }
+        }
+
+        // The byte array is longer than 33 bytes. It's an invalid secp256k1 key.
+        throw new IllegalArgumentException("Invalid BigInteger that is too long. It cannot be a valid private key.");
     }
 
     public static byte[] getEvmAddressFromString(final Key key) {

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
@@ -4,24 +4,29 @@ package com.hedera.node.app.hapi.utils.keys;
 import static com.hedera.node.app.hapi.utils.keys.KeyUtils.BC_PROVIDER;
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.cryptography.libsecp256k1.ContextualLibsecp256k1;
+import com.hedera.cryptography.libsecp256k1.Libsecp256k1;
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hederahashgraph.api.proto.java.Key;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.File;
 import java.io.InputStream;
+import java.lang.foreign.MemorySegment;
 import java.math.BigInteger;
 import java.security.KeyFactory;
 import java.security.interfaces.ECPrivateKey;
 import org.bouncycastle.jce.ECNamedCurveTable;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 import org.bouncycastle.jce.spec.ECPrivateKeySpec;
-import org.bouncycastle.math.ec.ECPoint;
 
 /**
  * Useful methods for interacting with SECP256K1 ECDSA keys.
  */
 public class Secp256k1Utils {
+    private static final ContextualLibsecp256k1 LIBSECP256K1 = ContextualLibsecp256k1.getInstance();
+
     public static final int ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH = 33;
 
     private static final int EVM_ADDRESS_BYTE_LENGTH = 20;
@@ -33,10 +38,40 @@ public class Secp256k1Utils {
                 || contractId.evmAddressOrElse(Bytes.EMPTY).length() == EVM_ADDRESS_BYTE_LENGTH;
     }
 
+    private record Cache(byte[] pubkey, MemorySegment pubkeySeg, long[] len, MemorySegment lenSeg) {}
+
+    private static final ThreadLocal<Cache> CACHE = new ThreadLocal<>() {
+        @Override
+        protected Cache initialValue() {
+            final byte[] pubkey = new byte[Libsecp256k1.PUBLIC_KEY_BYTES];
+            final long[] len = new long[1];
+            return new Cache(pubkey, MemorySegment.ofArray(pubkey), len, MemorySegment.ofArray(len));
+        }
+    };
+
     public static byte[] extractEcdsaPublicKey(final ECPrivateKey key) {
-        final ECPoint pointQ =
-                ECNamedCurveTable.getParameterSpec("secp256k1").getG().multiply(key.getS());
-        return pointQ.getEncoded(true);
+        final Cache cache = CACHE.get();
+
+        if (LIBSECP256K1.secp256k1EcPubkeyCreate(
+                        cache.pubkeySeg, MemorySegment.ofArray(EthTxData.asUnsignedByteArray(key.getS())))
+                != 1) {
+            throw new IllegalArgumentException("secp256k1EcPubkeyCreate failed. The private key is probably invalid.");
+        }
+
+        final byte[] serializedPubkey = new byte[ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH];
+        cache.len[0] = serializedPubkey.length;
+        if (LIBSECP256K1.secp256k1EcPubkeySerialize(
+                                MemorySegment.ofArray(serializedPubkey),
+                                cache.lenSeg,
+                                cache.pubkeySeg,
+                                Libsecp256k1.SECP256K1_EC_COMPRESSED)
+                        != 1
+                || cache.len[0] != serializedPubkey.length) {
+            throw new IllegalArgumentException(
+                    "secp256k1EcPubkeySerialize failed. The private key is probably invalid.");
+        }
+
+        return serializedPubkey;
     }
 
     public static byte[] getEvmAddressFromString(final Key key) {

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/BEVM.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/BEVM.java
@@ -2,6 +2,7 @@
 package com.hedera.node.app.service.contract.impl.bonneville;
 
 import com.hedera.hapi.node.base.ContractID;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.node.app.service.contract.impl.exec.ActionSidecarContentTracer;
 import com.hedera.node.app.service.contract.impl.exec.AddressChecks;
 import com.hedera.node.app.service.contract.impl.exec.operations.CustomSelfDestructOperation;
@@ -1002,9 +1003,9 @@ class BEVM {
         if( halt != null) return halt;
 
         Bytes bytes = _mem.asBytes(adr, len);
-        Bytes keccak = org.hyperledger.besu.crypto.Hash.keccak256(bytes);
-        assert keccak.size() == 32; // Base implementation has changed?
-        return push32(keccak.toArrayUnsafe());
+        byte[] keccak = MiscCryptoUtils.keccak256DigestOf(bytes.toArrayUnsafe());
+        assert keccak.length == 32; // Base implementation has changed?
+        return push32(keccak);
     }
 
     // ---------------------

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/CallManager.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/CallManager.java
@@ -4,6 +4,7 @@ package com.hedera.node.app.service.contract.impl.bonneville;
 import static com.hedera.hapi.streams.CallOperationType.*;
 
 import com.hedera.hapi.streams.CallOperationType;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.node.app.service.contract.impl.exec.ActionSidecarContentTracer;
 import com.hedera.node.app.service.contract.impl.exec.failure.CustomExceptionalHaltReason;
 import com.hedera.node.app.service.contract.impl.exec.processors.PublicMessageProcessor;
@@ -98,7 +99,7 @@ public abstract class CallManager {
 
         // {FF, [sender 20bytes], [salt 32bytes], [code hash, 32bytes] }
         Bytes bytes = Bytes.concatenate(CREATE2_PREFIX, sender.getBytes(), salt, code.getCodeHash().getBytes());
-        Bytes32 hash = org.hyperledger.besu.crypto.Hash.keccak256(bytes);
+        Bytes32 hash = Bytes32.wrap(MiscCryptoUtils.keccak256DigestOf(bytes.toArrayUnsafe()));
         return Address.extract(hash);
     }
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/CodeV2.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/CodeV2.java
@@ -2,6 +2,7 @@
 package com.hedera.node.app.service.contract.impl.bonneville;
 
 import com.google.common.base.MoreObjects;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.node.app.service.contract.impl.state.AbstractMutableEvmAccount;
 import com.hedera.node.app.service.contract.impl.utils.TODO;
 import java.io.OutputStream;
@@ -10,6 +11,7 @@ import java.util.Base64;
 import java.util.BitSet;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Hash;
 
 // Bonneville Code object.  Immutable bare byte array.  Cached, hashed and
@@ -180,7 +182,7 @@ public class CodeV2 extends OutputStream {
 
     private Hash _kekhash;
     public Hash getCodeHash() {
-        return _kekhash == null ? (_kekhash = Hash.hash(getBytes())) : _kekhash;
+        return _kekhash == null ? (_kekhash = Hash.wrap(Bytes32.wrap(MiscCryptoUtils.keccak256DigestOf(getBytes().toArrayUnsafe())))) : _kekhash;
     }
 }
 // spotless:on

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/CodeV2.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/bonneville/CodeV2.java
@@ -6,6 +6,7 @@ import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.node.app.service.contract.impl.state.AbstractMutableEvmAccount;
 import com.hedera.node.app.service.contract.impl.utils.TODO;
 import java.io.OutputStream;
+import java.lang.foreign.MemorySegment;
 import java.util.ArrayList;
 import java.util.Base64;
 import java.util.BitSet;
@@ -180,9 +181,13 @@ public class CodeV2 extends OutputStream {
         return _bytes == null ? (_bytes = Bytes.wrap(_codes,_off,_len)) : _bytes;
     }
 
+    public MemorySegment getMemorySegment() {
+        return MemorySegment.ofArray(_codes).asSlice(_off, _len).asReadOnly();
+    }
+
     private Hash _kekhash;
     public Hash getCodeHash() {
-        return _kekhash == null ? (_kekhash = Hash.wrap(Bytes32.wrap(MiscCryptoUtils.keccak256DigestOf(getBytes().toArrayUnsafe())))) : _kekhash;
+        return _kekhash == null ? (_kekhash = Hash.wrap(Bytes32.wrap(MiscCryptoUtils.keccak256DigestOf(getMemorySegment())))) : _kekhash;
     }
 }
 // spotless:on

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
@@ -70,7 +70,7 @@ public class ProxyEvmAccount extends AbstractProxyEvmAccount {
     /// Assumes delegationAddress isn't empty, but shouldn't fail with an empty one.
     /// Up to the caller to decide if an empty delegationAddress should be treated differently.
     private static byte[] getCodeByteArray(final com.hedera.pbj.runtime.io.buffer.Bytes delegationAddress) {
-        final byte[] code = new byte[Math.toIntExact(delegationAddress.length()) + CODE_DELEGATION_PREFIX.size()];
+        final byte[] code = new byte[Math.toIntExact(delegationAddress.length() + CODE_DELEGATION_PREFIX.size())];
         System.arraycopy(CODE_DELEGATION_PREFIX.toArrayUnsafe(), 0, code, 0, CODE_DELEGATION_PREFIX.size());
         // The below call performs an efficient System.arraycopy() as well:
         delegationAddress.writeTo(code, CODE_DELEGATION_PREFIX.size());

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.contract.impl.state;
 
-import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.pbjToTuweniBytes;
 import static org.hyperledger.besu.evm.worldstate.CodeDelegationHelper.CODE_DELEGATION_PREFIX;
 
 import com.hedera.hapi.node.state.token.Account;
@@ -24,33 +23,58 @@ public class ProxyEvmAccount extends AbstractProxyEvmAccount {
 
     private final Account account;
 
+    /// A cache for the code. No synchronization for performance reasons.
+    private Bytes $code;
+    /// A cache for the codePBJ. No synchronization for performance reasons.
+    private com.hedera.pbj.runtime.io.buffer.Bytes $codePBJ;
+
     public ProxyEvmAccount(final Account account, @NonNull final DispatchingEvmFrameState state) {
         super(account.accountId(), state);
 
         this.account = account;
     }
 
+    /// {@inheritDoc}
+    /// Returns an eventually cached Bytes with the code prefixed by the CODE_DELEGATION_PREFIX.
+    /// Assumes that the caller does NOT modify the underlying bytes, even if they use toArrayUnsafe().
     @Override
     public @NonNull Bytes getCode() {
-        if (account.delegationAddress().length() == 0) {
-            return Bytes.EMPTY;
-        } else {
-            return createDelegationIndicator(pbjToTuweniBytes(account.delegationAddress()));
+        if ($code == null) {
+            if (account.delegationAddress().length() == 0) {
+                $code = Bytes.EMPTY;
+            } else {
+                $code = Bytes.wrap(getCodeByteArray(account.delegationAddress()));
+            }
         }
-    }
-
-    private static Bytes createDelegationIndicator(Bytes delegationAddress) {
-        return Bytes.concatenate(CODE_DELEGATION_PREFIX, delegationAddress);
+        return $code;
     }
 
     @Override
     public com.hedera.pbj.runtime.io.buffer.Bytes getCodePBJ() {
-        return createDelegationIndicatorPJB(account.delegationAddress());
+        if ($codePBJ == null) {
+            // NOTE: it would be way more efficient as:
+            // `$codePBJ = com.hedera.pbj.runtime.io.buffer.Bytes.wrap(getCode().toArrayUnsafe())`
+            // However, this getCodePBJ() prepends the prefix unconditionally,
+            // unlike the getCode() above. So we must recompute it the second time:
+            $codePBJ = createDelegationIndicatorPJB(account.delegationAddress());
+        }
+        return $codePBJ;
     }
 
     public static com.hedera.pbj.runtime.io.buffer.Bytes createDelegationIndicatorPJB(
             com.hedera.pbj.runtime.io.buffer.Bytes delegationAddress) {
-        return com.hedera.pbj.runtime.io.buffer.Bytes.merge(CODE_DELEGATION_PREFIX_PJB, delegationAddress);
+        return com.hedera.pbj.runtime.io.buffer.Bytes.wrap(getCodeByteArray(delegationAddress));
+    }
+
+    /// An efficient builder for a code byte[] that returns an unsafe array (because it's mutable).
+    /// Assumes delegationAddress isn't empty, but shouldn't fail with an empty one.
+    /// Up to the caller to decide if an empty delegationAddress should be treated differently.
+    private static byte[] getCodeByteArray(final com.hedera.pbj.runtime.io.buffer.Bytes delegationAddress) {
+        final byte[] code = new byte[Math.toIntExact(delegationAddress.length()) + CODE_DELEGATION_PREFIX.size()];
+        System.arraycopy(CODE_DELEGATION_PREFIX.toArrayUnsafe(), 0, code, 0, CODE_DELEGATION_PREFIX.size());
+        // The below call performs an efficient System.arraycopy() as well:
+        delegationAddress.writeTo(code, CODE_DELEGATION_PREFIX.size());
+        return code;
     }
 
     @Override

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
@@ -2,12 +2,13 @@
 package com.hedera.node.app.service.contract.impl.state;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.pbjToTuweniBytes;
-import static org.hyperledger.besu.crypto.Hash.keccak256;
 import static org.hyperledger.besu.evm.worldstate.CodeDelegationHelper.CODE_DELEGATION_PREFIX;
 
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 
@@ -57,7 +58,8 @@ public class ProxyEvmAccount extends AbstractProxyEvmAccount {
         if (account.delegationAddress().length() == 0) {
             return Code.EMPTY_CODE.getCodeHash();
         } else {
-            return Hash.wrap(keccak256(getCode()));
+            return Hash.wrap(
+                    Bytes32.wrap(MiscCryptoUtils.keccak256DigestOf(getCode().toArrayUnsafe())));
         }
     }
 }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ProxyEvmAccount.java
@@ -52,11 +52,7 @@ public class ProxyEvmAccount extends AbstractProxyEvmAccount {
     @Override
     public com.hedera.pbj.runtime.io.buffer.Bytes getCodePBJ() {
         if ($codePBJ == null) {
-            // NOTE: it would be way more efficient as:
-            // `$codePBJ = com.hedera.pbj.runtime.io.buffer.Bytes.wrap(getCode().toArrayUnsafe())`
-            // However, this getCodePBJ() prepends the prefix unconditionally,
-            // unlike the getCode() above. So we must recompute it the second time:
-            $codePBJ = createDelegationIndicatorPJB(account.delegationAddress());
+            $codePBJ = com.hedera.pbj.runtime.io.buffer.Bytes.wrap(getCode().toArrayUnsafe());
         }
         return $codePBJ;
     }

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ScheduleEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/ScheduleEvmAccount.java
@@ -2,11 +2,12 @@
 package com.hedera.node.app.service.contract.impl.state;
 
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HssSystemContract.HSS_EVM_ADDRESS;
-import static org.hyperledger.besu.crypto.Hash.keccak256;
 import static org.hyperledger.besu.evm.worldstate.CodeDelegationHelper.CODE_DELEGATION_PREFIX;
 
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.account.Account;
@@ -29,7 +30,8 @@ public class ScheduleEvmAccount extends AbstractEvmEntityAccount {
     // EIP-7702 delegation to HSS system contract
     public static final Bytes CODE = Bytes.concatenate(
             CODE_DELEGATION_PREFIX, Address.fromHexString(HSS_EVM_ADDRESS).getBytes());
-    public static final Hash CODE_HASH = Hash.wrap(keccak256(CODE));
+    public static final Hash CODE_HASH =
+            Hash.wrap(Bytes32.wrap(MiscCryptoUtils.keccak256DigestOf(CODE.toArrayUnsafe())));
     public static final com.hedera.pbj.runtime.io.buffer.Bytes CODE_PBJ =
             com.hedera.pbj.runtime.io.buffer.Bytes.wrap(CODE.toArrayUnsafe());
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/TokenEvmAccount.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/state/TokenEvmAccount.java
@@ -2,11 +2,12 @@
 package com.hedera.node.app.service.contract.impl.state;
 
 import static com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsSystemContract.HTS_167_EVM_ADDRESS;
-import static org.hyperledger.besu.crypto.Hash.keccak256;
 import static org.hyperledger.besu.evm.worldstate.CodeDelegationHelper.CODE_DELEGATION_PREFIX;
 
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.account.Account;
@@ -29,7 +30,8 @@ public class TokenEvmAccount extends AbstractEvmEntityAccount {
     // EIP-7702 delegation to HTS system contract
     public static final Bytes CODE = Bytes.concatenate(
             CODE_DELEGATION_PREFIX, Address.fromHexString(HTS_167_EVM_ADDRESS).getBytes());
-    public static final Hash CODE_HASH = Hash.wrap(keccak256(CODE));
+    public static final Hash CODE_HASH =
+            Hash.wrap(Bytes32.wrap(MiscCryptoUtils.keccak256DigestOf(CODE.toArrayUnsafe())));
     public static final com.hedera.pbj.runtime.io.buffer.Bytes CODE_PBJ =
             com.hedera.pbj.runtime.io.buffer.Bytes.wrap(CODE.toArrayUnsafe());
 

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyEvmAccountTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/state/ProxyEvmAccountTest.java
@@ -2,7 +2,6 @@
 package com.hedera.node.app.service.contract.impl.test.state;
 
 import static com.hedera.node.app.service.contract.impl.utils.ConversionUtils.pbjToTuweniBytes;
-import static org.hyperledger.besu.crypto.Hash.keccak256;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.Mockito.mock;
@@ -10,9 +9,11 @@ import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.node.app.service.contract.impl.state.DispatchingEvmFrameState;
 import com.hedera.node.app.service.contract.impl.state.ProxyEvmAccount;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
+import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Hash;
 import org.hyperledger.besu.evm.Code;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,7 +69,9 @@ class ProxyEvmAccountTest {
         final var delegationAddress = Bytes.fromHex("0000000000000000000000000000000000000001");
         when(ACCOUNT.delegationAddress()).thenReturn(delegationAddress);
         assertEquals(
-                Hash.wrap(keccak256(pbjToTuweniBytes(Bytes.fromHex("ef01000000000000000000000000000000000000000001")))),
+                Hash.wrap(Bytes32.wrap(MiscCryptoUtils.keccak256DigestOf(
+                        Bytes.fromHex("ef01000000000000000000000000000000000000000001")
+                                .toMemorySegment()))),
                 subject.getCodeHash());
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/Utils.java
@@ -25,6 +25,7 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.google.protobuf.ByteString;
 import com.hedera.hapi.node.base.HookCall;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.services.bdd.spec.HapiPropertySource;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
@@ -68,7 +69,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hiero.base.utility.CommonUtils;
-import org.hyperledger.besu.crypto.Hash;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -82,7 +82,7 @@ public class Utils {
     private static final String JSON_EXTENSION = ".json";
 
     public static ByteString eventSignatureOf(String event) {
-        return ByteString.copyFrom(Hash.keccak256(Bytes.wrap(event.getBytes())).toArray());
+        return ByteString.copyFrom(MiscCryptoUtils.keccak256DigestOf(event.getBytes()));
     }
 
     public static ByteString parsedToByteString(long shard, long realm, long n) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm38ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/Evm38ValidationSuite.java
@@ -40,6 +40,7 @@ import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.OrderedInIsolation;
@@ -58,7 +59,6 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.crypto.Hash;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -372,7 +372,7 @@ public class Evm38ValidationSuite {
         final var contract = "ExtCodeOperationsChecker";
         final var invalidAddress = "0x0000000000000000000000000000000000123456";
         final var expectedAccountHash =
-                ByteString.copyFrom(Hash.keccak256(Bytes.EMPTY).toArray());
+                ByteString.copyFrom(MiscCryptoUtils.keccak256DigestOf(Bytes.EMPTY.toArrayUnsafe()));
         final var hashOf = "hashOf";
 
         final String account = "account";
@@ -411,7 +411,7 @@ public class Evm38ValidationSuite {
                     final var contractCodeResult = spec.registry().getBytes("contractCodeHash");
                     final var contractBytecode = spec.registry().getBytes("contractBytecode");
                     final var expectedContractCodeHash = ByteString.copyFrom(
-                                    Hash.keccak256(Bytes.of(contractBytecode)).toArray())
+                                    MiscCryptoUtils.keccak256DigestOf(contractBytecode))
                             .toByteArray();
 
                     Assertions.assertEquals(expectedAccountHash, recordResult.getContractCallResult());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm38ValidationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/evm/batch/AtomicEvm38ValidationSuite.java
@@ -40,6 +40,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 import static com.hederahashgraph.api.proto.java.TokenType.NON_FUNGIBLE_UNIQUE;
 
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.OrderedInIsolation;
@@ -55,7 +56,6 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.crypto.Hash;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -299,7 +299,7 @@ class AtomicEvm38ValidationSuite {
         final var contract = "ExtCodeOperationsChecker";
         final var invalidAddress = "0x0000000000000000000000000000000000123456";
         final var expectedAccountHash =
-                ByteString.copyFrom(Hash.keccak256(Bytes.EMPTY).toArray());
+                ByteString.copyFrom(MiscCryptoUtils.keccak256DigestOf(Bytes.EMPTY.toArrayUnsafe()));
         final var hashOf = "hashOf";
 
         final String account = "account";
@@ -341,7 +341,7 @@ class AtomicEvm38ValidationSuite {
                     final var contractCodeResult = spec.registry().getBytes("contractCodeHash");
                     final var contractBytecode = spec.registry().getBytes("contractBytecode");
                     final var expectedContractCodeHash = ByteString.copyFrom(
-                                    Hash.keccak256(Bytes.of(contractBytecode)).toArray())
+                                    MiscCryptoUtils.keccak256DigestOf(contractBytecode))
                             .toByteArray();
 
                     Assertions.assertEquals(expectedAccountHash, recordResult.getContractCallResult());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/AtomicOpCodesSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/AtomicOpCodesSuite.java
@@ -38,6 +38,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.support.TestLifecycle;
@@ -58,7 +59,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.crypto.Hash;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DynamicTest;
@@ -245,7 +245,7 @@ class AtomicOpCodesSuite {
         final var contract = "ExtCodeOperationsChecker";
         final var invalidAddress = "0x0000000000000000000000000000000000123456";
         final var expectedAccountHash =
-                ByteString.copyFrom(Hash.keccak256(Bytes.EMPTY).toArray());
+                ByteString.copyFrom(MiscCryptoUtils.keccak256DigestOf(Bytes.EMPTY.toArrayUnsafe()));
         final var hashOf = "hashOf";
 
         final String account = "account";
@@ -286,7 +286,7 @@ class AtomicOpCodesSuite {
                     final var contractCodeResult = spec.registry().getBytes("contractCodeHash");
                     final var contractBytecode = spec.registry().getBytes("contractBytecode");
                     final var expectedContractCodeHash = ByteString.copyFrom(
-                                    Hash.keccak256(Bytes.of(contractBytecode)).toArray())
+                                    MiscCryptoUtils.keccak256DigestOf(contractBytecode))
                             .toByteArray();
 
                     Assertions.assertEquals(expectedAccountHash, recordResult.getContractCallResult());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeHashOperationSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/opcodes/ExtCodeHashOperationSuite.java
@@ -23,12 +23,12 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
 
 import com.google.protobuf.ByteString;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.spec.HapiSpecOperation;
 import com.hedera.services.bdd.spec.assertions.ContractFnResultAsserts;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
-import org.hyperledger.besu.crypto.Hash;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -41,7 +41,7 @@ public class ExtCodeHashOperationSuite {
         final var contract = "ExtCodeOperationsChecker";
         final var invalidAddress = "0x0000000000000000000000000000000000123456";
         final var expectedAccountHash =
-                ByteString.copyFrom(Hash.keccak256(Bytes.EMPTY).toArray());
+                ByteString.copyFrom(MiscCryptoUtils.keccak256DigestOf(Bytes.EMPTY.toArrayUnsafe()));
         final var hashOf = "hashOf";
 
         final String account = "account";
@@ -80,7 +80,7 @@ public class ExtCodeHashOperationSuite {
                     final var contractCodeResult = spec.registry().getBytes("contractCodeHash");
                     final var contractBytecode = spec.registry().getBytes("contractBytecode");
                     final var expectedContractCodeHash = ByteString.copyFrom(
-                                    Hash.keccak256(Bytes.of(contractBytecode)).toArray())
+                                    MiscCryptoUtils.keccak256DigestOf(contractBytecode))
                             .toByteArray();
 
                     Assertions.assertEquals(expectedAccountHash, recordResult.getContractCallResult());

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/CryptoCreateSimpleFeesTest.java
@@ -48,10 +48,12 @@ import static org.hiero.base.utility.CommonUtils.hex;
 import static org.hiero.hapi.support.fees.Extra.KEYS;
 import static org.hiero.hapi.support.fees.Extra.PROCESSING_BYTES;
 import static org.hiero.hapi.support.fees.Extra.SIGNATURES;
-import static org.hyperledger.besu.crypto.Hash.keccak256;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.protobuf.ByteString;
+import com.hedera.cryptography.libsecp256k1.ContextualLibsecp256k1;
+import com.hedera.cryptography.libsecp256k1.Libsecp256k1;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.HapiTestLifecycle;
 import com.hedera.services.bdd.junit.LeakyHapiTest;
@@ -59,14 +61,11 @@ import com.hedera.services.bdd.junit.support.TestLifecycle;
 import com.hedera.services.bdd.spec.keys.KeyShape;
 import com.hedera.services.bdd.spec.keys.SigControl;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.lang.foreign.MemorySegment;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.bytes.Bytes32;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.math.ec.ECPoint;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DynamicTest;
@@ -83,6 +82,7 @@ import org.junit.jupiter.api.Tag;
 @Tag(SIMPLE_FEES)
 @HapiTestLifecycle
 public class CryptoCreateSimpleFeesTest {
+    private static final ContextualLibsecp256k1 LIBSECP256K1 = ContextualLibsecp256k1.getInstance();
 
     private static final String PAYER = "payer";
     private static final String ADMIN_KEY = "adminKey";
@@ -235,21 +235,32 @@ public class CryptoCreateSimpleFeesTest {
                                 ecdsaKey.getECDSASecp256K1().toByteArray();
                         log.info("Compressed ECDSA key length: {}", compressedPubKey.length);
 
-                        // decompress to uncompressed format
-                        final var params = SECNamedCurves.getByName("secp256k1");
-                        final var curve = params.getCurve();
-                        final ECPoint point = curve.decodePoint(compressedPubKey);
+                        final byte[] pubkey = new byte[Libsecp256k1.PUBLIC_KEY_BYTES];
+                        final MemorySegment pubkeySeg = MemorySegment.ofArray(pubkey);
+                        if (LIBSECP256K1.secp256k1EcPubkeyParse(
+                                        pubkeySeg, MemorySegment.ofArray(compressedPubKey), compressedPubKey.length)
+                                != 1) {
+                            throw new IllegalStateException("secp256k1EcPubkeyParse failed");
+                        }
+                        final byte[] uncompressed = new byte[Libsecp256k1.PUBLIC_KEY_BYTES + 1];
+                        final long[] uncompressedLen = new long[] {uncompressed.length};
+                        if (LIBSECP256K1.secp256k1EcPubkeySerialize(
+                                        MemorySegment.ofArray(uncompressed),
+                                        MemorySegment.ofArray(uncompressedLen),
+                                        pubkeySeg,
+                                        Libsecp256k1.SECP256K1_EC_UNCOMPRESSED)
+                                != 1) {
+                            throw new IllegalStateException("secp256k1EcPubkeySerialize failed");
+                        }
 
-                        // get uncompressed public key bytes
-                        final byte[] uncompressed = point.getEncoded(false);
-                        if (uncompressed.length != 65 || uncompressed[0] != 0x04) {
+                        if (uncompressedLen[0] != 65 || uncompressed[0] != 0x04) {
                             throw new IllegalStateException("Invalid uncompressed ECDSA public key");
                         }
 
                         // compute the EVM address from the uncompressed public key
                         final byte[] raw = Arrays.copyOfRange(uncompressed, 1, uncompressed.length);
-                        final Bytes32 hash = keccak256(Bytes.wrap(raw));
-                        final byte[] evmAddress = hash.slice(12, 20).toArray();
+                        final byte[] hash = MiscCryptoUtils.keccak256DigestOf(raw);
+                        final byte[] evmAddress = Arrays.copyOfRange(hash, 12, 12 + 20);
                         final ByteString alias = ByteString.copyFrom(evmAddress);
 
                         log.info("Uncompressed ECDSA length: {}", raw.length);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/hip1195/Hip1195StorageTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/hip1195/Hip1195StorageTest.java
@@ -35,7 +35,6 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REJECTED_BY_AC
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static org.hiero.base.utility.CommonUtils.unhex;
-import static org.hyperledger.besu.crypto.Hash.keccak256;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import com.esaulpaugh.headlong.abi.Single;
@@ -43,6 +42,7 @@ import com.esaulpaugh.headlong.abi.TupleType;
 import com.google.protobuf.ByteString;
 import com.hedera.hapi.node.hooks.EvmHookMappingEntry;
 import com.hedera.hapi.node.state.token.Account;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.EmbeddedHapiTest;
 import com.hedera.services.bdd.junit.HapiTest;
@@ -263,8 +263,7 @@ public class Hip1195StorageTest {
     @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
     final Stream<DynamicTest> storageSettingWorks() {
         final var passcode = "open-sesame";
-        final var passcodeHash = Bytes.wrap(keccak256(org.apache.tuweni.bytes.Bytes.wrap(passcode.getBytes(UTF_8)))
-                .toArray());
+        final var passcodeHash = Bytes.wrap(MiscCryptoUtils.keccak256DigestOf(passcode.getBytes(UTF_8)));
         final var tupleType = TupleType.parse("(string)");
         final var correctPassword = ByteString.copyFrom(tupleType.encode(Single.of(passcode)));
         final var wrongPassword = ByteString.copyFrom(tupleType.encode(Single.of("open-sunflower")));
@@ -319,8 +318,7 @@ public class Hip1195StorageTest {
     @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
     final Stream<DynamicTest> contractStorageSettingWorks() {
         final var passcode = "open-sesame";
-        final var passHash32 = Bytes.wrap(keccak256(org.apache.tuweni.bytes.Bytes.wrap(passcode.getBytes(UTF_8)))
-                .toArray());
+        final var passHash32 = Bytes.wrap(MiscCryptoUtils.keccak256DigestOf(passcode.getBytes(UTF_8)));
         final var tupleType = TupleType.parse("(string)");
         final var correctPassword = ByteString.copyFrom(tupleType.encode(Single.of(passcode)));
         final var wrongPassword = ByteString.copyFrom(tupleType.encode(Single.of("open-sunflower")));


### PR DESCRIPTION
**Description**:
In this PR, in separate commits, I'm:
1. Reverting b7dd5355a36126863c44800ff321b5427ac69409 to reintroduce a fix that reduces Bouncy Castle and Besu usages (see https://github.com/hiero-ledger/hiero-consensus-node/pull/26871 )
2. Modifying the `Secp256k1Utils.extractEcdsaPublicKey()` logic by using a new `asPrivateKeyByteArray32()` instead of the old `EthTxData.asUnsignedByteArray()` because ECDSA private keys require slightly different representations with a specific padding/alignment.

Note that we still have to preserve the `EthTxData.asUnsignedByteArray()` because other code relies on the Bouncy Castle-borrowed logic (e.g. ledger id extraction for Ethereum.) However, when dealing with ESCDA private keys, we need to pass exactly 32 bytes to the native library, and hence we must use a different method to convert a BigInteger into that byte array. That's what the new `asPrivateKeyByteArray32()` is doing.

**Related issue(s)**:

Fixes #26898

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
