### PR TITLE
feat: 26845: In-memory virtual maps support - 2

### DIFF
--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -849,28 +849,38 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
      */
     @Override
     public void merge() {
-        final long start = System.currentTimeMillis();
         if (!isDestroyed()) {
-            throw new IllegalStateException("merge is legal only after this node is destroyed");
+            throw new IllegalStateException("Merge is only allowed on destroyed copies");
         }
         if (!isImmutable()) {
-            throw new IllegalStateException("merge is only allowed on immutable copies");
+            throw new IllegalStateException("Merge is only allowed on immutable copies");
         }
         if (!isHashed()) {
-            throw new IllegalStateException("copy must be hashed before it is merged");
+            throw new IllegalStateException("The copy must be hashed before it is merged");
         }
         if (merged.get()) {
-            throw new IllegalStateException("this copy has already been merged");
+            throw new IllegalStateException("The copy has already been merged");
         }
         if (flushed.get()) {
-            throw new IllegalStateException("a flushed copy can not be merged");
+            throw new IllegalStateException("The copy has already been flushed");
         }
+
+        if (estimatedSizeExceedsFlushThreshold()) {
+            // Virtual map copy is requested to merge, but its estimated size exceeds the flush
+            // threshold. This is clear indication of in-memory mode, when the map is too small
+            // (in number of entities, not size in bytes) to be flushed. In this mode, let's
+            // get rid of all garbage in the node cache before merging to the next copy
+            garbageCollect();
+        }
+
+        final long start = System.currentTimeMillis();
+
         cache.merge();
         merged.set(true);
 
         final long end = System.currentTimeMillis();
         statistics.recordMerge(end - start);
-        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Merged in {} ms", end - start);
+        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Merged v{} in {} ms", getFastCopyVersion(), end - start);
     }
 
     /**
@@ -923,9 +933,19 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         if (shouldBeFlushed.get()) {
             return true;
         }
+        // The map is small enough to avoid flushes and keep all data in memory. Instead of
+        // being flushed to disk, this map copy will be merged+compacted to the newer copy
+        if (size() <= virtualMapConfig.inMemorySizeThreshold()) {
+            return false;
+        }
         // Otherwise check its size and compare against flush threshold
+        return estimatedSizeExceedsFlushThreshold();
+    }
+
+    private boolean estimatedSizeExceedsFlushThreshold() {
         final long threshold = flushCandidateThreshold.get();
-        return (threshold > 0) && (estimatedSize() >= threshold);
+        assert threshold > 0;
+        return estimatedSize() >= threshold;
     }
 
     /**
@@ -957,21 +977,29 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
      */
     @Override
     public void flush() {
-        if (!isImmutable()) {
-            throw new IllegalStateException("mutable copies can not be flushed");
+        if (!isDestroyed()) {
+            throw new IllegalStateException("Flush is only allowed on destroyed copies");
         }
-        if (flushed.get()) {
-            throw new IllegalStateException("This map has already been flushed");
+        if (!isImmutable()) {
+            throw new IllegalStateException("Flush is only allowed on immutable copies");
+        }
+        if (!isHashed()) {
+            throw new IllegalStateException("The copy must be hashed before it is flushed");
         }
         if (merged.get()) {
-            throw new IllegalStateException("a merged copy can not be flushed");
+            throw new IllegalStateException("The copy has already been merged");
+        }
+        if (flushed.get()) {
+            throw new IllegalStateException("The copy has already been flushed");
         }
 
         final long start = System.currentTimeMillis();
+
         flush(cache, dataSource);
         cache.release();
-        final long end = System.currentTimeMillis();
         flushed.set(true);
+
+        final long end = System.currentTimeMillis();
 
         try {
             // If an async snapshot was requested via createSnapshotAsync(), write the snapshot
@@ -1004,12 +1032,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
 
         flushLatch.countDown();
         statistics.recordFlush(end - start);
-        logger.debug(
-                VIRTUAL_MERKLE_STATS.getMarker(),
-                "Flushed {} v{} in {} ms",
-                LABEL,
-                cache.getFastCopyVersion(),
-                end - start);
+        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flushed v{} in {} ms", cache.getFastCopyVersion(), end - start);
     }
 
     private void flush(VirtualNodeCache cacheToFlush, VirtualDataSource ds) {
@@ -1037,6 +1060,34 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
             logger.error(EXCEPTION.getMarker(), "Error while flushing VirtualMap", ex);
             throw new UncheckedIOException(ex);
         }
+    }
+
+    private void garbageCollect() {
+        assert isDestroyed();
+        assert isImmutable();
+        assert isHashed();
+        assert !merged.get();
+        assert !flushed.get();
+
+        final long start = System.currentTimeMillis();
+
+        try {
+            final Stream<VirtualLeafBytes> deletedLeaves = cache.deletedLeaves();
+            dataSource.saveRecords(
+                    dataSource.getFirstLeafPath(),
+                    dataSource.getLastLeafPath(),
+                    Stream.empty(),
+                    Stream.empty(),
+                    deletedLeaves,
+                    false);
+        } catch (final IOException z) {
+            logger.error(EXCEPTION.getMarker(), "Error while deleting leaves from data source", z);
+            throw new UncheckedIOException(z);
+        }
+        cache.garbageCollect();
+
+        final long end = System.currentTimeMillis();
+        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "GCed v{} in {} ms", getFastCopyVersion(), end - start);
     }
 
     @Override

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -689,7 +689,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
             // the data source, and the path above can be used as the old path
             final VirtualLeafBytes<V> existing = cache.lookupLeafByPath(path);
             final VirtualLeafBytes<V> updated;
-            if (existing != null) {
+            if ((existing != null) && (existing != VirtualNodeCache.DELETED_LEAF_RECORD)) {
                 updated = valueCodec != null
                         ? existing.withValue(value, valueCodec)
                         : existing.withValueBytes(valueBytes);
@@ -866,11 +866,21 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         }
 
         if (estimatedSizeExceedsFlushThreshold()) {
+            assert estimatedGarbageSizeExceedsThreshold();
+//            logger.info(VIRTUAL_MERKLE_STATS.getMarker(),
+//                    "GC before v{}: est={} grb={}",
+//                    cache.getFastCopyVersion(),
+//                    cache.getEstimatedSize(),
+//                    cache.getEstimatedGarbageSize());
             // Virtual map copy is requested to merge, but its estimated size exceeds the flush
             // threshold. This is clear indication of in-memory mode, when the map is too small
             // (in number of entities, not size in bytes) to be flushed. In this mode, let's
             // get rid of all garbage in the node cache before merging to the next copy
             garbageCollect();
+//            logger.info(VIRTUAL_MERKLE_STATS.getMarker(),
+//                    "GC after v{}: est={}",
+//                    cache.getFastCopyVersion(),
+//                    cache.getEstimatedSize());
         }
 
         final long start = System.currentTimeMillis();
@@ -880,7 +890,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
 
         final long end = System.currentTimeMillis();
         statistics.recordMerge(end - start);
-        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Merged v{} in {} ms", getFastCopyVersion(), end - start);
+        logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "Merged v{} in {} ms", getFastCopyVersion(), end - start);
     }
 
     /**
@@ -933,19 +943,27 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         if (shouldBeFlushed.get()) {
             return true;
         }
-        // The map is small enough to avoid flushes and keep all data in memory. Instead of
-        // being flushed to disk, this map copy will be merged+compacted to the newer copy
-        if (size() <= virtualMapConfig.inMemorySizeThreshold()) {
+        // Check its size and compare against flush threshold. If the threshold is not reached,
+        // the copy should not be flushed regardless of how much garbage is in it
+        if (!estimatedSizeExceedsFlushThreshold()) {
             return false;
         }
-        // Otherwise check its size and compare against flush threshold
-        return estimatedSizeExceedsFlushThreshold();
+        return !estimatedGarbageSizeExceedsThreshold();
     }
 
     private boolean estimatedSizeExceedsFlushThreshold() {
         final long threshold = flushCandidateThreshold.get();
         assert threshold > 0;
         return estimatedSize() >= threshold;
+    }
+
+    private boolean estimatedGarbageSizeExceedsThreshold() {
+        final double percent = virtualMapConfig.percentFlushGarbageThreshold();
+        if (percent > 99.99) {
+            // Avoid cache.getEstimatedGarbageSize() below as it may be costly
+            return false;
+        }
+        return 100.0 * cache.getEstimatedGarbageSize() / cache.getEstimatedSize() >= percent;
     }
 
     /**
@@ -1032,7 +1050,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
 
         flushLatch.countDown();
         statistics.recordFlush(end - start);
-        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flushed v{} in {} ms", cache.getFastCopyVersion(), end - start);
+        logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "Flushed v{} in {} ms", cache.getFastCopyVersion(), end - start);
     }
 
     private void flush(VirtualNodeCache cacheToFlush, VirtualDataSource ds) {
@@ -1069,10 +1087,13 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         assert !merged.get();
         assert !flushed.get();
 
-        final long start = System.currentTimeMillis();
+        long start = System.currentTimeMillis();
 
         try {
             final Stream<VirtualLeafBytes> deletedLeaves = cache.deletedLeaves();
+//            long end = System.currentTimeMillis();
+//            logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "GCed1 v{} in {} ms", getFastCopyVersion(), end - start);
+//            start = end;
             dataSource.saveRecords(
                     dataSource.getFirstLeafPath(),
                     dataSource.getLastLeafPath(),
@@ -1080,6 +1101,9 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
                     Stream.empty(),
                     deletedLeaves,
                     false);
+//            end = System.currentTimeMillis();
+//            logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "GCed2 v{} in {} ms", getFastCopyVersion(), end - start);
+//            start = end;
         } catch (final IOException z) {
             logger.error(EXCEPTION.getMarker(), "Error while deleting leaves from data source", z);
             throw new UncheckedIOException(z);
@@ -1087,7 +1111,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         cache.garbageCollect();
 
         final long end = System.currentTimeMillis();
-        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "GCed v{} in {} ms", getFastCopyVersion(), end - start);
+        logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "GCed v{} in {} ms", getFastCopyVersion(), end - start);
     }
 
     @Override

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/VirtualMap.java
@@ -865,22 +865,15 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
             throw new IllegalStateException("The copy has already been flushed");
         }
 
+        // This copy is being merged. Typically, this indicates estimated copy size is
+        // below the flush threshold. However, it may be above the threshold, if there
+        // is a lot of redundant data (obsolete mutations in the node cache).
         if (estimatedSizeExceedsFlushThreshold()) {
-            assert estimatedGarbageSizeExceedsThreshold();
-//            logger.info(VIRTUAL_MERKLE_STATS.getMarker(),
-//                    "GC before v{}: est={} grb={}",
-//                    cache.getFastCopyVersion(),
-//                    cache.getEstimatedSize(),
-//                    cache.getEstimatedGarbageSize());
-            // Virtual map copy is requested to merge, but its estimated size exceeds the flush
-            // threshold. This is clear indication of in-memory mode, when the map is too small
-            // (in number of entities, not size in bytes) to be flushed. In this mode, let's
-            // get rid of all garbage in the node cache before merging to the next copy
+            assert estimatedGarbageSizeExceedsGarbageThreshold();
+            // The size of the copy is large, and it contains lots of redundant data. It's
+            // time to collect garbage. Live data set after garbage collection will be
+            // merged into the next virtual map copy
             garbageCollect();
-//            logger.info(VIRTUAL_MERKLE_STATS.getMarker(),
-//                    "GC after v{}: est={}",
-//                    cache.getFastCopyVersion(),
-//                    cache.getEstimatedSize());
         }
 
         final long start = System.currentTimeMillis();
@@ -890,7 +883,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
 
         final long end = System.currentTimeMillis();
         statistics.recordMerge(end - start);
-        logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "Merged v{} in {} ms", getFastCopyVersion(), end - start);
+        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Merged v{} in {} ms", getFastCopyVersion(), end - start);
     }
 
     /**
@@ -948,16 +941,27 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         if (!estimatedSizeExceedsFlushThreshold()) {
             return false;
         }
-        return !estimatedGarbageSizeExceedsThreshold();
+        // The copy is large enough, it should be either flushed or merged after GC
+        return !estimatedGarbageSizeExceedsGarbageThreshold();
     }
 
+    /**
+     * Returns {@code true}, if estimated size of the current virtual map copy
+     * exceeds the flush threshold. See {@link VirtualMapConfig#copyFlushCandidateThreshold()}
+     * for details.
+     */
     private boolean estimatedSizeExceedsFlushThreshold() {
         final long threshold = flushCandidateThreshold.get();
         assert threshold > 0;
         return estimatedSize() >= threshold;
     }
 
-    private boolean estimatedGarbageSizeExceedsThreshold() {
+    /**
+     * Returns {@code true}, if estimated size of redundant data in the current virtual map copy
+     * exceeds the garbage threshold. See {@link VirtualMapConfig#percentFlushGarbageThreshold()}
+     * for details.
+     */
+    private boolean estimatedGarbageSizeExceedsGarbageThreshold() {
         final double percent = virtualMapConfig.percentFlushGarbageThreshold();
         if (percent > 99.99) {
             // Avoid cache.getEstimatedGarbageSize() below as it may be costly
@@ -1050,7 +1054,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
 
         flushLatch.countDown();
         statistics.recordFlush(end - start);
-        logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "Flushed v{} in {} ms", cache.getFastCopyVersion(), end - start);
+        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flushed v{} in {} ms", cache.getFastCopyVersion(), end - start);
     }
 
     private void flush(VirtualNodeCache cacheToFlush, VirtualDataSource ds) {
@@ -1080,6 +1084,14 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         }
     }
 
+    /**
+     * Removes all redundant data from this virtual map copy. After garbage collection, the
+     * copy can be merged.
+     *
+     * <p>Important note: all deleted mutations in the node cache for this copy are considered
+     * redundant and will be removed. However, the data source may contain values for these
+     * deleted keys, so all deleted keys are first flushed to the data source.
+     */
     private void garbageCollect() {
         assert isDestroyed();
         assert isImmutable();
@@ -1091,9 +1103,6 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
 
         try {
             final Stream<VirtualLeafBytes> deletedLeaves = cache.deletedLeaves();
-//            long end = System.currentTimeMillis();
-//            logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "GCed1 v{} in {} ms", getFastCopyVersion(), end - start);
-//            start = end;
             dataSource.saveRecords(
                     dataSource.getFirstLeafPath(),
                     dataSource.getLastLeafPath(),
@@ -1101,9 +1110,6 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
                     Stream.empty(),
                     deletedLeaves,
                     false);
-//            end = System.currentTimeMillis();
-//            logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "GCed2 v{} in {} ms", getFastCopyVersion(), end - start);
-//            start = end;
         } catch (final IOException z) {
             logger.error(EXCEPTION.getMarker(), "Error while deleting leaves from data source", z);
             throw new UncheckedIOException(z);
@@ -1111,7 +1117,7 @@ public final class VirtualMap extends AbstractVirtualRoot implements Labeled, Vi
         cache.garbageCollect();
 
         final long end = System.currentTimeMillis();
-        logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "GCed v{} in {} ms", getFastCopyVersion(), end - start);
+        logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "GCed v{} in {} ms", getFastCopyVersion(), end - start);
     }
 
     @Override

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
@@ -19,12 +19,6 @@ import com.swirlds.config.api.validation.annotation.Min;
  *      by {@code virtualMap.percentHashThreads} and {@link Runtime#availableProcessors()}.
  * @param reconnectMode
  *      Reconnect mode. For the list of accepted values, see {@link VirtualMapReconnectMode}.
- * @param inMemorySizeThreshold
- *      When estimated virtual map size in bytes exceeds {@link #copyFlushCandidateThreshold}, the map is
- *      flushed to its data source. However, if the number of entities in the map is smaller than this
- *      in-memory threshold, the flush is not performed, but the map is merged to the newer copy with
- *      compaction instead. If the threshold is zero, all flushes are performed as expected regardless
- *      of the current virtual map size (in entities, not in bytes).
  * @param reconnectFlushInterval
  *      During reconnect, virtual nodes are periodically flushed to disk after they are hashed. This
  *      interval indicates the number of nodes to hash before they are flushed to disk. If zero, all
@@ -36,9 +30,13 @@ import com.swirlds.config.api.validation.annotation.Min;
  * 		The number of threads to devote to cache cleaning. If not set, defaults to the number of threads implied by
  *      {@code virtualMap.percentCleanerThreads} and {@link Runtime#availableProcessors()}.
  * @param copyFlushCandidateThreshold
- *      Virtual map copy flush threshold. A copy can be flushed to disk only if its size exceeds this
- *      threshold. If in-memory mode is enabled by setting {@link #inMemorySizeThreshold}, make sure the
- *      flush threshold is at least 2.5-3 times larger than the size of max map elements in bytes.
+ *      Virtual map copy flush threshold, in bytes. If estimated copy size exceeds the threshold,
+ *      and it contains less than {@link #percentFlushGarbageThreshold} redundant data, it will be
+ *      flushed to disk.
+ * @param percentFlushGarbageThreshold
+ *      When estimated copy size exceeds {@link #copyFlushCandidateThreshold}, and ratio of redundant data
+ *      in the copy to estimated copy size exceeds this threshold, in percent, the copy gets garbage collected,
+ *      i.e. all redundant data is purged from it. Then the copy can be merged into the newer copy.
  * @param familyThrottleThreshold
  *      Virtual map family throttle threshold. When estimated size of all unreleased copies of the same virtual
  *      root exceeds this threshold, virtual pipeline starts applying backpressure on creating new root copies.
@@ -59,12 +57,11 @@ public record VirtualMapConfig(
         @Min(0) @Max(100) @ConfigProperty(defaultValue = "50.0") double percentHashThreads,
         @Min(-1) @ConfigProperty(defaultValue = "-1") int numHashThreads,
         @ConfigProperty(defaultValue = PULL_TOP_TO_BOTTOM) String reconnectMode,
-        @Min(0) @ConfigProperty(defaultValue = "0") long inMemorySizeThreshold,
         @Min(0) @ConfigProperty(defaultValue = "500000") int reconnectFlushInterval,
         @Min(0) @Max(100) @ConfigProperty(defaultValue = "25.0") double percentCleanerThreads,
         @Min(-1) @ConfigProperty(defaultValue = "-1") int numCleanerThreads,
         @Min(1) @ConfigProperty(defaultValue = "1200000000") long copyFlushCandidateThreshold,
-        @Min(0) @Max(200) @ConfigProperty(defaultValue = "100") double percentFlushGarbageThreshold,
+        @Min(0) @Max(100) @ConfigProperty(defaultValue = "50") double percentFlushGarbageThreshold,
         @Min(-1) @Max(100) @ConfigProperty(defaultValue = "10.0") double familyThrottlePercent,
         @Min(-1) @ConfigProperty(defaultValue = "-1") long familyThrottleThreshold,
         @Min(1) @ConfigProperty(defaultValue = "37748736") int valueParseMaxSizeBytes,

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
@@ -15,10 +15,16 @@ import com.swirlds.config.api.validation.annotation.Min;
  * 		Gets the percentage (from 0.0 to 100.0) of available processors to devote to hashing
  * 		threads. Ignored if an explicit number of threads is given via {@code virtualMap.numHashThreads}.
  * @param numHashThreads
- * 		The number of threads to devote to hashing. If not set, defaults to the number of threads implied by
- *        {@code virtualMap.percentHashThreads} and {@link Runtime#availableProcessors()}.
+ * 		The number of threads to devote to hashing. If not set, defaults to the number of threads implied
+ *      by {@code virtualMap.percentHashThreads} and {@link Runtime#availableProcessors()}.
  * @param reconnectMode
  *      Reconnect mode. For the list of accepted values, see {@link VirtualMapReconnectMode}.
+ * @param inMemorySizeThreshold
+ *      When estimated virtual map size in bytes exceeds {@link #copyFlushCandidateThreshold}, the map is
+ *      flushed to its data source. However, if the number of entities in the map is smaller than this
+ *      in-memory threshold, the flush is not performed, but the map is merged to the newer copy with
+ *      compaction instead. If the threshold is zero, all flushes are performed as expected regardless
+ *      of the current virtual map size (in entities, not in bytes).
  * @param reconnectFlushInterval
  *      During reconnect, virtual nodes are periodically flushed to disk after they are hashed. This
  *      interval indicates the number of nodes to hash before they are flushed to disk. If zero, all
@@ -31,7 +37,8 @@ import com.swirlds.config.api.validation.annotation.Min;
  *      {@code virtualMap.percentCleanerThreads} and {@link Runtime#availableProcessors()}.
  * @param copyFlushCandidateThreshold
  *      Virtual map copy flush threshold. A copy can be flushed to disk only if its size exceeds this
- *      threshold.
+ *      threshold. If in-memory mode is enabled by setting {@link #inMemorySizeThreshold}, make sure the
+ *      flush threshold is at least 2.5-3 times larger than the size of max map elements in bytes.
  * @param familyThrottleThreshold
  *      Virtual map family throttle threshold. When estimated size of all unreleased copies of the same virtual
  *      root exceeds this threshold, virtual pipeline starts applying backpressure on creating new root copies.
@@ -52,6 +59,7 @@ public record VirtualMapConfig(
         @Min(0) @Max(100) @ConfigProperty(defaultValue = "50.0") double percentHashThreads,
         @Min(-1) @ConfigProperty(defaultValue = "-1") int numHashThreads,
         @ConfigProperty(defaultValue = PULL_TOP_TO_BOTTOM) String reconnectMode,
+        @Min(0) @ConfigProperty(defaultValue = "0") long inMemorySizeThreshold,
         @Min(0) @ConfigProperty(defaultValue = "500000") int reconnectFlushInterval,
         @Min(0) @Max(100) @ConfigProperty(defaultValue = "25.0") double percentCleanerThreads,
         @Min(-1) @ConfigProperty(defaultValue = "-1") int numCleanerThreads,

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/config/VirtualMapConfig.java
@@ -64,6 +64,7 @@ public record VirtualMapConfig(
         @Min(0) @Max(100) @ConfigProperty(defaultValue = "25.0") double percentCleanerThreads,
         @Min(-1) @ConfigProperty(defaultValue = "-1") int numCleanerThreads,
         @Min(1) @ConfigProperty(defaultValue = "1200000000") long copyFlushCandidateThreshold,
+        @Min(0) @Max(200) @ConfigProperty(defaultValue = "100") double percentFlushGarbageThreshold,
         @Min(-1) @Max(100) @ConfigProperty(defaultValue = "10.0") double familyThrottlePercent,
         @Min(-1) @ConfigProperty(defaultValue = "-1") long familyThrottleThreshold,
         @Min(1) @ConfigProperty(defaultValue = "37748736") int valueParseMaxSizeBytes,

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -32,6 +32,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -233,6 +234,8 @@ public final class VirtualNodeCache {
      * Estimated size of all hashes in dirtyHashes. This size is updated on every hash operation (put, delete).
      */
     private final AtomicLong estimatedHashesSizeInBytes = new AtomicLong(0);
+
+    private final AtomicLong estimatedGarbageSizeInBytes = new AtomicLong(0);
 
     /**
      * Indicates if this virtual cache instance contains mutations from older cache versions as a result of cache merge
@@ -466,14 +469,23 @@ public final class VirtualNodeCache {
 
         estimatedLeavesSizeInBytes.set(0);
         estimatedHashesSizeInBytes.set(0);
+        estimatedGarbageSizeInBytes.set(0);
 
         // Dirty leaves
         purgeOnGC(keyToDirtyLeafIndex, dirtyLeaves);
         //noinspection NonAtomicOperationOnVolatileField
         dirtyLeaves = new ConcurrentArray<>(dirtyLeaves.stream()
                 // notFiltered also covers all deleted mutations
-                .filter(Mutation::notFiltered)
-                .peek(m -> estimatedLeavesSizeInBytes.addAndGet(m.value.getSizeInBytes())));
+                .filter(Mutation::notFiltered));
+        // parallelTraverse() seems faster than to add peek() to the stream to calculate the size
+        try {
+            dirtyLeaves.parallelTraverse(cleaningPool, (_, m) -> {
+                estimatedLeavesSizeInBytes.addAndGet(m.value.getSizeInBytes());
+            }).getAndRethrow();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
         estimatedLeavesSizeInBytes.addAndGet(dirtyLeaves.estimatedStorageMemoryOverhead());
 
         // Dirty leaf paths
@@ -481,8 +493,15 @@ public final class VirtualNodeCache {
         //noinspection NonAtomicOperationOnVolatileField
         dirtyLeafPaths = new ConcurrentArray<>(dirtyLeafPaths.stream()
                 // notFiltered also covers all deleted mutations
-                .filter(Mutation::notFiltered)
-                .peek(m -> estimatedLeavesSizeInBytes.addAndGet(m.value.length())));
+                .filter(Mutation::notFiltered));
+        try {
+            dirtyLeafPaths.parallelTraverse(cleaningPool, (_, m) -> {
+                estimatedLeavesSizeInBytes.addAndGet(m.value.length());
+            }).getAndRethrow();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
         estimatedLeavesSizeInBytes.addAndGet(dirtyLeafPaths.estimatedStorageMemoryOverhead());
 
         // Dirty hashes
@@ -490,9 +509,15 @@ public final class VirtualNodeCache {
         //noinspection NonAtomicOperationOnVolatileField
         dirtyHashChunks = new ConcurrentArray<>(dirtyHashChunks.stream()
                 // notFiltered also covers all deleted mutations
-                .filter(Mutation::notFiltered)
-                .peek(m -> estimatedHashesSizeInBytes.addAndGet(
-                        (long) m.value.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength())));
+                .filter(Mutation::notFiltered));
+        try {
+            dirtyHashChunks.parallelTraverse(cleaningPool, (_, m) -> {
+                estimatedHashesSizeInBytes.addAndGet((long) m.value.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
+            }).getAndRethrow();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
         estimatedHashesSizeInBytes.addAndGet(dirtyHashChunks.estimatedStorageMemoryOverhead());
     }
 
@@ -551,6 +576,10 @@ public final class VirtualNodeCache {
      * Seals this cache, making it immutable. A sealed cache can still be merged with another sealed cache.
      */
     public void seal() {
+        if (leafIndexesAreImmutable.get() && hashesAreImmutable.get()) {
+            // Already sealed
+            return;
+        }
         leafIndexesAreImmutable.set(true);
         hashesAreImmutable.set(true);
         dirtyLeaves.seal();
@@ -603,7 +632,7 @@ public final class VirtualNodeCache {
 
         // Get the first data element (mutation) in the list based on the key,
         // and then create or update the associated mutation.
-        keyToDirtyLeafIndex.compute(key, (k, mutations) -> mutate(leaf, mutations));
+        keyToDirtyLeafIndex.compute(key, (_, mutations) -> mutate(leaf, mutations, false));
     }
 
     /**
@@ -628,9 +657,9 @@ public final class VirtualNodeCache {
         final Bytes key = leaf.keyBytes();
         assert key != Bytes.EMPTY : "Keys cannot be empty";
         assert key.length() > 0 : "Keys cannot be empty";
-        keyToDirtyLeafIndex.compute(key, (k, mutations) -> {
-            mutations = mutate(leaf, mutations);
-            mutations.setDeleted(true);
+        keyToDirtyLeafIndex.compute(key, (_, mutations) -> {
+            mutations = mutate(leaf, mutations, true);
+            assert mutations.isDeleted();
             assert pathToDirtyKeyIndex.get(leaf.path()).isDeleted() : "It should be deleted too";
             return mutations;
         });
@@ -819,7 +848,7 @@ public final class VirtualNodeCache {
         }
 
         final Map<Bytes, VirtualLeafBytes> leaves = new ConcurrentHashMap<>();
-        final StandardFuture<Void> result = dirtyLeaves.parallelTraverse(cleaningPool, (i, element) -> {
+        final StandardFuture<Void> result = dirtyLeaves.parallelTraverse(cleaningPool, (_, element) -> {
             if (element.isDeleted()) {
                 final Bytes key = element.key;
                 final Mutation<Bytes, VirtualLeafBytes> mutation = lookup(keyToDirtyLeafIndex.get(key));
@@ -855,7 +884,7 @@ public final class VirtualNodeCache {
         throwIfInternalsImmutable();
 
         final long hashChunkId = chunk.getChunkId();
-        idToDirtyHashChunkIndex.compute(hashChunkId, (id, mutation) -> {
+        idToDirtyHashChunkIndex.compute(hashChunkId, (_, mutation) -> {
             if ((mutation == null) || (mutation.version != fastCopyVersion.get())) {
                 mutation = new Mutation<>(mutation, hashChunkId, chunk, fastCopyVersion.get());
                 dirtyHashChunks.add(mutation);
@@ -1021,7 +1050,7 @@ public final class VirtualNodeCache {
      * @throws NullPointerException if {@code dirtyPaths} is null.
      */
     private void updateKeyAtPath(final Bytes value, final long path) {
-        pathToDirtyKeyIndex.compute(path, (key, mutation) -> {
+        pathToDirtyKeyIndex.compute(path, (_, mutation) -> {
             if (mutation == null || mutation.version != fastCopyVersion.get()) {
                 // It must be that there is *NO* mutation in the dirtyPaths for this cache version.
                 // I don't have an easy way to assert it programmatically, but by inspection, it must be true.
@@ -1064,12 +1093,11 @@ public final class VirtualNodeCache {
      */
     public VirtualHashChunk preloadHashChunk(final long path) {
         final long hashChunkId = VirtualHashChunk.chunkPathToChunkId(path, hashChunkHeight);
-        return idToDirtyHashChunkIndex.compute(hashChunkId, (id, mutation) -> {
+        return idToDirtyHashChunkIndex.compute(hashChunkId, (_, mutation) -> {
                     Mutation<Long, VirtualHashChunk> nextMutation = mutation;
                     while (nextMutation != null && nextMutation.version > fastCopyVersion.get()) {
                         nextMutation = nextMutation.next;
                     }
-                    long sizeDelta = 0;
                     if (nextMutation == null) {
                         VirtualHashChunk hashChunk = loadHashChunk(hashChunkId);
                         if (hashChunk == null) {
@@ -1079,16 +1107,15 @@ public final class VirtualNodeCache {
                         }
                         nextMutation = new Mutation<>(null, hashChunkId, hashChunk, fastCopyVersion.get());
                         dirtyHashChunks.add(nextMutation);
-                        sizeDelta += (long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength();
+                        estimatedHashesSizeInBytes.addAndGet((long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
                     } else if (nextMutation.version != fastCopyVersion.get()) {
                         final VirtualHashChunk hashChunk = nextMutation.value.copy();
                         nextMutation = new Mutation<>(nextMutation, hashChunkId, hashChunk, fastCopyVersion.get());
                         dirtyHashChunks.add(nextMutation);
-                        sizeDelta += (long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength();
+                        estimatedHashesSizeInBytes.addAndGet((long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
                     } else {
                         assert nextMutation.notFiltered();
                     }
-                    estimatedHashesSizeInBytes.addAndGet(sizeDelta);
                     return nextMutation;
                 })
                 .value;
@@ -1129,7 +1156,9 @@ public final class VirtualNodeCache {
      * @return The mutation for this leaf.
      */
     private Mutation<Bytes, VirtualLeafBytes> mutate(
-            @NonNull final VirtualLeafBytes leaf, @Nullable Mutation<Bytes, VirtualLeafBytes> mutation) {
+            @NonNull final VirtualLeafBytes leaf,
+            @Nullable Mutation<Bytes, VirtualLeafBytes> mutation,
+            boolean isDelete) {
         long sizeDelta = 0;
         // We only create a new mutation if one of the following is true:
         //  - There is no mutation in the cache (mutation == null)
@@ -1137,11 +1166,11 @@ public final class VirtualNodeCache {
         if (mutation == null || mutation.version != fastCopyVersion.get()) {
             // Only the latest copy can change leaf data, and it cannot ever be merged into while changing,
             // So it should be true that this cache does not have this leaf in dirtyLeaves.
-
             // Create a new mutation
             final Mutation<Bytes, VirtualLeafBytes> newerMutation =
                     new Mutation<>(mutation, leaf.keyBytes(), leaf, fastCopyVersion.get());
             dirtyLeaves.add(newerMutation);
+            newerMutation.setDeleted(isDelete);
             mutation = newerMutation;
             sizeDelta += leaf.getSizeInBytes();
         } else if (mutation.value != leaf) {
@@ -1150,10 +1179,10 @@ public final class VirtualNodeCache {
             assert mutation.value.keyBytes().equals(leaf.keyBytes());
             sizeDelta -= mutation.value.getSizeInBytes();
             mutation.value = leaf;
-            mutation.setDeleted(false);
+            mutation.setDeleted(isDelete);
             sizeDelta += mutation.value.getSizeInBytes();
         } else {
-            mutation.setDeleted(false);
+            mutation.setDeleted(isDelete);
         }
         estimatedLeavesSizeInBytes.addAndGet(sizeDelta);
         return mutation;
@@ -1170,7 +1199,7 @@ public final class VirtualNodeCache {
      * @param <V>   The value type referenced by the mutation list
      */
     private <K, V> void purge(final ConcurrentArray<Mutation<K, V>> array, final Map<K, Mutation<K, V>> index) {
-        array.parallelTraverse(cleaningPool, (i, element) -> {
+        array.parallelTraverse(cleaningPool, (_, element) -> {
             // If a cache copy is released after flush, some mutations may be already marked as
             // filtered in dirtyLeavesForFlush() and dirtyHashesForFlush(). When a mutation is
             // filtered, it means there is a newer mutation for the same key in the same cache
@@ -1210,7 +1239,7 @@ public final class VirtualNodeCache {
      * @param <V>   The value type referenced by the mutation list
      */
     private <K, V> void filterMutations(final ConcurrentArray<Mutation<K, V>> array) {
-        final BiConsumer<Integer, Mutation<K, V>> action = (i, mutation) -> {
+        final BiConsumer<Integer, Mutation<K, V>> action = (_, mutation) -> {
             // local variable is required because mutation.next can be changed by another thread to null
             // see https://github.com/hashgraph/hedera-services/issues/7046 for the context
             final Mutation<K, V> nextMutation = mutation.next;
@@ -1286,6 +1315,30 @@ public final class VirtualNodeCache {
         }
     }
 
+    private <K, V> void estimateGarbage(
+            final ConcurrentArray<Mutation<K, V>> array,
+            final Map<K, Mutation<K, V>> map,
+            final AtomicLong garbageSize,
+            final Function<V, Long> getSize) {
+        final BiConsumer<Integer, Mutation<K, V>> action = (_, mutation) -> {
+            final Mutation<K, V> nextMutation = mutation.next;
+            if ((nextMutation != null) && !nextMutation.isDeleted() && (nextMutation.value != null)) {
+                garbageSize.addAndGet(getSize.apply(nextMutation.value));
+            }
+            if (mutation.isDeleted() && (mutation.value != null)) {
+                // Deleted mutations are considered garbage, even if they are overridden in
+                // later versions
+                garbageSize.addAndGet(getSize.apply(mutation.value));
+            }
+        };
+        try {
+            array.parallelTraverse(cleaningPool, action).getAndRethrow();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
     /**
      * Copies the mutations from {@code src} into {@code dst} with the following constraints:
      * <ul>
@@ -1331,6 +1384,19 @@ public final class VirtualNodeCache {
         return estimatedLeavesSizeInBytes.get() + estimatedHashesSizeInBytes.get();
     }
 
+    public long getEstimatedGarbageSize() {
+        assert leafIndexesAreImmutable.get() && hashesAreImmutable.get();
+        long size = estimatedGarbageSizeInBytes.get();
+        if (size <= 0) {
+            estimateGarbage(dirtyLeaves, keyToDirtyLeafIndex, estimatedGarbageSizeInBytes, l -> (long) l.getSizeInBytes());
+            estimateGarbage(dirtyLeafPaths, pathToDirtyKeyIndex, estimatedGarbageSizeInBytes, Bytes::length);
+            estimateGarbage(dirtyHashChunks, idToDirtyHashChunkIndex, estimatedGarbageSizeInBytes,
+                    h -> (long) h.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
+            size = estimatedGarbageSizeInBytes.get();
+        }
+        return size;
+    }
+
     /**
      * Helper method that throws a MutabilityException if the leaf is immutable.
      */
@@ -1357,6 +1423,7 @@ public final class VirtualNodeCache {
      * @param <V> The type of data held by the mutation.
      */
     private static final class Mutation<K, V> {
+
         private volatile Mutation<K, V> next;
         private final long version; // The version of the cache that owns this mutation
         private final K key;

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -456,10 +456,27 @@ public final class VirtualNodeCache {
         }
     }
 
+    /**
+     * Removes all redundant mutations from this cache copy.
+     *
+     * <p>There are two types of redundant mutations. First, a mutation can be overridden by
+     * a mutation for the same key/path/id in a newer version. It doesn't make sense to keep
+     * the older mutation in the cache, it would be filtered later anyway. Second, deleted
+     * mutations are also considered redundant, even if there are no newer mutations. Such
+     * deleted mutations are used to get a stream of deleted leaves to flush into the data
+     * source before GC. See comments in VirtualMap.garbageCollect() for details.
+     *
+     * <p>All non-redundant mutations are added to new concurrent arrays. These arrays will
+     * later be used to merge the cache copy to a newer copy.
+     *
+     * <p>Index maps are updated, too. For every key/path/id in this cache copy, only the
+     * latest mutation is left in the chain of mutations in the index map. If the latest
+     * mutation is marked as deleted, the corresponding entry is removed from the map
+     * completely.
+     */
     public void garbageCollect() {
         // Cache garbage collection. All redundant mutations are purged. A mutation is redundant,
-        // if the same key / path / chunk ID is updated in multiple versions. This may only happen
-        // if this cache copy is a merged copy
+        // if the same key / path / chunk ID is updated in multiple versions
 
         // Only the oldest copies can be garbage collected, similar to flushes
         final VirtualNodeCache n = next.get();
@@ -473,15 +490,20 @@ public final class VirtualNodeCache {
 
         // Dirty leaves
         purgeOnGC(keyToDirtyLeafIndex, dirtyLeaves);
+        // purgeOnGC() marks mutations as filtered and removes them from the index map, but
+        // it doesn't update the concurrent array. A new array needs to be created from all
+        // mutations not marked as filtered in purgeOnGC()
         //noinspection NonAtomicOperationOnVolatileField
         dirtyLeaves = new ConcurrentArray<>(dirtyLeaves.stream()
                 // notFiltered also covers all deleted mutations
                 .filter(Mutation::notFiltered));
         // parallelTraverse() seems faster than to add peek() to the stream to calculate the size
         try {
-            dirtyLeaves.parallelTraverse(cleaningPool, (_, m) -> {
-                estimatedLeavesSizeInBytes.addAndGet(m.value.getSizeInBytes());
-            }).getAndRethrow();
+            dirtyLeaves
+                    .parallelTraverse(cleaningPool, (_, m) -> {
+                        estimatedLeavesSizeInBytes.addAndGet(m.value.getSizeInBytes());
+                    })
+                    .getAndRethrow();
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
@@ -495,9 +517,11 @@ public final class VirtualNodeCache {
                 // notFiltered also covers all deleted mutations
                 .filter(Mutation::notFiltered));
         try {
-            dirtyLeafPaths.parallelTraverse(cleaningPool, (_, m) -> {
-                estimatedLeavesSizeInBytes.addAndGet(m.value.length());
-            }).getAndRethrow();
+            dirtyLeafPaths
+                    .parallelTraverse(cleaningPool, (_, m) -> {
+                        estimatedLeavesSizeInBytes.addAndGet(m.value.length());
+                    })
+                    .getAndRethrow();
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
@@ -511,9 +535,12 @@ public final class VirtualNodeCache {
                 // notFiltered also covers all deleted mutations
                 .filter(Mutation::notFiltered));
         try {
-            dirtyHashChunks.parallelTraverse(cleaningPool, (_, m) -> {
-                estimatedHashesSizeInBytes.addAndGet((long) m.value.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
-            }).getAndRethrow();
+            dirtyHashChunks
+                    .parallelTraverse(cleaningPool, (_, m) -> {
+                        estimatedHashesSizeInBytes.addAndGet(
+                                (long) m.value.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
+                    })
+                    .getAndRethrow();
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
@@ -1107,12 +1134,14 @@ public final class VirtualNodeCache {
                         }
                         nextMutation = new Mutation<>(null, hashChunkId, hashChunk, fastCopyVersion.get());
                         dirtyHashChunks.add(nextMutation);
-                        estimatedHashesSizeInBytes.addAndGet((long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
+                        estimatedHashesSizeInBytes.addAndGet(
+                                (long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
                     } else if (nextMutation.version != fastCopyVersion.get()) {
                         final VirtualHashChunk hashChunk = nextMutation.value.copy();
                         nextMutation = new Mutation<>(nextMutation, hashChunkId, hashChunk, fastCopyVersion.get());
                         dirtyHashChunks.add(nextMutation);
-                        estimatedHashesSizeInBytes.addAndGet((long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
+                        estimatedHashesSizeInBytes.addAndGet(
+                                (long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
                     } else {
                         assert nextMutation.notFiltered();
                     }
@@ -1388,9 +1417,13 @@ public final class VirtualNodeCache {
         assert leafIndexesAreImmutable.get() && hashesAreImmutable.get();
         long size = estimatedGarbageSizeInBytes.get();
         if (size <= 0) {
-            estimateGarbage(dirtyLeaves, keyToDirtyLeafIndex, estimatedGarbageSizeInBytes, l -> (long) l.getSizeInBytes());
+            estimateGarbage(
+                    dirtyLeaves, keyToDirtyLeafIndex, estimatedGarbageSizeInBytes, l -> (long) l.getSizeInBytes());
             estimateGarbage(dirtyLeafPaths, pathToDirtyKeyIndex, estimatedGarbageSizeInBytes, Bytes::length);
-            estimateGarbage(dirtyHashChunks, idToDirtyHashChunkIndex, estimatedGarbageSizeInBytes,
+            estimateGarbage(
+                    dirtyHashChunks,
+                    idToDirtyHashChunkIndex,
+                    estimatedGarbageSizeInBytes,
                     h -> (long) h.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
             size = estimatedGarbageSizeInBytes.get();
         }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 import java.util.stream.Stream;
@@ -224,17 +225,16 @@ public final class VirtualNodeCache {
     private volatile ConcurrentArray<Mutation<Long, VirtualHashChunk>> dirtyHashChunks = new ConcurrentArray<>();
 
     /**
-     * Estimated size of all leaf records in dirtyLeaves. This size is calculated lazily during the first call to
-     * {@link #getEstimatedSize()}. This method may only be called after {@link #leafIndexesAreImmutable} is updated to
-     * true.
+     * Estimated size of this cache copy, in bytes. It includes: key bytes in dirty leaf paths,
+     * leaf record sizes in dirty leaves, and hash chunk sizes in dirty hash chunks.
      */
-    private final AtomicLong estimatedLeavesSizeInBytes = new AtomicLong(0);
+    private final AtomicLong estimatedSizeInBytes = new AtomicLong(0);
 
     /**
-     * Estimated size of all hashes in dirtyHashes. This size is updated on every hash operation (put, delete).
+     * Estimated size of redundant (garbage) mutations in this cache copy, in bytes.
+     *
+     * <p>This value is calculated lazily on the first call to {@link #getEstimatedGarbageSize()}.
      */
-    private final AtomicLong estimatedHashesSizeInBytes = new AtomicLong(0);
-
     private final AtomicLong estimatedGarbageSizeInBytes = new AtomicLong(0);
 
     /**
@@ -426,8 +426,7 @@ public final class VirtualNodeCache {
         purge(dirtyLeafPaths, pathToDirtyKeyIndex);
         purge(dirtyHashChunks, idToDirtyHashChunkIndex);
 
-        estimatedLeavesSizeInBytes.set(0);
-        estimatedHashesSizeInBytes.set(0);
+        estimatedSizeInBytes.set(0);
 
         dirtyLeaves = null;
         dirtyLeafPaths = null;
@@ -484,8 +483,7 @@ public final class VirtualNodeCache {
             throw new IllegalStateException("Cannot garbage collect, the copy is not the oldest");
         }
 
-        estimatedLeavesSizeInBytes.set(0);
-        estimatedHashesSizeInBytes.set(0);
+        estimatedSizeInBytes.set(0);
         estimatedGarbageSizeInBytes.set(0);
 
         // Dirty leaves
@@ -501,14 +499,14 @@ public final class VirtualNodeCache {
         try {
             dirtyLeaves
                     .parallelTraverse(cleaningPool, (_, m) -> {
-                        estimatedLeavesSizeInBytes.addAndGet(m.value.getSizeInBytes());
+                        estimatedSizeInBytes.addAndGet(m.value.getSizeInBytes());
                     })
                     .getAndRethrow();
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
-        estimatedLeavesSizeInBytes.addAndGet(dirtyLeaves.estimatedStorageMemoryOverhead());
+        estimatedSizeInBytes.addAndGet(dirtyLeaves.estimatedStorageMemoryOverhead());
 
         // Dirty leaf paths
         purgeOnGC(pathToDirtyKeyIndex, dirtyLeafPaths);
@@ -519,14 +517,14 @@ public final class VirtualNodeCache {
         try {
             dirtyLeafPaths
                     .parallelTraverse(cleaningPool, (_, m) -> {
-                        estimatedLeavesSizeInBytes.addAndGet(m.value.length());
+                        estimatedSizeInBytes.addAndGet(m.value.length());
                     })
                     .getAndRethrow();
         } catch (final InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
-        estimatedLeavesSizeInBytes.addAndGet(dirtyLeafPaths.estimatedStorageMemoryOverhead());
+        estimatedSizeInBytes.addAndGet(dirtyLeafPaths.estimatedStorageMemoryOverhead());
 
         // Dirty hashes
         purgeOnGC(idToDirtyHashChunkIndex, dirtyHashChunks);
@@ -537,7 +535,7 @@ public final class VirtualNodeCache {
         try {
             dirtyHashChunks
                     .parallelTraverse(cleaningPool, (_, m) -> {
-                        estimatedHashesSizeInBytes.addAndGet(
+                        estimatedSizeInBytes.addAndGet(
                                 (long) m.value.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
                     })
                     .getAndRethrow();
@@ -545,7 +543,7 @@ public final class VirtualNodeCache {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
-        estimatedHashesSizeInBytes.addAndGet(dirtyHashChunks.estimatedStorageMemoryOverhead());
+        estimatedSizeInBytes.addAndGet(dirtyHashChunks.estimatedStorageMemoryOverhead());
     }
 
     /**
@@ -581,8 +579,7 @@ public final class VirtualNodeCache {
         p.dirtyLeafPaths.merge(dirtyLeafPaths);
         p.dirtyHashChunks.merge(dirtyHashChunks);
         // Estimated sizes include both mutations and concurrent array overheads
-        p.estimatedLeavesSizeInBytes.addAndGet(estimatedLeavesSizeInBytes.get());
-        p.estimatedHashesSizeInBytes.addAndGet(estimatedHashesSizeInBytes.get());
+        p.estimatedSizeInBytes.addAndGet(estimatedSizeInBytes.get());
         p.mergedCopy.set(true);
 
         // Remove this cache from the chain and wire the prev and next caches together.
@@ -613,9 +610,9 @@ public final class VirtualNodeCache {
         dirtyHashChunks.seal();
         dirtyLeafPaths.seal();
         // Update estimated size to include concurrent arrays storage overhead
-        estimatedHashesSizeInBytes.addAndGet(dirtyHashChunks.estimatedStorageMemoryOverhead());
-        estimatedLeavesSizeInBytes.addAndGet(
-                dirtyLeaves.estimatedStorageMemoryOverhead() + dirtyLeafPaths.estimatedStorageMemoryOverhead());
+        estimatedSizeInBytes.addAndGet(dirtyHashChunks.estimatedStorageMemoryOverhead());
+        estimatedSizeInBytes.addAndGet(dirtyLeaves.estimatedStorageMemoryOverhead());
+        estimatedSizeInBytes.addAndGet(dirtyLeafPaths.estimatedStorageMemoryOverhead());
     }
 
     // --------------------------------------------------------------------------------------------
@@ -915,10 +912,10 @@ public final class VirtualNodeCache {
             if ((mutation == null) || (mutation.version != fastCopyVersion.get())) {
                 mutation = new Mutation<>(mutation, hashChunkId, chunk, fastCopyVersion.get());
                 dirtyHashChunks.add(mutation);
-                estimatedHashesSizeInBytes.addAndGet((long) chunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
+                estimatedSizeInBytes.addAndGet((long) chunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
             } else {
                 assert mutation.notFiltered();
-                // All hash chunks are of the same size, no need to update estimatedHashesSizeInBytes
+                // All hash chunks are of the same size, no need to update estimated size
                 mutation.value = chunk;
             }
             return mutation;
@@ -1085,19 +1082,19 @@ public final class VirtualNodeCache {
                 mutation = new Mutation<>(mutation, path, value, fastCopyVersion.get());
                 mutation.setDeleted(value == null);
                 if (value != null) {
-                    estimatedLeavesSizeInBytes.addAndGet(value.length());
+                    estimatedSizeInBytes.addAndGet(value.length());
                 }
                 // Hold a reference to this newest mutation in this cache
                 dirtyLeafPaths.add(mutation);
             } else if (mutation.value != value) {
                 assert mutation.notFiltered();
                 if (mutation.value != null) {
-                    estimatedLeavesSizeInBytes.addAndGet(-mutation.value.length());
+                    estimatedSizeInBytes.addAndGet(-mutation.value.length());
                 }
                 // This mutation already exists in this version. Simply update its value and deleted status
                 mutation.value = value;
                 if (mutation.value != null) {
-                    estimatedLeavesSizeInBytes.addAndGet(mutation.value.length());
+                    estimatedSizeInBytes.addAndGet(mutation.value.length());
                 }
                 mutation.setDeleted(value == null);
             }
@@ -1134,13 +1131,13 @@ public final class VirtualNodeCache {
                         }
                         nextMutation = new Mutation<>(null, hashChunkId, hashChunk, fastCopyVersion.get());
                         dirtyHashChunks.add(nextMutation);
-                        estimatedHashesSizeInBytes.addAndGet(
+                        estimatedSizeInBytes.addAndGet(
                                 (long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
                     } else if (nextMutation.version != fastCopyVersion.get()) {
                         final VirtualHashChunk hashChunk = nextMutation.value.copy();
                         nextMutation = new Mutation<>(nextMutation, hashChunkId, hashChunk, fastCopyVersion.get());
                         dirtyHashChunks.add(nextMutation);
-                        estimatedHashesSizeInBytes.addAndGet(
+                        estimatedSizeInBytes.addAndGet(
                                 (long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
                     } else {
                         assert nextMutation.notFiltered();
@@ -1213,7 +1210,7 @@ public final class VirtualNodeCache {
         } else {
             mutation.setDeleted(isDelete);
         }
-        estimatedLeavesSizeInBytes.addAndGet(sizeDelta);
+        estimatedSizeInBytes.addAndGet(sizeDelta);
         return mutation;
     }
 
@@ -1344,20 +1341,17 @@ public final class VirtualNodeCache {
         }
     }
 
-    private <K, V> void estimateGarbage(
-            final ConcurrentArray<Mutation<K, V>> array,
-            final Map<K, Mutation<K, V>> map,
-            final AtomicLong garbageSize,
-            final Function<V, Long> getSize) {
+    private <K, V> long estimateGarbage(final ConcurrentArray<Mutation<K, V>> array, final Function<V, Long> getSize) {
+        final LongAdder gs = new LongAdder();
         final BiConsumer<Integer, Mutation<K, V>> action = (_, mutation) -> {
             final Mutation<K, V> nextMutation = mutation.next;
             if ((nextMutation != null) && !nextMutation.isDeleted() && (nextMutation.value != null)) {
-                garbageSize.addAndGet(getSize.apply(nextMutation.value));
+                gs.add(getSize.apply(nextMutation.value));
             }
             if (mutation.isDeleted() && (mutation.value != null)) {
                 // Deleted mutations are considered garbage, even if they are overridden in
                 // later versions
-                garbageSize.addAndGet(getSize.apply(mutation.value));
+                gs.add(getSize.apply(mutation.value));
             }
         };
         try {
@@ -1366,6 +1360,7 @@ public final class VirtualNodeCache {
             Thread.currentThread().interrupt();
             throw new RuntimeException(e);
         }
+        return gs.sum();
     }
 
     /**
@@ -1407,25 +1402,24 @@ public final class VirtualNodeCache {
 
     /**
      * Get estimated size of this cache copy. The size includes all leaf records in dirtyLeaves, all keys in
-     * dirtyLeafPaths, and all hashes in dirtyHashes.
+     * dirtyLeafPaths, and all hashes in dirtyHashChunks.
      */
     public long getEstimatedSize() {
-        return estimatedLeavesSizeInBytes.get() + estimatedHashesSizeInBytes.get();
+        return estimatedSizeInBytes.get();
     }
 
+    /**
+     * Get estimated size of redundant data in this cache copy. This method may only be called on
+     * sealed copies.
+     */
     public long getEstimatedGarbageSize() {
         assert leafIndexesAreImmutable.get() && hashesAreImmutable.get();
         long size = estimatedGarbageSizeInBytes.get();
-        if (size <= 0) {
-            estimateGarbage(
-                    dirtyLeaves, keyToDirtyLeafIndex, estimatedGarbageSizeInBytes, l -> (long) l.getSizeInBytes());
-            estimateGarbage(dirtyLeafPaths, pathToDirtyKeyIndex, estimatedGarbageSizeInBytes, Bytes::length);
-            estimateGarbage(
-                    dirtyHashChunks,
-                    idToDirtyHashChunkIndex,
-                    estimatedGarbageSizeInBytes,
-                    h -> (long) h.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
-            size = estimatedGarbageSizeInBytes.get();
+        if (size == 0) {
+            size += estimateGarbage(dirtyLeaves, l -> (long) l.getSizeInBytes());
+            size += estimateGarbage(dirtyLeafPaths, Bytes::length);
+            size += estimateGarbage(dirtyHashChunks, h -> (long) h.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
+            estimatedGarbageSizeInBytes.set(size);
         }
         return size;
     }

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCache.java
@@ -5,6 +5,7 @@ import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 import static com.swirlds.logging.legacy.LogMarker.VIRTUAL_MERKLE_STATS;
 import static java.util.Objects.requireNonNull;
 import static org.hiero.base.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
+import static org.hiero.base.crypto.Cryptography.DEFAULT_DIGEST_TYPE;
 
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.base.function.CheckedFunction;
@@ -37,7 +38,6 @@ import org.apache.logging.log4j.Logger;
 import org.hiero.base.concurrent.framework.config.CompositeThreadNameProvider;
 import org.hiero.base.concurrent.framework.config.ThreadConfiguration;
 import org.hiero.base.concurrent.futures.StandardFuture;
-import org.hiero.base.crypto.Cryptography;
 import org.hiero.base.exceptions.PlatformException;
 
 /**
@@ -453,6 +453,49 @@ public final class VirtualNodeCache {
         }
     }
 
+    public void garbageCollect() {
+        // Cache garbage collection. All redundant mutations are purged. A mutation is redundant,
+        // if the same key / path / chunk ID is updated in multiple versions. This may only happen
+        // if this cache copy is a merged copy
+
+        // Only the oldest copies can be garbage collected, similar to flushes
+        final VirtualNodeCache n = next.get();
+        if (n != null) {
+            throw new IllegalStateException("Cannot garbage collect, the copy is not the oldest");
+        }
+
+        estimatedLeavesSizeInBytes.set(0);
+        estimatedHashesSizeInBytes.set(0);
+
+        // Dirty leaves
+        purgeOnGC(keyToDirtyLeafIndex, dirtyLeaves);
+        //noinspection NonAtomicOperationOnVolatileField
+        dirtyLeaves = new ConcurrentArray<>(dirtyLeaves.stream()
+                // notFiltered also covers all deleted mutations
+                .filter(Mutation::notFiltered)
+                .peek(m -> estimatedLeavesSizeInBytes.addAndGet(m.value.getSizeInBytes())));
+        estimatedLeavesSizeInBytes.addAndGet(dirtyLeaves.estimatedStorageMemoryOverhead());
+
+        // Dirty leaf paths
+        purgeOnGC(pathToDirtyKeyIndex, dirtyLeafPaths);
+        //noinspection NonAtomicOperationOnVolatileField
+        dirtyLeafPaths = new ConcurrentArray<>(dirtyLeafPaths.stream()
+                // notFiltered also covers all deleted mutations
+                .filter(Mutation::notFiltered)
+                .peek(m -> estimatedLeavesSizeInBytes.addAndGet(m.value.length())));
+        estimatedLeavesSizeInBytes.addAndGet(dirtyLeafPaths.estimatedStorageMemoryOverhead());
+
+        // Dirty hashes
+        purgeOnGC(idToDirtyHashChunkIndex, dirtyHashChunks);
+        //noinspection NonAtomicOperationOnVolatileField
+        dirtyHashChunks = new ConcurrentArray<>(dirtyHashChunks.stream()
+                // notFiltered also covers all deleted mutations
+                .filter(Mutation::notFiltered)
+                .peek(m -> estimatedHashesSizeInBytes.addAndGet(
+                        (long) m.value.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength())));
+        estimatedHashesSizeInBytes.addAndGet(dirtyHashChunks.estimatedStorageMemoryOverhead());
+    }
+
     /**
      * Merges this cache with the previous (newer) one by removing it from the chain of cache
      * copies. All mutations from this cache are appended to the target cache copy. No changes
@@ -816,8 +859,7 @@ public final class VirtualNodeCache {
             if ((mutation == null) || (mutation.version != fastCopyVersion.get())) {
                 mutation = new Mutation<>(mutation, hashChunkId, chunk, fastCopyVersion.get());
                 dirtyHashChunks.add(mutation);
-                estimatedHashesSizeInBytes.addAndGet(
-                        (long) chunk.getChunkSize() * Cryptography.DEFAULT_DIGEST_TYPE.digestLength());
+                estimatedHashesSizeInBytes.addAndGet((long) chunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength());
             } else {
                 assert mutation.notFiltered();
                 // All hash chunks are of the same size, no need to update estimatedHashesSizeInBytes
@@ -986,12 +1028,21 @@ public final class VirtualNodeCache {
                 // Create a mutation for this version pointing to the next oldest mutation (if any).
                 mutation = new Mutation<>(mutation, path, value, fastCopyVersion.get());
                 mutation.setDeleted(value == null);
+                if (value != null) {
+                    estimatedLeavesSizeInBytes.addAndGet(value.length());
+                }
                 // Hold a reference to this newest mutation in this cache
                 dirtyLeafPaths.add(mutation);
             } else if (mutation.value != value) {
                 assert mutation.notFiltered();
+                if (mutation.value != null) {
+                    estimatedLeavesSizeInBytes.addAndGet(-mutation.value.length());
+                }
                 // This mutation already exists in this version. Simply update its value and deleted status
                 mutation.value = value;
+                if (mutation.value != null) {
+                    estimatedLeavesSizeInBytes.addAndGet(mutation.value.length());
+                }
                 mutation.setDeleted(value == null);
             }
             return mutation;
@@ -1028,12 +1079,12 @@ public final class VirtualNodeCache {
                         }
                         nextMutation = new Mutation<>(null, hashChunkId, hashChunk, fastCopyVersion.get());
                         dirtyHashChunks.add(nextMutation);
-                        sizeDelta += (long) hashChunk.getChunkSize() * Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+                        sizeDelta += (long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength();
                     } else if (nextMutation.version != fastCopyVersion.get()) {
                         final VirtualHashChunk hashChunk = nextMutation.value.copy();
                         nextMutation = new Mutation<>(nextMutation, hashChunkId, hashChunk, fastCopyVersion.get());
                         dirtyHashChunks.add(nextMutation);
-                        sizeDelta += (long) hashChunk.getChunkSize() * Cryptography.DEFAULT_DIGEST_TYPE.digestLength();
+                        sizeDelta += (long) hashChunk.getChunkSize() * DEFAULT_DIGEST_TYPE.digestLength();
                     } else {
                         assert nextMutation.notFiltered();
                     }
@@ -1126,7 +1177,7 @@ public final class VirtualNodeCache {
             // copy. When this newer mutation is purged, it also takes care of the filtered
             // mutation, so there is no need to handle filtered mutations explicitly
             if (element.notFiltered()) {
-                index.compute(element.key, (key, mutation) -> {
+                index.compute(element.key, (_, mutation) -> {
                     if ((mutation == null) || element.equals(mutation)) {
                         // Already removed for a more recent mutation
                         return null;
@@ -1165,6 +1216,66 @@ public final class VirtualNodeCache {
             final Mutation<K, V> nextMutation = mutation.next;
             if (nextMutation != null) {
                 nextMutation.setFiltered();
+            }
+        };
+        try {
+            array.parallelTraverse(cleaningPool, action).getAndRethrow();
+        } catch (final InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * This method is somewhat similar to {@link #filterMutations(ConcurrentArray)} above, but called
+     * during garbage collection rather than flush. It iterates over all mutations in the specified
+     * array and removes all obsolete mutations (sets all "next"s to null). This implies the method
+     * may only be called on the very last (oldest) cache copy, this is checked in {@link #garbageCollect()}}.
+     * All removed mutations are marked as filtered, so they can be filtered out later easily.
+     *
+     * <p>Besides obsolete mutations, this method also marks deleted mutations as filtered. This method
+     * is only called during garbage collection. This means, the current cache copy is the oldest in the
+     * chain, it works in the in-memory mode, so there is no data in the data source. If a mutation is
+     * deleted, no need to store the corresponding key anywhere, that's why deleted mutations are
+     * filtered. If a filtered deleted mutation is the latest, the corresponding entry is removed from
+     * the map completely.
+     */
+    private <K, V> void purgeOnGC(final Map<K, Mutation<K, V>> map, final ConcurrentArray<Mutation<K, V>> array) {
+        // In most cases, this cache copy is merged, i.e. contains mutations from multiple older
+        // copies. Some of these mutations are for the same key, so it makes sense to leave only
+        // the latest one and mark all others as filtered. However, sometimes a single cache copy
+        // is large enough for garbage collection. No older mutations to filter, but there may
+        // still be deleted mutations that can be filtered, too. This is why there is no check
+        // for mergedCopy.get() here
+        final BiConsumer<Integer, Mutation<K, V>> action = (_, mutation) -> {
+            final Mutation<K, V> nextMutation = mutation.next;
+            if (nextMutation != null) {
+                // nextMutation is overridden by mutation, so it can be filtered (even if
+                // mutation is also filtered by even newer mutation). Filtered mutations stay
+                // in the array for now. When a new clean array is created later, all filtered
+                // mutations will be thrown away
+                assert nextMutation.notFiltered() || nextMutation.isDeleted();
+                nextMutation.setFiltered();
+                // Remove nextMutation from the linked list of mutations in the map
+                mutation.next = null;
+            }
+            // If a mutation is deleted, it can be filtered, too, even if there is a newer
+            // mutation for this key. For it to work, the data source must be guaranteed to
+            // not contain the key, otherwise future calls for the key will find the old
+            // value in the data source. This guarantee is provided by VirtualMap.garbageColect(),
+            // which removes all deleted keys from the data source before collecting garbage
+            // from this cache copy
+            if (mutation.isDeleted()) {
+                mutation.setFiltered();
+                // If the mutation is the latest in the chain of mutations, delete the
+                // corresponding map entry (linked list of mutations) completely to keep
+                // the map small
+                map.compute(mutation.key, (_, m) -> {
+                    if (m == mutation) {
+                        return null;
+                    }
+                    return m;
+                });
             }
         };
         try {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -45,7 +45,7 @@ import org.hiero.base.concurrent.framework.config.ThreadConfiguration;
  * For a copy to be merged, it must be released, it should not be flushable, the next copy in the
  * family must exist and must be immutable.
  *
- * <p></p>Before a copy is flushed or merged, it gets hashed, if not hashed already. Copies are
+ * <p>Before a copy is flushed or merged, it gets hashed, if not hashed already. Copies are
  * hashed in order, i.e. a copy is hashed after all its older copies are hashed.
  */
 public class VirtualPipeline {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -27,72 +27,26 @@ import org.hiero.base.concurrent.framework.config.CompositeThreadNameProvider;
 import org.hiero.base.concurrent.framework.config.ThreadConfiguration;
 
 /**
- * <p>
- * Manages the lifecycle of {@link VirtualRoot} family objects created via {@link VirtualRoot#copy()}.
- * </p>
+ * Virtual pipeline is a mechanism to manage lifecycle of {@link VirtualRoot} family. A family is
+ * a set of virtual roots, where every root is a copy of the previous object.
  *
- * <p>
- * This pipeline is responsible for enforcing the following invariants and constraints:
- * </p>
+ * <p>A copy is typically registered to a pipeline right when it is created. When a copy gets
+ * released, i.e. no references to it exist, the pipeline is notified, so it can process the
+ * copy. A pipeline stores all copies registered to it. Once a copy is processed (flushed or
+ * merged) after destroy, the copy is removed from the pipeline.
  *
- * <hr>
- * <p><strong>General</strong></p>
+ * <p>Pipelines use single thread executors to run {@link #hashFlushMerge()} method. The method
+ * checks the oldest copy. If a copy is flushed or merged, it is removed from the pipeline, and
+ * the next copy (which is now the oldest) is processed. If a copy cannot be processed, no newer
+ * copies are processed.
  *
- * <ul>
- * 	<li>all copies must be <strong>flushed</strong> or <strong>merged</strong> prior to eviction from memory</li>
- * 	<li>a copy can only be <strong>flushed</strong> or <strong>merged</strong>, not both</li>
- * 	<li>no <strong>flushes</strong> or <strong>merges</strong> are processed during copy detachment</li>
- * 	<li>pipelines can be terminated {@link #shutdown(boolean)} when all copies are destroyed or destroy of any copy throws an exception.
- * 	    A terminated pipeline is not required to <strong>flush</strong> or <strong>merge</strong>
- * 		copies before those copies are collected by the java garbage collector.</li>
- * </ul>
+ * <p>A virtual root copy can be either flushed or merged, but not both. For a copy to be flushed,
+ * it must be released, and its {@link VirtualRoot#shouldBeFlushed()} method must return true.
+ * For a copy to be merged, it must be released, it should not be flushable, the next copy in the
+ * family must exist and must be immutable.
  *
- * <hr>
- * <p><strong>Flushing</strong></p>
- * <ul>
- *  <li>only immutable copies can be <strong>flushed</strong></li>
- *  <li>only the oldest released copy can be <strong>flushed</strong></li>
- *  <li>copies with {@link VirtualRoot#shouldBeFlushed()} returning true are guaranteed to be flushed;
- * other copies may be flushed, too</li>
- * 	<li>a copy can be either flushed or merged, but not both</li>
- * </ul>
- *
- * <hr>
- * <p><strong>Merging</strong></p>
- * <ul>
- * 	<li>only destroyed or detached copies can be <strong>merged</strong>
- * 	<li>copies can ony be <strong>merged</strong> into immutable copies</li>
- * 	<li>a copy can be either merged or flushed, but not both</li>
- * </ul>
- *
- * <hr>
- * <p><strong>Hashing</strong></p>
- * <ul>
- * <li>
- * hashes must happen in order, that is the copy from round N must be hashed before the copy from round N+1 is hashed
- * </li>
- * <li>
- * copies must be hashed before they are <strong>flushed</strong>
- * </li>
- * <li>
- * copies must be hashed before they are <strong>merged</strong>
- * </li>
- * <li>
- * the copy that is being <strong>merged</strong> into must be hashed before the merge
- * </li>
- * </ul>
- *
- * <hr>
- * <p><strong>Thread Safety</strong></p>
- * <ul>
- * 	<li><strong>merging</strong> and <strong>flushing</strong> are not thread safe with respect to other
- * 		<strong>merge</strong>/<strong>flush</strong> operations in the general case.</li>
- * 	<li><strong>merged</strong> and <strong>flushing</strong> are not thread safe with respect to hashing on the copies
- * 		being <strong>merged</strong> or <strong>flushed</strong></li>
- * 	<li>terminated pipelines will wait for any <strong>merges</strong> or <strong>flushes</strong> to complete
- * 		before shutting down the pipeline. This method can be called concurrently to all other methods. Any concurrent
- * 		calls that race with this one and come after will not execute.</li>
- * </ul>
+ * <p></p>Before a copy is flushed or merged, it gets hashed, if not hashed already. Copies are
+ * hashed in order, i.e. a copy is hashed after all its older copies are hashed.
  */
 public class VirtualPipeline {
 
@@ -469,22 +423,22 @@ public class VirtualPipeline {
             }
             if (!copy.isDestroyed()) {
                 // All operations below are only applicable to destroyed copies.
-                // Does isDestroy() make isImmutable() check above obsolete?
                 break;
             }
             if (!copy.isHashed()) {
                 hashCopy(copy);
             }
             if (shouldBeFlushed(copy)) {
-                logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "Flush {}", copy.getFastCopyVersion());
+                logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flush {}", copy.getFastCopyVersion());
                 flush(copy);
                 copies.remove(next);
             } else if (canBeMerged(next)) {
                 assert !copy.isMerged();
-                logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "Merge {}", copy.getFastCopyVersion());
+                logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Merge {}", copy.getFastCopyVersion());
                 merge(next);
                 copies.remove(next);
             } else {
+                // The oldest copy can't be flushed or merged. No need to process newer copies
                 break;
             }
 

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -418,9 +418,7 @@ public class VirtualPipeline {
         if (copy.isFlushed()) {
             throw new IllegalStateException("copy is already flushed");
         }
-        if (!copy.isHashed()) {
-            hashCopy(copy);
-        }
+        assert copy.isHashed();
         copy.flush();
     }
 
@@ -445,20 +443,14 @@ public class VirtualPipeline {
      */
     private void merge(final PipelineListNode<VirtualRoot> node) {
         final VirtualRoot copy = node.getValue();
-
         if (copy.isMerged()) {
             throw new IllegalStateException("copy is already merged");
         }
-
-        if (!copy.isHashed()) {
-            hashCopy(copy);
-        }
-
+        assert copy.isHashed();
         final VirtualRoot next = node.getNext().getValue();
         if (!next.isHashed()) {
             hashCopy(next);
         }
-
         copy.merge();
     }
 
@@ -480,13 +472,16 @@ public class VirtualPipeline {
                 // Does isDestroy() make isImmutable() check above obsolete?
                 break;
             }
+            if (!copy.isHashed()) {
+                hashCopy(copy);
+            }
             if (shouldBeFlushed(copy)) {
-                logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flush {}", copy.getFastCopyVersion());
+                logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "Flush {}", copy.getFastCopyVersion());
                 flush(copy);
                 copies.remove(next);
             } else if (canBeMerged(next)) {
                 assert !copy.isMerged();
-                logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Merge {}", copy.getFastCopyVersion());
+                logger.info(VIRTUAL_MERKLE_STATS.getMarker(), "Merge {}", copy.getFastCopyVersion());
                 merge(next);
                 copies.remove(next);
             } else {

--- a/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
+++ b/platform-sdk/swirlds-virtualmap/src/main/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipeline.java
@@ -388,8 +388,7 @@ public class VirtualPipeline {
      * Check if this copy should be flushed.
      */
     private boolean shouldBeFlushed(final VirtualRoot copy) {
-        return copy.shouldBeFlushed() // either explicitly marked to flush or based on its size
-                && copy.isDestroyed();
+        return copy.shouldBeFlushed(); // either explicitly marked to flush or based on its size
     }
 
     /**
@@ -433,7 +432,6 @@ public class VirtualPipeline {
         final PipelineListNode<VirtualRoot> mergeTarget = mergeCandidate.getNext();
 
         return !copy.shouldBeFlushed() // shouldn't be flushed
-                && copy.isDestroyed() // copy must be destroyed
                 && mergeTarget != null // target must exist
                 && mergeTarget.getValue().isImmutable(); // target must be immutable
     }
@@ -471,12 +469,18 @@ public class VirtualPipeline {
         PipelineListNode<VirtualRoot> next = copies.getFirst();
         // Iterate from the oldest copy to the newest
         while ((next != null) && !Thread.currentThread().isInterrupted()) {
+            assert next == copies.getFirst();
             final VirtualRoot copy = next.getValue();
             // The newest copy. Nothing can be done to it
             if (!copy.isImmutable()) {
                 break;
             }
-            if ((next == copies.getFirst()) && shouldBeFlushed(copy)) {
+            if (!copy.isDestroyed()) {
+                // All operations below are only applicable to destroyed copies.
+                // Does isDestroy() make isImmutable() check above obsolete?
+                break;
+            }
+            if (shouldBeFlushed(copy)) {
                 logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Flush {}", copy.getFastCopyVersion());
                 flush(copy);
                 copies.remove(next);
@@ -485,6 +489,8 @@ public class VirtualPipeline {
                 logger.debug(VIRTUAL_MERKLE_STATS.getMarker(), "Merge {}", copy.getFastCopyVersion());
                 merge(next);
                 copies.remove(next);
+            } else {
+                break;
             }
 
             next = next.getNext();

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -746,7 +746,7 @@ class VirtualMapTests extends VirtualTestBase {
             throw new AssertionError("nodeCacheSizeMb metric is not a gauge");
         }
 
-        long metricValue = (long) metric.get(ValueType.VALUE);
+        final long metricValue = (long) metric.get(ValueType.VALUE);
         for (int i = 0; i < 100; i++) {
             for (int j = 0; j < 50; j++) {
                 map0.put(
@@ -759,14 +759,13 @@ class VirtualMapTests extends VirtualTestBase {
             map0.release();
             map0 = map1;
 
-            long newValue = (long) metric.get(ValueType.VALUE);
-            assertTrue(
-                    newValue >= metricValue,
-                    "Node cache size must be increasing" + " old value = " + metricValue + " new value = " + newValue);
-            metricValue = newValue;
+            assertEventuallyTrue(
+                    () -> (long) metric.get(ValueType.VALUE) > metricValue,
+                    Duration.ofMillis(1000),
+                    "Node cache size must increase");
         }
 
-        final long value = metricValue;
+        final long value = (long) metric.get(ValueType.VALUE);;
 
         final VirtualMap lastMap = map0;
         lastMap.enableFlush();
@@ -776,11 +775,8 @@ class VirtualMapTests extends VirtualTestBase {
         map1.release();
 
         assertEventuallyTrue(
-                () -> {
-                    long lastValue = (long) metric.get(ValueType.VALUE);
-                    return lastValue < value;
-                },
-                Duration.ofSeconds(4),
+                () -> (long) metric.get(ValueType.VALUE) < value,
+                Duration.ofMillis(1000),
                 "Node cache size must decrease after flush");
     }
 
@@ -1378,17 +1374,17 @@ class VirtualMapTests extends VirtualTestBase {
     }
 
     @Test
-    void noFlushesBelowInMemoryThreshold() throws InterruptedException {
-        final int inMemorySizeThreshold = 10;
+    void garbageAboveThresholdResultsInGC() throws InterruptedException {
+        final int size = 63;
         final Configuration config = ConfigurationBuilder.create()
                 .autoDiscoverExtensions()
-                .withValue("virtualMap.inMemorySizeThreshold", "" + inMemorySizeThreshold)
-                // Any copy should be flushed
-                .withValue("virtualMap.copyFlushCandidateThreshold", "1")
+                .withValue("virtualMap.copyFlushCandidateThreshold", "64000")
+                // Enable flushes, if garbage is less than 55%
+                .withValue("virtualMap.percentFlushGarbageThreshold", "5")
                 .build();
         final VirtualMap map0 = createMap(config);
 
-        for (int i = 0; i < inMemorySizeThreshold; i++) {
+        for (int i = 0; i < size; i++) {
             map0.put(TestKey.longToKey(i), new TestValue("" + i), TestValueCodec.INSTANCE);
         }
         final VirtualMap map1 = map0.copy();
@@ -1396,56 +1392,133 @@ class VirtualMapTests extends VirtualTestBase {
         map0.release();
 
         Thread.sleep(500);
-        assertFalse(map0.isFlushed());
-        assertFalse(map0.isMerged());
+        assertFalse(map0.isFlushed()); // Flush threshold not exceeded
+        assertFalse(map0.isMerged()); // Next copy is not released yet, can't merge
 
         final VirtualMap map2 = map1.copy();
         map1.getHash();
         map1.release();
 
-        Thread.sleep(500);
+        // map1: no leaf updates, no dirty hashes -> estimated size is only concurrent array overhead,
+        // 3 arrays x 8K each = 24K, so it should be merged
+        assertEventuallyTrue(map0::isMerged, Duration.ofMillis(1000), "Copy 0 must be merged");
         assertFalse(map0.isFlushed());
 
-        // Add one more item to exceed the in-memory threshold
-        map2.put(TestKey.longToKey(11), new TestValue("11"), TestValueCodec.INSTANCE);
+        // map1 is released -> map0 is merged to it. Estimated map1 size: 24K array overhead from
+        // map0 (3 arrays x 8K each), 2K leaf updates from map0, 3K hash updates from map0, no
+        // dirty leaves/hashes in map1 -> total size is slightly below 55K. Flush threshold is set
+        // to a higher value, so map1 should not be flushed, but merged to map2
+
+        // Update all the values. It will create some garbage, both leaves and hashes
+        for (int i = 0; i < size; i++) {
+            map2.put(TestKey.longToKey(i), new TestValue("u" + i), TestValueCodec.INSTANCE);
+        }
 
         final VirtualMap map3 = map2.copy();
         map2.getHash();
         map2.release();
-        assertEventuallyTrue(map0::isMerged, Duration.ofMillis(1000), "Copy 1 should be merged");
+
+        assertEventuallyTrue(map1::isMerged, Duration.ofMillis(1000), "Copy 1 should be merged");
+        assertFalse(map1.isFlushed());
+
+        // map2: all changes from map1, plus some dirty leaves, plus some dirty hashes, plus
+        // concurrent arrays overhead - about 84K total. Garbage is 2K dirty leaves and 3K
+        // dirty hashes - 5K garbage, which is slightly above 6%. Garbage threshold is set to 5%,
+        // so map2 should be GCed+merged rather than flushed
+
+        Thread.sleep(500);
+        assertFalse(map2.isFlushed()); // Above garbage threshold -> no flush
+        assertFalse(map2.isMerged()); // map3 is not released yet, can't merge
+
+        final VirtualMap map4 = map3.copy();
+        map3.getHash();
+        map3.release();
+
+        assertEventuallyTrue(map2::isMerged, Duration.ofMillis(1000), "Copy 2 should be merged");
+
+        map4.release();
+    }
+
+    // This test case is quite similar to garbageAboveThresholdResultsInGC() above, except
+    // the garbage threshold is set to 7% instead of 5%. It should trigger a GC + merge
+    // instead of a flush. Size math for all copies is the same, see comments in the
+    // previous test
+    @Test
+    void garbageBelowThresholdResultsInFlush() throws InterruptedException {
+        final int size = 63;
+        final Configuration config = ConfigurationBuilder.create()
+                .autoDiscoverExtensions()
+                .withValue("virtualMap.copyFlushCandidateThreshold", "64000")
+                // Enable flushes, if garbage is less than 50%
+                .withValue("virtualMap.percentFlushGarbageThreshold", "7")
+                .build();
+        final VirtualMap map0 = createMap(config);
+
+        for (int i = 0; i < size; i++) {
+            map0.put(TestKey.longToKey(i), new TestValue("" + i), TestValueCodec.INSTANCE);
+        }
+        final VirtualMap map1 = map0.copy();
+        map0.getHash();
+        map0.release();
+
+        Thread.sleep(500);
+        assertFalse(map0.isFlushed()); // Flush threshold not exceeded
+        assertFalse(map0.isMerged()); // Next copy is not released yet, can't merge
+
+        final VirtualMap map2 = map1.copy();
+        map1.getHash();
+        map1.release();
+
+        assertEventuallyTrue(map0::isMerged, Duration.ofMillis(1000), "Copy 0 must be merged");
+        assertFalse(map0.isFlushed());
+
+        for (int i = 0; i < size; i++) {
+            map2.put(TestKey.longToKey(i), new TestValue("u" + i), TestValueCodec.INSTANCE);
+        }
+
+        final VirtualMap map3 = map2.copy();
+        map2.getHash();
+        map2.release();
+
+        assertEventuallyTrue(map1::isMerged, Duration.ofMillis(1000), "Copy 1 should be merged");
+        assertFalse(map1.isFlushed());
+
         assertEventuallyTrue(map2::isFlushed, Duration.ofMillis(1000), "Copy 2 should be flushed");
+        assertFalse(map2.isMerged());
 
         map3.release();
     }
 
     @Test
     void garbageCollectRemovesDeletedLeaves() throws InterruptedException {
-        final int inMemorySizeThreshold = 10;
+        final int size = 10;
         final Configuration config = ConfigurationBuilder.create()
                 .autoDiscoverExtensions()
-                .withValue("virtualMap.inMemorySizeThreshold", "" + inMemorySizeThreshold)
+                // All copies are subject to flush or GC
                 .withValue("virtualMap.copyFlushCandidateThreshold", "1")
+                // Only zero garbage should result in a flush
+                .withValue("virtualMap.percentFlushGarbageThreshold", "0.01")
                 .build();
         final VirtualMap map0 = createMap(config);
 
-        for (int i = 0; i < inMemorySizeThreshold + 1; i++) {
+        for (int i = 0; i < size; i++) {
             map0.put(TestKey.longToKey(i), new TestValue("" + i), TestValueCodec.INSTANCE);
         }
-        assertTrue(map0.shouldBeFlushed()); // VM size exceeds in-memory threshold
 
         final VirtualMap map1 = map0.copy();
         map0.getHash();
+        // Zero garbage -> flush
+        assertTrue(map0.shouldBeFlushed());
         map0.release();
         map0.waitUntilFlushed();
 
-        // This removes one key and also brings VM size to below the in-memory threshold, so
-        // there should be no more flushes
-        final Bytes toDelete = TestKey.longToKey(inMemorySizeThreshold);
+        final Bytes toDelete = TestKey.longToKey(size - 1);
         map1.remove(toDelete);
-        assertFalse(map1.shouldBeFlushed());
 
         final VirtualMap map2 = map1.copy();
         map1.getHash();
+        // The deleted key results in a garbage mutation -> no flush, but GC
+        assertFalse(map1.shouldBeFlushed());
         map1.release();
 
         // Create one more copy, so map2 becomes immutable/destroyed, and map1 can be merged

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -25,6 +25,8 @@ import static org.mockito.Mockito.when;
 import com.hedera.pbj.runtime.Codec;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.base.state.MutabilityException;
+import com.swirlds.config.api.Configuration;
+import com.swirlds.config.api.ConfigurationBuilder;
 import com.swirlds.metrics.api.Counter;
 import com.swirlds.metrics.api.LongGauge;
 import com.swirlds.metrics.api.Metric;
@@ -1373,6 +1375,96 @@ class VirtualMapTests extends VirtualTestBase {
         map2.release();
         map3.release();
         map4.release();
+    }
+
+    @Test
+    void noFlushesBelowInMemoryThreshold() throws InterruptedException {
+        final int inMemorySizeThreshold = 10;
+        final Configuration config = ConfigurationBuilder.create()
+                .autoDiscoverExtensions()
+                .withValue("virtualMap.inMemorySizeThreshold", "" + inMemorySizeThreshold)
+                // Any copy should be flushed
+                .withValue("virtualMap.copyFlushCandidateThreshold", "1")
+                .build();
+        final VirtualMap map0 = createMap(config);
+
+        for (int i = 0; i < inMemorySizeThreshold; i++) {
+            map0.put(TestKey.longToKey(i), new TestValue("" + i), TestValueCodec.INSTANCE);
+        }
+        final VirtualMap map1 = map0.copy();
+        map0.getHash();
+        map0.release();
+
+        Thread.sleep(500);
+        assertFalse(map0.isFlushed());
+        assertFalse(map0.isMerged());
+
+        final VirtualMap map2 = map1.copy();
+        map1.getHash();
+        map1.release();
+
+        Thread.sleep(500);
+        assertFalse(map0.isFlushed());
+
+        // Add one more item to exceed the in-memory threshold
+        map2.put(TestKey.longToKey(11), new TestValue("11"), TestValueCodec.INSTANCE);
+
+        final VirtualMap map3 = map2.copy();
+        map2.getHash();
+        map2.release();
+        assertEventuallyTrue(map0::isMerged, Duration.ofMillis(1000), "Copy 1 should be merged");
+        assertEventuallyTrue(map2::isFlushed, Duration.ofMillis(1000), "Copy 2 should be flushed");
+
+        map3.release();
+    }
+
+    @Test
+    void garbageCollectRemovesDeletedLeaves() throws InterruptedException {
+        final int inMemorySizeThreshold = 10;
+        final Configuration config = ConfigurationBuilder.create()
+                .autoDiscoverExtensions()
+                .withValue("virtualMap.inMemorySizeThreshold", "" + inMemorySizeThreshold)
+                .withValue("virtualMap.copyFlushCandidateThreshold", "1")
+                .build();
+        final VirtualMap map0 = createMap(config);
+
+        for (int i = 0; i < inMemorySizeThreshold + 1; i++) {
+            map0.put(TestKey.longToKey(i), new TestValue("" + i), TestValueCodec.INSTANCE);
+        }
+        assertTrue(map0.shouldBeFlushed()); // VM size exceeds in-memory threshold
+
+        final VirtualMap map1 = map0.copy();
+        map0.getHash();
+        map0.release();
+        map0.waitUntilFlushed();
+
+        // This removes one key and also brings VM size to below the in-memory threshold, so
+        // there should be no more flushes
+        final Bytes toDelete = TestKey.longToKey(inMemorySizeThreshold);
+        map1.remove(toDelete);
+        assertFalse(map1.shouldBeFlushed());
+
+        final VirtualMap map2 = map1.copy();
+        map1.getHash();
+        map1.release();
+
+        // Create one more copy, so map2 becomes immutable/destroyed, and map1 can be merged
+        final VirtualMap map3 = map2.copy();
+        map2.getHash();
+        map2.release();
+
+        assertEventuallyTrue(map1::isMerged, Duration.ofMillis(1000), "Copy 1 should be merged");
+
+        // map1 is merged, and in-memory mode is on. The deleted key should be removed both from
+        // the cache and the data source
+        assertFalse(map2.containsKey(toDelete));
+        assertNull(map2.getBytes(toDelete));
+        assertNull(map2.getCache().lookupLeafByKey(toDelete));
+        assertFalse(map3.containsKey(toDelete));
+        assertNull(map3.getBytes(toDelete));
+        assertNull(map3.getCache().lookupLeafByKey(toDelete));
+
+        map3.release();
     }
 
     private void validateDeletedLeaves(

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualMapTests.java
@@ -765,7 +765,8 @@ class VirtualMapTests extends VirtualTestBase {
                     "Node cache size must increase");
         }
 
-        final long value = (long) metric.get(ValueType.VALUE);;
+        final long value = (long) metric.get(ValueType.VALUE);
+        ;
 
         final VirtualMap lastMap = map0;
         lastMap.enableFlush();

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualTestBase.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/VirtualTestBase.java
@@ -100,6 +100,10 @@ public class VirtualTestBase {
         return new VirtualLeafBytes<>(path, TestKey.longToKey(key), new TestValue(value), TestValueCodec.INSTANCE);
     }
 
+    protected VirtualLeafBytes<TestValue> leaf(long path, Bytes key, TestValue value) {
+        return new VirtualLeafBytes<>(path, key, value, TestValueCodec.INSTANCE);
+    }
+
     protected VirtualLeafBytes<TestValue> appleLeaf(long path) {
         lastALeaf = lastALeaf == null
                 ? new VirtualLeafBytes<>(path, A_KEY, APPLE, TestValueCodec.INSTANCE)

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCacheTest.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/cache/VirtualNodeCacheTest.java
@@ -48,6 +48,7 @@ import org.hiero.base.crypto.Cryptography;
 import org.hiero.base.crypto.CryptographyException;
 import org.hiero.base.crypto.Hash;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Tag;
@@ -2669,6 +2670,112 @@ class VirtualNodeCacheTest extends VirtualTestBase {
         final List<VirtualLeafBytes> dirtyLeaves =
                 snapshot.dirtyLeavesForFlush(1, 3).toList();
         assertFalse(dirtyLeaves.isEmpty(), "Snapshot should have dirty leaves for flush");
+    }
+
+    @Test
+    @DisplayName("Basic garbage collection")
+    void garbageCollectTest() {
+
+        final VirtualNodeCache cache0 = cache;
+        cache0.putLeaf(appleLeaf(8));
+        cache0.putLeaf(cherryLeaf(9));
+        cache0.putLeaf(eggplantLeaf(10));
+        cache0.putLeaf(figLeaf(11));
+
+        final VirtualNodeCache cache1 = cache0.copy();
+        cache1.putLeaf(bananaLeaf(12));
+        cache1.putLeaf(cuttlefishLeaf(19));
+        cache1.putLeaf(dateLeaf(13));
+        cache1.putLeaf(emuLeaf(20));
+        cache1.deleteLeaf(figLeaf(11));
+        cache0.prepareForHashing();
+        cache0.seal();
+
+        final VirtualNodeCache cache2 = cache1.copy();
+        cache2.putLeaf(dogLeaf(22));
+        cache2.putLeaf(leaf(30, E_KEY, EXOPLANET));
+        cache1.prepareForHashing();
+        cache1.seal();
+
+        cache2.prepareForHashing();
+        cache2.seal();
+
+        // Check cache0 contains leaves for C, E, and F. This will no longer be true after caches are
+        // merged and compacted
+        assertNotNull(cache0.lookupLeafByKey(C_KEY));
+        assertNotNull(cache0.lookupLeafByKey(E_KEY));
+        assertNotNull(cache0.lookupLeafByKey(F_KEY));
+        // cache1 contains leaf F, but it's deleted in version 1, so the leaf is actually just a marker
+        assertNotNull(cache1.lookupLeafByKey(F_KEY));
+        assertEquals(-1, cache1.lookupLeafByKey(F_KEY).path());
+
+        final long cache0OrigSize = cache0.getEstimatedSize();
+        final long cache1OrigSize = cache1.getEstimatedSize();
+        final long cache2OrigSize = cache2.getEstimatedSize();
+
+        // Merge cache0 into cache1. Garbage collection here is basically a no-op
+        cache0.garbageCollect();
+        cache0.merge();
+        final List<TestValue> expected1 = asList(APPLE, BANANA, CUTTLEFISH, DATE, EMU, null, null);
+        validateCache(cache1, expected1);
+        final long cache1MergedSize = cache1.getEstimatedSize();
+        assertTrue(cache1MergedSize == cache0OrigSize + cache1OrigSize);
+
+        // Merge cache1 into cache2. cache1 contains two mutations for E_KEY: EGGPLANT in version 0
+        // and EMU in version 1. The older one must be removed during garbage collection. The merged
+        // cache2 will then contain two mutations for this key: EMU from merged cache1 and
+        // EXOPLANET from version 2. One entry should be removed for C_KEY, too
+        cache1.garbageCollect();
+        cache1.merge();
+        final List<TestValue> expected2 = asList(APPLE, BANANA, CUTTLEFISH, DOG, EXOPLANET, null, null);
+        validateCache(cache2, expected2);
+        final long cache2MergedSize = cache2.getEstimatedSize();
+        assertTrue(cache2MergedSize < cache0OrigSize + cache1OrigSize + cache2OrigSize);
+        assertTrue(cache2MergedSize < cache1MergedSize + cache2OrigSize);
+        // There is no VirtualNodeCache API to check some mutations are really purged from shared
+        // node cache maps. A workaround is to query cache0. If it can't find a leaf, this must
+        // indicate the old mutation for version 0 is purged
+        assertNull(cache0.lookupLeafByKey(C_KEY));
+        assertNull(cache0.lookupLeafByKey(E_KEY));
+        assertNull(cache0.lookupLeafByKey(F_KEY));
+        // Now mutations for key F should be purged from caches completely. No marker (deleted) leaves
+        assertNull(cache1.lookupLeafByKey(F_KEY));
+        assertNull(cache2.lookupLeafByKey(F_KEY));
+    }
+
+    @Test
+    void garbageCollectRemovesDeletedMutations() {
+        final VirtualNodeCache cache0 = cache;
+        for (int i = 0; i < 10; i++) {
+            cache0.putLeaf(leaf(100 + i, 100 + i, i));
+        }
+
+        final VirtualNodeCache cache1 = cache0.copy();
+        cache0.prepareForHashing();
+        cache0.seal();
+        for (int i = 0; i < 10; i++) {
+            cache1.deleteLeaf(leaf(100 + i, 100 + i, i));
+            cache1.putLeaf(leaf(200 + i, 200 + i, i));
+        }
+
+        cache1.copy();
+        cache1.prepareForHashing();
+        cache1.seal();
+        cache0.merge();
+        final List<VirtualLeafBytes> deleted1Leaves = cache1.deletedLeaves().toList();
+        for (int i = 0; i < 10; i++) {
+            Assertions.assertTrue(deleted1Leaves.contains(leaf(100 + i, 100 + i, i)));
+            // DELETED_LEAF_RECORD indicates the cache contains a mutation, but it's deleted
+            Assertions.assertEquals(DELETED_LEAF_RECORD, cache1.lookupLeafByPath(100 + i));
+            Assertions.assertEquals(DELETED_LEAF_RECORD, cache1.lookupLeafByKey(TestKey.longToKey(100 + i)));
+        }
+
+        cache1.garbageCollect();
+        for (int i = 0; i < 10; i++) {
+            // Check that the deleted mutations have been removed from the cache
+            Assertions.assertNull(cache1.lookupLeafByPath(100 + i));
+            Assertions.assertNull(cache1.lookupLeafByKey(TestKey.longToKey(100 + i)));
+        }
     }
 
     // ----------------------------------------------------------------------

--- a/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
+++ b/platform-sdk/swirlds-virtualmap/src/test/java/com/swirlds/virtualmap/internal/pipeline/VirtualPipelineTests.java
@@ -130,16 +130,6 @@ class VirtualPipelineTests {
                 // The oldest undestroyed copy has been found, and it's older than this copy
                 if (copy.shouldBeFlushed()) {
                     assertFalse(copy.isFlushed(), "only the oldest copy can be flushed. Copy #" + copy.getCopyIndex());
-                } else {
-                    if (copy.isDestroyed() && copy.isImmutable()) {
-                        final DummyVirtualRoot next = index + 1 < copies.size() ? copies.get(index + 1) : null;
-                        if (next != null && next.isImmutable()) {
-                            interruptOnTimeout(
-                                    2_000,
-                                    copy::waitUntilMerged,
-                                    "copy should quickly become merged. Copy #" + copy.getCopyIndex());
-                        }
-                    }
                 }
             } else {
                 // The oldest undestroyed copy has not yet been encountered
@@ -687,13 +677,9 @@ class VirtualPipelineTests {
             copies.get(i).release();
         }
 
-        copies.get(4).waitUntilMerged();
         for (int i = 0; i < copyCount; i++) {
             DummyVirtualRoot copy = copies.get(i);
             assertFalse(copy.isFlushed(), "Copy should not yet be flushed");
-            if ((i != 0) && (i < 5)) {
-                assertTrue(copy.isMerged(), "Copy should be merged by now " + copy.getCopyIndex());
-            }
         }
 
         copies.get(0).release();

--- a/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/VirtualMapTestUtils.java
+++ b/platform-sdk/swirlds-virtualmap/src/testFixtures/java/com/swirlds/virtualmap/test/fixtures/VirtualMapTestUtils.java
@@ -39,8 +39,12 @@ public final class VirtualMapTestUtils {
             DEFAULT_CONFIGURATION.getConfigData(VirtualMapConfig.class);
 
     public static VirtualMap createMap() {
+        return createMap(DEFAULT_CONFIGURATION);
+    }
+
+    public static VirtualMap createMap(final Configuration config) {
         final VirtualDataSourceBuilder builder = new InMemoryBuilder();
-        return new VirtualMap(builder, DEFAULT_CONFIGURATION);
+        return new VirtualMap(builder, config);
     }
 
     public static Hash hash(final long t) {


### PR DESCRIPTION
Fix summary:

* A new config is added to `VirtualMapConfig`: `percentFlushGarbageThreshold`
* This config is used, when estimated size of a VM copy exceeds the flush threshold. If redundant (garbage) data in the copy is less than `percentFlushGarbageThreshold` percent of estimated total copy size, then the copy is flushed to disk, as usual. Otherwise the copy gets garbage collected and then merged to the newer copy
* Estimated garbage size is done lazily
* Minor other improvements and cleanups
* Some new unit tests are added to check how the new config works

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/26845
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>
