### PR TITLE
feat: Rework block root hashing to a fixed 16-slot merkle tree

### DIFF
--- a/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/state_proof.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/block/stream/state_proof.proto
@@ -34,9 +34,13 @@ message StateProof {
      * The merkle paths that prove the nodes in the block merkle tree.
      * This field SHALL contain, in the following order:
      * - The merkle path from the consensus timestamp leaf to the root.
-     * - The merkle path from the previous block root (the "left-most"
-     *   node on level 5) to it's (single) internal node parent (on level
-     *   1, adjacent to the block's consensus timestamp).
+     * - The merkle path from the previous block root hash (branch 1, the
+     *   left-most of the sixteen branches, at depth four in the branch
+     *   sub-tree and depth five from the block root) up to the root of
+     *   that sub-tree, which is the right child of the block root and the
+     *   sibling of the block's consensus timestamp leaf. This path SHALL
+     *   carry one sibling per level, four in total, each present and each
+     *   carrying a hash.
      * - The merkle path of the root of the entire block merkle tree.
      */
     repeated MerklePath paths = 1;
@@ -63,8 +67,13 @@ message StateProof {
  *    block root hash. For these the `hash` field is set.
  * 3. Merkle paths in the middle between another merkle path and the root. For
  *    these, none of the fields are set.
- * Merkle paths can only include sibling nodes for binary internal nodes. If
- * there is a unary node in the path a new MerklePath must be started.
+ *
+ * A step inside a MerklePath combines the running hash with a `SiblingNode`,
+ * so a path only covers internal nodes that have two children. A single-child
+ * internal node is represented between paths instead: the path ends at that
+ * child, and the path named by `next_path_index` is the parent. Such nodes
+ * occur in the state tree, so a path proving a state item MUST be split at
+ * each one. The block root tree has none, so a block path is never split.
  */
 message MerklePath {
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamManager.java
@@ -34,10 +34,12 @@ public interface BlockStreamManager extends BlockRecordInfo, StateHashedListener
     byte[] HASH_OF_ZERO_BYTES = noThrowSha384HashOf(new byte[] {0x0});
     Bytes HASH_OF_ZERO = Bytes.wrap(HASH_OF_ZERO_BYTES);
 
-    /*
-     * Typically there are four siblings per block, but in our case the right penultimate root (i.e. the right child of a block's root hash) is merely a composition of its left child hash, requiring no other inputs. <b>This must change if we ever use one of the reserved roots for anything.</b>
+    /**
+     * The number of sibling hashes on the path from a block's first branch up to its root: one per level
+     * of the eight assigned branches, plus the root of the reserved branches 9-16. The block root's other
+     * child, the consensus timestamp leaf, is carried separately and is not counted here.
      */
-    int NUM_SIBLINGS_PER_BLOCK = 3;
+    int NUM_SIBLINGS_PER_BLOCK = 4;
 
     /**
      * The types of work that may be identified as pending within a block.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockImplUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockImplUtils.java
@@ -20,7 +20,6 @@ public class BlockImplUtils {
 
     public static final byte[] LEAF_PREFIX = {0x0};
     public static final Bytes LEAF_PREFIX_BYTES = Bytes.wrap(LEAF_PREFIX);
-    public static final byte[] SINGLE_CHILD_INTERNAL_NODE_PREFIX = {0x1};
     public static final byte[] INTERNAL_NODE_PREFIX = {0x2};
     public static final Bytes INTERNAL_NODE_PREFIX_BYTES = Bytes.wrap(INTERNAL_NODE_PREFIX);
 
@@ -121,10 +120,6 @@ public class BlockImplUtils {
 
     public static byte[] hashLeaf(@NonNull final MessageDigest digest, @NonNull final byte[] leafData) {
         return hashOfAll(digest, LEAF_PREFIX, leafData);
-    }
-
-    public static Bytes hashInternalNodeSingleChild(@NonNull final Bytes hash) {
-        return sha384HashOfAll(SINGLE_CHILD_INTERNAL_NODE_PREFIX, hash.toByteArray());
     }
 
     public static Bytes hashInternalNode(@NonNull final Bytes leftHash, @NonNull final byte[] rightHash) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockRootTree.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockRootTree.java
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl;
+
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.ASSIGNED_SLOT_COUNT;
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.EMPTY_SUBTREE;
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.SLOT_COUNT;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.block.stream.MerkleSiblingHash;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.node.app.blocks.impl.BlockRootTreeHasher.RootAndSiblingHashes;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+
+/**
+ * The block-stream-facing entry point to the block root tree, used by block production, the wrapped record
+ * block path.
+ *
+ * <p>Callers supply only the {@link BlockRootTreeHasher#ASSIGNED_SLOT_COUNT} branches that carry data; this
+ * class pads the reserved branches with {@link BlockRootTreeHasher#EMPTY_SUBTREE} and delegates to
+ * {@link CachedReservedHalfBlockRootTreeHasher}. It is the single place that knows which branches are
+ * assigned, so it is the place to change when a reserved branch is first used.
+ *
+ * <table border="1">
+ *   <caption>Block root tree branches</caption>
+ *   <tr><th>Branch</th><th>Content</th><th>{@code EMPTY_SUBTREE} when</th></tr>
+ *   <tr><td>1</td><td>previous block root hash</td><td>genesis, by value (block -1 is the empty tree)</td></tr>
+ *   <tr><td>2</td><td>root of the tree of all previous block root hashes</td><td>block 0</td></tr>
+ *   <tr><td>3</td><td>start of block state root hash</td><td>wrapped record blocks, block 0</td></tr>
+ *   <tr><td>4</td><td>consensus headers root</td><td>no consensus header items</td></tr>
+ *   <tr><td>5</td><td>input items root</td><td>no input items</td></tr>
+ *   <tr><td>6</td><td>output items root</td><td>no output items</td></tr>
+ *   <tr><td>7</td><td>state changes root</td><td>no state change items</td></tr>
+ *   <tr><td>8</td><td>trace data root</td><td>no trace items &mdash; common</td></tr>
+ *   <tr><td>9-16</td><td>reserved</td><td>always, until assigned</td></tr>
+ * </table>
+ *
+ * <p>A wrapped record block uses this same tree, with branches 3, 4, 5, 7 and 8 empty and branch 6 carrying
+ * the output items root.
+ *
+ * <h2>Assigning a reserved branch</h2>
+ * <p>The tree's shape does not change when branch 9 is first used — its value simply stops being
+ * {@link BlockRootTreeHasher#EMPTY_SUBTREE}, and no other branch moves. The code does need three changes,
+ * all of them here or one level down, because this class fixes the caller-facing arity at
+ * {@link BlockRootTreeHasher#ASSIGNED_SLOT_COUNT} and {@link CachedReservedHalfBlockRootTreeHasher} caches
+ * the reserved half:
+ * <ol>
+ *   <li>Raise {@link BlockRootTreeHasher#ASSIGNED_SLOT_COUNT}, so callers pass the extra branch root and
+ *       {@link #withReservedSlots} pads one fewer.</li>
+ *   <li>Point {@code HASHER} at {@link StreamingBlockRootTreeHasher}, which folds all sixteen branches and
+ *       assumes nothing about which are empty, or extend
+ *       {@link CachedReservedHalfBlockRootTreeHasher} to fold the branches it no longer knows to be empty.
+ *       That implementation rejects a populated reserved branch rather than silently hashing the cached
+ *       value, so this cannot be missed.</li>
+ *   <li>Update the callers to supply the new branch root.</li>
+ * </ol>
+ * The wire format, the sibling count and every existing branch's proof path are unaffected.
+ */
+public final class BlockRootTree {
+    /**
+     * The hash of an empty branch, to pass for any assigned branch with no content. Re-exported from
+     * {@link BlockRootTreeHasher#EMPTY_SUBTREE} so callers need only this class.
+     */
+    public static final Bytes EMPTY_SUBTREE = BlockRootTreeHasher.EMPTY_SUBTREE;
+
+    private static final BlockRootTreeHasher HASHER = CachedReservedHalfBlockRootTreeHasher.INSTANCE;
+
+    private BlockRootTree() {
+        throw new UnsupportedOperationException("Utility Class");
+    }
+
+    /**
+     * Computes a block's root hash and the sibling hashes an indirect proof needs to climb from branch 1 to
+     * that root.
+     *
+     * @param timestampLeafHash the already-hashed timestamp leaf, {@code hashLeaf(Timestamp.PROTOBUF.toBytes(ts))}
+     * @param slots the {@link BlockRootTreeHasher#ASSIGNED_SLOT_COUNT} assigned branch roots, each already
+     *              hashed as a leaf or an internal node and so not hashed again here; use
+     *              {@link BlockRootTreeHasher#EMPTY_SUBTREE} for a branch with no leaves
+     * @return the block root hash and the sibling hashes on branch 1's path
+     */
+    public static RootAndSiblingHashes computeRootAndSiblings(
+            @NonNull final Bytes timestampLeafHash, @NonNull final Bytes... slots) {
+        return HASHER.computeRootAndSiblings(timestampLeafHash, withReservedSlots(slots));
+    }
+
+    /**
+     * Computes a block's root hash, for callers that do not need the sibling hashes.
+     *
+     * @param timestampLeafHash the already-hashed timestamp leaf
+     * @param slots the assigned branch roots
+     * @return the block root hash
+     */
+    public static Bytes computeBlockRootHash(@NonNull final Bytes timestampLeafHash, @NonNull final Bytes... slots) {
+        return HASHER.computeBlockRootHash(timestampLeafHash, withReservedSlots(slots));
+    }
+
+    /**
+     * Computes a block's root hash from an unhashed consensus timestamp.
+     *
+     * @param consensusTimestamp the block's first consensus timestamp
+     * @param slots the assigned branch roots
+     * @return the block root hash
+     */
+    public static Bytes computeBlockRootHash(
+            @NonNull final Timestamp consensusTimestamp, @NonNull final Bytes... slots) {
+        return computeBlockRootHash(hashTimestampLeaf(consensusTimestamp), slots);
+    }
+
+    /**
+     * Hashes a consensus timestamp as the block root's left-hand leaf.
+     *
+     * @param consensusTimestamp the timestamp to hash
+     * @return the leaf hash
+     */
+    public static Bytes hashTimestampLeaf(@NonNull final Timestamp consensusTimestamp) {
+        return BlockImplUtils.hashLeaf(Timestamp.PROTOBUF.toBytes(requireNonNull(consensusTimestamp)));
+    }
+
+    /**
+     * Expands the assigned branches to the full tree by padding the reserved branches with
+     * {@link BlockRootTreeHasher#EMPTY_SUBTREE}.
+     *
+     * @param assignedSlots the assigned branch roots
+     * @return all {@link BlockRootTreeHasher#SLOT_COUNT} branch roots
+     */
+    private static Bytes[] withReservedSlots(final Bytes[] assignedSlots) {
+        requireNonNull(assignedSlots, "branch roots must not be null");
+        if (assignedSlots.length != ASSIGNED_SLOT_COUNT) {
+            throw new IllegalArgumentException(
+                    "Expected exactly %d branch roots but got %d".formatted(ASSIGNED_SLOT_COUNT, assignedSlots.length));
+        }
+        final var slots = new Bytes[SLOT_COUNT];
+        System.arraycopy(assignedSlots, 0, slots, 0, ASSIGNED_SLOT_COUNT);
+        Arrays.fill(slots, ASSIGNED_SLOT_COUNT, SLOT_COUNT, EMPTY_SUBTREE);
+        return slots;
+    }
+
+    /**
+     * A convenience for building the assigned branches of a block whose sub-trees are mostly empty.
+     *
+     * @return an array of {@link BlockRootTreeHasher#ASSIGNED_SLOT_COUNT} empty branch hashes
+     */
+    public static Bytes[] emptyAssignedSlots() {
+        final var slots = new Bytes[ASSIGNED_SLOT_COUNT];
+        Arrays.fill(slots, EMPTY_SUBTREE);
+        return slots;
+    }
+
+    /** The {@link MerkleSiblingHash} count every block's proof carries; see {@link BlockRootTreeHasher}. */
+    public static int siblingCount() {
+        return BlockRootTreeHasher.SIBLING_COUNT;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockRootTreeHasher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockRootTreeHasher.java
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl;
+
+import static com.hedera.node.app.blocks.BlockStreamManager.HASH_OF_ZERO;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.block.stream.MerkleSiblingHash;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Builds the block root tree from its {@link #SLOT_COUNT} branches.
+ *
+ * <p>Every block has the same tree:
+ * <pre>
+ *     blockRootHash = hashInternalNode( hashLeaf(consensusTimestamp), subtreesRootHash )
+ * </pre>
+ * where {@code subtreesRootHash} is the root over all {@link #SLOT_COUNT} pre-hashed branch roots. A branch
+ * with no leaves contributes {@link #EMPTY_SUBTREE}.
+ *
+ * <p>Because the branch count is a power of two, every branch sits at the same depth in every block. Proof
+ * generation relies on this: a branch's path to the root is fixed regardless of which branches are empty.
+ *
+ * <p>Two implementations satisfy this contract and are freely interchangeable.
+ * {@link StreamingBlockRootTreeHasher} states the algorithm plainly, folding every branch with
+ * {@link IncrementalStreamingHasher}. {@link CachedReservedHalfBlockRootTreeHasher} is what production uses;
+ * it reaches the same hashes by caching the invariant root of the reserved branches and unrolling the folds.
+ * {@code BlockRootTreeHasherTest} runs the whole contract against both and asserts they agree.
+ *
+ * @see BlockRootTree for the block-stream-facing entry point, which supplies the reserved branches
+ */
+public interface BlockRootTreeHasher {
+    /** The number of branches making up the block root tree's merkle root. */
+    int SLOT_COUNT = 16;
+
+    /**
+     * The number of branches carrying data. Branches 9-16 are reserved and contribute
+     * {@link #EMPTY_SUBTREE}; assigning one changes only that branch's value, leaving the shape and every
+     * other branch's path untouched.
+     */
+    int ASSIGNED_SLOT_COUNT = 8;
+
+    /** The number of sibling hashes on the path from branch 1 to the block root, one per level. */
+    int SIBLING_COUNT = Integer.numberOfTrailingZeros(SLOT_COUNT);
+
+    /** The hash of an empty branch, {@code sha384(0x00)}. */
+    Bytes EMPTY_SUBTREE = HASH_OF_ZERO;
+
+    /** A block's root hash together with the sibling hashes on the path from branch 1 up to the root. */
+    record RootAndSiblingHashes(Bytes blockRootHash, MerkleSiblingHash[] siblingHashes) {}
+
+    /**
+     * Computes a block's root hash and the sibling hashes an indirect proof needs to climb from branch 1 to
+     * that root.
+     *
+     * <p>A block is not always signed directly. When it is proven indirectly, the proof starts from branch 1
+     * (the previous block root hash) and climbs to the block root, so it must carry the hash of the sibling
+     * met at each level — the nodes a verifier cannot recompute because it does not hold the other branches.
+     * The block root tree is a perfect tree, so that is exactly {@link #SIBLING_COUNT} of them, whatever a
+     * block contains. See {@code BlockStateProofGenerator}.
+     *
+     * <p>Branch 1 is the leftmost leaf, so every sibling on its path is a right sibling: branch 2, then the
+     * root of branches 3-4, then the root of branches 5-8, then the root of branches 9-16. The timestamp
+     * leaf is the block root's left child and is carried separately by the proof, so it does not appear here.
+     *
+     * @param timestampLeafHash the already-hashed timestamp leaf, {@code hashLeaf(Timestamp.PROTOBUF.toBytes(ts))}
+     * @param slots all {@link #SLOT_COUNT} branch roots, each already hashed as a leaf or an internal node
+     *              and so not hashed again here; use {@link #EMPTY_SUBTREE} for a branch with no leaves
+     * @return the block root hash and the sibling hashes on branch 1's path
+     */
+    RootAndSiblingHashes computeRootAndSiblings(@NonNull Bytes timestampLeafHash, @NonNull Bytes... slots);
+
+    /**
+     * Computes a block's root hash, for callers that do not need the sibling hashes.
+     *
+     * @param timestampLeafHash the already-hashed timestamp leaf
+     * @param slots all {@link #SLOT_COUNT} branch roots
+     * @return the block root hash
+     */
+    default Bytes computeBlockRootHash(@NonNull final Bytes timestampLeafHash, @NonNull final Bytes... slots) {
+        return computeRootAndSiblings(timestampLeafHash, slots).blockRootHash();
+    }
+
+    /**
+     * Checks the arguments every implementation requires: a timestamp leaf, and exactly {@link #SLOT_COUNT}
+     * non-null branch roots.
+     *
+     * @param timestampLeafHash the already-hashed timestamp leaf
+     * @param slots the branch roots to validate
+     * @throws IllegalArgumentException if the branch count is wrong
+     * @throws NullPointerException if the timestamp leaf or any branch is null
+     */
+    static void validate(final Bytes timestampLeafHash, final Bytes[] slots) {
+        requireNonNull(timestampLeafHash, "timestampLeafHash must not be null");
+        requireNonNull(slots, "branch roots must not be null");
+        if (slots.length != SLOT_COUNT) {
+            throw new IllegalArgumentException(
+                    "Expected exactly %d branch roots but got %d".formatted(SLOT_COUNT, slots.length));
+        }
+        for (int i = 0; i < slots.length; i++) {
+            requireNonNull(slots[i], "Branch " + (i + 1) + " must not be null; use EMPTY_SUBTREE for an empty branch");
+        }
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStateProofGenerator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStateProofGenerator.java
@@ -23,21 +23,18 @@ import org.apache.commons.lang3.stream.Streams;
 public class BlockStateProofGenerator {
 
     /**
-     * Each intermediate block contributes: its Merkle siblings, a null-hash sentinel for the
-     * single-child internal node wrap, and its timestamp leaf hash
+     * Each intermediate block contributes: its Merkle siblings and its timestamp leaf hash
      */
-    public static final int UNSIGNED_BLOCK_SIBLING_COUNT = BlockStreamManagerImpl.NUM_SIBLINGS_PER_BLOCK + 2;
+    public static final int UNSIGNED_BLOCK_SIBLING_COUNT = BlockStreamManagerImpl.NUM_SIBLINGS_PER_BLOCK + 1;
     /**
-     * The signed block contributes: its Merkle siblings and a null-hash sentinel for the
-     * single-child internal node wrap (the timestamp lives in Merkle Path 1, not here)
+     * The signed block contributes only its Merkle siblings; its timestamp lives in Merkle Path 1, not here
      */
-    public static final int SIGNED_BLOCK_SIBLING_COUNT = BlockStreamManagerImpl.NUM_SIBLINGS_PER_BLOCK + 1;
+    public static final int SIGNED_BLOCK_SIBLING_COUNT = BlockStreamManagerImpl.NUM_SIBLINGS_PER_BLOCK;
 
     /**
      * Each block's state proof consists of exactly three Merkle paths: the timestamp of the signed block,
-     * the block root hash + sibling hashes forming the path to the single-child internal node at the same
-     * level as the signed block's timestamp (encoded as a null-hash SiblingNode sentinel), and a trivial
-     * final parent path for the signed block's root
+     * the block root hash + sibling hashes forming the path up to the signed block's sub-tree root, and a
+     * trivial final parent path for the signed block's root
      */
     public static final int EXPECTED_MERKLE_PATH_COUNT = 3;
 
@@ -116,14 +113,14 @@ public class BlockStateProofGenerator {
         final var mp1 = MerklePath.newBuilder().timestampLeaf(tsBytes).nextPathIndex(ROOT_HASH_MERKLE_PATH_INDEX);
 
         // Merkle Path 2: starting from the block-to-prove's root hash, enumerate sibling hashes for all
-        // subsequent blocks up through the signed block. A null-hash SiblingNode sentinel at the end encodes
-        // the single-child internal node wrapping (depth2Node2) for the signed block.
+        // subsequent blocks up through the signed block. Each block contributes NUM_SIBLINGS_PER_BLOCK
+        // siblings, the last of which is the root of its reserved branches 9-16.
         MerklePath.Builder mp2 = MerklePath.newBuilder()
                 .hash(currentPendingBlock.blockHash())
                 .nextPathIndex(ROOT_HASH_MERKLE_PATH_INDEX);
 
         // Skip the current block's own siblings (we start from its root hash) and collect siblings for each
-        // subsequent indirect block, plus the signed block's siblings and null-hash sentinel
+        // subsequent indirect block, plus the signed block's siblings
         final var siblings = new ArrayList<SiblingNode>();
         for (int i = 0; i < numIndirectBlocks - 1; i++) {
             final long currentBlockNum = minBlockNum + 1 + i;
@@ -145,18 +142,14 @@ public class BlockStateProofGenerator {
                         .hash(s.siblingHash())
                         .build());
             }
-            siblings.add(SiblingNode.newBuilder()
-                    .build()); // Add the single-child internal node (with null-hash sentinal) for loop's current block
-            // (s)
             final var hashedTs = BlockImplUtils.hashLeaf(Timestamp.PROTOBUF.toBytes(block.blockTimestamp()));
             siblings.add(SiblingNode.newBuilder().isLeft(true).hash(hashedTs).build());
         }
 
-        // Merkle Path 2 Continued: add sibling hashes for the signed block, then a null-hash sentinel
-        // to represent the single-child internal node wrapping (depth2Node2). The timestamp is in mp1.
+        // Merkle Path 2 Continued: add sibling hashes for the signed block. Its timestamp is in mp1.
         final var signedBlock = allPendingBlocks.get(latestSignedBlockNumber);
-        // The verifier expects exactly NUM_SIBLINGS_PER_BLOCK sibling hashes for the signed block too; the
-        // trailing null-hash sentinel below is added separately. Fail fast if the actual count drifts.
+        // The verifier expects exactly NUM_SIBLINGS_PER_BLOCK sibling hashes for the signed block too.
+        // Fail fast if the actual count drifts.
         if (signedBlock.siblingHashes().length != BlockStreamManagerImpl.NUM_SIBLINGS_PER_BLOCK) {
             throw new IllegalStateException("Signed block #%d produced %d sibling hashes but exactly %d were expected"
                     .formatted(
@@ -170,7 +163,6 @@ public class BlockStateProofGenerator {
                     .hash(s.siblingHash())
                     .build());
         }
-        siblings.add(SiblingNode.newBuilder().build()); // null-hash sentinel
         mp2.siblings(siblings);
 
         // Merkle Path 3: the parent/block root path

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -11,7 +11,6 @@ import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.NONE;
 import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.POST_UPGRADE_WORK;
 import static com.hedera.node.app.blocks.impl.BlockImplUtils.HASH_SIZE;
 import static com.hedera.node.app.blocks.impl.BlockImplUtils.appendHash;
-import static com.hedera.node.app.blocks.impl.BlockImplUtils.hashLeaf;
 import static com.hedera.node.app.blocks.impl.streaming.FileBlockItemWriter.blockDirFor;
 import static com.hedera.node.app.blocks.impl.streaming.FileBlockItemWriter.cleanUpPendingBlock;
 import static com.hedera.node.app.blocks.impl.streaming.FileBlockItemWriter.loadContiguousPendingBlocks;
@@ -28,7 +27,6 @@ import static org.hiero.consensus.platformstate.PlatformStateUtils.creationSeman
 import com.google.common.annotations.VisibleForTesting;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.BlockProof;
-import com.hedera.hapi.block.stream.MerkleSiblingHash;
 import com.hedera.hapi.block.stream.StateProof;
 import com.hedera.hapi.block.stream.TssSignedBlockProof;
 import com.hedera.hapi.block.stream.output.BlockHeader;
@@ -435,17 +433,18 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         stateChangesHasher.addLeaf(BlockItem.PROTOBUF.toBytes(lastStateChanges).toByteArray());
         final var lastBlockFinalStateChangesHash = Bytes.wrap(stateChangesHasher.computeRootHash());
 
-        return combine(
-                        prevBlockHash,
-                        allPrevBlocksHash,
-                        blockStreamInfo.startOfBlockStateHash(),
-                        blockStreamInfo.consensusHeaderRootHash(),
-                        blockStreamInfo.inputTreeRootHash(),
-                        blockStreamInfo.outputItemRootHash(),
-                        lastBlockFinalStateChangesHash,
-                        blockStreamInfo.traceDataRootHash(),
-                        blockStreamInfo.blockTimeOrThrow())
-                .blockRootHash();
+        // Straight to BlockRootTree rather than through combine(), which also derives the sibling hashes
+        // that only a pending proof needs
+        return BlockRootTree.computeBlockRootHash(
+                blockStreamInfo.blockTimeOrThrow(),
+                prevBlockHash,
+                allPrevBlocksHash,
+                blockStreamInfo.startOfBlockStateHash(),
+                blockStreamInfo.consensusHeaderRootHash(),
+                blockStreamInfo.inputTreeRootHash(),
+                blockStreamInfo.outputItemRootHash(),
+                lastBlockFinalStateChangesHash,
+                blockStreamInfo.traceDataRootHash());
     }
 
     @Override
@@ -1615,8 +1614,10 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
     }
 
     /**
-     * Resets the subtree hashers for branches 4-8 to empty states. Since these subtrees only contain data specific to
-     * the current block, they need to be reset whenever a new block starts.
+     * Resets the hashers for the block root tree's per-block sub-trees (branches 4-8, see
+     * {@link BlockRootTree}).
+     * Since these subtrees only contain data specific to the current block, they need to be reset whenever a
+     * new block starts.
      */
     private void resetSubtrees() {
         // Branch 4
@@ -1631,25 +1632,22 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         traceDataHasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
     }
 
-    private record RootAndSiblingHashes(Bytes blockRootHash, MerkleSiblingHash[] siblingHashes) {}
-
     /**
-     * Combines the given branch hashes into a block root hash and sibling hashes for a pending proof.
+     * Fills the {@link BlockRootTree} branches with this block's sub-tree roots and computes its root hash.
      * Since it's not known whether the pending proof will be directly signed at this point in the block's
      * lifecycle, the sibling hashes required for an indirect proof are also computed.
      * <p>
-     * Note that all of these initial hash values should have all been hashed prior to this point, whether
-     * as a leaf node (prefixed with {@link BlockImplUtils#LEAF_PREFIX}) or as an internal node (prefixed
-     * with {@link BlockImplUtils#INTERNAL_NODE_PREFIX}). Therefore, they should <b>not</b> be hashed
-     * again until combined with another hash.
+     * All of these values have already been hashed, whether as a leaf node (prefixed with
+     * {@link BlockImplUtils#LEAF_PREFIX}) or as an internal node (prefixed with
+     * {@link BlockImplUtils#INTERNAL_NODE_PREFIX}), so they are not hashed again until combined with
+     * another hash.
      * <p>
-     * While {@code prevBlockHash} could programmatically be null, in practice it never should be. Even
-     * in the case of the genesis block, this value should be {@link BlockStreamManager#HASH_OF_ZERO}. For
-     * all other blocks, it should be the actual previous block's root hash.
+     * At the genesis block {@code prevBlockHash} is {@link BlockStreamManager#HASH_OF_ZERO}; for all other
+     * blocks it is the previous block's root hash.
      * @return the block root hash and all possibly-required sibling hashes, ordered from bottom (the
-     * leaf level, depth six) to top (the root, depth one)
+     * branch level) to top (the root)
      */
-    private static RootAndSiblingHashes combine(
+    private static BlockRootTreeHasher.RootAndSiblingHashes combine(
             @NonNull final Bytes prevBlockHash,
             @NonNull final Bytes prevBlockRootsHash,
             @NonNull final Bytes startingStateHash,
@@ -1660,43 +1658,16 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             @NonNull final Bytes traceDataHash,
             @NonNull final Timestamp firstConsensusTimeOfCurrentBlock) {
         requireNonNull(prevBlockHash);
-
-        // Compute depth five hashes
-        final var depth5Node1 = BlockImplUtils.hashInternalNode(prevBlockHash, prevBlockRootsHash);
-        final var depth5Node2 = BlockImplUtils.hashInternalNode(startingStateHash, consensusHeaderHash);
-        final var depth5Node3 = BlockImplUtils.hashInternalNode(inputsHash, outputsHash);
-        final var depth5Node4 = BlockImplUtils.hashInternalNode(stateChangesHash, traceDataHash);
-
-        // Compute depth four hashes
-        final var depth4Node1 = BlockImplUtils.hashInternalNode(depth5Node1, depth5Node2);
-        final var depth4Node2 = BlockImplUtils.hashInternalNode(depth5Node3, depth5Node4);
-
-        // Compute depth three hash (there's no node 2 hash as the reserved subroots aren't encoded anywhere in the
-        // tree)
-        final var depth3Node1 = BlockImplUtils.hashInternalNode(depth4Node1, depth4Node2);
-
-        // Compute depth two hashes (timestamp + last right sibling)
-        final var tsBytes = Timestamp.PROTOBUF.toBytes(firstConsensusTimeOfCurrentBlock);
-        final var depth2Node1 = hashLeaf(tsBytes);
-        // (Depth 2, Node 2) represents the subroot of the tree where the actual data combine with the future reserved
-        // roots 9-16, so we treat its child as the only child (even though other future roots may exist later).
-        final var depth2Node2 = BlockImplUtils.hashInternalNodeSingleChild(depth3Node1);
-
-        // Compute the block's root hash (depth 1)
-        final var rootHash = BlockImplUtils.hashInternalNode(depth2Node1, depth2Node2);
-
-        return new RootAndSiblingHashes(rootHash, new MerkleSiblingHash[] {
-            // Level 6 first sibling (right child)
-            new MerkleSiblingHash(false, prevBlockRootsHash),
-            // Level 5 first sibling (right child)
-            new MerkleSiblingHash(false, depth5Node2),
-            // Level 4 first sibling (right child)
-            new MerkleSiblingHash(false, depth4Node2)
-            // Level 3 has no sibling because reserved roots 9-16 aren't represented as real subroots in the tree. It's
-            // just a single child node hash operation. NOTE: if any of the reserved roots are ever included in the
-            // tree, this level's hash will need to be re-added as an internal node here.
-            // Level 2's _left_ sibling–the block's timestamp–is represented explicitly outside these sibling hashes
-        });
+        return BlockRootTree.computeRootAndSiblings(
+                BlockRootTree.hashTimestampLeaf(firstConsensusTimeOfCurrentBlock),
+                prevBlockHash,
+                prevBlockRootsHash,
+                startingStateHash,
+                consensusHeaderHash,
+                inputsHash,
+                outputsHash,
+                stateChangesHash,
+                traceDataHash);
     }
 
     private static Instant firstConsensusTimestampOf(final Round round) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/CachedReservedHalfBlockRootTreeHasher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/CachedReservedHalfBlockRootTreeHasher.java
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl;
+
+import com.hedera.hapi.block.stream.MerkleSiblingHash;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+
+/**
+ * The block root tree with its folds unrolled and the reserved half cached: the production implementation.
+ *
+ * <p>The tree's shape is fixed, so the pairwise folds are written out rather than streamed — no hasher, no
+ * list, no boxing — and the nodes on branch 1's path are named as they are computed instead of being recovered
+ * afterwards. Branches 9-16 are empty in every block today, so their root
+ * is folded once at class load rather than per block, bringing the cost to nine hashes.
+ *
+ * <p>Those shortcuts are the only difference from {@link StreamingBlockRootTreeHasher}; the two produce
+ * identical hashes, which {@code BlockRootTreeHasherTest} asserts for every combination of populated and
+ * empty branches.
+ */
+public final class CachedReservedHalfBlockRootTreeHasher implements BlockRootTreeHasher {
+    /**
+     * The instance to use. This class declares no instance fields — the cached reserved half is a static
+     * constant — so it is immutable and safe to use concurrently, including by tests running in parallel.
+     * It exists only so the implementation can be passed as a {@link BlockRootTreeHasher} without each
+     * caller allocating an identical stateless object.
+     */
+    public static final CachedReservedHalfBlockRootTreeHasher INSTANCE = new CachedReservedHalfBlockRootTreeHasher();
+
+    private CachedReservedHalfBlockRootTreeHasher() {
+        // Use INSTANCE; there is no per-instance state to justify another
+    }
+
+    /**
+     * The root of the reserved branches 9-16, all of which are {@link #EMPTY_SUBTREE}. Folded once here rather
+     * than per block, since it cannot vary while those branches are unused.
+     *
+     * <p>When a reserved branch is first assigned, this shortcut no longer holds and this implementation must
+     * fold that half for real, as {@link StreamingBlockRootTreeHasher} already does.
+     */
+    public static final Bytes EMPTY_RESERVED_HALF = StreamingBlockRootTreeHasher.streamedRootOf(reservedSlots());
+
+    @Override
+    public RootAndSiblingHashes computeRootAndSiblings(
+            @NonNull final Bytes timestampLeafHash, @NonNull final Bytes... slots) {
+        BlockRootTreeHasher.validate(timestampLeafHash, slots);
+        for (int i = ASSIGNED_SLOT_COUNT; i < SLOT_COUNT; i++) {
+            if (!EMPTY_SUBTREE.equals(slots[i])) {
+                throw new IllegalArgumentException(
+                        ("Branch %d is reserved and must be EMPTY_SUBTREE for this implementation; "
+                                        + "use StreamingBlockRootTreeHasher to assign it")
+                                .formatted(i + 1));
+            }
+        }
+
+        final var branches12 = BlockImplUtils.hashInternalNode(slots[0], slots[1]);
+        final var branches34 = BlockImplUtils.hashInternalNode(slots[2], slots[3]);
+        final var branches56 = BlockImplUtils.hashInternalNode(slots[4], slots[5]);
+        final var branches78 = BlockImplUtils.hashInternalNode(slots[6], slots[7]);
+        final var branches1234 = BlockImplUtils.hashInternalNode(branches12, branches34);
+        final var branches5678 = BlockImplUtils.hashInternalNode(branches56, branches78);
+        final var assignedHalfRootHash = BlockImplUtils.hashInternalNode(branches1234, branches5678);
+
+        final var subtreesRootHash = BlockImplUtils.hashInternalNode(assignedHalfRootHash, EMPTY_RESERVED_HALF);
+        final var blockRootHash = BlockImplUtils.hashInternalNode(timestampLeafHash, subtreesRootHash);
+
+        // The right sibling of branch 1's ancestor at each level, bottom-up
+        final var siblings = new MerkleSiblingHash[] {
+            new MerkleSiblingHash(false, slots[1]),
+            new MerkleSiblingHash(false, branches34),
+            new MerkleSiblingHash(false, branches5678),
+            new MerkleSiblingHash(false, EMPTY_RESERVED_HALF)
+        };
+        return new RootAndSiblingHashes(blockRootHash, siblings);
+    }
+
+    private static Bytes[] reservedSlots() {
+        final var slots = new Bytes[SLOT_COUNT - ASSIGNED_SLOT_COUNT];
+        Arrays.fill(slots, EMPTY_SUBTREE);
+        return slots;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/StreamingBlockRootTreeHasher.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/StreamingBlockRootTreeHasher.java
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl;
+
+import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
+
+import com.hedera.hapi.block.stream.MerkleSiblingHash;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * The plain statement of the block root tree: every branch goes into an {@link IncrementalStreamingHasher} and
+ * the root comes out. Each sibling is likewise the streamed root of the branch range beneath it.
+ *
+ * <p>This takes no shortcuts and assumes nothing about which branches are empty, which makes it the yardstick
+ * for {@link CachedReservedHalfBlockRootTreeHasher} and the implementation to reach for first if a reserved
+ * branch is ever assigned. Production should use {@link CachedReservedHalfBlockRootTreeHasher}.
+ */
+public final class StreamingBlockRootTreeHasher implements BlockRootTreeHasher {
+    /**
+     * The instance to use. This class declares no instance fields and every call allocates its own hasher,
+     * so it is immutable and safe to use concurrently — callers, including tests running in parallel, need
+     * no coordination. It exists only so the implementation can be passed as a
+     * {@link BlockRootTreeHasher} without each caller allocating an identical stateless object.
+     */
+    public static final StreamingBlockRootTreeHasher INSTANCE = new StreamingBlockRootTreeHasher();
+
+    private StreamingBlockRootTreeHasher() {
+        // Use INSTANCE; there is no per-instance state to justify another
+    }
+
+    @Override
+    public RootAndSiblingHashes computeRootAndSiblings(
+            @NonNull final Bytes timestampLeafHash, @NonNull final Bytes... slots) {
+        BlockRootTreeHasher.validate(timestampLeafHash, slots);
+
+        final var subtreesRootHash = streamedRootOf(slots);
+        final var blockRootHash = BlockImplUtils.hashInternalNode(timestampLeafHash, subtreesRootHash);
+
+        // Branch 1 is the leftmost leaf, so the sibling at level i is the root of the branch range
+        // [2^i, 2^(i+1)) — the half of branch 1's ancestor that branch 1 is not in
+        final var siblings = new MerkleSiblingHash[SIBLING_COUNT];
+        for (int level = 0; level < SIBLING_COUNT; level++) {
+            final int from = 1 << level;
+            final int to = from << 1;
+            siblings[level] = new MerkleSiblingHash(false, streamedRootOf(Arrays.copyOfRange(slots, from, to)));
+        }
+        return new RootAndSiblingHashes(blockRootHash, siblings);
+    }
+
+    /**
+     * Folds pre-hashed nodes into a single root with {@link IncrementalStreamingHasher}.
+     *
+     * @param nodes the pre-hashed nodes
+     * @return the root hash
+     */
+    public static Bytes streamedRootOf(@NonNull final Bytes[] nodes) {
+        final var hasher = new IncrementalStreamingHasher(sha384DigestOrThrow(), List.of(), 0);
+        for (final var node : nodes) {
+            hasher.addNodeByHash(node.toByteArray());
+        }
+        return Bytes.wrap(hasher.computeRootHash());
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/impl/BlockRecordManagerImpl.java
@@ -35,7 +35,7 @@ import com.hedera.hapi.streams.RecordStreamItem;
 import com.hedera.hapi.streams.TransactionSidecarRecord;
 import com.hedera.node.app.blocks.BlockHashSigner;
 import com.hedera.node.app.blocks.BlockItemWriter;
-import com.hedera.node.app.blocks.impl.BlockImplUtils;
+import com.hedera.node.app.blocks.impl.BlockRootTree;
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
 import com.hedera.node.app.quiescence.QuiescedHeartbeat;
 import com.hedera.node.app.quiescence.QuiescenceController;
@@ -103,8 +103,6 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
             // No-op
         }
     };
-
-    private static final Bytes EMPTY_INT_NODE = BlockImplUtils.hashInternalNode(HASH_OF_ZERO, HASH_OF_ZERO);
 
     /**
      * The number of blocks to keep multiplied by hash size. This is computed based on the
@@ -630,35 +628,27 @@ public final class BlockRecordManagerImpl implements BlockRecordManager {
             @NonNull final Bytes previousWrappedRecordBlockRootHash,
             @NonNull final Bytes allPrevBlocksRootHash,
             @NonNull final WrappedRecordFileBlockHashes entry) {
-        // Branch 1: previousWrappedRecordBlockRootHash
-        // Branch 2: allPrevBlocksRootHash
-        final Bytes depth5Node1 =
-                BlockImplUtils.hashInternalNode(previousWrappedRecordBlockRootHash, allPrevBlocksRootHash);
-
-        // Branches 3/4 (empty — no state hash or consensus header in wrapped record blocks)
-        @SuppressWarnings("UnnecessaryLocalVariable")
-        final Bytes depth5Node2 = EMPTY_INT_NODE;
-
-        // Branch 5: HASH_OF_ZERO (no inputs tree)
-        // Branch 6: outputItemsTreeRootHash
-        final Bytes outputTreeHash = entry.outputItemsTreeRootHash();
-        final Bytes depth5Node3 = BlockImplUtils.hashInternalNode(HASH_OF_ZERO, outputTreeHash);
-
-        // Branches 7/8 (empty — no state changes or trace data in wrapped record blocks)
-        @SuppressWarnings("UnnecessaryLocalVariable")
-        final Bytes depth5Node4 = EMPTY_INT_NODE;
-
-        // Intermediate depths 4, 3, and 2
-        final Bytes depth4Node1 = BlockImplUtils.hashInternalNode(depth5Node1, depth5Node2);
-        final Bytes depth4Node2 = BlockImplUtils.hashInternalNode(depth5Node3, depth5Node4);
-
-        final Bytes depth3Node1 = BlockImplUtils.hashInternalNode(depth4Node1, depth4Node2);
-
-        final Bytes depth2Node1 = entry.consensusTimestampHash();
-        final Bytes depth2Node2 = BlockImplUtils.hashInternalNodeSingleChild(depth3Node1);
-
-        // Final block root (depth 1)
-        return BlockImplUtils.hashInternalNode(depth2Node1, depth2Node2);
+        // A wrapped record block fills the same branches as any other block; only the previous block root, the
+        // all-previous-block-roots tree and the output items tree carry data. The consensus timestamp leaf
+        // is already hashed on the entry.
+        return BlockRootTree.computeBlockRootHash(
+                entry.consensusTimestampHash(),
+                // Branch 1: previous wrapped record block root hash
+                previousWrappedRecordBlockRootHash,
+                // Branch 2: root of the tree of all previous block root hashes
+                allPrevBlocksRootHash,
+                // Branch 3: no start-of-block state hash in a wrapped record block
+                BlockRootTree.EMPTY_SUBTREE,
+                // Branch 4: no consensus headers
+                BlockRootTree.EMPTY_SUBTREE,
+                // Branch 5: no input items
+                BlockRootTree.EMPTY_SUBTREE,
+                // Branch 6: the output items tree, holding the block header and the record file item
+                entry.outputItemsTreeRootHash(),
+                // Branch 7: no state changes
+                BlockRootTree.EMPTY_SUBTREE,
+                // Branch 8: no trace data
+                BlockRootTree.EMPTY_SUBTREE);
     }
 
     @Override

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockImplUtilsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockImplUtilsTest.java
@@ -94,29 +94,6 @@ class BlockImplUtilsTest {
 
     @SuppressWarnings("DataFlowIssue")
     @Test
-    void hashInternalNodeSingleChildWithNullParamThrows() {
-        assertThrows(NullPointerException.class, () -> BlockImplUtils.hashInternalNodeSingleChild(null));
-    }
-
-    @Test
-    void hashInternalNodeSingleChildAppendsSingleNodePrefix() {
-        final Bytes expected = Bytes.fromHex(
-                "25eeda015d2d5506ca98944d615c7502baede45e5d03725184b9516c923485738c0bba382a6ef4840a02c6bb3c27c452");
-
-        final MessageDigest digest = sha384DigestOrThrow();
-        final Bytes data = Bytes.fromHex(
-                "877a7ee7919309a359ee656d07e42504a2ab42c16089c235de87719c5ace1f00203c07a679d653d8d20458bf6c0ed143");
-        digest.update(BlockImplUtils.SINGLE_CHILD_INTERNAL_NODE_PREFIX);
-        final Bytes computed = Bytes.wrap(digest.digest(data.toByteArray()));
-        // Precondition: verify expected matches computed value
-        assertEquals(expected, computed);
-
-        final Bytes actual = BlockImplUtils.hashInternalNodeSingleChild(data);
-        assertEquals(expected, actual);
-    }
-
-    @SuppressWarnings("DataFlowIssue")
-    @Test
     void hashInternalNodeBytesWithNullParamsThrows() {
         assertThrows(NullPointerException.class, () -> BlockImplUtils.hashInternalNode(null, Bytes.EMPTY));
         assertThrows(NullPointerException.class, () -> BlockImplUtils.hashInternalNode(Bytes.EMPTY, (Bytes) null));
@@ -191,14 +168,6 @@ class BlockImplUtilsTest {
         final var actualLeafPrefix = BlockImplUtils.hashLeaf(data);
         assertEquals(computedLeafPrefix, actualLeafPrefix);
         assertNotEquals(computedNoPrefix, actualLeafPrefix);
-
-        digest.update(BlockImplUtils.SINGLE_CHILD_INTERNAL_NODE_PREFIX);
-        // 264184f6b083b2927d15d0a36395c653b98c4ea679e9e5df3c50848728015338d0a6a2649058a8e4671194843034b51f
-        data.writeTo(digest);
-        final var computedSingleChildPrefix = Bytes.wrap(digest.digest());
-        final var actualSingleChildPrefix = BlockImplUtils.hashInternalNodeSingleChild(data);
-        assertEquals(computedSingleChildPrefix, actualSingleChildPrefix);
-        assertNotEquals(computedNoPrefix, actualSingleChildPrefix);
 
         digest.update(BlockImplUtils.INTERNAL_NODE_PREFIX);
         // The internal node hash calculation requires two inputs, so use data twice

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockRootTreeHasherTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockRootTreeHasherTest.java
@@ -1,0 +1,286 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl;
+
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.ASSIGNED_SLOT_COUNT;
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.EMPTY_SUBTREE;
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.SIBLING_COUNT;
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.SLOT_COUNT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hedera.hapi.block.stream.MerkleSiblingHash;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Arrays;
+import java.util.List;
+import java.util.SplittableRandom;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+/**
+ * Tests the {@link BlockRootTreeHasher} contract against every implementation, and asserts the
+ * implementations agree with each other and with the cross-repo conformance constants.
+ *
+ * <p>The hex constants below are the values agreed with the Block Node implementation. They are the single
+ * check that both repos build the same tree, so they are written out literally here rather than recomputed
+ * from the code under test.
+ */
+class BlockRootTreeHasherTest {
+    /** {@code sha384(0x00)} — the hash of an empty branch. */
+    private static final Bytes EXPECTED_EMPTY_SUBTREE = Bytes.fromHex(
+            "bec021b4f368e3069134e012c2b4307083d3a9bdd206e24e5f0d86e13d6636655933ec2b413465966817a9c208a11717");
+
+    /** The root of the eight reserved branches 9-16, all empty. */
+    private static final Bytes EXPECTED_EMPTY_RESERVED_HALF = Bytes.fromHex(
+            "cf7e7647f57807006f4f5870d2210b5b4038d000b2bfa711bceeb7f4a327346b50c61fda4e5c68110b03ce708fb91cf8");
+
+    /** The root of all sixteen branches, all empty. */
+    private static final Bytes EXPECTED_ALL_EMPTY_ROOT = Bytes.fromHex(
+            "5028fe48c7fca408b16bd62b8089c8644be351cbc653e6786136ce144055d18f9495864b270772f664004eed7b97e6b7");
+
+    private static final Timestamp A_TIMESTAMP = new Timestamp(1_700_000_000L, 123_456_789);
+    private static final Bytes A_TIMESTAMP_LEAF = BlockRootTree.hashTimestampLeaf(A_TIMESTAMP);
+
+    /** Every implementation of the contract, so each test below runs against all of them. */
+    static Stream<Arguments> allImplementations() {
+        return Stream.of(
+                Arguments.of("streaming", StreamingBlockRootTreeHasher.INSTANCE),
+                Arguments.of("cachedReservedHalf", CachedReservedHalfBlockRootTreeHasher.INSTANCE));
+    }
+
+    @Nested
+    @DisplayName("Cross-repo conformance constants")
+    class ConformanceConstants {
+        @Test
+        @DisplayName("an empty sub-tree hashes to sha384(0x00)")
+        void emptySubtreeMatchesSpec() {
+            assertThat(EMPTY_SUBTREE).isEqualTo(EXPECTED_EMPTY_SUBTREE);
+        }
+
+        @Test
+        @DisplayName("the reserved branches 9-16 hash to the spec's value")
+        void reservedHalfMatchesSpec() {
+            assertThat(CachedReservedHalfBlockRootTreeHasher.EMPTY_RESERVED_HALF)
+                    .isEqualTo(EXPECTED_EMPTY_RESERVED_HALF);
+            assertThat(StreamingBlockRootTreeHasher.streamedRootOf(emptySlots(SLOT_COUNT / 2)))
+                    .isEqualTo(EXPECTED_EMPTY_RESERVED_HALF);
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("com.hedera.node.app.blocks.impl.BlockRootTreeHasherTest#allImplementations")
+        @DisplayName("a tree of sixteen empty branches matches the spec")
+        void allEmptyRootMatchesSpec(final String name, final BlockRootTreeHasher hasher) {
+            final var expected = BlockImplUtils.hashInternalNode(A_TIMESTAMP_LEAF, EXPECTED_ALL_EMPTY_ROOT);
+            assertThat(hasher.computeBlockRootHash(A_TIMESTAMP_LEAF, emptySlots(SLOT_COUNT)))
+                    .isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("Agreement between implementations")
+    class ImplementationAgreement {
+        /**
+         * Exhaustively covers all 2^8 combinations of populated and empty assigned branches, since the cached
+         * reserved half must hold no matter which branches happen to be empty.
+         */
+        @ParameterizedTest(name = "branch presence bitmask {0}")
+        @MethodSource("com.hedera.node.app.blocks.impl.BlockRootTreeHasherTest#everySlotPresenceCombination")
+        @DisplayName("both implementations agree for every combination of populated and empty branches")
+        void implementationsAgreeForEveryPresenceCombination(final int presenceBitmask) {
+            final var slots = slotsForPresence(presenceBitmask);
+
+            final var streaming = StreamingBlockRootTreeHasher.INSTANCE.computeRootAndSiblings(A_TIMESTAMP_LEAF, slots);
+            final var cached =
+                    CachedReservedHalfBlockRootTreeHasher.INSTANCE.computeRootAndSiblings(A_TIMESTAMP_LEAF, slots);
+
+            assertThat(cached.blockRootHash()).isEqualTo(streaming.blockRootHash());
+            assertThat(cached.siblingHashes()).isEqualTo(streaming.siblingHashes());
+        }
+
+        @Test
+        @DisplayName("both implementations agree on a wrapped record block")
+        void implementationsAgreeOnAWrappedRecordBlock() {
+            final var slots = emptySlots(SLOT_COUNT);
+            slots[0] = randomHash();
+            slots[1] = randomHash();
+            slots[5] = randomHash();
+
+            assertThat(CachedReservedHalfBlockRootTreeHasher.INSTANCE.computeBlockRootHash(A_TIMESTAMP_LEAF, slots))
+                    .isEqualTo(StreamingBlockRootTreeHasher.INSTANCE.computeBlockRootHash(A_TIMESTAMP_LEAF, slots));
+        }
+    }
+
+    @Nested
+    @DisplayName("Tree shape")
+    class TreeShape {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("com.hedera.node.app.blocks.impl.BlockRootTreeHasherTest#allImplementations")
+        @DisplayName("every block yields SIBLING_COUNT siblings, whatever is empty")
+        void siblingCountIsFixed(final String name, final BlockRootTreeHasher hasher) {
+            final var populated = populatedSlots();
+            final var allEmpty = emptySlots(SLOT_COUNT);
+            // The common case: no trace data
+            final var noTraceData = populatedSlots();
+            noTraceData[7] = EMPTY_SUBTREE;
+
+            for (final var slots : List.of(populated, allEmpty, noTraceData)) {
+                assertThat(hasher.computeRootAndSiblings(A_TIMESTAMP_LEAF, slots)
+                                .siblingHashes())
+                        .hasSize(SIBLING_COUNT);
+            }
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("com.hedera.node.app.blocks.impl.BlockRootTreeHasherTest#allImplementations")
+        @DisplayName("emptying a later branch does not move an earlier branch's path")
+        void emptyingASlotDoesNotMoveOthers(final String name, final BlockRootTreeHasher hasher) {
+            final var populated = populatedSlots();
+            final var noTraceData = populated.clone();
+            noTraceData[7] = EMPTY_SUBTREE;
+
+            final var withTrace = hasher.computeRootAndSiblings(A_TIMESTAMP_LEAF, populated);
+            final var withoutTrace = hasher.computeRootAndSiblings(A_TIMESTAMP_LEAF, noTraceData);
+
+            // Branch 8 only feeds the third sibling, so the other three are untouched and branch 1 keeps its depth
+            assertThat(withoutTrace.siblingHashes()[0]).isEqualTo(withTrace.siblingHashes()[0]);
+            assertThat(withoutTrace.siblingHashes()[1]).isEqualTo(withTrace.siblingHashes()[1]);
+            assertThat(withoutTrace.siblingHashes()[2]).isNotEqualTo(withTrace.siblingHashes()[2]);
+            assertThat(withoutTrace.siblingHashes()[3]).isEqualTo(withTrace.siblingHashes()[3]);
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("com.hedera.node.app.blocks.impl.BlockRootTreeHasherTest#allImplementations")
+        @DisplayName("the siblings climb from branch 1 back to the block root")
+        void siblingsReconstructTheRoot(final String name, final BlockRootTreeHasher hasher) {
+            final var slots = populatedSlots();
+            final var actual = hasher.computeRootAndSiblings(A_TIMESTAMP_LEAF, slots);
+
+            var hash = slots[0];
+            for (final var sibling : actual.siblingHashes()) {
+                assertThat(sibling.isFirst())
+                        .withFailMessage("Every sibling on branch 1's path is a right sibling")
+                        .isFalse();
+                hash = BlockImplUtils.hashInternalNode(hash, sibling.siblingHash());
+            }
+            hash = BlockImplUtils.hashInternalNode(A_TIMESTAMP_LEAF, hash);
+
+            assertThat(hash).isEqualTo(actual.blockRootHash());
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("com.hedera.node.app.blocks.impl.BlockRootTreeHasherTest#allImplementations")
+        @DisplayName("the siblings are the sub-tree roots on branch 1's path")
+        void siblingsAreTheSubtreeRootsOnSlotZerosPath(final String name, final BlockRootTreeHasher hasher) {
+            final var slots = populatedSlots();
+
+            final var expected = List.of(
+                    slots[1],
+                    StreamingBlockRootTreeHasher.streamedRootOf(Arrays.copyOfRange(slots, 2, 4)),
+                    StreamingBlockRootTreeHasher.streamedRootOf(Arrays.copyOfRange(slots, 4, 8)),
+                    StreamingBlockRootTreeHasher.streamedRootOf(Arrays.copyOfRange(slots, 8, 16)));
+
+            final var actual = Arrays.stream(hasher.computeRootAndSiblings(A_TIMESTAMP_LEAF, slots)
+                            .siblingHashes())
+                    .map(MerkleSiblingHash::siblingHash)
+                    .toList();
+
+            assertThat(actual).containsExactlyElementsOf(expected);
+        }
+    }
+
+    @Nested
+    @DisplayName("Reserved branches")
+    class ReservedSlots {
+        @Test
+        @DisplayName("the streaming implementation can assign a reserved branch")
+        void streamingSupportsAssigningAReservedSlot() {
+            final var slots = emptySlots(SLOT_COUNT);
+            final var withReservedEmpty =
+                    StreamingBlockRootTreeHasher.INSTANCE.computeBlockRootHash(A_TIMESTAMP_LEAF, slots);
+
+            slots[ASSIGNED_SLOT_COUNT] = randomHash();
+            assertThat(StreamingBlockRootTreeHasher.INSTANCE.computeBlockRootHash(A_TIMESTAMP_LEAF, slots))
+                    .isNotEqualTo(withReservedEmpty);
+        }
+
+        @Test
+        @DisplayName("the caching implementation refuses a populated reserved branch rather than ignoring it")
+        void cachedReservedHalfRejectsAPopulatedReservedSlot() {
+            final var slots = emptySlots(SLOT_COUNT);
+            slots[ASSIGNED_SLOT_COUNT] = randomHash();
+
+            assertThatThrownBy(() -> CachedReservedHalfBlockRootTreeHasher.INSTANCE.computeBlockRootHash(
+                            A_TIMESTAMP_LEAF, slots))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("reserved")
+                    .hasMessageContaining("StreamingBlockRootTreeHasher");
+        }
+    }
+
+    @Nested
+    @DisplayName("Input validation")
+    class InputValidation {
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("com.hedera.node.app.blocks.impl.BlockRootTreeHasherTest#allImplementations")
+        @DisplayName("the wrong number of branches is rejected")
+        void wrongSlotCountThrows(final String name, final BlockRootTreeHasher hasher) {
+            final var tooFew = emptySlots(SLOT_COUNT - 1);
+            assertThatThrownBy(() -> hasher.computeBlockRootHash(A_TIMESTAMP_LEAF, tooFew))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("16");
+        }
+
+        @ParameterizedTest(name = "{0}")
+        @MethodSource("com.hedera.node.app.blocks.impl.BlockRootTreeHasherTest#allImplementations")
+        @DisplayName("a null branch is rejected rather than silently treated as empty")
+        void nullSlotThrows(final String name, final BlockRootTreeHasher hasher) {
+            final var withNull = emptySlots(SLOT_COUNT);
+            withNull[3] = null;
+            assertThatThrownBy(() -> hasher.computeBlockRootHash(A_TIMESTAMP_LEAF, withNull))
+                    .isInstanceOf(NullPointerException.class)
+                    .hasMessageContaining("Branch 4");
+        }
+    }
+
+    private static Bytes[] emptySlots(final int n) {
+        final var slots = new Bytes[n];
+        Arrays.fill(slots, EMPTY_SUBTREE);
+        return slots;
+    }
+
+    /** All assigned branches populated, reserved branches empty — what a busy block looks like. */
+    private static Bytes[] populatedSlots() {
+        final var slots = emptySlots(SLOT_COUNT);
+        Arrays.setAll(slots, i -> i < ASSIGNED_SLOT_COUNT ? randomHash() : EMPTY_SUBTREE);
+        return slots;
+    }
+
+    /** Every combination of populated and empty assigned branches, as a bitmask where bit i means branch i+1 is set. */
+    static IntStream everySlotPresenceCombination() {
+        return IntStream.range(0, 1 << ASSIGNED_SLOT_COUNT);
+    }
+
+    private static Bytes[] slotsForPresence(final int presenceBitmask) {
+        final var slots = emptySlots(SLOT_COUNT);
+        Arrays.setAll(
+                slots,
+                i -> i < ASSIGNED_SLOT_COUNT && (presenceBitmask & (1 << i)) != 0 ? randomHash() : EMPTY_SUBTREE);
+        return slots;
+    }
+
+    private static final SplittableRandom RANDOM = new SplittableRandom(1_234_567L);
+
+    private static Bytes randomHash() {
+        final var bytes = new byte[BlockImplUtils.HASH_SIZE];
+        for (int i = 0; i < bytes.length; i++) {
+            bytes[i] = (byte) RANDOM.nextInt(256);
+        }
+        return Bytes.wrap(bytes);
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockRootTreeTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockRootTreeTest.java
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.blocks.impl;
+
+import static com.hedera.node.app.blocks.BlockStreamManager.NUM_SIBLINGS_PER_BLOCK;
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.ASSIGNED_SLOT_COUNT;
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.EMPTY_SUBTREE;
+import static com.hedera.node.app.blocks.impl.BlockRootTreeHasher.SLOT_COUNT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Arrays;
+import java.util.SplittableRandom;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests the block-stream-facing facade: that it pads the reserved branches and otherwise defers to
+ * {@link BlockRootTreeHasher}, whose own contract is covered by {@code BlockRootTreeHasherTest}.
+ */
+class BlockRootTreeTest {
+    private static final Timestamp A_TIMESTAMP = new Timestamp(1_700_000_000L, 123_456_789);
+
+    @Test
+    @DisplayName("the assigned branches are padded with empty reserved branches")
+    void assignedBranchesArePaddedWithEmptyReservedBranches() {
+        final var assigned = randomSlots(ASSIGNED_SLOT_COUNT);
+
+        final var allSlots = new Bytes[SLOT_COUNT];
+        System.arraycopy(assigned, 0, allSlots, 0, ASSIGNED_SLOT_COUNT);
+        Arrays.fill(allSlots, ASSIGNED_SLOT_COUNT, SLOT_COUNT, EMPTY_SUBTREE);
+
+        final var timestampLeaf = BlockRootTree.hashTimestampLeaf(A_TIMESTAMP);
+        assertThat(BlockRootTree.computeBlockRootHash(timestampLeaf, assigned))
+                .isEqualTo(StreamingBlockRootTreeHasher.INSTANCE.computeBlockRootHash(timestampLeaf, allSlots));
+    }
+
+    @Test
+    @DisplayName("the timestamp overload matches hashing the timestamp leaf first")
+    void timestampOverloadMatchesTheHashedLeaf() {
+        final var assigned = randomSlots(ASSIGNED_SLOT_COUNT);
+        assertThat(BlockRootTree.computeBlockRootHash(A_TIMESTAMP, assigned))
+                .isEqualTo(BlockRootTree.computeBlockRootHash(BlockRootTree.hashTimestampLeaf(A_TIMESTAMP), assigned));
+    }
+
+    @Test
+    @DisplayName("the timestamp leaf is the protobuf encoding hashed as a leaf")
+    void timestampLeafIsTheHashedProtobufEncoding() {
+        assertThat(BlockRootTree.hashTimestampLeaf(A_TIMESTAMP))
+                .isEqualTo(BlockImplUtils.hashLeaf(Timestamp.PROTOBUF.toBytes(A_TIMESTAMP)));
+    }
+
+    @Test
+    @DisplayName("a block carries NUM_SIBLINGS_PER_BLOCK siblings")
+    void siblingCountMatchesTheProofConstant() {
+        assertThat(BlockRootTree.computeRootAndSiblings(
+                                BlockRootTree.hashTimestampLeaf(A_TIMESTAMP), randomSlots(ASSIGNED_SLOT_COUNT))
+                        .siblingHashes())
+                .hasSize(NUM_SIBLINGS_PER_BLOCK);
+        assertThat(BlockRootTree.siblingCount()).isEqualTo(NUM_SIBLINGS_PER_BLOCK);
+    }
+
+    @Test
+    @DisplayName("emptyAssignedSlots yields the assigned branch count, all empty")
+    void emptyAssignedSlotsYieldsEmptyAssignedSlots() {
+        assertThat(BlockRootTree.emptyAssignedSlots())
+                .hasSize(ASSIGNED_SLOT_COUNT)
+                .containsOnly(EMPTY_SUBTREE);
+    }
+
+    @Test
+    @DisplayName("callers must supply exactly the assigned branches, not the full tree")
+    void wrongAssignedSlotCountThrows() {
+        final var timestampLeaf = BlockRootTree.hashTimestampLeaf(A_TIMESTAMP);
+        final var allSixteen = randomSlots(SLOT_COUNT);
+        assertThatThrownBy(() -> BlockRootTree.computeBlockRootHash(timestampLeaf, allSixteen))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("8");
+    }
+
+    private static final SplittableRandom RANDOM = new SplittableRandom(7_654_321L);
+
+    private static Bytes[] randomSlots(final int n) {
+        final var slots = new Bytes[n];
+        Arrays.setAll(slots, i -> {
+            final var bytes = new byte[BlockImplUtils.HASH_SIZE];
+            for (int j = 0; j < bytes.length; j++) {
+                bytes[j] = (byte) RANDOM.nextInt(256);
+            }
+            return Bytes.wrap(bytes);
+        });
+        return slots;
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStateProofGeneratorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStateProofGeneratorTest.java
@@ -214,9 +214,8 @@ class BlockStateProofGeneratorTest {
      * <ul>
      *   <li>Timestamp leaf: {@code hashLeaf(timestamp)}</li>
      *   <li>Sibling path (has siblings): accumulate from {@code startHash}; left siblings are
-     *       block timestamps and require {@code hashInternalNodeSingleChild} before combining.</li>
-     *   <li>Internal node (no content): combine the children that point to this path —
-     *       one child → {@code hashInternalNodeSingleChild}; two children →
+     *       block timestamps, right siblings are sub-tree roots.</li>
+     *   <li>Internal node (no content): combine the children that point to this path as
      *       {@code hashInternalNode(timestampChild, otherChild)}.</li>
      * </ul>
      * The terminal path (last in DFS order, {@code nextPathIndex < 0}) holds the root hash.
@@ -241,14 +240,8 @@ class BlockStateProofGeneratorTest {
                         .isEqualTo(startHash);
                 var current = startHash;
                 for (final SiblingNode sibling : path.siblings()) {
-                    if (sibling.hash().length() == 0) {
-                        // Null-hash sentinel: applies the single-child internal node wrap (depth3→depth2).
-                        // Present for every block — intermediate blocks have a timestamp after it;
-                        // the signed block does not (its timestamp is in mp1).
-                        current = BlockImplUtils.hashInternalNodeSingleChild(current);
-                    } else if (sibling.isLeft()) {
-                        // Left sibling is an indirect block's consensus timestamp; the sentinel
-                        // immediately before it has already applied the single-child wrap.
+                    if (sibling.isLeft()) {
+                        // Left sibling is an indirect block's consensus timestamp
                         current = BlockImplUtils.hashInternalNode(sibling.hash(), current);
                     } else {
                         current = BlockImplUtils.hashInternalNode(current, sibling.hash());
@@ -257,7 +250,7 @@ class BlockStateProofGeneratorTest {
                 pathHashes[i] = current;
             } else {
                 // Only mp3 (the root path) falls here. Its two children are mp1 (timestamp) and mp2
-                // (block-contents, which already incorporated the single-child wrap via the null sentinel).
+                // (block-contents, which already climbed to the signed block's sub-tree root).
                 Bytes timestampChildHash = null;
                 Bytes otherChildHash = null;
                 for (int j = 0; j < i; j++) {
@@ -383,8 +376,7 @@ class BlockStateProofGeneratorTest {
             Assertions.assertThat(paths.getFirst()).isEqualTo(expectedMp1);
 
             // Verify all the sibling hashes in mp2. Proof starts from the block's own root hash;
-            // siblings begin at the next block. The last sibling is a null-hash sentinel that encodes
-            // the single-child internal node wrapping (depth2Node2) for the signed block.
+            // siblings begin at the next block, the last for each block being its reserved-branches root.
             final var allMp2Hashes = paths.get(BLOCK_CONTENTS_PATH_INDEX).siblings();
 
             var finalHash = EXPECTED_BLOCK_HASHES.get(outerCurrentBlockNum);
@@ -397,10 +389,7 @@ class BlockStateProofGeneratorTest {
                 }
 
                 final var currentSibling = allMp2Hashes.get(i);
-                if (currentSibling.hash().length() == 0) {
-                    // Null-hash sentinel: single-child wrap (depth3→depth2), present for every block
-                    finalHash = BlockImplUtils.hashInternalNodeSingleChild(finalHash);
-                } else if (currentSibling.isLeft()) {
+                if (currentSibling.isLeft()) {
                     // Left sibling is an indirect block's consensus timestamp
                     finalHash = BlockImplUtils.hashInternalNode(currentSibling.hash(), finalHash);
                 } else {
@@ -408,7 +397,7 @@ class BlockStateProofGeneratorTest {
                 }
             }
 
-            // Combine depth2Node2 with the signed block's timestamp to reach the signed block root hash
+            // Combine the signed block's sub-tree root with its timestamp to reach the signed block root hash
             final var expectedHashedTsBytes = BlockImplUtils.hashLeaf(expectedSignedTsBytes);
             finalHash = BlockImplUtils.hashInternalNode(expectedHashedTsBytes, finalHash);
             Assertions.assertThat(finalHash).isEqualTo(expectedFinalBlockHash);
@@ -538,7 +527,9 @@ class BlockStateProofGeneratorTest {
     private static final Bytes[] EXPECTED_FIRST_SIBLING_HASHES = new Bytes[] {
         Bytes.fromBase64("vsAhtPNo4waRNOASwrQwcIPTqb3SBuJOXw2G4T1mNmVZM+wrQTRllmgXqcIIoRcX"),
         Bytes.fromBase64("szITXG1kGEeXF7DN1DvaAbyUh8cPXASqotbz+ddav6nSZkOGN3cg44MAtTf49zxN"),
-        Bytes.fromBase64("Neol38vLZtLyxE3J2b6Hah7XTQgwpu3e3TGlyDRlUbW7xA3gqXZnm3jGlXIY9S6j")
+        Bytes.fromBase64("Neol38vLZtLyxE3J2b6Hah7XTQgwpu3e3TGlyDRlUbW7xA3gqXZnm3jGlXIY9S6j"),
+        // The root of the reserved branches 9-16
+        Bytes.fromBase64("z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4")
     };
 
     private static final Map<Long, Timestamp> EXPECTED_BLOCK_TIMESTAMPS = Map.of(
@@ -558,17 +549,17 @@ class BlockStateProofGeneratorTest {
             TssSignedBlockProof.newBuilder().blockSignature(FINAL_SIGNATURE).build();
     private static final Map<Long, Bytes> EXPECTED_BLOCK_HASHES = Map.of(
             0L,
-            Bytes.fromBase64("fPVG8M+HGGrH+OcYj/Huzt21v8MGlTP/uGRGOffAnmfZiWY39pVejl8mz+G/Br/W"),
+            Bytes.fromBase64("uSoOcoQxNudtZLRHmr5xRGFJ6ulFlCpVkJGy66zOy79Eblzud7HXmWraO10BGNBe"),
             1L,
-            Bytes.fromBase64("ahOe8gN58oNlZ9ujl4qQPznwhcLb8lm3vpfBAawc9BWVgxhG9M/E9TEcg4IC8Q13"),
+            Bytes.fromBase64("bf8uIiwZm7Q7HuyWNUyu0Vm7BKaU3EtfQMpn3cWMr3DndK3EIVcXVbI9vdRe4unV"),
             2L,
-            Bytes.fromBase64("RRcfehwqOGFE5uitIhIaNoACq8s5exCg++1GtqgP33YVxh2DhPy87G9LpN4Guapz"),
+            Bytes.fromBase64("4ZovgLbr2KOVk3zTgjVWclMgIDTRR5wVMA16s2SVlcBTYM46z9g4IO7jBngztTPl"),
             3L,
-            Bytes.fromBase64("FwgU9fmkMUewLy4NinJTWlnx1ZhfynuD0u+Vwsjc+HbF8Ym1rh4msyRQUz++Ea2N"),
+            Bytes.fromBase64("rV4yBTsadYQcKbiLNurMTskWz0WglVts057Xu3RBWgclDsjZMWLifvoqx1uJPNHi"),
             4L,
-            Bytes.fromBase64("v0llIoDI9Srpl2Zoqag9xornzUmlaFguYKMB/IxbDlVCzMMVzkygo2QyxGXd0Nuf"),
+            Bytes.fromBase64("8Hz6NrOOi+iyv6fResvEZ8CQwzX1KVAlDZvpvrQBCqH79aY/8ElKowzPa9xYAdp2"),
             5L,
-            Bytes.fromBase64("BPQoPITnc3+YX70N8cVeRMlY+QekkYOHiVKxV2H9IO5eqFDTA+X6wkKmCsw1Lk4W"));
+            Bytes.fromBase64("6gXxZsMRh+2XEFovdXrdnKPW1uX0p8JtlreK3MvMLJX1+WmnzBaW/WtfSazGuzWg"));
     private static final Map<Long, Bytes> EXPECTED_PREVIOUS_BLOCK_HASHES;
 
     static {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
@@ -134,13 +134,13 @@ class BlockStreamManagerImplTest {
     private static final Bytes FAKE_RESTART_BLOCK_HASH = Bytes.fromHex("abcd".repeat(24));
     // Effective last block hash computed by the restart path from blockStreamInfoWith(Bytes.EMPTY, patch(0))
     private static final Bytes FAKE_PATCH_RESTART_HASH = Bytes.fromHex(
-            "8a9b0805563ed5dd88091b8d923fc5c8f76c61077685420ac34bb0d4e8c842eb198f855b183c93d62e05b25cef3384f4");
+            "2de59a37a8dfd9099e6baf892c04452aa8df8f04e3fadb852087a08c54efe001a94dd97a27be310ac2eded4020740ef8");
     // Effective last block hash computed by the restart path from blockStreamInfoWith(resultHashes, CREATION_VERSION)
     private static final Bytes FAKE_NON_EMPTY_RESULTS_RESTART_HASH = Bytes.fromHex(
-            "b223b5f8979cf1baf604069566ae2342dad59cd3ad39671cbc443ff454f085b8016eec56a625d62ea5fe8712a32bb21d");
+            "8234622d520f27d04f8349244a19f3253b32e081685382669bb2003beed31de1a53422cbf585cbb7698b20b0161ec380");
     // Effective last block hash computed by the restart path from blockStreamInfoWith(Bytes.EMPTY, CREATION_VERSION)
     private static final Bytes FAKE_EMPTY_RESULTS_RESTART_HASH = Bytes.fromHex(
-            "817533f6ffc53bb220740b443aa5b8c0b00160a6028c152bbe1d9a8db0674fb86918349cfc423de388f0fa6286f7f675");
+            "4ee4a6159b50ecf7a5de17d0bc9e088a2a756167cc237158ce1cf6d969a1c33b9c5d715ba808fac80a082280c6f90b1f");
     private static final Bytes N_MINUS_2_BLOCK_HASH = hashLeaf(Bytes.wrap((new byte[] {(byte) 0xAB})));
     private static final Bytes NONZERO_PREV_BLOCK_HASH =
             BlockImplUtils.appendHash(N_MINUS_2_BLOCK_HASH, Bytes.EMPTY, 256);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriterTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/FileBlockItemWriterTest.java
@@ -445,7 +445,8 @@ class FileBlockItemWriterTest {
                 .siblingHashesFromPrevBlockRoot(List.of(
                         new MerkleSiblingHash(true, Bytes.fromHex("1111")),
                         new MerkleSiblingHash(true, Bytes.fromHex("2222")),
-                        new MerkleSiblingHash(true, Bytes.fromHex("3333"))))
+                        new MerkleSiblingHash(true, Bytes.fromHex("3333")),
+                        new MerkleSiblingHash(true, Bytes.fromHex("4444"))))
                 .build();
         subject.flushPendingBlock(pendingProof);
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/record/BlockRecordManagerTest.java
@@ -887,6 +887,13 @@ final class BlockRecordManagerTest extends AppTestBase {
 
         private static final Bytes EMPTY_INT_NODE = BlockImplUtils.hashInternalNode(HASH_OF_ZERO, HASH_OF_ZERO);
 
+        /**
+         * The published cross-repo constant for the root of the eight empty reserved branches 9-16. Written
+         * out literally so this manual computation stays independent of the production tree builder.
+         */
+        private static final Bytes RESERVED_HALF = Bytes.fromHex(
+                "cf7e7647f57807006f4f5870d2210b5b4038d000b2bfa711bceeb7f4a327346b50c61fda4e5c68110b03ce708fb91cf8");
+
         @Test
         void producesHashOfCorrectSize() {
             final var result = BlockRecordManagerImpl.computeWrappedRecordBlockRootHash(
@@ -971,21 +978,22 @@ final class BlockRecordManagerTest extends AppTestBase {
             final var consensusHash = randomHash();
             final var entry = entryWith(outputHash, consensusHash);
 
-            // Manually compute the expected tree structure
-            final Bytes depth5Node1 = BlockImplUtils.hashInternalNode(prevBlockHash, allPrevRootHash);
-            final Bytes depth5Node2 = EMPTY_INT_NODE;
-            final Bytes depth5Node3 = BlockImplUtils.hashInternalNode(HASH_OF_ZERO, outputHash);
-            final Bytes depth5Node4 = EMPTY_INT_NODE;
+            // Manually compute the expected tree structure: a perfect 16-leaf tree whose branches 1, 2 and 6
+            // carry data, whose remaining branches are the empty sub-tree hash, and whose root is combined
+            // with the consensus timestamp leaf.
+            final Bytes branches12 = BlockImplUtils.hashInternalNode(prevBlockHash, allPrevRootHash);
+            final Bytes branches34 = EMPTY_INT_NODE;
+            final Bytes branches56 = BlockImplUtils.hashInternalNode(HASH_OF_ZERO, outputHash);
+            final Bytes branches78 = EMPTY_INT_NODE;
 
-            final Bytes depth4Node1 = BlockImplUtils.hashInternalNode(depth5Node1, depth5Node2);
-            final Bytes depth4Node2 = BlockImplUtils.hashInternalNode(depth5Node3, depth5Node4);
+            final Bytes branches1234 = BlockImplUtils.hashInternalNode(branches12, branches34);
+            final Bytes branches5678 = BlockImplUtils.hashInternalNode(branches56, branches78);
 
-            final Bytes depth3Node1 = BlockImplUtils.hashInternalNode(depth4Node1, depth4Node2);
+            final Bytes assignedHalf = BlockImplUtils.hashInternalNode(branches1234, branches5678);
+            // Branches 9-16 are all empty, so their root is the constant reserved half
+            final Bytes subtreesRoot = BlockImplUtils.hashInternalNode(assignedHalf, RESERVED_HALF);
 
-            final Bytes depth2Node1 = consensusHash;
-            final Bytes depth2Node2 = BlockImplUtils.hashInternalNodeSingleChild(depth3Node1);
-
-            final Bytes expected = BlockImplUtils.hashInternalNode(depth2Node1, depth2Node2);
+            final Bytes expected = BlockImplUtils.hashInternalNode(consensusHash, subtreesRoot);
 
             final var actual =
                     BlockRecordManagerImpl.computeWrappedRecordBlockRootHash(prevBlockHash, allPrevRootHash, entry);

--- a/hedera-node/hedera-app/src/test/resources/state-proof/0.pnd.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/0.pnd.json
@@ -1,15 +1,22 @@
 {
-  "blockHash": "fPVG8M+HGGrH+OcYj/Huzt21v8MGlTP/uGRGOffAnmfZiWY39pVejl8mz+G/Br/W",
+  "blockHash": "uSoOcoQxNudtZLRHmr5xRGFJ6ulFlCpVkJGy66zOy79Eblzud7HXmWraO10BGNBe",
   "previousBlockHash": "vsAhtPNo4waRNOASwrQwcIPTqb3SBuJOXw2G4T1mNmVZM+wrQTRllmgXqcIIoRcX",
   "blockTimestamp": {
     "seconds": "1767744161",
     "nanos": 615197000
   },
-  "siblingHashesFromPrevBlockRoot": [{
-    "siblingHash": "vsAhtPNo4waRNOASwrQwcIPTqb3SBuJOXw2G4T1mNmVZM+wrQTRllmgXqcIIoRcX"
-  }, {
-    "siblingHash": "szITXG1kGEeXF7DN1DvaAbyUh8cPXASqotbz+ddav6nSZkOGN3cg44MAtTf49zxN"
-  }, {
-    "siblingHash": "Neol38vLZtLyxE3J2b6Hah7XTQgwpu3e3TGlyDRlUbW7xA3gqXZnm3jGlXIY9S6j"
-  }]
+  "siblingHashesFromPrevBlockRoot": [
+    {
+      "siblingHash": "vsAhtPNo4waRNOASwrQwcIPTqb3SBuJOXw2G4T1mNmVZM+wrQTRllmgXqcIIoRcX"
+    },
+    {
+      "siblingHash": "szITXG1kGEeXF7DN1DvaAbyUh8cPXASqotbz+ddav6nSZkOGN3cg44MAtTf49zxN"
+    },
+    {
+      "siblingHash": "Neol38vLZtLyxE3J2b6Hah7XTQgwpu3e3TGlyDRlUbW7xA3gqXZnm3jGlXIY9S6j"
+    },
+    {
+      "siblingHash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
+    }
+  ]
 }

--- a/hedera-node/hedera-app/src/test/resources/state-proof/0.proof.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/0.proof.json
@@ -10,6 +10,7 @@
     }, {
       "hash": "oKwy15WJ3erRqyA8hGUOlH4nX0y3ZD3YmWkS9f88YkyQq+JZG3lS9rRGXLH3AZnD"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "wsQ3BgDUVIXphy0ylqTaBB0LdPqRi64h2Rb/ljf0X8asLbCruRA9JYAL3PvJGMbO"
@@ -20,6 +21,7 @@
     }, {
       "hash": "004DuVFfMVbFQCIYAwaGK7rx9cwBPjKUSQKqffVObUD+k/iGABUCmy9Zylv327HL"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "iKFyMv9MvyiIJn6wsU9hpYEIXaQQ2BMePaO0szKAsMgMNsoyQ3JtI/h/zTV1lBuG"
@@ -30,6 +32,7 @@
     }, {
       "hash": "rRQ1foC3TSQy/8XzwuazDAgHEPWiJ6cVSHHJuJ8SrGGJtyOHSLoPvWndkCOMggih"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "Yy1Mbhlhl8WpOySbX+lNHCdlQ5OW0NUqodtKxOfBaLJO/rkL/SP0YcoNKZaI3Cym"
@@ -40,6 +43,7 @@
     }, {
       "hash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "znJinguZ3lXCj+Unho/twmWbt/yXBpuMR0B0kLek1zETadNtumi6ZDieG9OovVIY"
@@ -50,9 +54,10 @@
     }, {
       "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }],
     "nextPathIndex": 2,
-    "hash": "fPVG8M+HGGrH+OcYj/Huzt21v8MGlTP/uGRGOffAnmfZiWY39pVejl8mz+G/Br/W"
+    "hash": "uSoOcoQxNudtZLRHmr5xRGFJ6ulFlCpVkJGy66zOy79Eblzud7HXmWraO10BGNBe"
   }, {
     "nextPathIndex": -1
   }],

--- a/hedera-node/hedera-app/src/test/resources/state-proof/1.pnd.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/1.pnd.json
@@ -1,16 +1,23 @@
 {
   "block": "1",
-  "blockHash": "ahOe8gN58oNlZ9ujl4qQPznwhcLb8lm3vpfBAawc9BWVgxhG9M/E9TEcg4IC8Q13",
-  "previousBlockHash": "fPVG8M+HGGrH+OcYj/Huzt21v8MGlTP/uGRGOffAnmfZiWY39pVejl8mz+G/Br/W",
+  "blockHash": "bf8uIiwZm7Q7HuyWNUyu0Vm7BKaU3EtfQMpn3cWMr3DndK3EIVcXVbI9vdRe4unV",
+  "previousBlockHash": "uSoOcoQxNudtZLRHmr5xRGFJ6ulFlCpVkJGy66zOy79Eblzud7HXmWraO10BGNBe",
   "blockTimestamp": {
     "seconds": "1767744172",
     "nanos": 723579000
   },
-  "siblingHashesFromPrevBlockRoot": [{
-    "siblingHash": "22Cc+zCK8yffvlToVTOO0ob7kxVwbgrI76ynandyPxy0JXM7MckEa7oMGiGSfn+9"
-  }, {
-    "siblingHash": "TtLoClaJllMWDEK+IUUVBU84Ln4gFyE4YAsdDmZzwsMwiPxgiFNqpa1R7XxkolT9"
-  }, {
-    "siblingHash": "oKwy15WJ3erRqyA8hGUOlH4nX0y3ZD3YmWkS9f88YkyQq+JZG3lS9rRGXLH3AZnD"
-  }]
+  "siblingHashesFromPrevBlockRoot": [
+    {
+      "siblingHash": "22Cc+zCK8yffvlToVTOO0ob7kxVwbgrI76ynandyPxy0JXM7MckEa7oMGiGSfn+9"
+    },
+    {
+      "siblingHash": "TtLoClaJllMWDEK+IUUVBU84Ln4gFyE4YAsdDmZzwsMwiPxgiFNqpa1R7XxkolT9"
+    },
+    {
+      "siblingHash": "oKwy15WJ3erRqyA8hGUOlH4nX0y3ZD3YmWkS9f88YkyQq+JZG3lS9rRGXLH3AZnD"
+    },
+    {
+      "siblingHash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
+    }
+  ]
 }

--- a/hedera-node/hedera-app/src/test/resources/state-proof/1.proof.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/1.proof.json
@@ -10,6 +10,7 @@
     }, {
       "hash": "004DuVFfMVbFQCIYAwaGK7rx9cwBPjKUSQKqffVObUD+k/iGABUCmy9Zylv327HL"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "iKFyMv9MvyiIJn6wsU9hpYEIXaQQ2BMePaO0szKAsMgMNsoyQ3JtI/h/zTV1lBuG"
@@ -20,6 +21,7 @@
     }, {
       "hash": "rRQ1foC3TSQy/8XzwuazDAgHEPWiJ6cVSHHJuJ8SrGGJtyOHSLoPvWndkCOMggih"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "Yy1Mbhlhl8WpOySbX+lNHCdlQ5OW0NUqodtKxOfBaLJO/rkL/SP0YcoNKZaI3Cym"
@@ -30,6 +32,7 @@
     }, {
       "hash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "znJinguZ3lXCj+Unho/twmWbt/yXBpuMR0B0kLek1zETadNtumi6ZDieG9OovVIY"
@@ -40,9 +43,10 @@
     }, {
       "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }],
     "nextPathIndex": 2,
-    "hash": "ahOe8gN58oNlZ9ujl4qQPznwhcLb8lm3vpfBAawc9BWVgxhG9M/E9TEcg4IC8Q13"
+    "hash": "bf8uIiwZm7Q7HuyWNUyu0Vm7BKaU3EtfQMpn3cWMr3DndK3EIVcXVbI9vdRe4unV"
   }, {
     "nextPathIndex": -1
   }],

--- a/hedera-node/hedera-app/src/test/resources/state-proof/2.pnd.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/2.pnd.json
@@ -1,16 +1,23 @@
 {
   "block": "2",
-  "blockHash": "RRcfehwqOGFE5uitIhIaNoACq8s5exCg++1GtqgP33YVxh2DhPy87G9LpN4Guapz",
-  "previousBlockHash": "ahOe8gN58oNlZ9ujl4qQPznwhcLb8lm3vpfBAawc9BWVgxhG9M/E9TEcg4IC8Q13",
+  "blockHash": "4ZovgLbr2KOVk3zTgjVWclMgIDTRR5wVMA16s2SVlcBTYM46z9g4IO7jBngztTPl",
+  "previousBlockHash": "bf8uIiwZm7Q7HuyWNUyu0Vm7BKaU3EtfQMpn3cWMr3DndK3EIVcXVbI9vdRe4unV",
   "blockTimestamp": {
     "seconds": "1767744173",
     "nanos": 794422000
   },
-  "siblingHashesFromPrevBlockRoot": [{
-    "siblingHash": "w5yEUQDjtDCNxcSBbZZWpkUzwG60E5gjlzhEV3Xakl2xvrVYP4lNdQGFbemBNWfH"
-  }, {
-    "siblingHash": "/rrgBqQoZEeoDc1UMNQ5Fx2Qcb7UFho6f1OAt1AW1SCORIsAjJkKBSlgBuie/H83"
-  }, {
-    "siblingHash": "004DuVFfMVbFQCIYAwaGK7rx9cwBPjKUSQKqffVObUD+k/iGABUCmy9Zylv327HL"
-  }]
+  "siblingHashesFromPrevBlockRoot": [
+    {
+      "siblingHash": "w5yEUQDjtDCNxcSBbZZWpkUzwG60E5gjlzhEV3Xakl2xvrVYP4lNdQGFbemBNWfH"
+    },
+    {
+      "siblingHash": "/rrgBqQoZEeoDc1UMNQ5Fx2Qcb7UFho6f1OAt1AW1SCORIsAjJkKBSlgBuie/H83"
+    },
+    {
+      "siblingHash": "004DuVFfMVbFQCIYAwaGK7rx9cwBPjKUSQKqffVObUD+k/iGABUCmy9Zylv327HL"
+    },
+    {
+      "siblingHash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
+    }
+  ]
 }

--- a/hedera-node/hedera-app/src/test/resources/state-proof/2.proof.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/2.proof.json
@@ -10,6 +10,7 @@
     }, {
       "hash": "rRQ1foC3TSQy/8XzwuazDAgHEPWiJ6cVSHHJuJ8SrGGJtyOHSLoPvWndkCOMggih"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "Yy1Mbhlhl8WpOySbX+lNHCdlQ5OW0NUqodtKxOfBaLJO/rkL/SP0YcoNKZaI3Cym"
@@ -20,6 +21,7 @@
     }, {
       "hash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "znJinguZ3lXCj+Unho/twmWbt/yXBpuMR0B0kLek1zETadNtumi6ZDieG9OovVIY"
@@ -30,9 +32,10 @@
     }, {
       "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }],
     "nextPathIndex": 2,
-    "hash": "RRcfehwqOGFE5uitIhIaNoACq8s5exCg++1GtqgP33YVxh2DhPy87G9LpN4Guapz"
+    "hash": "4ZovgLbr2KOVk3zTgjVWclMgIDTRR5wVMA16s2SVlcBTYM46z9g4IO7jBngztTPl"
   }, {
     "nextPathIndex": -1
   }],

--- a/hedera-node/hedera-app/src/test/resources/state-proof/3.pnd.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/3.pnd.json
@@ -1,16 +1,23 @@
 {
   "block": "3",
-  "blockHash": "FwgU9fmkMUewLy4NinJTWlnx1ZhfynuD0u+Vwsjc+HbF8Ym1rh4msyRQUz++Ea2N",
-  "previousBlockHash": "RRcfehwqOGFE5uitIhIaNoACq8s5exCg++1GtqgP33YVxh2DhPy87G9LpN4Guapz",
+  "blockHash": "rV4yBTsadYQcKbiLNurMTskWz0WglVts057Xu3RBWgclDsjZMWLifvoqx1uJPNHi",
+  "previousBlockHash": "4ZovgLbr2KOVk3zTgjVWclMgIDTRR5wVMA16s2SVlcBTYM46z9g4IO7jBngztTPl",
   "blockTimestamp": {
     "seconds": "1767744174",
     "nanos": 880399000
   },
-  "siblingHashesFromPrevBlockRoot": [{
-    "siblingHash": "CvzQfYS60EGmJNk3Fp4O+FXA//0Uv89XvkXnWdO3aPtHBz5vZDVyb7JJ0ggDhzfD"
-  }, {
-    "siblingHash": "DVAH1wXI3PrCj2ea5bMp4kzw3gC+vXC4OnGYWpv/RvcSfkQyNwJeVL8uzGH1hlTm"
-  }, {
-    "siblingHash": "rRQ1foC3TSQy/8XzwuazDAgHEPWiJ6cVSHHJuJ8SrGGJtyOHSLoPvWndkCOMggih"
-  }]
+  "siblingHashesFromPrevBlockRoot": [
+    {
+      "siblingHash": "CvzQfYS60EGmJNk3Fp4O+FXA//0Uv89XvkXnWdO3aPtHBz5vZDVyb7JJ0ggDhzfD"
+    },
+    {
+      "siblingHash": "DVAH1wXI3PrCj2ea5bMp4kzw3gC+vXC4OnGYWpv/RvcSfkQyNwJeVL8uzGH1hlTm"
+    },
+    {
+      "siblingHash": "rRQ1foC3TSQy/8XzwuazDAgHEPWiJ6cVSHHJuJ8SrGGJtyOHSLoPvWndkCOMggih"
+    },
+    {
+      "siblingHash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
+    }
+  ]
 }

--- a/hedera-node/hedera-app/src/test/resources/state-proof/3.proof.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/3.proof.json
@@ -10,6 +10,7 @@
     }, {
       "hash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }, {
       "isLeft": true,
       "hash": "znJinguZ3lXCj+Unho/twmWbt/yXBpuMR0B0kLek1zETadNtumi6ZDieG9OovVIY"
@@ -20,9 +21,10 @@
     }, {
       "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }],
     "nextPathIndex": 2,
-    "hash": "FwgU9fmkMUewLy4NinJTWlnx1ZhfynuD0u+Vwsjc+HbF8Ym1rh4msyRQUz++Ea2N"
+    "hash": "rV4yBTsadYQcKbiLNurMTskWz0WglVts057Xu3RBWgclDsjZMWLifvoqx1uJPNHi"
   }, {
     "nextPathIndex": -1
   }],

--- a/hedera-node/hedera-app/src/test/resources/state-proof/4.pnd.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/4.pnd.json
@@ -1,16 +1,23 @@
 {
   "block": "4",
-  "blockHash": "v0llIoDI9Srpl2Zoqag9xornzUmlaFguYKMB/IxbDlVCzMMVzkygo2QyxGXd0Nuf",
-  "previousBlockHash": "FwgU9fmkMUewLy4NinJTWlnx1ZhfynuD0u+Vwsjc+HbF8Ym1rh4msyRQUz++Ea2N",
+  "blockHash": "8Hz6NrOOi+iyv6fResvEZ8CQwzX1KVAlDZvpvrQBCqH79aY/8ElKowzPa9xYAdp2",
+  "previousBlockHash": "rV4yBTsadYQcKbiLNurMTskWz0WglVts057Xu3RBWgclDsjZMWLifvoqx1uJPNHi",
   "blockTimestamp": {
     "seconds": "1767744175",
     "nanos": 898747000
   },
-  "siblingHashesFromPrevBlockRoot": [{
-    "siblingHash": "cn0Ddk8hX88jkCBuJ7THFudcsor1mvg0YtXMz/Mu/GVzeYtE0w/k7B+cKpyStplD"
-  }, {
-    "siblingHash": "RNTgGz49T2CudBOxhuvW5jgmc32GbmvUCnB5IaeEHzUuKPuulSPTkOzB5t9zK6Fq"
-  }, {
-    "siblingHash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
-  }]
+  "siblingHashesFromPrevBlockRoot": [
+    {
+      "siblingHash": "cn0Ddk8hX88jkCBuJ7THFudcsor1mvg0YtXMz/Mu/GVzeYtE0w/k7B+cKpyStplD"
+    },
+    {
+      "siblingHash": "RNTgGz49T2CudBOxhuvW5jgmc32GbmvUCnB5IaeEHzUuKPuulSPTkOzB5t9zK6Fq"
+    },
+    {
+      "siblingHash": "0ucoGyOgFpzUzk6Y81qhhg3M2Cq2jq76djXY4JLD66a86/6rIcaeFWQ8hXATbqu8"
+    },
+    {
+      "siblingHash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
+    }
+  ]
 }

--- a/hedera-node/hedera-app/src/test/resources/state-proof/4.proof.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/4.proof.json
@@ -10,9 +10,10 @@
     }, {
       "hash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
     }, {
+      "hash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
     }],
     "nextPathIndex": 2,
-    "hash": "v0llIoDI9Srpl2Zoqag9xornzUmlaFguYKMB/IxbDlVCzMMVzkygo2QyxGXd0Nuf"
+    "hash": "8Hz6NrOOi+iyv6fResvEZ8CQwzX1KVAlDZvpvrQBCqH79aY/8ElKowzPa9xYAdp2"
   }, {
     "nextPathIndex": -1
   }],

--- a/hedera-node/hedera-app/src/test/resources/state-proof/5.pnd.json
+++ b/hedera-node/hedera-app/src/test/resources/state-proof/5.pnd.json
@@ -1,16 +1,23 @@
 {
   "block": "5",
-  "blockHash": "BPQoPITnc3+YX70N8cVeRMlY+QekkYOHiVKxV2H9IO5eqFDTA+X6wkKmCsw1Lk4W",
-  "previousBlockHash": "v0llIoDI9Srpl2Zoqag9xornzUmlaFguYKMB/IxbDlVCzMMVzkygo2QyxGXd0Nuf",
+  "blockHash": "6gXxZsMRh+2XEFovdXrdnKPW1uX0p8JtlreK3MvMLJX1+WmnzBaW/WtfSazGuzWg",
+  "previousBlockHash": "8Hz6NrOOi+iyv6fResvEZ8CQwzX1KVAlDZvpvrQBCqH79aY/8ElKowzPa9xYAdp2",
   "blockTimestamp": {
     "seconds": "1767744176",
     "nanos": 922790000
   },
-  "siblingHashesFromPrevBlockRoot": [{
-    "siblingHash": "BdoXf4WCEndsm3NIJ7C4TDDweNRRJqqSgBqKiN3lzbdbAcYdMhQTd2FegpGoUlwO"
-  }, {
-    "siblingHash": "lbGRmXLsb2EqHMNynKogINix1X+C9CCCFyCWmUPL1EDLd1K710ljf4Am8YjJLsfV"
-  }, {
-    "siblingHash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
-  }]
+  "siblingHashesFromPrevBlockRoot": [
+    {
+      "siblingHash": "BdoXf4WCEndsm3NIJ7C4TDDweNRRJqqSgBqKiN3lzbdbAcYdMhQTd2FegpGoUlwO"
+    },
+    {
+      "siblingHash": "lbGRmXLsb2EqHMNynKogINix1X+C9CCCFyCWmUPL1EDLd1K710ljf4Am8YjJLsfV"
+    },
+    {
+      "siblingHash": "6YOxpdswmQwQoVLCZj8cHLWapR/HA+CFwZ/YbPwzK3JhKfCtReOjAqJCuAHmmAUX"
+    },
+    {
+      "siblingHash": "z352R/V4BwBvT1hw0iELW0A40ACyv6cRvO639KMnNGtQxh/aTlxoEQsDznCPuRz4"
+    }
+  ]
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/IndirectProofSequenceValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/IndirectProofSequenceValidator.java
@@ -472,10 +472,7 @@ class IndirectProofSequenceValidator {
         final var allSiblings = mp2.siblings();
         var hash = mp2.hashOrThrow();
         for (final SiblingNode sibling : allSiblings) {
-            if (sibling.hash().length() == 0) {
-                // Null-hash sentinel: applies single-child wrap (depth3→depth2). Present for every block.
-                hash = BlockImplUtils.hashInternalNodeSingleChild(hash);
-            } else if (sibling.isLeft()) {
+            if (sibling.isLeft()) {
                 hash = BlockImplUtils.hashInternalNode(sibling.hash(), hash);
             } else {
                 hash = BlockImplUtils.hashInternalNode(hash, sibling.hash());
@@ -494,10 +491,10 @@ class IndirectProofSequenceValidator {
 
     private static int expectedSiblingsFrom(final long numIntermediateBlocks) {
         // Each intermediate block (between the proven block and the signed block) contributes
-        // UNSIGNED_BLOCK_SIBLING_COUNT siblings (3 right siblings + null sentinel + timestamp)
+        // UNSIGNED_BLOCK_SIBLING_COUNT siblings (4 right siblings + timestamp)
         final var intermediateSiblingCount = (int) (numIntermediateBlocks * UNSIGNED_BLOCK_SIBLING_COUNT);
 
-        // The signed block contributes SIGNED_BLOCK_SIBLING_COUNT siblings (3 right siblings + null sentinel).
+        // The signed block contributes SIGNED_BLOCK_SIBLING_COUNT siblings (4 right siblings).
         // Its timestamp lives in Merkle Path 1, not in the sibling list.
         return intermediateSiblingCount + SIGNED_BLOCK_SIBLING_COUNT;
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/StateChangesValidator.java
@@ -811,19 +811,22 @@ public class StateChangesValidator implements BlockStreamValidator {
         return Bytes.wrap(digest.digest());
     }
 
-    private static Bytes hashInternalNodeSingleChild(final Bytes hash) {
-        final var digest = sha384DigestOrThrow();
-        digest.update(BlockImplUtils.SINGLE_CHILD_INTERNAL_NODE_PREFIX);
-        digest.update(hash.toByteArray());
-        return Bytes.wrap(digest.digest());
-    }
-
     private static Bytes hashInternalNode(final Bytes leftChildHash, final Bytes rightChildHash) {
         final var digest = sha384DigestOrThrow();
         digest.update(BlockImplUtils.INTERNAL_NODE_PREFIX);
         digest.update(leftChildHash.toByteArray());
         digest.update(rightChildHash.toByteArray());
         return Bytes.wrap(digest.digest());
+    }
+
+    /**
+     * The root of the eight empty reserved branches 9-16, derived here rather than read from production.
+     * Expected value: {@code cf7e7647f57807006f4f5870d2210b5b4038d000b2bfa711bceeb7f4a327346b50c61fda4e5c68110b03ce708fb91cf8}.
+     */
+    private static Bytes emptyReservedHalf() {
+        final var pairOfEmpties = hashInternalNode(BlockStreamManager.HASH_OF_ZERO, BlockStreamManager.HASH_OF_ZERO);
+        final var fourEmpties = hashInternalNode(pairOfEmpties, pairOfEmpties);
+        return hashInternalNode(fourEmpties, fourEmpties);
     }
 
     private record RootAndSiblingHashes(Bytes blockRootHash, MerkleSiblingHash[] siblingHashes) {}
@@ -844,31 +847,28 @@ public class StateChangesValidator implements BlockStreamValidator {
         final var outputTreeHash = Bytes.wrap(outputTreeHasher.computeRootHash());
         final var traceDataHash = Bytes.wrap(traceDataHasher.computeRootHash());
 
-        // Compute depth five hashes
-        final var depth5Node1 = hashInternalNode(previousBlockHash, prevBlocksRootHash);
-        final var depth5Node2 = hashInternalNode(startOfBlockStateHash, consensusHeaderHash);
-        final var depth5Node3 = hashInternalNode(inputTreeHash, outputTreeHash);
-        final var depth5Node4 = hashInternalNode(finalStateChangesHash, traceDataHash);
+        // Built by hand, on purpose. This validator must not share the block root tree implementation with
+        // block production: if it did, any error in that implementation would be reproduced here and the
+        // validator would pass regardless. Branches 1-8 carry data, branches 9-16 are reserved and empty.
+        final var branches12 = hashInternalNode(previousBlockHash, prevBlocksRootHash);
+        final var branches34 = hashInternalNode(startOfBlockStateHash, consensusHeaderHash);
+        final var branches56 = hashInternalNode(inputTreeHash, outputTreeHash);
+        final var branches78 = hashInternalNode(finalStateChangesHash, traceDataHash);
+        final var branches1234 = hashInternalNode(branches12, branches34);
+        final var branches5678 = hashInternalNode(branches56, branches78);
+        final var assignedHalf = hashInternalNode(branches1234, branches5678);
 
-        // Compute depth four hashes
-        final var depth4Node1 = hashInternalNode(depth5Node1, depth5Node2);
-        final var depth4Node2 = hashInternalNode(depth5Node3, depth5Node4);
+        final var reservedHalf = emptyReservedHalf();
+        final var subtreesRoot = hashInternalNode(assignedHalf, reservedHalf);
+        final var timestampLeaf = hashLeaf(Timestamp.PROTOBUF.toBytes(blockTimestamp));
+        final var root = hashInternalNode(timestampLeaf, subtreesRoot);
 
-        // Compute depth three hash (no 'node 2' at this level since reserved subroots 9-16 aren't encoded in the tree)
-        final var depth3Node1 = hashInternalNode(depth4Node1, depth4Node2);
-
-        // Compute depth two hashes (timestamp + last right sibling)
-        final var timestamp = Timestamp.PROTOBUF.toBytes(blockTimestamp);
-        final var depth2Node1 = hashLeaf(timestamp);
-        final var depth2Node2 = hashInternalNodeSingleChild(depth3Node1);
-
-        // Compute the block's root hash (depth 1)
-        final var root = hashInternalNode(depth2Node1, depth2Node2);
-
+        // The right sibling of branch 1's ancestor at each level, bottom-up
         return new RootAndSiblingHashes(root, new MerkleSiblingHash[] {
             new MerkleSiblingHash(false, prevBlocksRootHash),
-            new MerkleSiblingHash(false, depth5Node2),
-            new MerkleSiblingHash(false, depth4Node2),
+            new MerkleSiblingHash(false, branches34),
+            new MerkleSiblingHash(false, branches5678),
+            new MerkleSiblingHash(false, reservedHalf)
         });
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/WrapsFreeBlockSignaturesValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/block/WrapsFreeBlockSignaturesValidator.java
@@ -36,6 +36,7 @@ import com.hedera.hapi.node.state.hints.HintsKeySet;
 import com.hedera.hapi.node.state.primitives.ProtoBytes;
 import com.hedera.hapi.services.auxiliary.hints.HintsPartialSignatureTransactionBody;
 import com.hedera.node.app.ServicesMain;
+import com.hedera.node.app.blocks.BlockStreamManager;
 import com.hedera.node.app.blocks.impl.BlockImplUtils;
 import com.hedera.node.app.blocks.impl.BlockStreamManagerImpl;
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
@@ -1313,22 +1314,40 @@ public class WrapsFreeBlockSignaturesValidator implements BlockStreamValidator {
         final var outputTreeHash = Bytes.wrap(outputTreeHasher.computeRootHash());
         final var traceDataHash = Bytes.wrap(traceDataHasher.computeRootHash());
 
-        final var depth5Node1 = BlockImplUtils.hashInternalNode(previousBlockHash, prevBlocksRootHash);
-        final var depth5Node2 = BlockImplUtils.hashInternalNode(startOfBlockStateHash, consensusHeaderHash);
-        final var depth5Node3 = BlockImplUtils.hashInternalNode(inputTreeHash, outputTreeHash);
-        final var depth5Node4 = BlockImplUtils.hashInternalNode(finalStateChangesHash, traceDataHash);
-        final var depth4Node1 = BlockImplUtils.hashInternalNode(depth5Node1, depth5Node2);
-        final var depth4Node2 = BlockImplUtils.hashInternalNode(depth5Node3, depth5Node4);
-        final var depth3Node1 = BlockImplUtils.hashInternalNode(depth4Node1, depth4Node2);
-        final var depth2Node1 = BlockImplUtils.hashLeaf(Timestamp.PROTOBUF.toBytes(blockTimestamp));
-        final var depth2Node2 = BlockImplUtils.hashInternalNodeSingleChild(depth3Node1);
-        final var root = BlockImplUtils.hashInternalNode(depth2Node1, depth2Node2);
+        // Built by hand, on purpose. This validator must not share the block root tree implementation with
+        // block production: if it did, any error in that implementation would be reproduced here and the
+        // validator would pass regardless. Branches 1-8 carry data, branches 9-16 are reserved and empty.
+        final var branches12 = BlockImplUtils.hashInternalNode(previousBlockHash, prevBlocksRootHash);
+        final var branches34 = BlockImplUtils.hashInternalNode(startOfBlockStateHash, consensusHeaderHash);
+        final var branches56 = BlockImplUtils.hashInternalNode(inputTreeHash, outputTreeHash);
+        final var branches78 = BlockImplUtils.hashInternalNode(finalStateChangesHash, traceDataHash);
+        final var branches1234 = BlockImplUtils.hashInternalNode(branches12, branches34);
+        final var branches5678 = BlockImplUtils.hashInternalNode(branches56, branches78);
+        final var assignedHalf = BlockImplUtils.hashInternalNode(branches1234, branches5678);
 
+        final var reservedHalf = emptyReservedHalf();
+        final var subtreesRoot = BlockImplUtils.hashInternalNode(assignedHalf, reservedHalf);
+        final var timestampLeaf = BlockImplUtils.hashLeaf(Timestamp.PROTOBUF.toBytes(blockTimestamp));
+        final var root = BlockImplUtils.hashInternalNode(timestampLeaf, subtreesRoot);
+
+        // The right sibling of branch 1's ancestor at each level, bottom-up
         return new RootAndSiblingHashes(root, new MerkleSiblingHash[] {
             new MerkleSiblingHash(false, prevBlocksRootHash),
-            new MerkleSiblingHash(false, depth5Node2),
-            new MerkleSiblingHash(false, depth4Node2),
+            new MerkleSiblingHash(false, branches34),
+            new MerkleSiblingHash(false, branches5678),
+            new MerkleSiblingHash(false, reservedHalf)
         });
+    }
+
+    /**
+     * The root of the eight empty reserved branches 9-16, derived here rather than read from production.
+     * Expected value: {@code cf7e7647f57807006f4f5870d2210b5b4038d000b2bfa711bceeb7f4a327346b50c61fda4e5c68110b03ce708fb91cf8}.
+     */
+    private static Bytes emptyReservedHalf() {
+        final var pairOfEmpties =
+                BlockImplUtils.hashInternalNode(BlockStreamManager.HASH_OF_ZERO, BlockStreamManager.HASH_OF_ZERO);
+        final var fourEmpties = BlockImplUtils.hashInternalNode(pairOfEmpties, pairOfEmpties);
+        return BlockImplUtils.hashInternalNode(fourEmpties, fourEmpties);
     }
 
     private static List<Block> readBlocksFrom(@NonNull final Path blockStreamsDir) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/RcdFileBlockHashReplay.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/RcdFileBlockHashReplay.java
@@ -1,9 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.spec.utilops.upgrade;
 
-import static com.hedera.node.app.blocks.BlockStreamManager.HASH_OF_ZERO;
 import static com.hedera.node.app.blocks.impl.BlockImplUtils.hashInternalNode;
-import static com.hedera.node.app.blocks.impl.BlockImplUtils.hashInternalNodeSingleChild;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.block.internal.WrappedRecordFileBlockHashes;
@@ -11,6 +9,7 @@ import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.streams.RecordStreamFile;
 import com.hedera.hapi.streams.SidecarFile;
 import com.hedera.hapi.streams.TransactionSidecarRecord;
+import com.hedera.node.app.blocks.BlockStreamManager;
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
 import com.hedera.node.app.hapi.utils.exports.recordstreaming.RecordStreamingUtils;
 import com.hedera.node.app.records.impl.WrappedRecordFileBlockHashesCalculator;
@@ -43,7 +42,6 @@ public final class RcdFileBlockHashReplay {
     private static final Logger log = LogManager.getLogger(RcdFileBlockHashReplay.class);
 
     private static final int DEFAULT_MAX_SIDECAR_SIZE_BYTES = 256 * 1024 * 1024;
-    private static final Bytes EMPTY_INT_NODE = hashInternalNode(HASH_OF_ZERO, HASH_OF_ZERO);
 
     private RcdFileBlockHashReplay() {}
 
@@ -185,19 +183,31 @@ public final class RcdFileBlockHashReplay {
             @NonNull final Bytes prevWrappedBlockHash,
             @NonNull final Bytes allPrevBlocksRootHash,
             @NonNull final WrappedRecordFileBlockHashes entry) {
-        final Bytes depth5Node1 = hashInternalNode(prevWrappedBlockHash, allPrevBlocksRootHash);
-        final Bytes depth5Node2 = EMPTY_INT_NODE;
-        final Bytes depth5Node3 = hashInternalNode(HASH_OF_ZERO, entry.outputItemsTreeRootHash());
-        final Bytes depth5Node4 = EMPTY_INT_NODE;
+        // Built by hand, on purpose. This replay must not share the block root tree implementation with
+        // block production: if it did, any error in that implementation would be reproduced here and the
+        // replay would agree with production regardless. A wrapped record block populates only branches 1, 2
+        // and 6; every other branch, assigned or reserved, is the empty sub-tree hash.
+        final var empty = BlockStreamManager.HASH_OF_ZERO;
+        final var branches12 = hashInternalNode(prevWrappedBlockHash, allPrevBlocksRootHash);
+        final var branches34 = hashInternalNode(empty, empty);
+        final var branches56 = hashInternalNode(empty, entry.outputItemsTreeRootHash());
+        final var branches78 = hashInternalNode(empty, empty);
+        final var branches1234 = hashInternalNode(branches12, branches34);
+        final var branches5678 = hashInternalNode(branches56, branches78);
+        final var assignedHalf = hashInternalNode(branches1234, branches5678);
 
-        final Bytes depth4Node1 = hashInternalNode(depth5Node1, depth5Node2);
-        final Bytes depth4Node2 = hashInternalNode(depth5Node3, depth5Node4);
-        final Bytes depth3Node1 = hashInternalNode(depth4Node1, depth4Node2);
+        final var subtreesRoot = hashInternalNode(assignedHalf, emptyReservedHalf());
+        return hashInternalNode(entry.consensusTimestampHash(), subtreesRoot);
+    }
 
-        final Bytes depth2Node1 = entry.consensusTimestampHash();
-        final Bytes depth2Node2 = hashInternalNodeSingleChild(depth3Node1);
-
-        return hashInternalNode(depth2Node1, depth2Node2);
+    /**
+     * The root of the eight empty reserved branches 9-16, derived here rather than read from production.
+     * Expected value: {@code cf7e7647f57807006f4f5870d2210b5b4038d000b2bfa711bceeb7f4a327346b50c61fda4e5c68110b03ce708fb91cf8}.
+     */
+    private static Bytes emptyReservedHalf() {
+        final var pairOfEmpties = hashInternalNode(BlockStreamManager.HASH_OF_ZERO, BlockStreamManager.HASH_OF_ZERO);
+        final var fourEmpties = hashInternalNode(pairOfEmpties, pairOfEmpties);
+        return hashInternalNode(fourEmpties, fourEmpties);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/VerifyCutoverBlockStreamOp.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/utilops/upgrade/VerifyCutoverBlockStreamOp.java
@@ -16,6 +16,7 @@ import com.hedera.hapi.block.stream.output.SingletonUpdateChange;
 import com.hedera.hapi.node.base.Timestamp;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.hapi.node.state.blockrecords.RunningHashes;
+import com.hedera.node.app.blocks.BlockStreamManager;
 import com.hedera.node.app.blocks.impl.BlockImplUtils;
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
 import com.hedera.node.app.hapi.utils.CommonUtils;
@@ -251,17 +252,31 @@ public class VerifyCutoverBlockStreamOp extends UtilOp {
         final var stateChangesHash = Bytes.wrap(stateChangesHasher.computeRootHash());
         final var traceDataHash = Bytes.wrap(traceDataHasher.computeRootHash());
 
-        final var d5n1 = BlockImplUtils.hashInternalNode(previousBlockHash, prevBlockRootsHash);
-        final var d5n2 = BlockImplUtils.hashInternalNode(startOfBlockStateHash, consensusHeaderHash);
-        final var d5n3 = BlockImplUtils.hashInternalNode(inputsHash, outputsHash);
-        final var d5n4 = BlockImplUtils.hashInternalNode(stateChangesHash, traceDataHash);
-        final var d4n1 = BlockImplUtils.hashInternalNode(d5n1, d5n2);
-        final var d4n2 = BlockImplUtils.hashInternalNode(d5n3, d5n4);
-        final var d3n1 = BlockImplUtils.hashInternalNode(d4n1, d4n2);
-        final var tsBytes = Timestamp.PROTOBUF.toBytes(blockTimestamp);
-        final var d2n1 = BlockImplUtils.hashLeaf(tsBytes);
-        final var d2n2 = BlockImplUtils.hashInternalNodeSingleChild(d3n1);
-        return BlockImplUtils.hashInternalNode(d2n1, d2n2);
+        // Built by hand, on purpose. This check must not share the block root tree implementation with block
+        // production: if it did, any error in that implementation would be reproduced here and the check
+        // would pass regardless. Branches 1-8 carry data, branches 9-16 are reserved and empty.
+        final var branches12 = BlockImplUtils.hashInternalNode(previousBlockHash, prevBlockRootsHash);
+        final var branches34 = BlockImplUtils.hashInternalNode(startOfBlockStateHash, consensusHeaderHash);
+        final var branches56 = BlockImplUtils.hashInternalNode(inputsHash, outputsHash);
+        final var branches78 = BlockImplUtils.hashInternalNode(stateChangesHash, traceDataHash);
+        final var branches1234 = BlockImplUtils.hashInternalNode(branches12, branches34);
+        final var branches5678 = BlockImplUtils.hashInternalNode(branches56, branches78);
+        final var assignedHalf = BlockImplUtils.hashInternalNode(branches1234, branches5678);
+
+        final var subtreesRoot = BlockImplUtils.hashInternalNode(assignedHalf, emptyReservedHalf());
+        final var timestampLeaf = BlockImplUtils.hashLeaf(Timestamp.PROTOBUF.toBytes(blockTimestamp));
+        return BlockImplUtils.hashInternalNode(timestampLeaf, subtreesRoot);
+    }
+
+    /**
+     * The root of the eight empty reserved branches 9-16, derived here rather than read from production.
+     * Expected value: {@code cf7e7647f57807006f4f5870d2210b5b4038d000b2bfa711bceeb7f4a327346b50c61fda4e5c68110b03ce708fb91cf8}.
+     */
+    private static Bytes emptyReservedHalf() {
+        final var pairOfEmpties =
+                BlockImplUtils.hashInternalNode(BlockStreamManager.HASH_OF_ZERO, BlockStreamManager.HASH_OF_ZERO);
+        final var fourEmpties = BlockImplUtils.hashInternalNode(pairOfEmpties, pairOfEmpties);
+        return BlockImplUtils.hashInternalNode(fourEmpties, fourEmpties);
     }
 
     @Override

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableTssTests.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/integration/RepeatableTssTests.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.suites.integration;
 
+import static com.hedera.node.app.blocks.impl.BlockStateProofGenerator.SIGNED_BLOCK_SIBLING_COUNT;
 import static com.hedera.node.config.types.StreamMode.RECORDS;
 import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_TSS_CONTROL;
 import static com.hedera.services.bdd.junit.TestTags.INTEGRATION;
@@ -189,8 +190,7 @@ public class RepeatableTssTests {
         final var mp2 = merklePaths.get(mp1NextPath - 1);
         assertFalse(mp2.hasTimestampLeaf());
         assertTrue(mp2.hasHash());
-        assertEquals(
-                BlockStreamManager.NUM_SIBLINGS_PER_BLOCK + 1, mp2.siblings().size());
+        assertEquals(SIGNED_BLOCK_SIBLING_COUNT, mp2.siblings().size());
 
         // 5. As above, the first path's next index points directly to path 3, which should be either an internal node
         // or the root


### PR DESCRIPTION
**Description**:
This PR cherry-picks a8221352ea1833d9256a523b2ad3c283f921d854 for release/0.78


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
