### PR TITLE
fix: bound long-running Solo deployment steps in XTS panels with step-level timeouts

### DIFF
--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -149,6 +149,7 @@ jobs:
 
       # Set up solo
       - name: Configure and run solo
+        timeout-minutes: 15
         env:
           INPUT_MIRROR_NODE_VERSION: ${{ inputs.mirror-node-version }}
         run: |

--- a/.github/workflows/820-call-mirror-node-regression.yaml
+++ b/.github/workflows/820-call-mirror-node-regression.yaml
@@ -105,6 +105,7 @@ jobs:
 
       - name: Configure and run solo
         id: run-solo
+        timeout-minutes: 15
         env:
           MIRROR_NODE_VERSION: ${{ inputs.mirror-node-version || '0.161.0' }}
         run: |

--- a/.github/workflows/821-call-block-node-regression.yaml
+++ b/.github/workflows/821-call-block-node-regression.yaml
@@ -366,6 +366,7 @@ jobs:
 
       # node deployment
       - name: Solo Nodes deployment (BN/CN/MN)
+        timeout-minutes: 15
         run: |
           solo block node add --deployment "${{ env.SOLO_DEPLOYMENT }}" --release-tag "${{ env.CN_LATEST_TAG }}" --cluster-ref kind-${{ env.SOLO_CLUSTER_NAME }} --chart-version "${{ env.BLOCK_NODE_TAG }}"
           solo keys consensus generate --gossip-keys --tls-keys -i node1 --deployment "${{ env.SOLO_DEPLOYMENT }}"

--- a/.github/workflows/825-call-migration-testing.yaml
+++ b/.github/workflows/825-call-migration-testing.yaml
@@ -114,6 +114,7 @@ jobs:
       #   4a) Mirror importer log scan for ERROR-level entries
       - name: Run migration test
         id: run-migration-tests
+        timeout-minutes: 25
         env:
           KEEP_NETWORK: "true" # keep kind alive so post-run log collection can reach it
         run: ./hedera-node/test-clients/scripts/solo/migration-testing/solo-migration-test.sh


### PR DESCRIPTION
## Summary

`Execute XTS / Block Node Regression Panel` failed with a grey "cancelled" icon on 3 consecutive reruns of [run 32512033889](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/32512033889), each ~1 hour in, while it passed cleanly in isolation ([run 32552625135](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/32552625135)).

Root cause: the `Solo Nodes deployment (BN/CN/MN)` step has no timeout of its own. It hung inside the Solo CLI's internal readiness poll — zero log output for ~55 minutes — until the job's blanket `timeout-minutes: 60` fired and force-cancelled the whole job. That's why it showed a grey "cancelled" icon instead of a red failure: no pass/fail signal was ever produced, just a timeout catching an unbounded step.

This PR adds a step-level `timeout-minutes` to that step and to every other XTS panel step with the same shape — a single long-running step that shells out to `solo` commands to stand up a kind/Solo network, with no bound of its own — so a hang fails fast with a clear step-timeout signal instead of silently riding the job-level timeout.

Sizes are ~3x each step's observed normal duration (from a recent successful run):

| Workflow | Step | Normal duration | New timeout |
|---|---|---|---|
| `821-call-block-node-regression.yaml` | `Solo Nodes deployment (BN/CN/MN)` | ~5m | 15m |
| `818-call-json-rpc-relay-regression.yaml` | `Configure and run solo` | ~3m45s | 15m |
| `820-call-mirror-node-regression.yaml` | `Configure and run solo` | ~4m11s | 15m |
| `825-call-migration-testing.yaml` | `Run migration test` | ~8m28s | 25m |

`826-call-solo-078-to-079-cutover.yaml` was checked and already wraps its deploy/cutover script in its own shell-level `timeout --signal=SIGINT --kill-after=5m 100m ...` guard, so it's excluded — already protected against this exact failure mode.

Out of scope: HAPI/Otter/Hammer/Timing-Sensitive/JRS panels — different risk profile (bounded test suites, not unbounded infra-provisioning steps), not part of the identified pattern.

## Test plan

- [x] All four edited files parse as valid YAML (`ruby -ryaml`)
- [x] Diff reviewed — exactly the four one-line `timeout-minutes` insertions, nothing else changed
- [x] Observe next CITR XTS run: normal runs unaffected (all four steps finish well under their new caps) 
https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/32594619651
- [ ] a recurrence of the hang should now show a named step timeout instead of an hour-long grey "cancelled" job
