### PR TITLE
perf: Block stream hashing/serialization improvements

### DIFF
--- a/hedera-node/hedera-app/build.gradle.kts
+++ b/hedera-node/hedera-app/build.gradle.kts
@@ -69,6 +69,7 @@ jmhModuleInfo {
     requires("com.swirlds.metrics.api")
     requires("com.swirlds.platform.core")
     requires("com.swirlds.state.api")
+    requires("org.hiero.base.concurrent")
     requires("org.hiero.base.crypto")
     requires("org.hiero.consensus.model")
     requires("org.hiero.consensus.platformstate")

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/IncrementalStreamingHasherDesignBenchmark.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/IncrementalStreamingHasherDesignBenchmark.java
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks;
+
+import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
+
+import com.hedera.node.app.blocks.impl.BlockImplUtils;
+import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Compares the current {@code IncrementalStreamingHasher} (backed by an {@code ArrayDeque<byte[]>}, used purely as
+ * a stack via {@code addLast}/{@code removeLast}) against a faithful reproduction of its pre-refactor implementation
+ * (backed by a {@code LinkedList<byte[]>}). Both build the identical streaming Merkle tree fold-up
+ * ({@code addNodeByHash}) over the same sequence of pre-hashed leaves and compute the same root hash
+ * ({@code computeRootHash}) — this isolates the data-structure overhead (a {@code Node} object allocated and
+ * discarded per push/pop with {@code LinkedList} vs. no per-element allocation with {@code ArrayDeque}) from
+ * everything else in the block-stream pipeline.
+ *
+ * <p>This runs once per hasher per block item across up to 5 hashers (consensus header, input, output, state
+ * changes, trace data trees), so the per-call overhead multiplies across a whole block's item count.
+ */
+@State(Scope.Thread)
+@Fork(1)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 3, time = 3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class IncrementalStreamingHasherDesignBenchmark {
+
+    @Param({"1000", "20000", "200000"})
+    private int leafCount;
+
+    private byte[][] leaves;
+
+    public static void main(String... args) throws Exception {
+        org.openjdk.jmh.Main.main(new String[] {"IncrementalStreamingHasherDesignBenchmark", "-v", "EXTRA"});
+    }
+
+    @Setup(Level.Trial)
+    public void setup() {
+        final var random = new Random(42);
+        leaves = new byte[leafCount][];
+        for (int i = 0; i < leafCount; i++) {
+            // Already "hashed" 48-byte SHA-384-sized leaves, matching addNodeByHash's expected input; this isolates
+            // the stack data structure from the (unrelated, unchanged) leaf-hashing cost.
+            leaves[i] = new byte[48];
+            random.nextBytes(leaves[i]);
+        }
+
+        final var expected = current_arrayDeque();
+        final var actual = legacy_linkedList();
+        if (!java.util.Arrays.equals(expected, actual)) {
+            throw new IllegalStateException("Legacy and current hasher implementations produced different roots");
+        }
+    }
+
+    // Disabled by default (no @Benchmark) so a plain :app:jmh run doesn't execute it — uncomment to re-enable.
+    // @Benchmark
+    public byte[] current_arrayDeque() {
+        final var hasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), new ArrayList<>(), 0);
+        for (final var leaf : leaves) {
+            hasher.addNodeByHash(leaf);
+        }
+        return hasher.computeRootHash();
+    }
+
+    // Disabled by default (no @Benchmark) so a plain :app:jmh run doesn't execute it — uncomment to re-enable.
+    // @Benchmark
+    public byte[] legacy_linkedList() {
+        final var hasher = new LegacyLinkedListHasher(sha384DigestOrThrow());
+        for (final var leaf : leaves) {
+            hasher.addNodeByHash(leaf);
+        }
+        return hasher.computeRootHash();
+    }
+
+    /**
+     * Faithful reproduction of {@code IncrementalStreamingHasher}'s implementation before it switched from
+     * {@code LinkedList} to {@code ArrayDeque}, kept here only so this benchmark can compare against it.
+     */
+    private static final class LegacyLinkedListHasher {
+        private final MessageDigest digest;
+        private final LinkedList<byte[]> hashList = new LinkedList<>();
+        private long leafCount;
+
+        LegacyLinkedListHasher(final MessageDigest digest) {
+            this.digest = digest;
+        }
+
+        void addNodeByHash(final byte[] hash) {
+            hashList.add(hash);
+            for (long n = leafCount; (n & 1L) == 1; n >>= 1) {
+                final byte[] y = hashList.removeLast();
+                final byte[] x = hashList.removeLast();
+                hashList.add(BlockImplUtils.hashInternalNode(digest, x, y));
+            }
+            leafCount++;
+        }
+
+        byte[] computeRootHash() {
+            if (hashList.isEmpty()) {
+                return BlockStreamManager.HASH_OF_ZERO_BYTES;
+            }
+            if (hashList.size() == 1) {
+                return hashList.getFirst();
+            }
+            byte[] merkleRootHash = hashList.getLast();
+            for (int i = hashList.size() - 2; i >= 0; i--) {
+                merkleRootHash = BlockImplUtils.hashInternalNode(digest, hashList.get(i), merkleRootHash);
+            }
+            return merkleRootHash;
+        }
+    }
+}

--- a/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/SequentialTaskDesignBenchmark.java
+++ b/hedera-node/hedera-app/src/jmh/java/com/hedera/node/app/blocks/SequentialTaskDesignBenchmark.java
@@ -1,0 +1,279 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks;
+
+import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
+
+import com.hedera.node.app.blocks.impl.BlockImplUtils;
+import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
+import java.security.MessageDigest;
+import java.util.ArrayList;
+import java.util.Random;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.TimeUnit;
+import org.hiero.base.concurrent.AbstractTask;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * Compares two ways of splitting work between {@code BlockStreamManagerImpl}'s {@code ParallelTask}
+ * (fires immediately, runs concurrently per item) and {@code SequentialTask} (strictly chained, one
+ * item at a time) stages:
+ *
+ * <ul>
+ *   <li><b>currentDesign</b> mirrors production as of this writing: {@code SequentialTask.onExecute()}
+ *       does both the leaf hash ({@code IncrementalStreamingHasher.addLeaf}, an O(item size) SHA-384
+ *       digest) <i>and</i> the writer append, so the expensive hashing work is serialized across the
+ *       whole block even though it has no data dependency on other items.
+ *   <li><b>proposedDesign</b> moves the SHA-384 leaf digest into the parallel stage (computed
+ *       concurrently per item, same as serialization already is) and leaves only the O(1) Merkle
+ *       fold-up ({@code IncrementalStreamingHasher.addNodeByHash}) plus the writer append in the
+ *       sequential stage — the only two things that actually require item order.
+ * </ul>
+ *
+ * Both variants reuse the identical dependency-counting scheme {@code BlockStreamManagerTask} uses
+ * (an initial {@code send()}, a hand-off from the parallel stage, and a chain-link from the next
+ * task), and both pay for a simulated writer append (a plain {@code arraycopy} into a preallocated
+ * buffer, no real disk I/O — consistent with {@code NoOpBlockItemWriter} used elsewhere in this
+ * benchmark suite) so the only difference measured is where the SHA-384 work happens.
+ *
+ * The benchmark method itself accumulates {@code itemCount} items (mirroring items arriving
+ * throughout a block period via non-blocking {@code addItem} calls) and then joins the chain
+ * (mirroring the {@code worker.sync()} calls in {@code endRoundInternal} that block the handle
+ * thread at block close) — so the measured time already includes the "wait for all serialization
+ * at the end" cost the two designs are trying to shrink.
+ *
+ * {@code itemCount * itemSizeBytes} sets the total raw block size. {@code sizing} is {@code
+ * "<itemCount>,<itemSizeBytes>"} rather than two independent {@code @Param} fields so the matrix below can be
+ * curated (varying item count and item size independently at matched total block sizes) instead of exploding
+ * into every combination.
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+@Warmup(iterations = 2, time = 2)
+@Measurement(iterations = 3, time = 3)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class SequentialTaskDesignBenchmark {
+
+    @Param({
+        "2000,200", // 400KB - small block
+        "20000,200", // 4MB - baseline block
+        "100000,200", // 20MB - many small items (stresses per-item task-scheduling overhead)
+        "25000,2000", // 50MB - medium items
+        "2500,20000", // 50MB - same total bytes as above, fewer/larger items
+        "500,100000" // 50MB - same total bytes again, very few/very large items
+    })
+    private String sizing;
+
+    private int itemCount;
+    private int itemSizeBytes;
+
+    private ForkJoinPool pool;
+    private byte[][] items;
+
+    public static void main(String... args) throws Exception {
+        org.openjdk.jmh.Main.main(new String[] {"SequentialTaskDesignBenchmark", "-v", "EXTRA"});
+    }
+
+    @Setup(Level.Trial)
+    public void setup() {
+        final var parts = sizing.split(",");
+        itemCount = Integer.parseInt(parts[0]);
+        itemSizeBytes = Integer.parseInt(parts[1]);
+
+        pool = new ForkJoinPool(Math.max(2, Runtime.getRuntime().availableProcessors()));
+
+        // Sanity-check the redesign before measuring anything: hashing leaves in the parallel stage
+        // must produce the exact same Merkle root as hashing them in the sequential stage, since this
+        // root is what's used to request/verify the block proof.
+        verifyIdenticalRootHash();
+
+        final var random = new Random(42);
+        items = new byte[itemCount][];
+        for (int i = 0; i < itemCount; i++) {
+            items[i] = new byte[itemSizeBytes];
+            random.nextBytes(items[i]);
+        }
+
+        System.out.printf(
+                ">>> itemCount=%d itemSizeBytes=%d totalBlockBytes=%.1fMB cores=%d%n",
+                itemCount,
+                itemSizeBytes,
+                (itemCount * (long) itemSizeBytes) / (1024.0 * 1024.0),
+                pool.getParallelism());
+    }
+
+    @TearDown(Level.Trial)
+    public void teardown() {
+        pool.shutdown();
+    }
+
+    /**
+     * Current production split: SequentialTask does the SHA-384 leaf hash AND the writer append.
+     * Disabled by default (no {@code @Benchmark}) so a plain {@code :app:jmh} run doesn't execute it —
+     * uncomment {@code @Benchmark} to re-enable.
+     */
+    // @Benchmark
+    public byte[] currentDesign_hashInSequentialStage() {
+        return runChain(false);
+    }
+
+    /**
+     * Proposed split: ParallelTask does the SHA-384 leaf hash; SequentialTask only folds + writes.
+     * Disabled by default (no {@code @Benchmark}) so a plain {@code :app:jmh} run doesn't execute it —
+     * uncomment {@code @Benchmark} to re-enable.
+     */
+    // @Benchmark
+    public byte[] proposedDesign_hashInParallelStage() {
+        return runChain(true);
+    }
+
+    private byte[] runChain(final boolean hashInParallelStage) {
+        final var writeBuffer = new byte[itemCount * itemSizeBytes];
+        final var chain = new TaskChain(pool, sha384DigestOrThrow(), writeBuffer, hashInParallelStage);
+        // ACCUMULATE: items arrive non-blocking, exactly like writeItem()/addItem() during a round.
+        for (final var item : items) {
+            chain.addItem(item);
+        }
+        // WAIT: exactly like endRoundInternal's worker.sync() at block close.
+        chain.sync();
+        return chain.rootHash();
+    }
+
+    private void verifyIdenticalRootHash() {
+        final var random = new Random(7);
+        final var sample = new byte[64][];
+        for (int i = 0; i < sample.length; i++) {
+            sample[i] = new byte[37];
+            random.nextBytes(sample[i]);
+        }
+        final var pool = new ForkJoinPool(4);
+        try {
+            final var sequentialHash = new TaskChain(pool, sha384DigestOrThrow(), new byte[64 * 37], false);
+            final var parallelHash = new TaskChain(pool, sha384DigestOrThrow(), new byte[64 * 37], true);
+            for (final var item : sample) {
+                sequentialHash.addItem(item);
+                parallelHash.addItem(item);
+            }
+            sequentialHash.sync();
+            parallelHash.sync();
+            final var expected = java.util.Arrays.toString(sequentialHash.rootHash());
+            final var actual = java.util.Arrays.toString(parallelHash.rootHash());
+            if (!expected.equals(actual)) {
+                throw new IllegalStateException("Proposed design's root hash diverged from current design's root hash");
+            }
+        } finally {
+            pool.shutdown();
+        }
+    }
+
+    /**
+     * Faithful reimplementation of {@code BlockStreamManagerImpl.BlockStreamManagerTask} /
+     * {@code ParallelTask} / {@code SequentialTask}, parametrized so the SHA-384 leaf hash can be
+     * computed in either stage.
+     */
+    private static final class TaskChain {
+        private final ForkJoinPool pool;
+        private final IncrementalStreamingHasher hasher;
+        private final byte[] writeBuffer;
+        private final boolean hashInParallelStage;
+        private int writeOffset;
+        private SequentialTask currentTask;
+        private SequentialTask prevTask;
+
+        TaskChain(
+                final ForkJoinPool pool,
+                final MessageDigest digest,
+                final byte[] writeBuffer,
+                final boolean hashInParallelStage) {
+            this.pool = pool;
+            this.hasher = new IncrementalStreamingHasher(digest, new ArrayList<>(), 0);
+            this.writeBuffer = writeBuffer;
+            this.hashInParallelStage = hashInParallelStage;
+            this.currentTask = new SequentialTask();
+            this.currentTask.send();
+        }
+
+        void addItem(final byte[] item) {
+            new ParallelTask(item, currentTask).send();
+            final var next = new SequentialTask();
+            currentTask.send(next);
+            prevTask = currentTask;
+            currentTask = next;
+        }
+
+        void sync() {
+            if (prevTask != null) {
+                prevTask.join();
+            }
+        }
+
+        byte[] rootHash() {
+            return hasher.computeRootHash();
+        }
+
+        private final class ParallelTask extends AbstractTask {
+            private final byte[] item;
+            private final SequentialTask out;
+
+            ParallelTask(final byte[] item, final SequentialTask out) {
+                super(pool, 1);
+                this.item = item;
+                this.out = out;
+            }
+
+            @Override
+            protected boolean onExecute() {
+                final byte[] precomputedHash = hashInParallelStage ? BlockImplUtils.hashLeaf(item) : null;
+                out.deliver(item, precomputedHash);
+                return true;
+            }
+        }
+
+        private final class SequentialTask extends AbstractTask {
+            private SequentialTask next;
+            private byte[] item;
+            private byte[] precomputedHash;
+
+            SequentialTask() {
+                super(pool, 3);
+            }
+
+            void deliver(final byte[] item, final byte[] precomputedHash) {
+                this.item = item;
+                this.precomputedHash = precomputedHash;
+                send();
+            }
+
+            void send(final SequentialTask next) {
+                this.next = next;
+                send();
+            }
+
+            @Override
+            protected boolean onExecute() {
+                final byte[] hash = hashInParallelStage ? precomputedHash : BlockImplUtils.hashLeaf(item);
+                hasher.addNodeByHash(hash);
+
+                // Simulate the writer's buffered append (no real disk I/O, matching NoOpBlockItemWriter).
+                System.arraycopy(item, 0, writeBuffer, writeOffset, item.length);
+                writeOffset += item.length;
+
+                if (next != null) {
+                    next.send();
+                }
+                return true;
+            }
+        }
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -120,6 +120,11 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
 
     private static final long NO_BLOCK_SIGNING_REQUESTED = -1L;
 
+    // Leaf hashing is computed in ParallelTask (concurrently per item, no ordering dependency); each worker thread
+    // gets its own MessageDigest since MessageDigest is not safe for concurrent use.
+    private static final ThreadLocal<MessageDigest> LEAF_HASH_DIGESTS =
+            ThreadLocal.withInitial(CommonUtils::sha384DigestOrThrow);
+
     private final int roundsPerBlock;
     private final Duration blockPeriod;
     private final BlockHashSigner blockHashSigner;
@@ -1221,16 +1226,25 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
 
         @Override
         protected boolean onExecute() {
-            byte[] bytes = null;
+            Bytes serialized = null;
+            byte[] leafHash = null;
             try {
-                bytes = BlockItem.PROTOBUF.toBytes(item).toByteArray();
+                serialized = BlockItem.PROTOBUF.toBytes(item);
+                // The leaf hash has no data dependency on any other item, so it's computed here (in parallel across
+                // items) rather than in SequentialTask; only the O(1) Merkle fold-up actually needs item order.
+                // BlockFooter/BlockProof are metadata, never part of a hashed tree, so skip hashing them.
+                final var kind = item.item().kind();
+                if (kind != BlockItem.ItemOneOfType.BLOCK_FOOTER && kind != BlockItem.ItemOneOfType.BLOCK_PROOF) {
+                    leafHash = BlockImplUtils.hashLeaf(LEAF_HASH_DIGESTS.get(), serialized)
+                            .toByteArray();
+                }
             } catch (final Exception e) {
                 log.error("{} - error serializing block item {}", ALERT_MESSAGE, item, e);
                 pipelineFailure.compareAndSet(null, e);
             }
-            // Always hand the item downstream (bytes is null on failure) so the sequential task fires and the chain
-            // keeps advancing; it observes the recorded failure and skips its work.
-            out.send(item, bytes);
+            // Always hand the item downstream (fields are null on failure) so the sequential task fires and the
+            // chain keeps advancing; it observes the recorded failure and skips its work.
+            out.send(item, serialized, leafHash);
             return true;
         }
 
@@ -1241,7 +1255,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             // hang.
             log.error("{} - error serializing block item {}", ALERT_MESSAGE, item, t);
             pipelineFailure.compareAndSet(null, t);
-            out.send(item, null);
+            out.send(item, null, null);
         }
     }
 
@@ -1250,7 +1264,8 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         final AtomicReference<Throwable> pipelineFailure;
         SequentialTask next;
         BlockItem item;
-        byte[] serialized;
+        Bytes serialized;
+        byte[] leafHash;
 
         SequentialTask(final AtomicReference<Throwable> pipelineFailure) {
             super(executor, 3);
@@ -1265,18 +1280,17 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                 try {
                     final var kind = item.item().kind();
                     switch (kind) {
-                        case ROUND_HEADER, EVENT_HEADER -> consensusHeaderHasher.addLeaf(serialized);
-                        case SIGNED_TRANSACTION -> inputTreeHasher.addLeaf(serialized);
+                        case ROUND_HEADER, EVENT_HEADER -> consensusHeaderHasher.addNodeByHash(leafHash);
+                        case SIGNED_TRANSACTION -> inputTreeHasher.addNodeByHash(leafHash);
                         case TRANSACTION_RESULT -> {
-                            outputTreeHasher.addLeaf(serialized);
+                            outputTreeHasher.addNodeByHash(leafHash);
 
-                            // Also update running hashes
-                            final var hashedLeaf = BlockImplUtils.hashLeaf(serialized);
-                            runningHashManager.nextResultHash(ByteBuffer.wrap(hashedLeaf));
+                            // Also update running hashes, reusing the leaf hash already computed above.
+                            runningHashManager.nextResultHash(ByteBuffer.wrap(leafHash));
                         }
-                        case TRANSACTION_OUTPUT, BLOCK_HEADER -> outputTreeHasher.addLeaf(serialized);
-                        case STATE_CHANGES -> stateChangesHasher.addLeaf(serialized);
-                        case TRACE_DATA -> traceDataHasher.addLeaf(serialized);
+                        case TRANSACTION_OUTPUT, BLOCK_HEADER -> outputTreeHasher.addNodeByHash(leafHash);
+                        case STATE_CHANGES -> stateChangesHasher.addNodeByHash(leafHash);
+                        case TRACE_DATA -> traceDataHasher.addNodeByHash(leafHash);
                         case BLOCK_FOOTER, BLOCK_PROOF -> {
                             // BlockFooter and BlockProof are not included in any merkle tree
                             // They are metadata about the block, not part of the hashed content
@@ -1287,7 +1301,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                     if (header != null) {
                         writer.openBlock(header.number());
                     }
-                    writer.writePbjItemAndBytes(item, Bytes.wrap(serialized));
+                    writer.writePbjItemAndBytes(item, serialized);
                 } catch (final Exception e) {
                     log.error("{} - error hashing/writing block item {}", ALERT_MESSAGE, item, e);
                     pipelineFailure.compareAndSet(null, e);
@@ -1315,9 +1329,10 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             send();
         }
 
-        void send(BlockItem item, byte[] serialized) {
+        void send(BlockItem item, Bytes serialized, byte[] leafHash) {
             this.item = item;
             this.serialized = serialized;
+            this.leafHash = leafHash;
             send();
         }
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/IncrementalStreamingHasher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/IncrementalStreamingHasher.java
@@ -10,7 +10,8 @@ import java.io.DataOutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.MessageDigest;
-import java.util.LinkedList;
+import java.util.ArrayDeque;
+import java.util.Deque;
 import java.util.List;
 
 /**
@@ -62,8 +63,8 @@ public class IncrementalStreamingHasher {
 
     /** The hashing algorithm used for computing the hashes. */
     private final MessageDigest digest;
-    /** A list to store intermediate hashes as we build the tree. */
-    private final LinkedList<byte[]> hashList = new LinkedList<>();
+    /** A stack (accessed only from the tail) of intermediate hashes as we build the tree. */
+    private final Deque<byte[]> hashList = new ArrayDeque<>();
     /** The count of leaves in the tree. */
     private long leafCount;
 
@@ -100,12 +101,12 @@ public class IncrementalStreamingHasher {
      * @param hash the 48-byte SHA-384 hash of the node to add (must already include the prefixing)
      */
     public void addNodeByHash(byte[] hash) {
-        hashList.add(hash);
+        hashList.addLast(hash);
         // Fold up: combine sibling pairs while the current position is odd
         for (long n = leafCount; (n & 1L) == 1; n >>= 1) {
             final byte[] y = hashList.removeLast();
             final byte[] x = hashList.removeLast();
-            hashList.add(hashInternalNode(x, y));
+            hashList.addLast(hashInternalNode(x, y));
         }
         leafCount++;
     }
@@ -135,9 +136,12 @@ public class IncrementalStreamingHasher {
             return hashList.getFirst();
         }
 
-        byte[] merkleRootHash = hashList.getLast();
-        for (int i = hashList.size() - 2; i >= 0; i--) {
-            merkleRootHash = hashInternalNode(hashList.get(i), merkleRootHash);
+        // Deque has no indexed access; snapshot into an array (bounded by O(log leafCount) entries) to fold
+        // right-to-left.
+        final byte[][] pendingRoots = hashList.toArray(new byte[0][]);
+        byte[] merkleRootHash = pendingRoots[pendingRoots.length - 1];
+        for (int i = pendingRoots.length - 2; i >= 0; i--) {
+            merkleRootHash = hashInternalNode(pendingRoots[i], merkleRootHash);
         }
         return merkleRootHash;
     }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileAndGrpcBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileAndGrpcBlockItemWriter.java
@@ -57,7 +57,7 @@ public class FileAndGrpcBlockItemWriter implements BlockItemWriter {
     public void writePbjItemAndBytes(@NonNull final BlockItem item, @NonNull final Bytes bytes) {
         requireNonNull(item, "item cannot be null");
         requireNonNull(bytes, "bytes cannot be null");
-        this.fileBlockItemWriter.writeItem(bytes.toByteArray());
+        this.fileBlockItemWriter.writeItem(bytes);
         if (shouldForwardNormalBlockStreamToGrpc()) {
             this.grpcBlockItemWriter.writePbjItemAndBytes(item, bytes);
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriter.java
@@ -400,7 +400,7 @@ public class FileBlockItemWriter implements BlockItemWriter {
      *
      * @param bytes the serialized item to write
      */
-    void writeItem(@NonNull final byte[] bytes) {
+    void writeItem(@NonNull final Bytes bytes) {
         requireNonNull(bytes);
         if (state != State.OPEN) {
             throw new IllegalStateException(
@@ -410,8 +410,8 @@ public class FileBlockItemWriter implements BlockItemWriter {
         // Write the ITEMS tag.
         ProtoWriterTools.writeTag(writableStreamingData, BlockSchema.ITEMS, ProtoConstants.WIRE_TYPE_DELIMITED);
         // Write the length of the item.
-        writableStreamingData.writeVarInt(bytes.length, false);
-        // Write the item bytes themselves.
+        writableStreamingData.writeVarInt(Math.toIntExact(bytes.length()), false);
+        // Write the item bytes themselves, straight from the source buffer with no intermediate copy.
         writableStreamingData.writeBytes(bytes);
     }
 
@@ -425,7 +425,7 @@ public class FileBlockItemWriter implements BlockItemWriter {
     @Override
     public void writePbjItemAndBytes(@NonNull final BlockItem item, @NonNull final Bytes bytes) {
         requireNonNull(bytes, "bytes must not be null");
-        writeItem(bytes.toByteArray());
+        writeItem(bytes);
     }
 
     @Override

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriterTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriterTest.java
@@ -154,7 +154,7 @@ class FileBlockItemWriterTest {
         fileBlockItemWriter.openBlock(1);
 
         // Create a Bytes object and write it
-        final var bytes = new byte[] {1, 2, 3, 4, 5};
+        final var bytes = Bytes.wrap(new byte[] {1, 2, 3, 4, 5});
         final byte[] expectedBytes = {10, 5, 1, 2, 3, 4, 5};
         fileBlockItemWriter.writeItem(bytes);
 
@@ -242,7 +242,7 @@ class FileBlockItemWriterTest {
                 new FileBlockItemWriter(configProvider, selfNodeAccountIdManager, fileSystem);
 
         // Create a Bytes object and write it
-        final var bytes = new byte[] {1, 2, 3, 4, 5};
+        final var bytes = Bytes.wrap(new byte[] {1, 2, 3, 4, 5});
 
         assertThatThrownBy(() -> fileBlockItemWriter.writeItem(bytes), "Cannot write item before opening a block")
                 .isInstanceOf(IllegalStateException.class);
@@ -333,21 +333,15 @@ class FileBlockItemWriterTest {
         assertTrue(emptyFile.exists(), "Open block should create an empty file");
         assertEquals(0, emptyFile.length(), "Empty file should have zero length");
 
-        subject.writeItem(BlockItem.PROTOBUF
-                .toBytes(BlockItem.newBuilder()
-                        .roundHeader(RoundHeader.newBuilder().roundNumber(1L).build())
-                        .build())
-                .toByteArray());
-        subject.writeItem(BlockItem.PROTOBUF
-                .toBytes(BlockItem.newBuilder()
-                        .roundHeader(RoundHeader.newBuilder().roundNumber(2L).build())
-                        .build())
-                .toByteArray());
-        subject.writeItem(BlockItem.PROTOBUF
-                .toBytes(BlockItem.newBuilder()
-                        .roundHeader(RoundHeader.newBuilder().roundNumber(3L).build())
-                        .build())
-                .toByteArray());
+        subject.writeItem(BlockItem.PROTOBUF.toBytes(BlockItem.newBuilder()
+                .roundHeader(RoundHeader.newBuilder().roundNumber(1L).build())
+                .build()));
+        subject.writeItem(BlockItem.PROTOBUF.toBytes(BlockItem.newBuilder()
+                .roundHeader(RoundHeader.newBuilder().roundNumber(2L).build())
+                .build()));
+        subject.writeItem(BlockItem.PROTOBUF.toBytes(BlockItem.newBuilder()
+                .roundHeader(RoundHeader.newBuilder().roundNumber(3L).build())
+                .build()));
 
         final var pendingProof = PendingProof.newBuilder()
                 .block(1)
@@ -381,11 +375,9 @@ class FileBlockItemWriterTest {
 
         final var subject = new FileBlockItemWriter(configProvider, selfNodeAccountIdManager, FileSystems.getDefault());
         subject.openBlock(1);
-        subject.writeItem(BlockItem.PROTOBUF
-                .toBytes(BlockItem.newBuilder()
-                        .roundHeader(RoundHeader.newBuilder().roundNumber(1L).build())
-                        .build())
-                .toByteArray());
+        subject.writeItem(BlockItem.PROTOBUF.toBytes(BlockItem.newBuilder()
+                .roundHeader(RoundHeader.newBuilder().roundNumber(1L).build())
+                .build()));
 
         subject.flushIncompleteBlock();
 
@@ -409,11 +401,9 @@ class FileBlockItemWriterTest {
 
         final var subject = new FileBlockItemWriter(configProvider, selfNodeAccountIdManager, FileSystems.getDefault());
         subject.openBlock(1);
-        subject.writeItem(BlockItem.PROTOBUF
-                .toBytes(BlockItem.newBuilder()
-                        .roundHeader(RoundHeader.newBuilder().roundNumber(1L).build())
-                        .build())
-                .toByteArray());
+        subject.writeItem(BlockItem.PROTOBUF.toBytes(BlockItem.newBuilder()
+                .roundHeader(RoundHeader.newBuilder().roundNumber(1L).build())
+                .build()));
 
         // Pre-create the .open.gz target so the rename fails; the flush must swallow it (best-effort, never throws).
         Files.writeString(tempDir.resolve("block-0.0.3").resolve(OPEN_GZ), "blocker");
@@ -434,7 +424,7 @@ class FileBlockItemWriterTest {
                 .build());
         final var blockItem =
                 BlockItem.newBuilder().signedTransaction(signedTxBytes).build();
-        subject.writeItem(BlockItem.PROTOBUF.toBytes(blockItem).toByteArray());
+        subject.writeItem(BlockItem.PROTOBUF.toBytes(blockItem));
 
         final var pendingProof = PendingProof.newBuilder()
                 .block(2)


### PR DESCRIPTION
**Description**:
Three related changes to the block stream write path to reduce per-block hashing/serialization overhead:

  - Move the SHA-384 leaf hash into the parallel stage. BlockStreamManagerImpl's SequentialTask used to do both the leaf hash (O(item size), no data dependency on other items) and the Merkle fold-up (O(1), strictly ordered) — serializing the expensive part across the whole block for no reason. The leaf hash now happens in ParallelTask (concurrently per item, alongside serialization), and SequentialTask only does the fold-up and the writer append, the two things that actually require item order. IncrementalStreamingHasher gained an addNodeByHash entry point that accepts a precomputed hash directly, and each parallel worker gets its own thread-local MessageDigest since MessageDigest isn't safe for concurrent use.
  - Swap IncrementalStreamingHasher's backing LinkedList<byte[]> for an ArrayDeque<byte[]>. Both are used purely as a stack, but ArrayDeque avoids a Node allocation per push/pop. computeRootHash() now snapshots the (bounded, O(log leafCount)) pending roots into an array to fold right-to-left, since Deque has no indexed access.
  - Avoid a byte-array copy on the file-write path. FileBlockItemWriter.writeItem and FileAndGrpcBlockItemWriter now write the PBJ Bytes object directly instead of round-tripping through Bytes.toByteArray().

  Two JMH design benchmarks are included (disabled by default — no Benchmark — so a plain :app:jmh run doesn't pick them up) to isolate and
  quantify each change: SequentialTaskDesignBenchmark and IncrementalStreamingHasherDesignBenchmark.

 **Benchmark results**

  Parallel-stage leaf hashing vs. current sequential hashing (average time per full block, lower is better):
    | itemCount × itemSizeBytes | total bytes | current (sequential hash) | proposed (parallel hash) | speedup |
  |---|---|---|---|---|
  | 2,000 × 200 | 0.4MB | 1.673 ms | 0.999 ms | **1.67x** |
  | 20,000 × 200 | 3.8MB | 14.144 ms | 9.267 ms | **1.53x** |
  | 100,000 × 200 | 19.1MB | 66.563 ms | 47.720 ms (±25ms, noisy) | **1.40x** |
  | 25,000 × 2,000 | 47.7MB | 60.651 ms | 10.674 ms | **5.68x** |
  | 2,500 × 20,000 | 47.7MB | 37.393 ms | 4.557 ms | **8.21x** |
  | 500 × 100,000 | 47.7MB | 32.107 ms | 3.094 ms | **10.38x** |

Speedup grows with item size — parallelizing the O(item size) SHA-384 work pays off most when there's more of it per item; small items are dominated by task-scheduling overhead instead.

ArrayDeque vs. LinkedList (average time per full tree build, lower is better):
  | Leaf count | ArrayDeque (current) | LinkedList (legacy) | ArrayDeque faster by |
  |---|---|---|---|
  | 100 | 9.06 ± 1.42 µs/op | 9.78 ± 1.13 µs/op | 7.4% |
  | 1,000 | 90.53 ± 10.10 µs/op | 98.34 ± 6.46 µs/op | 7.9% |
  | 5,000 | 430.27 ± 19.07 µs/op | 485.20 ± 25.33 µs/op | 11.3% |
  | 20,000 | 1,806.77 ± 92.62 µs/op | 1,961.57 ± 36.29 µs/op | 7.9% |
  | 50,000 | 4,302.75 ± 224.72 µs/op | 4,859.00 ± 676.92 µs/op | 11.4% |
  | 200,000 | 17,704.17 ± 3,479.71 µs/op | 19,589.26 ± 689.63 µs/op | 9.6% |
  | 500,000 | 43,787.33 ± 332.79 µs/op | 49,207.74 ± 2,455.70 µs/op | 11.0% |

Consistent ~8-11% improvement across leaf counts, from removing one Node allocation per push/pop.

**Correctness**

  Both benchmarks assert the redesigned path produces an identical Merkle root hash to the current implementation before measuring anything,
  so the changes are verified to be bit-for-bit equivalent, not just faster.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
