### PR TITLE
chore: reduce Bouncy Castle usages further

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigs.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxSigs.java
@@ -24,13 +24,13 @@ public record EthTxSigs(byte[] publicKey, byte[] address) {
 
     private static final Logger logger = LogManager.getLogger(EthTxSigs.class);
 
-    // Per https://www.google.com/search?q=secp256k1+curve+n
-    // N = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
-    // or in decimal:
-    private static final BigInteger N =
+    /// secp256k1 curve N number. Per https://www.google.com/search?q=secp256k1+curve+n
+    /// N = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141
+    /// or in decimal:
+    public static final BigInteger SECP256K1_CURVE_N =
             new BigInteger("115792089237316195423570985008687907852837564279074904382605163141518161494337");
     // Lower-half boundary (N >> 1) by EIP-2 standard.
-    private static final BigInteger HALF_N = N.shiftRight(1);
+    private static final BigInteger HALF_N = SECP256K1_CURVE_N.shiftRight(1);
 
     public static EthTxSigs extractSignatures(EthTxData ethTx) {
         final var message = calculateSignableMessage(ethTx);
@@ -155,7 +155,7 @@ public record EthTxSigs(byte[] publicKey, byte[] address) {
 
         byte[] dataHash = MiscCryptoUtils.keccak256DigestOf(message);
 
-        checkInBounds(r, N);
+        checkInBounds(r, SECP256K1_CURVE_N);
         checkInBounds(s, HALF_N);
         // The RLP library output won't include leading zeros, which means
         // a simple (r, s) concatenation breaks signature verification below

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/Secp256k1Utils.java
@@ -49,11 +49,16 @@ public class Secp256k1Utils {
     };
 
     public static byte[] extractEcdsaPublicKey(final ECPrivateKey key) {
+        return extractEcdsaPublicKey(asPrivateKeyByteArray32(key.getS()));
+    }
+
+    /// Extracts an ECDSA public key from a 32-bytes-long private key.
+    /// An IllegalArgumentException is thrown if the input isn't a 32 bytes array
+    /// or is otherwise an invalid private key.
+    public static byte[] extractEcdsaPublicKey(final byte[] privateKeyBytes) {
         final Cache cache = CACHE.get();
 
-        if (LIBSECP256K1.secp256k1EcPubkeyCreate(
-                        cache.pubkeySeg, MemorySegment.ofArray(asPrivateKeyByteArray32(key.getS())))
-                != 1) {
+        if (LIBSECP256K1.secp256k1EcPubkeyCreate(cache.pubkeySeg, MemorySegment.ofArray(privateKeyBytes)) != 1) {
             throw new IllegalArgumentException("secp256k1EcPubkeyCreate failed. The private key is probably invalid.");
         }
 
@@ -76,8 +81,13 @@ public class Secp256k1Utils {
     /// Returns an unsigned byte[] representation of a BigInteger, dropping the leading zero byte
     /// if present, aligning remaining bytes to the right, and padding with zeros to 32 bytes.
     public static byte[] asPrivateKeyByteArray32(final BigInteger value) {
-        final byte[] bytes = value.toByteArray();
+        return asPrivateKeyByteArray32(value.toByteArray());
+    }
 
+    /// Accepts an array of 33 or fewer bytes, dropping the leading "33rd" zero byte, aligning
+    /// remaining bytes to the right, and padding with zeros to 32 bytes if needed.
+    /// The result is a byte[32], or an IllegalArgumentException if the input is malformed.
+    public static byte[] asPrivateKeyByteArray32(final byte[] bytes) {
         if (bytes.length == 32) {
             return bytes;
         } else {

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -25,7 +25,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.HexFormat;
 import java.util.List;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
 import org.hiero.base.utility.CommonUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -33,8 +32,6 @@ import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 class EthTxDataTest {
-    private static final BigInteger N = SECNamedCurves.getByName("secp256k1").getN();
-
     static final String SIGNATURE_ADDRESS = "a94f5374fce5edbc8e2a8697c15331677e6ebf0b";
     static final String SIGNATURE_PUBKEY = "033a514176466fa815ed481ffad09110a2d344f6c9b78c1d14afc351c3a51be33d";
     static final String RAW_TX_TYPE_0 =
@@ -213,7 +210,7 @@ class EthTxDataTest {
     void extractSignatureThrowsWithInvalidR() {
         final var rCurvePointAtNEip155Tx = requireNonNull(
                         EthTxData.populateEthTxData(HexFormat.of().parseHex(EIP155_DEMO)))
-                .replaceR(N.toByteArray());
+                .replaceR(EthTxSigs.SECP256K1_CURVE_N.toByteArray());
         assertThrows(IllegalArgumentException.class, () -> EthTxSigs.extractSignatures(rCurvePointAtNEip155Tx));
         final var rCurvePointAt0Eip155Tx = requireNonNull(
                         EthTxData.populateEthTxData(HexFormat.of().parseHex(EIP155_DEMO)))
@@ -225,7 +222,7 @@ class EthTxDataTest {
     void extractSignatureThrowsWithInvalidS() {
         final var sCurvePointAtNEip155Tx = requireNonNull(
                         EthTxData.populateEthTxData(HexFormat.of().parseHex(EIP155_DEMO)))
-                .replaceS(N.toByteArray());
+                .replaceS(EthTxSigs.SECP256K1_CURVE_N.toByteArray());
         assertThrows(IllegalArgumentException.class, () -> EthTxSigs.extractSignatures(sCurvePointAtNEip155Tx));
         final var sCurvePointAt0Eip155Tx = requireNonNull(
                         EthTxData.populateEthTxData(HexFormat.of().parseHex(EIP155_DEMO)))

--- a/hedera-node/hedera-token-service-impl/build.gradle.kts
+++ b/hedera-node/hedera-token-service-impl/build.gradle.kts
@@ -19,6 +19,7 @@ testModuleInfo {
     requires("com.google.protobuf")
     requires("net.i2p.crypto.eddsa")
     requires("org.assertj.core")
+    requires("org.bouncycastle.provider")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.mockito")

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/BlocklistParser.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/BlocklistParser.java
@@ -4,20 +4,17 @@ package com.hedera.node.app.service.token.impl;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.node.app.hapi.utils.EthSigsUtils;
+import com.hedera.node.app.hapi.utils.keys.Secp256k1Utils;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.math.BigInteger;
 import java.util.Collections;
 import java.util.HexFormat;
 import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.bouncycastle.asn1.sec.SECNamedCurves;
-import org.bouncycastle.crypto.params.ECDomainParameters;
-import org.bouncycastle.crypto.params.ECPublicKeyParameters;
 
 /**
  * Encapsulates the logic for reading blocked accounts from file.
@@ -104,28 +101,9 @@ public class BlocklistParser {
             throw new IllegalArgumentException("Failed to decode line " + line, iae);
         }
 
-        final var publicKeyBytes = ecdsaPrivateToPublicKey(privateKeyBytes);
+        final var publicKeyBytes = Secp256k1Utils.extractEcdsaPublicKey(privateKeyBytes);
         final var evmAddressBytes = EthSigsUtils.recoverAddressFromPubKey(publicKeyBytes);
         return new BlockedInfo(Bytes.wrap(evmAddressBytes), parts[1]);
-    }
-
-    /**
-     * Derives the ECDSA public key bytes from the given ECDSA private key bytes.
-     *
-     * @param privateKeyBytes ECDSA private key bytes
-     * @return ECDSA public key bytes
-     */
-    private static byte[] ecdsaPrivateToPublicKey(byte[] privateKeyBytes) {
-        final var ecdsaSecp256K1Curve = SECNamedCurves.getByName("secp256k1");
-        final var ecdsaSecp256K1Domain = new ECDomainParameters(
-                ecdsaSecp256K1Curve.getCurve(),
-                ecdsaSecp256K1Curve.getG(),
-                ecdsaSecp256K1Curve.getN(),
-                ecdsaSecp256K1Curve.getH());
-        final var privateKeyData = new BigInteger(1, privateKeyBytes);
-        var q = ecdsaSecp256K1Domain.getG().multiply(privateKeyData);
-        var publicParams = new ECPublicKeyParameters(q, ecdsaSecp256K1Domain);
-        return publicParams.getQ().getEncoded(true);
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/module-info.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/module-info.java
@@ -38,6 +38,5 @@ module com.hedera.node.app.service.token.impl {
     requires com.github.spotbugs.annotations;
     requires com.google.common;
     requires org.apache.logging.log4j;
-    requires org.bouncycastle.provider;
     requires tuweni.bytes;
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/deterministic/Bip0032.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/keys/deterministic/Bip0032.java
@@ -9,15 +9,16 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.KeySpec;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 import javax.crypto.Mac;
+import javax.crypto.SecretKeyFactory;
 import javax.crypto.ShortBufferException;
+import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.SecretKeySpec;
 import net.i2p.crypto.eddsa.EdDSAPrivateKey;
-import org.bouncycastle.crypto.digests.SHA512Digest;
-import org.bouncycastle.crypto.generators.PKCS5S2ParametersGenerator;
-import org.bouncycastle.crypto.params.KeyParameter;
 
 public class Bip0032 {
     private static final int KEY_SIZE = 512;
@@ -43,10 +44,14 @@ public class Bip0032 {
     }
 
     public static byte[] seedFrom(String mnemonic) {
-        var salt = "mnemonic";
-        var gen = new PKCS5S2ParametersGenerator(new SHA512Digest());
-        gen.init(mnemonic.getBytes(UTF_8), salt.getBytes(UTF_8), ITERATIONS);
-        return ((KeyParameter) gen.generateDerivedParameters(KEY_SIZE)).getKey();
+        final String salt = "mnemonic";
+        final KeySpec spec = new PBEKeySpec(mnemonic.toCharArray(), salt.getBytes(UTF_8), ITERATIONS, KEY_SIZE);
+        try {
+            final SecretKeyFactory factory = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA512");
+            return factory.generateSecret(spec).getEncoded();
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     public static byte[] privateKeyFrom(byte[] seed)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumTransactionCanonicalRlpTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/EthereumTransactionCanonicalRlpTest.java
@@ -31,6 +31,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import com.esaulpaugh.headlong.util.Integers;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.EthSigsUtils;
+import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.spec.SpecOperation;
@@ -39,7 +40,6 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.stream.Stream;
-import org.bouncycastle.jcajce.provider.digest.Keccak;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
@@ -107,8 +107,9 @@ public class EthereumTransactionCanonicalRlpTest {
                         .via("canonicalAfterRefusal")
                         .hasKnownStatus(SUCCESS),
                 getTxnRecord("canonicalAfterRefusal")
-                        .hasPriority(
-                                recordWith().status(SUCCESS).ethereumHash(ByteString.copyFrom(keccak256(canonical)))),
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .ethereumHash(ByteString.copyFrom(MiscCryptoUtils.keccak256DigestOf(canonical)))),
                 getAutoCreatedAccountBalance(REJECTION_SENDER.recipientKey())
                         .hasTinyBars(changeFromSnapshot("rejectionRecipientBefore", TRANSFER_TINYBARS)),
                 getAliasedAccountInfo(REJECTION_SENDER.senderKey())
@@ -134,8 +135,9 @@ public class EthereumTransactionCanonicalRlpTest {
                         .via("exactSubmission")
                         .hasKnownStatus(SUCCESS),
                 getTxnRecord("exactSubmission")
-                        .hasPriority(
-                                recordWith().status(SUCCESS).ethereumHash(ByteString.copyFrom(keccak256(canonical)))),
+                        .hasPriority(recordWith()
+                                .status(SUCCESS)
+                                .ethereumHash(ByteString.copyFrom(MiscCryptoUtils.keccak256DigestOf(canonical)))),
                 getAutoCreatedAccountBalance(CANONICAL_SENDER.recipientKey())
                         .hasTinyBars(changeFromSnapshot("canonicalRecipientBefore", TRANSFER_TINYBARS)),
                 getAliasedAccountInfo(CANONICAL_SENDER.senderKey())
@@ -163,10 +165,6 @@ public class EthereumTransactionCanonicalRlpTest {
         final var extended = Arrays.copyOf(canonical, canonical.length + 1);
         extended[canonical.length] = TRAILING_BYTE;
         return extended;
-    }
-
-    private static byte[] keccak256(final byte[] bytes) {
-        return new Keccak.Digest256().digest(bytes);
     }
 
     /// Left-pads `value` to a 32-byte secp256k1 private key.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/utils/Signing.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/utils/Signing.java
@@ -20,7 +20,6 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.lang.foreign.MemorySegment;
 import java.math.BigInteger;
 import org.apache.tuweni.bytes.Bytes;
-import org.bouncycastle.math.ec.rfc8032.Ed25519;
 
 /**
  * Utility methods for signing messages
@@ -82,13 +81,6 @@ public final class Signing {
         System.arraycopy(sig, 0, result, 0, 64);
         result[64] = (byte) (recId[0] + 27);
         return result;
-    }
-
-    public static byte[] signMessageEd25519(final byte[] message, byte[] privateKey) {
-        byte[] signature = new byte[Ed25519.SIGNATURE_SIZE];
-        Ed25519.sign(privateKey, 0, message, 0, message.length, signature, 0);
-
-        return signature;
     }
 
     public static Object[] signCodeDelegation(


### PR DESCRIPTION
**Description**:
Replacing a few more Bouncy Castle usages for which we have alternatives.

All the remaining usages require either adding new APIs to hiero-cryptography (which we cannot do temporarily due to backward-incompatible changes there), using or replicating JDK preview APIs (such as for PEM files handling), or developing a deeper expertise and reimplementing certain logic (such as ECPrivateKey objects handling for secp256k1.) So we'll tackle these remaining usages in the future.

**Related issue(s)**:

Fixes #26938

**Notes for reviewer**:
All tests should pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
