### PR TITLE
test: cover platform-active status independence of committed TSS reconciliation state

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsControllerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsControllerImplTest.java
@@ -1021,6 +1021,105 @@ class HintsControllerImplTest {
                 onHintsFinished);
     }
 
+    // --- Platform-active status independence of committed state ---
+    // The node-local platform-active flag must never change what is written to the (Merkle-backed)
+    // hints store: the store writes are functions of consensus time and state, so they occur with the
+    // same values whether or not this node is ACTIVE. isActive gates only this node's own async
+    // self-submission of its contribution (a gossip action that itself writes no state). Each test
+    // below mirrors an isActive=true test above and asserts the same consensus-derived store write.
+
+    @Test
+    void setsPreprocessingStartTimeEvenWhenNodeIsNotActive() {
+        setupWith(UNFINISHED_CONSTRUCTION);
+        given(weights.targetNodeWeights()).willReturn(TARGET_NODE_WEIGHTS);
+        given(weights.numTargetNodesInSource()).willReturn(2);
+        given(store.setPreprocessingStartTime(UNFINISHED_CONSTRUCTION.constructionId(), PREPROCESSING_START_TIME))
+                .willReturn(CONSTRUCTION_WITH_START_TIME);
+
+        subject.addHintsKeyPublication(EXPECTED_NODE_ONE_PUBLICATION, INITIAL_CRS);
+        subject.addHintsKeyPublication(TARDY_NODE_TWO_PUBLICATION, INITIAL_CRS);
+        given(library.validateHintsKey(any(), any(), anyInt(), anyInt())).willReturn(true);
+        runScheduledTasks();
+
+        subject.advanceConstruction(PREPROCESSING_START_TIME, store, false);
+
+        // State write uses the consensus timestamp, regardless of node-local ACTIVE status
+        verify(store).setPreprocessingStartTime(UNFINISHED_CONSTRUCTION.constructionId(), PREPROCESSING_START_TIME);
+        // ...but the node does not schedule/submit its own preprocessing vote when not ACTIVE
+        assertTrue(scheduledTasks.isEmpty());
+        verify(submissions, never()).submitHintsVote(eq(CONSTRUCTION_ID), any(PreprocessedKeys.class));
+    }
+
+    @Test
+    void movesToNextNodeEvenWhenNodeIsNotActive() {
+        setupWith(UNFINISHED_CONSTRUCTION);
+
+        given(store.getCrsState())
+                .willReturn(CRSState.newBuilder()
+                        .stage(CRSStage.GATHERING_CONTRIBUTIONS)
+                        .nextContributingNodeId(1L)
+                        .contributionEndTime(asTimestamp(CONSENSUS_NOW.minus(Duration.ofSeconds(7))))
+                        .crs(INITIAL_CRS)
+                        .build());
+
+        given(weights.sourceNodeIds()).willReturn(SOURCE_NODE_IDS);
+        subject.setFinalCrsFuture(
+                CompletableFuture.completedFuture(new HintsControllerImpl.CRSValidation(INITIAL_CRS, 1)));
+
+        subject.advanceCrsWork(CONSENSUS_NOW, store, false);
+
+        // State write happens regardless of node-local ACTIVE status
+        verify(store).moveToNextNode(2L, CONSENSUS_NOW.plus(Duration.ofSeconds(10)));
+    }
+
+    @Test
+    void advancesCrsStateEvenWhenNodeIsNotActive() {
+        setupWith(UNFINISHED_CONSTRUCTION);
+
+        given(store.getCrsState())
+                .willReturn(CRSState.newBuilder()
+                        .stage(CRSStage.WAITING_FOR_ADOPTING_FINAL_CRS)
+                        .nextContributingNodeId(null)
+                        .contributionEndTime(asTimestamp(CONSENSUS_NOW.minus(Duration.ofSeconds(7))))
+                        .crs(INITIAL_CRS)
+                        .build());
+        given(weights.sourceNodeWeights()).willReturn(SOURCE_NODE_WEIGHTS);
+        subject.setFinalCrsFuture(
+                CompletableFuture.completedFuture(new HintsControllerImpl.CRSValidation(INITIAL_CRS, 1)));
+
+        subject.advanceCrsWork(CONSENSUS_NOW, store, false);
+
+        // CRS state transition is written regardless of node-local ACTIVE status
+        verify(store)
+                .setCrsState(CRSState.newBuilder()
+                        .stage(CRSStage.GATHERING_CONTRIBUTIONS)
+                        .nextContributingNodeId(0L)
+                        .contributionEndTime(asTimestamp(CONSENSUS_NOW.plus(Duration.ofSeconds(10))))
+                        .crs(INITIAL_CRS)
+                        .build());
+    }
+
+    @Test
+    void doesNotSelfSubmitCrsUpdateWhenNodeIsNotActive() {
+        setupWith(UNFINISHED_CONSTRUCTION);
+
+        given(store.getCrsState())
+                .willReturn(CRSState.newBuilder()
+                        .stage(CRSStage.GATHERING_CONTRIBUTIONS)
+                        .nextContributingNodeId(SELF_ID)
+                        .contributionEndTime(asTimestamp(CONSENSUS_NOW.plus(Duration.ofSeconds(7))))
+                        .crs(INITIAL_CRS)
+                        .build());
+        // drain any task scheduled during setup
+        while (scheduledTasks.poll() != null) {}
+
+        subject.advanceCrsWork(CONSENSUS_NOW, store, false);
+
+        // Only the node-local self-submission is gated by isActive: no task scheduled, nothing submitted
+        assertTrue(scheduledTasks.isEmpty());
+        verify(submissions, never()).submitCrsUpdate(any(), any());
+    }
+
     private void setupWith(@NonNull final HintsConstruction construction) {
         setupWith(
                 construction,

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsControllerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsControllerImplTest.java
@@ -1073,7 +1073,7 @@ class HintsControllerImplTest {
     }
 
     @Test
-    void advancesCrsStateEvenWhenNodeIsNotActive() {
+    void repeatsProcessEvenWhenNodeIsNotActive() {
         setupWith(UNFINISHED_CONSTRUCTION);
 
         given(store.getCrsState())
@@ -1110,14 +1110,77 @@ class HintsControllerImplTest {
                         .contributionEndTime(asTimestamp(CONSENSUS_NOW.plus(Duration.ofSeconds(7))))
                         .crs(INITIAL_CRS)
                         .build());
-        // drain any task scheduled during setup
-        while (scheduledTasks.poll() != null) {}
+        assertTrue(scheduledTasks.isEmpty());
 
         subject.advanceCrsWork(CONSENSUS_NOW, store, false);
 
         // Only the node-local self-submission is gated by isActive: no task scheduled, nothing submitted
         assertTrue(scheduledTasks.isEmpty());
         verify(submissions, never()).submitCrsUpdate(any(), any());
+    }
+
+    @Test
+    void setsFinalCrsIfAllIdsCompletedEvenWhenNodeIsNotActive() {
+        setupWith(UNFINISHED_CONSTRUCTION);
+
+        given(store.getCrsState())
+                .willReturn(CRSState.newBuilder()
+                        .stage(CRSStage.GATHERING_CONTRIBUTIONS)
+                        .nextContributingNodeId(null)
+                        .crs(INITIAL_CRS)
+                        .build());
+
+        subject.advanceCrsWork(CONSENSUS_NOW, store, false);
+
+        // The GATHERING -> WAITING_FOR_ADOPTING_FINAL_CRS transition is written regardless of ACTIVE status
+        verify(store)
+                .setCrsState(CRSState.newBuilder()
+                        .stage(CRSStage.WAITING_FOR_ADOPTING_FINAL_CRS)
+                        .nextContributingNodeId(null)
+                        .contributionEndTime(asTimestamp(CONSENSUS_NOW.plus(Duration.ofSeconds(5))))
+                        .crs(INITIAL_CRS)
+                        .build());
+    }
+
+    @Test
+    void setsFinalCrsAndRemovesContributionEndTimeEvenWhenNodeIsNotActive() {
+        setupWith(UNFINISHED_CONSTRUCTION);
+
+        given(store.getCrsState())
+                .willReturn(CRSState.newBuilder()
+                        .stage(CRSStage.WAITING_FOR_ADOPTING_FINAL_CRS)
+                        .nextContributingNodeId(null)
+                        .contributionEndTime(asTimestamp(CONSENSUS_NOW.minus(Duration.ofSeconds(7))))
+                        .crs(INITIAL_CRS)
+                        .build());
+        given(weights.sourceNodeWeights()).willReturn(SOURCE_NODE_WEIGHTS);
+        subject.setFinalCrsFuture(
+                CompletableFuture.completedFuture(new HintsControllerImpl.CRSValidation(INITIAL_CRS, 18)));
+
+        subject.advanceCrsWork(CONSENSUS_NOW, store, false);
+
+        // The threshold-met -> COMPLETED adoption is written regardless of ACTIVE status
+        verify(store)
+                .setCrsState(CRSState.newBuilder()
+                        .crs(INITIAL_CRS)
+                        .stage(CRSStage.COMPLETED)
+                        .nextContributingNodeId(null)
+                        .contributionEndTime((Timestamp) null)
+                        .build());
+    }
+
+    @Test
+    void doesNotPublishHintsKeyWhenNodeIsNotActive() {
+        setupWith(UNFINISHED_CONSTRUCTION);
+        // remove crs publication task
+        scheduledTasks.poll();
+        given(weights.numTargetNodesInSource()).willReturn(2);
+
+        subject.advanceConstruction(PREPROCESSING_START_TIME, store, false);
+
+        // isActive=false gates this node's own hinTS-key publication: nothing scheduled or submitted
+        assertNull(scheduledTasks.poll());
+        verify(submissions, never()).submitHintsKey(anyInt(), anyInt(), any());
     }
 
     private void setupWith(@NonNull final HintsConstruction construction) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsControllerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/HintsControllerImplTest.java
@@ -1175,12 +1175,18 @@ class HintsControllerImplTest {
         // remove crs publication task
         scheduledTasks.poll();
         given(weights.numTargetNodesInSource()).willReturn(2);
+        given(weights.targetNodeWeights()).willReturn(new TreeMap<>(Map.of(SELF_ID, 1L)));
+        given(weights.targetIncludes(SELF_ID)).willReturn(true);
 
+        // Inactive node: even with every publication precondition satisfied (targetIncludes(SELF_ID)=true),
+        // isActive=false gates this node's own hinTS-key publication -- nothing is scheduled or submitted.
         subject.advanceConstruction(PREPROCESSING_START_TIME, store, false);
-
-        // isActive=false gates this node's own hinTS-key publication: nothing scheduled or submitted
         assertNull(scheduledTasks.poll());
         verify(submissions, never()).submitHintsKey(anyInt(), anyInt(), any());
+
+        // Identical state, active node: the publication task IS now scheduled -- proving isActive is the sole gate.
+        subject.advanceConstruction(PREPROCESSING_START_TIME, store, true);
+        assertNotNull(scheduledTasks.poll());
     }
 
     private void setupWith(@NonNull final HintsConstruction construction) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/ProofControllerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/ProofControllerImplTest.java
@@ -371,6 +371,21 @@ class ProofControllerImplTest {
     }
 
     @Test
+    void setsAssemblyTimeEvenWhenNodeIsNotActive() {
+        // With every target node's proof key present (none expected here), assembly starts now. The
+        // resulting store write uses the consensus timestamp and must occur regardless of whether this
+        // node is ACTIVE; only the node's own proof-key self-submission is gated by ACTIVE status.
+        given(weights.numTargetNodesInSource()).willReturn(0);
+        given(writableHistoryStore.setAssemblyTime(CONSTRUCTION_ID, Instant.EPOCH.plusSeconds(1)))
+                .willReturn(construction);
+
+        subject.advanceConstruction(Instant.EPOCH.plusSeconds(1), METADATA, writableHistoryStore, false, tssConfig);
+
+        verify(writableHistoryStore).setAssemblyTime(CONSTRUCTION_ID, Instant.EPOCH.plusSeconds(1));
+        verify(submissions, never()).submitProofKeyPublication(any());
+    }
+
+    @Test
     void advanceConstructionDelegatesToProverWhenAssemblyStartedAndInactive() {
         construction = HistoryProofConstruction.newBuilder()
                 .constructionId(CONSTRUCTION_ID)

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/ProofControllerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/ProofControllerImplTest.java
@@ -372,9 +372,11 @@ class ProofControllerImplTest {
 
     @Test
     void setsAssemblyTimeEvenWhenNodeIsNotActive() {
-        // With every target node's proof key present (none expected here), assembly starts now. The
-        // resulting store write uses the consensus timestamp and must occur regardless of whether this
-        // node is ACTIVE; only the node's own proof-key self-submission is gated by ACTIVE status.
+        // With every target node's proof key present (none expected here) assembly starts now, so the
+        // assembly-time write uses the consensus timestamp regardless of ACTIVE status. This branch returns
+        // right after that write and never reaches the publish step in either state, so the never-publish
+        // check below is incidental — the ACTIVE-gating of proof-key publication itself is proven by
+        // advanceConstructionPublishesKeyWhenMetadataMissingAndActive / ...DoesNotPublishKeyWhenInactive.
         given(weights.numTargetNodesInSource()).willReturn(0);
         given(writableHistoryStore.setAssemblyTime(CONSTRUCTION_ID, Instant.EPOCH.plusSeconds(1)))
                 .willReturn(construction);
@@ -537,6 +539,83 @@ class ProofControllerImplTest {
 
         verify(writableHistoryStore).getLedgerId();
         verify(prover).advance(eq(now), eq(construction), eq(METADATA), any(), eq(tssConfig), any(), eq(true));
+        verify(writableHistoryStore).failForReason(CONSTRUCTION_ID, reason);
+    }
+
+    @Test
+    void finishesProofEvenWhenNodeIsNotActive() {
+        construction = HistoryProofConstruction.newBuilder()
+                .constructionId(CONSTRUCTION_ID)
+                .assemblyStartTime(asTimestamp(Instant.EPOCH))
+                .build();
+        subject = new ProofControllerImpl(
+                SELF_ID,
+                keyPair,
+                construction,
+                weights,
+                executor,
+                submissions,
+                machine,
+                keyPublications,
+                wrapsMessagePublications,
+                existingVotes,
+                historyService,
+                historyLibrary,
+                proverFactory,
+                null,
+                historyProofMetrics,
+                DEFAULT_TSS_CONFIG);
+
+        final var proof = aValidProof();
+        given(writableHistoryStore.getLedgerId()).willReturn(Bytes.EMPTY);
+        given(prover.advance(any(), any(), any(), any(), eq(tssConfig), any(), anyBoolean()))
+                .willReturn(new HistoryProver.Outcome.Completed(proof));
+        given(writableHistoryStore.completeProof(CONSTRUCTION_ID, proof)).willReturn(construction);
+
+        final var now = Instant.EPOCH.plusSeconds(1);
+        subject.advanceConstruction(now, METADATA, writableHistoryStore, false, tssConfig);
+
+        // The Completed-outcome commit write happens regardless of ACTIVE status; isActive only rides
+        // into prover.advance as the can-submit flag.
+        verify(prover).advance(eq(now), eq(construction), eq(METADATA), any(), eq(tssConfig), any(), eq(false));
+        verify(writableHistoryStore).completeProof(CONSTRUCTION_ID, proof);
+    }
+
+    @Test
+    void failsConstructionEvenWhenNodeIsNotActive() {
+        construction = HistoryProofConstruction.newBuilder()
+                .constructionId(CONSTRUCTION_ID)
+                .assemblyStartTime(asTimestamp(Instant.EPOCH))
+                .build();
+        subject = new ProofControllerImpl(
+                SELF_ID,
+                keyPair,
+                construction,
+                weights,
+                executor,
+                submissions,
+                machine,
+                keyPublications,
+                wrapsMessagePublications,
+                existingVotes,
+                historyService,
+                historyLibrary,
+                proverFactory,
+                null,
+                historyProofMetrics,
+                DEFAULT_TSS_CONFIG);
+
+        final var reason = "test-failure";
+        given(writableHistoryStore.getLedgerId()).willReturn(Bytes.EMPTY);
+        given(prover.advance(any(), any(), any(), any(), eq(tssConfig), any(), anyBoolean()))
+                .willReturn(new HistoryProver.Outcome.Failed(reason));
+        given(writableHistoryStore.failForReason(CONSTRUCTION_ID, reason)).willReturn(construction);
+
+        final var now = Instant.EPOCH.plusSeconds(1);
+        subject.advanceConstruction(now, METADATA, writableHistoryStore, false, tssConfig);
+
+        // The Failed-outcome commit write happens regardless of ACTIVE status.
+        verify(prover).advance(eq(now), eq(construction), eq(METADATA), any(), eq(tssConfig), any(), eq(false));
         verify(writableHistoryStore).failForReason(CONSTRUCTION_ID, reason);
     }
 


### PR DESCRIPTION
## Description

Adds regression-guard unit tests around the TSS reconciliation path in the handle
workflow, pinning down an important determinism property: the node-local
platform-active flag (`isActive`) must never change what is written to the
Merkle-backed hinTS/history stores.

In `HintsControllerImpl.advanceConstruction`/`advanceCrsWork` and
`ProofControllerImpl.advanceConstruction`, the store writes are functions of
consensus time and consensus state. `isActive` is used only to gate a node's own
asynchronous self-submission of its contribution (preprocessing vote, CRS update,
hinTS/proof key publication) — a gossip action that writes no state. The existing
tests only exercised these methods with `isActive=true`, so nothing guarded the
flag-independence of the committed writes.

## Tests added (no production code changed)

`HintsControllerImplTest`:
- `setsPreprocessingStartTimeEvenWhenNodeIsNotActive` — the preprocessing-start-time
  write occurs with the consensus timestamp when `isActive=false`; the node's own
  vote is not submitted.
- `movesToNextNodeEvenWhenNodeIsNotActive` — the `moveToNextNode` write occurs with
  the same consensus-derived arguments when `isActive=false`.
- `advancesCrsStateEvenWhenNodeIsNotActive` — the CRS state transition is written
  identically when `isActive=false`.
- `doesNotSelfSubmitCrsUpdateWhenNodeIsNotActive` — when `isActive=false`, no CRS
  update is self-submitted and no async task is scheduled.

`ProofControllerImplTest`:
- `setsAssemblyTimeEvenWhenNodeIsNotActive` — the assembly-time write occurs with the
  consensus timestamp when `isActive=false`; the node's own proof key is not published.

Each test mirrors an existing `isActive=true` test and asserts the same
consensus-derived store write via exact-argument matchers, so any future change that
makes a committed write depend on `isActive` will fail these tests.

## Related issue(s)

N/A
