### PR TITLE
fix: exclude staking records from ChildCallDataSize halt assert

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/validation/ChildCallDataSizeValidationTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/validation/ChildCallDataSizeValidationTest.java
@@ -68,8 +68,8 @@ public class ChildCallDataSizeValidationTest {
                         .exposingResultTo(res -> Assertions.assertFalse((Boolean) res[0])),
                 getTxnRecord(txName + "halt")
                         .andAllChildRecords()
-                        .hasChildRecordCount(0) // there should be no child records, because it is halts
-                );
+                        // no child records, because it halts; staking-period rollover records are excluded
+                        .hasNonStakingChildRecordCount(0));
     }
 
     @LeakyHapiTest


### PR DESCRIPTION
Halt assert used `hasChildRecordCount(0)`, which counts the end-of-staking-period child record injected when a call lands on a staking rollover (`staking.periodMins=1`). Switched to `hasNonStakingChildRecordCount(0)`, matching what #26403 already did to the success assert.

Closes #26517