### PR TITLE
build: reduce redundancy in 'test-clients/build.gradle.kts'

### DIFF
--- a/hedera-node/test-clients/build.gradle.kts
+++ b/hedera-node/test-clients/build.gradle.kts
@@ -95,37 +95,6 @@ tasks.register<JavaExec>("runTestClient") {
     mainClass = providers.gradleProperty("testClient")
 }
 
-tasks.test {
-    testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = configurations.testRuntimeClasspath.get().plus(files(tasks.jar))
-
-    // Unlike other tests, these intentionally corrupt embedded state to test FAIL_INVALID
-    // code paths; hence we do not run LOG_VALIDATION after the test suite finishes
-    useJUnitPlatform { includeTags("(INTEGRATION|STREAM_VALIDATION)") }
-
-    systemProperty("junit.jupiter.execution.parallel.enabled", true)
-    systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
-    // Surprisingly, the Gradle JUnitPlatformTestExecutionListener fails to gather result
-    // correctly if test classes run in parallel (concurrent execution WITHIN a test class
-    // is fine). So we need to force the test classes to run in the same thread. Luckily this
-    // is not a huge limitation, as our test classes generally have enough non-leaky tests to
-    // get a material speed up. See https://github.com/gradle/gradle/issues/6453.
-    systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "same_thread")
-    systemProperty(
-        "junit.jupiter.testclass.order.default",
-        "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
-    )
-    // Tell our launcher to target an embedded network whose mode is set per-class
-    systemProperty("hapi.spec.embedded.mode", "per-class")
-
-    jvmArgs(
-        "--enable-native-access=com.hedera.common.nativesupport,com.hedera.cryptography.libsecp256k1,com.hedera.cryptography.libsodium"
-    )
-
-    // Scale heap and processor count to match available resources
-    jvmArgumentProviders.add(TestResourceArgumentsProvider())
-}
-
 val miscTags =
     "!(INTEGRATION|CRYPTO|TOKEN|RESTART|UPGRADE|SMART_CONTRACT|ND_RECONNECT|LONG_RUNNING|STATE_THROTTLING|ISS|BLOCK_NODE|GENESIS_SUBPROCESS|SIMPLE_FEES|ATOMIC_BATCH|WRAPS_DOWNLOAD)"
 val miscTagsSerial = "$miscTags&SERIAL"
@@ -255,7 +224,10 @@ val prCheckPlatformOverrides =
             "platformStatus.observingStatusDelay=10s,reconnect.minimumTimeBetweenReconnects=10s"
     )
 val prCheckPrepareUpgradeOffsets = mapOf("hapiTestAdhoc" to "PT300S")
-val prCheckAssertAtLeastOneWraps = setOf("hapiTestWraps", "hapiTestCutover")
+val prCheckAssertAtLeastOneWraps =
+    gradle.startParameter.taskNames.any { setOf("hapiTestWraps", "hapiTestCutover").contains(it) }
+val prCheckIsSimpleFeesEmbedded =
+    gradle.startParameter.taskNames.contains("hapiTestSimpleFeesEmbedded")
 // Path to the extracted WRAPS proving-key artifacts (decider_pp.bin, decider_vp.bin,
 // nova_pp.bin, nova_vp.bin); blank disables WRAPS proof assertions in the ceremony tests
 val tssLibWrapsArtifactsPath = System.getenv("TSS_LIB_WRAPS_ARTIFACTS_PATH") ?: ""
@@ -287,10 +259,52 @@ val prCheckNetSizeOverrides =
         "hapiTestWrapsDownload" to "3",
     )
 
+val embeddedBaseTags =
+    mapOf(
+        "hapiTestMiscEmbedded" to "EMBEDDED&!(SIMPLE_FEES|CRYPTO|ATOMIC_BATCH)",
+        "hapiTestSimpleFeesEmbedded" to "EMBEDDED&SIMPLE_FEES",
+        "hapiTestCryptoEmbedded" to "EMBEDDED&CRYPTO",
+        "hapiTestAtomicBatchEmbedded" to "EMBEDDED&ATOMIC_BATCH",
+    )
+val prEmbeddedCheckTags = embeddedBaseTags.mapValues { (_, tags) -> "($tags)" }
+
+val repeatableBaseTags = mapOf("hapiTestMiscRepeatable" to "REPEATABLE&!CRYPTO")
+val prRepeatableCheckTags = repeatableBaseTags.mapValues { (_, tags) -> "($tags)" }
+
+// Choose a different initial port for each test task if running as PR check
+val initialPort =
+    gradle.startParameter.taskNames
+        .map { prCheckStartPorts[it] ?: "" }
+        .filter { it.isNotBlank() }
+        .firstOrNull() ?: ""
+
+// Gather platform-level overrides (settings.txt) into a single comma-separated list
+val platformOverrides =
+    gradle.startParameter.taskNames
+        .mapNotNull { prCheckPlatformOverrides[it] }
+        .joinToString(separator = ",")
+
+val networkSize =
+    gradle.startParameter.taskNames
+        .map { prCheckNetSizeOverrides[it] ?: "" }
+        .filter { it.isNotBlank() }
+        .firstOrNull() ?: "4"
+
+val prepareUpgradeOffsets =
+    gradle.startParameter.taskNames
+        .mapNotNull { prCheckPrepareUpgradeOffsets[it] }
+        .joinToString(",")
+
+// Gather overrides into a single comma‐separated list
+val testOverrides =
+    gradle.startParameter.taskNames
+        .mapNotNull { prCheckPropOverrides[it] }
+        .joinToString(separator = ",")
+
 tasks {
     prCheckTags.forEach { (taskName, _) ->
         register(taskName) {
-            getByName(taskName).group = "hapi-test"
+            group = "hapi-test"
             dependsOn(
                 if (
                     (taskName.contains("Crypto") ||
@@ -307,494 +321,271 @@ tasks {
         }
     }
     remoteCheckTags.forEach { (taskName, _) -> register(taskName) { dependsOn("testRemote") } }
-}
-
-tasks.register<Test>("testSubprocess") {
-    testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = configurations.testRuntimeClasspath.get().plus(files(tasks.jar))
-    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
-
-    // Isolate each subtask's working directory so logs are not overwritten
-    val subtaskName =
-        gradle.startParameter.taskNames.firstOrNull { prCheckTags.containsKey(it) } ?: ""
-    if (subtaskName.isNotBlank()) {
-        systemProperty("hapi.spec.subtask.name", subtaskName)
-    }
-
-    val ciTagExpression =
-        gradle.startParameter.taskNames
-            .stream()
-            .map { prCheckTags[it] ?: "" }
-            .filter { it.isNotBlank() }
-            .toList()
-            .joinToString("|")
-    useJUnitPlatform {
-        includeTags(
-            if (ciTagExpression.isBlank()) "none()|!(EMBEDDED|REPEATABLE)"
-            // We don't want to run typical stream or log validation for ISS or BLOCK_NODE
-            // cases
-            else if (ciTagExpression.contains("ISS") || ciTagExpression.contains("BLOCK_NODE"))
-                "(${ciTagExpression})&!(EMBEDDED|REPEATABLE)"
-            else "(${ciTagExpression}|STREAM_VALIDATION|LOG_VALIDATION)&!(EMBEDDED|REPEATABLE)"
-        )
-        excludeTags("CONCURRENT_SUBPROCESS_VALIDATION")
-    }
-
-    // Choose a different initial port for each test task if running as PR check
-    val initialPort =
-        gradle.startParameter.taskNames
-            .stream()
-            .map { prCheckStartPorts[it] ?: "" }
-            .filter { it.isNotBlank() }
-            .findFirst()
-            .orElse("")
-    systemProperty("hapi.spec.initial.port", initialPort)
-    // There's nothing special about shard/realm 11.12, except that they are non-zero values.
-    // We want to run all tests that execute as part of `testSubprocess`–that is to say,
-    // the majority of the hapi tests - with a nonzero shard/realm
-    // to maintain confidence that we haven't fallen back into the habit of assuming 0.0
-    systemProperty("hapi.spec.default.shard", 11)
-    systemProperty("hapi.spec.default.realm", 12)
-
-    // Gather overrides into a single comma‐separated list
-    val testOverrides =
-        gradle.startParameter.taskNames
-            .mapNotNull { prCheckPropOverrides[it] }
-            .joinToString(separator = ",")
-    // Only set the system property if non-empty
-    if (testOverrides.isNotBlank()) {
-        systemProperty("hapi.spec.test.overrides", testOverrides)
-    }
-
-    // Gather platform-level overrides (settings.txt) into a single comma-separated list
-    val platformOverrides =
-        gradle.startParameter.taskNames
-            .mapNotNull { prCheckPlatformOverrides[it] }
-            .joinToString(separator = ",")
-    if (platformOverrides.isNotBlank()) {
-        systemProperty("hapi.spec.platform.overrides", platformOverrides)
-    }
-
-    if (gradle.startParameter.taskNames.any(prCheckAssertAtLeastOneWraps::contains)) {
-        systemProperty("hapi.spec.assertAtLeastOneWraps", "true")
-    }
-    gradle.startParameter.taskNames
-        .firstOrNull(prCheckTssLibWrapsArtifactsPaths::containsKey)
-        ?.let {
-            systemProperty(
-                "hapi.spec.tssLibWrapsArtifactsPath",
-                prCheckTssLibWrapsArtifactsPaths.getValue(it),
-            )
-        }
-
-    val prepareUpgradeOffsets =
-        gradle.startParameter.taskNames
-            .mapNotNull { prCheckPrepareUpgradeOffsets[it] }
-            .joinToString(",")
-    if (prepareUpgradeOffsets.isNotEmpty()) {
-        systemProperty("hapi.spec.prepareUpgradeOffsets", prepareUpgradeOffsets)
-    }
-
-    val networkSize =
-        gradle.startParameter.taskNames
-            .stream()
-            .map { prCheckNetSizeOverrides[it] ?: "" }
-            .filter { it.isNotBlank() }
-            .findFirst()
-            .orElse("4")
-    systemProperty("hapi.spec.network.size", networkSize)
-
-    // Note the 1/4 threshold for the restart check; DabEnabledUpgradeTest is a chaotic
-    // churn of fast upgrades with heavy use of override networks, and there is a node
-    // removal step that happens without giving enough time for the next hinTS scheme
-    // to be completed, meaning a 1/3 threshold in the *actual* roster only accounts for
-    // 1/4 total weight in the out-of-date hinTS verification key,
-    val hintsThresholdDenominator =
-        if (gradle.startParameter.taskNames.contains("hapiTestRestart")) "4" else "3"
-    systemProperty("hapi.spec.hintsThresholdDenominator", hintsThresholdDenominator)
-    systemProperty("hapi.spec.block.stateproof.verification", "false")
-
-    // Default quiet mode is "false" unless we are running in CI or set it explicitly to "true"
-    systemProperty(
-        "hapi.spec.quiet.mode",
-        System.getProperty("hapi.spec.quiet.mode")
-            ?: if (ciTagExpression.isNotBlank()) "true" else "false",
-    )
-    systemProperty("junit.jupiter.execution.parallel.enabled", true)
-    systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
-    // Surprisingly, the Gradle JUnitPlatformTestExecutionListener fails to gather result
-    // correctly if test classes run in parallel (concurrent execution WITHIN a test class
-    // is fine). So we need to force the test classes to run in the same thread. Luckily this
-    // is not a huge limitation, as our test classes generally have enough non-leaky tests to
-    // get a material speed up. See https://github.com/gradle/gradle/issues/6453.
-    systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "same_thread")
-    systemProperty(
-        "junit.jupiter.testclass.order.default",
-        "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
-    )
-
-    jvmArgs(
-        "--enable-native-access=com.hedera.common.nativesupport,com.hedera.cryptography.libsecp256k1,com.hedera.cryptography.libsodium"
-    )
-    jvmArgumentProviders.add(TestResourceArgumentsProvider())
-    maxParallelForks = 1
-}
-
-tasks.register<Test>("testSubprocessConcurrent") {
-    testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = configurations.testRuntimeClasspath.get().plus(files(tasks.jar))
-    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
-
-    // Isolate each subtask's working directory so logs are not overwritten
-    val subtaskName =
-        gradle.startParameter.taskNames.firstOrNull { prCheckTags.containsKey(it) } ?: ""
-    if (subtaskName.isNotBlank()) {
-        systemProperty("hapi.spec.subtask.name", subtaskName)
-    }
-
-    val ciTagExpression =
-        gradle.startParameter.taskNames
-            .stream()
-            .map { prCheckTags[it] ?: "" }
-            .filter { it.isNotBlank() }
-            .toList()
-            .joinToString("|")
-    useJUnitPlatform {
-        includeTags(
-            if (ciTagExpression.isBlank()) "none()|!(EMBEDDED|REPEATABLE|ISS)"
-            // We don't want to run typical stream or log validation for ISS or BLOCK_NODE
-            // cases
-            else if (ciTagExpression.contains("ISS") || ciTagExpression.contains("BLOCK_NODE"))
-                "(${ciTagExpression})&!(EMBEDDED|REPEATABLE)"
-            else "(${ciTagExpression}|CONCURRENT_SUBPROCESS_VALIDATION)&!(EMBEDDED|REPEATABLE|ISS)"
-        )
-        // Exclude SERIAL tests except CONCURRENT_SUBPROCESS_VALIDATION which runs validation last
-        // via @Isolated
-        excludeTags("SERIAL&!CONCURRENT_SUBPROCESS_VALIDATION")
-    }
-
-    // Choose a different initial port for each test task if running as PR check
-    val initialPort =
-        gradle.startParameter.taskNames
-            .stream()
-            .map { prCheckStartPorts[it] ?: "" }
-            .filter { it.isNotBlank() }
-            .findFirst()
-            .orElse("")
-    systemProperty("hapi.spec.initial.port", initialPort)
-    // There's nothing special about shard/realm 11.12, except that they are non-zero values.
-    // We want to run all tests that execute as part of `testSubprocess`–that is to say,
-    // the majority of the hapi tests - with a nonzero shard/realm
-    // to maintain confidence that we haven't fallen back into the habit of assuming 0.0
-    systemProperty("hapi.spec.default.shard", 11)
-    systemProperty("hapi.spec.default.realm", 12)
-
-    // Gather overrides into a single comma‐separated list
-    val testOverrides =
-        gradle.startParameter.taskNames
-            .mapNotNull { prCheckPropOverrides[it] }
-            .joinToString(separator = ",")
-    // Only set the system property if non-empty
-    if (testOverrides.isNotBlank()) {
-        systemProperty("hapi.spec.test.overrides", testOverrides)
-    }
-
-    // Gather platform-level overrides (settings.txt) into a single comma-separated list
-    val platformOverrides =
-        gradle.startParameter.taskNames
-            .mapNotNull { prCheckPlatformOverrides[it] }
-            .joinToString(separator = ",")
-    if (platformOverrides.isNotBlank()) {
-        systemProperty("hapi.spec.platform.overrides", platformOverrides)
-    }
-
-    if (gradle.startParameter.taskNames.any(prCheckAssertAtLeastOneWraps::contains)) {
-        systemProperty("hapi.spec.assertAtLeastOneWraps", "true")
-    }
-    gradle.startParameter.taskNames
-        .firstOrNull(prCheckTssLibWrapsArtifactsPaths::containsKey)
-        ?.let {
-            systemProperty(
-                "hapi.spec.tssLibWrapsArtifactsPath",
-                prCheckTssLibWrapsArtifactsPaths.getValue(it),
-            )
-        }
-
-    val prepareUpgradeOffsets =
-        gradle.startParameter.taskNames
-            .mapNotNull { prCheckPrepareUpgradeOffsets[it] }
-            .joinToString(",")
-    if (prepareUpgradeOffsets.isNotEmpty()) {
-        systemProperty("hapi.spec.prepareUpgradeOffsets", prepareUpgradeOffsets)
-    }
-
-    val networkSize =
-        gradle.startParameter.taskNames
-            .stream()
-            .map { prCheckNetSizeOverrides[it] ?: "" }
-            .filter { it.isNotBlank() }
-            .findFirst()
-            .orElse("4")
-    systemProperty("hapi.spec.network.size", networkSize)
-
-    // Note the 1/4 threshold for the restart check; DabEnabledUpgradeTest is a chaotic
-    // churn of fast upgrades with heavy use of override networks, and there is a node
-    // removal step that happens without giving enough time for the next hinTS scheme
-    // to be completed, meaning a 1/3 threshold in the *actual* roster only accounts for
-    // 1/4 total weight in the out-of-date hinTS verification key,
-    val hintsThresholdDenominator =
-        if (gradle.startParameter.taskNames.contains("hapiTestRestart")) "4" else "3"
-    systemProperty("hapi.spec.hintsThresholdDenominator", hintsThresholdDenominator)
-    systemProperty("hapi.spec.block.stateproof.verification", "false")
-
-    // Default quiet mode is "false" unless we are running in CI or set it explicitly to "true"
-    systemProperty(
-        "hapi.spec.quiet.mode",
-        System.getProperty("hapi.spec.quiet.mode")
-            ?: if (ciTagExpression.isNotBlank()) "true" else "false",
-    )
-    // Signal to SharedNetworkLauncherSessionListener that this is subprocess concurrent mode,
-    // so it arms the validation latch for ConcurrentSubprocessValidationTest
-    systemProperty("hapi.spec.subprocess.concurrent", "true")
-    systemProperty("junit.jupiter.execution.parallel.enabled", true)
-    systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
-    systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "concurrent")
-    // Limit concurrent test classes to prevent transaction backlog
-    // Use fixed strategy with parallelism based on node count: 3 nodes → 3 threads, 4 nodes → 2
-    // threads
-    val testParallelism = if ((networkSize.toIntOrNull() ?: 4) <= 3) 3 else 2
-    systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
-    systemProperty("junit.jupiter.execution.parallel.config.fixed.parallelism", "$testParallelism")
-    systemProperty(
-        "junit.jupiter.testclass.order.default",
-        "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
-    )
-
-    jvmArgs(
-        "--enable-native-access=com.hedera.common.nativesupport,com.hedera.cryptography.libsecp256k1,com.hedera.cryptography.libsodium"
-    )
-    jvmArgumentProviders.add(TestResourceArgumentsProvider())
-    maxParallelForks = 1
-}
-
-tasks.register<Test>("testRemote") {
-    testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = configurations.testRuntimeClasspath.get().plus(files(tasks.jar))
-    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
-
-    // Isolate each subtask's working directory so logs are not overwritten
-    val subtaskName =
-        gradle.startParameter.taskNames.firstOrNull { remoteCheckTags.containsKey(it) } ?: ""
-    if (subtaskName.isNotBlank()) {
-        systemProperty("hapi.spec.subtask.name", subtaskName)
-    }
-
-    systemProperty("hapi.spec.remote", "true")
-    // Support overriding a single remote target network for all executing specs
-    System.getenv("REMOTE_TARGET")?.let { systemProperty("hapi.spec.nodes.remoteYml", it) }
-
-    val ciTagExpression =
-        gradle.startParameter.taskNames
-            .stream()
-            .map { remoteCheckTags[it] ?: "" }
-            .filter { it.isNotBlank() }
-            .toList()
-            .joinToString("|")
-    useJUnitPlatform {
-        includeTags(
-            if (ciTagExpression.isBlank()) "none()|!(EMBEDDED|REPEATABLE)"
-            else "(${ciTagExpression}&!(EMBEDDED|REPEATABLE))"
-        )
-    }
-
-    if (gradle.startParameter.taskNames.any(prCheckAssertAtLeastOneWraps::contains)) {
-        systemProperty("hapi.spec.assertAtLeastOneWraps", "true")
-    }
-    gradle.startParameter.taskNames
-        .firstOrNull(prCheckTssLibWrapsArtifactsPaths::containsKey)
-        ?.let {
-            systemProperty(
-                "hapi.spec.tssLibWrapsArtifactsPath",
-                prCheckTssLibWrapsArtifactsPaths.getValue(it),
-            )
-        }
-
-    val prepareUpgradeOffsets =
-        gradle.startParameter.taskNames
-            .mapNotNull { prCheckPrepareUpgradeOffsets[it] }
-            .joinToString(",")
-    if (prepareUpgradeOffsets.isNotEmpty()) {
-        systemProperty("hapi.spec.prepareUpgradeOffsets", prepareUpgradeOffsets)
-    }
-
-    // Default quiet mode is "false" unless we are running in CI or set it explicitly to "true"
-    systemProperty(
-        "hapi.spec.quiet.mode",
-        System.getProperty("hapi.spec.quiet.mode")
-            ?: if (ciTagExpression.isNotBlank()) "true" else "false",
-    )
-    systemProperty("junit.jupiter.execution.parallel.enabled", true)
-    systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
-    // Surprisingly, the Gradle JUnitPlatformTestExecutionListener fails to gather result
-    // correctly if test classes run in parallel (concurrent execution WITHIN a test class
-    // is fine). So we need to force the test classes to run in the same thread. Luckily this
-    // is not a huge limitation, as our test classes generally have enough non-leaky tests to
-    // get a material speed up. See https://github.com/gradle/gradle/issues/6453.
-    systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "same_thread")
-    systemProperty(
-        "junit.jupiter.testclass.order.default",
-        "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
-    )
-
-    jvmArgs(
-        "--enable-native-access=com.hedera.common.nativesupport,com.hedera.cryptography.libsecp256k1,com.hedera.cryptography.libsodium"
-    )
-    jvmArgumentProviders.add(TestResourceArgumentsProvider())
-    maxParallelForks = 1
-}
-
-val embeddedTasks =
-    setOf(
-        "hapiTestCryptoEmbedded",
-        "hapiTestMiscEmbedded",
-        "hapiTestSimpleFeesEmbedded",
-        "hapiTestAtomicBatchEmbedded",
-    )
-
-val embeddedBaseTags =
-    mapOf(
-        "hapiTestMiscEmbedded" to "EMBEDDED&!(SIMPLE_FEES|CRYPTO|ATOMIC_BATCH)",
-        "hapiTestSimpleFeesEmbedded" to "EMBEDDED&SIMPLE_FEES",
-        "hapiTestCryptoEmbedded" to "EMBEDDED&CRYPTO",
-        "hapiTestAtomicBatchEmbedded" to "EMBEDDED&ATOMIC_BATCH",
-    )
-
-val prEmbeddedCheckTags = embeddedBaseTags.mapValues { (_, tags) -> "($tags)" }
-
-tasks {
     prEmbeddedCheckTags.forEach { (taskName, _) ->
         register(taskName) {
-            getByName(taskName).group = "hapi-test-embedded"
+            group = "hapi-test-embedded"
             dependsOn("testEmbedded")
         }
     }
-}
-
-// Runs tests against an embedded network that supports concurrent tests
-tasks.register<Test>("testEmbedded") {
-    testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = configurations.testRuntimeClasspath.get().plus(files(tasks.jar))
-    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
-
-    // Isolate each subtask's working directory so logs are not overwritten
-    val subtaskName =
-        gradle.startParameter.taskNames.firstOrNull { prEmbeddedCheckTags.containsKey(it) } ?: ""
-    if (subtaskName.isNotBlank()) {
-        systemProperty("hapi.spec.subtask.name", subtaskName)
-    }
-
-    val ciTagExpression =
-        gradle.startParameter.taskNames
-            .stream()
-            .map { prEmbeddedCheckTags[it] ?: "" }
-            .filter { it.isNotBlank() }
-            .toList()
-            .joinToString("|")
-    useJUnitPlatform {
-        includeTags(
-            if (ciTagExpression.isBlank())
-                "none()|!(RESTART|ND_RECONNECT|UPGRADE|REPEATABLE|ONLY_SUBPROCESS|ISS)"
-            else "(${ciTagExpression}|STREAM_VALIDATION|LOG_VALIDATION)&!(INTEGRATION|ISS)"
-        )
-    }
-
-    systemProperty("junit.jupiter.execution.parallel.enabled", true)
-    systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
-    // Surprisingly, the Gradle JUnitPlatformTestExecutionListener fails to gather result
-    // correctly if test classes run in parallel (concurrent execution WITHIN a test class
-    // is fine). So we need to force the test classes to run in the same thread. Luckily this
-    // is not a huge limitation, as our test classes generally have enough non-leaky tests to
-    // get a material speed up. See https://github.com/gradle/gradle/issues/6453.
-    systemProperty("junit.jupiter.execution.parallel.mode.classes.default", "same_thread")
-    systemProperty(
-        "junit.jupiter.testclass.order.default",
-        "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
-    )
-    // Tell our launcher to target a concurrent embedded network
-    systemProperty("hapi.spec.embedded.mode", "concurrent")
-    // Running all the tests that are executed in testEmbedded with 0 for shard and realm,
-    // so we can maintain confidence that there are no regressions in the code.
-    systemProperty("hapi.spec.default.shard", 0)
-    systemProperty("hapi.spec.default.realm", 0)
-
-    if (gradle.startParameter.taskNames.contains("hapiTestSimpleFeesEmbedded")) {
-        systemProperty("fees.createSimpleFeeSchedule", "true")
-        systemProperty("fees.simpleFeesEnabled", "true")
-    }
-
-    jvmArgs(
-        "--enable-native-access=com.hedera.common.nativesupport,com.hedera.cryptography.libsecp256k1,com.hedera.cryptography.libsodium"
-    )
-    // Scale heap and processor count to match available resources
-    jvmArgumentProviders.add(TestResourceArgumentsProvider())
-}
-
-val repeatableBaseTags = mapOf("hapiTestMiscRepeatable" to "REPEATABLE&!CRYPTO")
-
-val prRepeatableCheckTags = repeatableBaseTags.mapValues { (_, tags) -> "($tags)" }
-
-tasks {
     prRepeatableCheckTags.forEach { (taskName, _) ->
         register(taskName) { dependsOn("testRepeatable") }
     }
 }
 
+// Unlike other tests, these intentionally corrupt embedded state to test FAIL_INVALID
+// code paths; hence we do not run LOG_VALIDATION after the test suite finishes
+tasks.registerHapiTest(
+    "test",
+    emptyMap(),
+    "(INTEGRATION|STREAM_VALIDATION)",
+    embeddedMode = "per-class",
+    junitParallelMode = "same_thread",
+)
+
+tasks.registerHapiTest(
+    "testSubprocess",
+    prCheckTags,
+    "none()|!(EMBEDDED|REPEATABLE)",
+    ciDefaultTags = "|CONCURRENT_SUBPROCESS_VALIDATION)&!(EMBEDDED|REPEATABLE|ISS",
+    ciDefaultTagsWithoutStreamAndLogValidation = ")&!(EMBEDDED|REPEATABLE",
+    excludeTags = "CONCURRENT_SUBPROCESS_VALIDATION",
+    junitParallelMode = "same_thread",
+    initialPort = initialPort,
+    // There's nothing special about shard/realm 11.12, except that they are non-zero values.
+    // We want to run all tests that execute as part of `testSubprocess`–that is to say,
+    // the majority of the hapi tests - with a nonzero shard/realm
+    // to maintain confidence that we haven't fallen back into the habit of assuming 0.0
+    defaultShard = 11,
+    defaultRealm = 12,
+    // Note the 1/4 threshold for the restart check; DabEnabledUpgradeTest is a chaotic
+    // churn of fast upgrades with heavy use of override networks, and there is a node
+    // removal step that happens without giving enough time for the next hinTS scheme
+    // to be completed, meaning a 1/3 threshold in the *actual* roster only accounts for
+    // 1/4 total weight in the out-of-date hinTS verification key.
+    hapiSpecHintsThresholdDenominator =
+        if (gradle.startParameter.taskNames.contains("hapiTestRestart")) "4" else "3",
+    hapiSpecBlockStateproofVerificationOff = true,
+)
+
+tasks.registerHapiTest(
+    "testSubprocessConcurrent",
+    prCheckTags,
+    "none()|!(EMBEDDED|REPEATABLE|ISS)",
+    ciDefaultTags = "|CONCURRENT_SUBPROCESS_VALIDATION)&!(EMBEDDED|REPEATABLE|ISS",
+    ciDefaultTagsWithoutStreamAndLogValidation = ")&!(EMBEDDED|REPEATABLE",
+    excludeTags = "SERIAL&!CONCURRENT_SUBPROCESS_VALIDATION",
+    junitParallelMode = "concurrent",
+    junitFixedParallelism = if (networkSize.toInt() <= 3) 3 else 2,
+    initialPort = initialPort,
+    // There's nothing special about shard/realm 11.12, except that they are non-zero values.
+    // We want to run all tests that execute as part of `testSubprocess`–that is to say,
+    // the majority of the hapi tests - with a nonzero shard/realm
+    // to maintain confidence that we haven't fallen back into the habit of assuming 0.0
+    defaultShard = 11,
+    defaultRealm = 12,
+    // Note the 1/4 threshold for the restart check; DabEnabledUpgradeTest is a chaotic
+    // churn of fast upgrades with heavy use of override networks, and there is a node
+    // removal step that happens without giving enough time for the next hinTS scheme
+    // to be completed, meaning a 1/3 threshold in the *actual* roster only accounts for
+    // 1/4 total weight in the out-of-date hinTS verification key.
+    hapiSpecSubprocessConcurrent = true,
+    hapiSpecHintsThresholdDenominator =
+        if (gradle.startParameter.taskNames.contains("hapiTestRestart")) "4" else "3",
+    hapiSpecBlockStateproofVerificationOff = true,
+)
+
+tasks.registerHapiTest(
+    "testRemote",
+    remoteCheckTags,
+    "none()|!(EMBEDDED|REPEATABLE)",
+    ciDefaultTags = "&!(EMBEDDED|REPEATABLE)",
+    junitParallelMode = "same_thread",
+    hapiSpecRemote = true,
+)
+
+// Runs tests against an embedded network that supports concurrent tests
+tasks.registerHapiTest(
+    "testEmbedded",
+    prEmbeddedCheckTags,
+    "none()|!(RESTART|ND_RECONNECT|UPGRADE|REPEATABLE|ONLY_SUBPROCESS|ISS)",
+    ciDefaultTags = "|STREAM_VALIDATION|LOG_VALIDATION)&!(INTEGRATION|ISS",
+    // Tell our launcher to target a concurrent embedded network
+    embeddedMode = "concurrent",
+    junitParallelMode = "same_thread",
+    // Running all the tests that are executed in testEmbedded with 0 for shard and realm,
+    // so we can maintain confidence that there are no regressions in the code.
+    defaultShard = 0,
+    defaultRealm = 0,
+)
+
 // Runs tests against an embedded network that achieves repeatable results by running tests in a
 // single thread
-tasks.register<Test>("testRepeatable") {
-    testClassesDirs = sourceSets.main.get().output.classesDirs
-    classpath = configurations.testRuntimeClasspath.get().plus(files(tasks.jar))
-    if (!EnvAccess.isCiServer(providers)) doNotTrackState("Don't skip execution of hapi test tasks")
+tasks.registerHapiTest(
+    "testRepeatable",
+    prRepeatableCheckTags,
+    "none()|!(RESTART|ND_RECONNECT|UPGRADE|EMBEDDED|NOT_REPEATABLE|ONLY_SUBPROCESS|ISS)",
+    ciDefaultTags = "|STREAM_VALIDATION|LOG_VALIDATION)&!(INTEGRATION|ISS|EMBEDDED",
+    embeddedMode = "repeatable",
+)
 
-    // Isolate each subtask's working directory so logs are not overwritten
-    val subtaskName =
-        gradle.startParameter.taskNames.firstOrNull { prRepeatableCheckTags.containsKey(it) } ?: ""
-    if (subtaskName.isNotBlank()) {
-        systemProperty("hapi.spec.subtask.name", subtaskName)
-    }
+fun TaskContainer.registerHapiTest(
+    name: String,
+    ciTags: Map<String, String>,
+    defaultTags: String,
+    ciDefaultTags: String? = null,
+    ciDefaultTagsWithoutStreamAndLogValidation: String? = null,
+    excludeTags: String? = null,
+    embeddedMode: String? = null,
+    // Surprisingly, the Gradle JUnitPlatformTestExecutionListener fails to gather result
+    // correctly if test classes run in parallel (concurrent execution WITHIN a test class
+    // is fine). So we need to force the test classes to run in the same thread. Luckily this
+    // is not a huge limitation, as our test classes generally have enough non-leaky tests to
+    // get a material speed up. See https://github.com/gradle/gradle/issues/6453.
+    // That's why parallel mode is set to 'same_thread' for certain cases
+    junitParallelMode: String? = null,
+    junitFixedParallelism: Int? = null,
+    initialPort: String? = null,
+    defaultShard: Int? = null,
+    defaultRealm: Int? = null,
+    hapiSpecSubprocessConcurrent: Boolean = false,
+    hapiSpecHintsThresholdDenominator: String? = null,
+    hapiSpecBlockStateproofVerificationOff: Boolean = false,
+    hapiSpecRemote: Boolean = false,
+) {
+    (if (name == "test") test else register<Test>(name)).configure {
+        val ciTagExpression =
+            gradle.startParameter.taskNames
+                .map { ciTags[it] ?: "" }
+                .filter { it.isNotBlank() }
+                .toList()
+                .joinToString("|")
 
-    val ciTagExpression =
-        gradle.startParameter.taskNames
-            .stream()
-            .map { prRepeatableCheckTags[it] ?: "" }
-            .filter { it.isNotBlank() }
-            .toList()
-            .joinToString("|")
-    useJUnitPlatform {
-        includeTags(
-            if (ciTagExpression.isBlank())
-                "none()|!(RESTART|ND_RECONNECT|UPGRADE|EMBEDDED|NOT_REPEATABLE|ONLY_SUBPROCESS|ISS)"
-            else "(${ciTagExpression}|STREAM_VALIDATION|LOG_VALIDATION)&!(INTEGRATION|ISS|EMBEDDED)"
+        val subtaskName =
+            gradle.startParameter.taskNames.firstOrNull { ciTags.containsKey(it) } ?: ""
+
+        // Shared configuration of all test tasks
+        testClassesDirs = sourceSets.main.get().output.classesDirs
+        classpath = configurations.testRuntimeClasspath.get().plus(files(jar))
+
+        if (!EnvAccess.isCiServer(providers))
+            doNotTrackState("Don't skip execution of hapi test tasks locally")
+
+        // Scale heap and processor count to match available resources
+        jvmArgumentProviders.add(TestResourceArgumentsProvider())
+        // Enable native access for hedera cryptography modules
+        jvmArgs(
+            "--enable-native-access=" +
+                "com.hedera.common.nativesupport," +
+                "com.hedera.cryptography.libsecp256k1," +
+                "com.hedera.cryptography.libsodium"
         )
-    }
+        // Isolate each subtask's working directory so logs are not overwritten
+        if (subtaskName.isNotBlank()) {
+            systemProperty("hapi.spec.subtask.name", subtaskName)
+        }
+        if (testOverrides.isNotBlank()) {
+            systemProperty("hapi.spec.test.overrides", testOverrides)
+        }
+        if (platformOverrides.isNotBlank()) {
+            systemProperty("hapi.spec.platform.overrides", platformOverrides)
+        }
+        if (prepareUpgradeOffsets.isNotBlank()) {
+            systemProperty("hapi.spec.prepareUpgradeOffsets", prepareUpgradeOffsets)
+        }
+        if (prCheckAssertAtLeastOneWraps) {
+            systemProperty("hapi.spec.assertAtLeastOneWraps", "true")
+        }
+        if (prCheckIsSimpleFeesEmbedded) {
+            systemProperty("fees.createSimpleFeeSchedule", "true")
+            systemProperty("fees.simpleFeesEnabled", "true")
+        }
+        systemProperty("hapi.spec.network.size", networkSize)
+        // Default quiet mode is "false" unless we are running in CI or set it explicitly to "true"
+        systemProperty(
+            "hapi.spec.quiet.mode",
+            providers
+                .systemProperty("hapi.spec.quiet.mode")
+                .getOrElse(if (ciTagExpression.isNotBlank()) "true" else "false"),
+        )
+        gradle.startParameter.taskNames
+            .firstOrNull(prCheckTssLibWrapsArtifactsPaths::containsKey)
+            ?.let {
+                systemProperty(
+                    "hapi.spec.tssLibWrapsArtifactsPath",
+                    prCheckTssLibWrapsArtifactsPaths.getValue(it),
+                )
+            }
+        // Pass a system property "KEY=VALUE" to the test JVM via "-PsysProp.KEY=VALUE"
+        providers.gradlePropertiesPrefixedBy("sysProp.").get().forEach { (k, v) ->
+            systemProperty(k.removePrefix("sysProp."), v)
+        }
 
-    // Disable all parallelism
-    systemProperty("junit.jupiter.execution.parallel.enabled", false)
-    systemProperty(
-        "junit.jupiter.testclass.order.default",
-        "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
-    )
-    // Tell our launcher to target a repeatable embedded network
-    systemProperty("hapi.spec.embedded.mode", "repeatable")
-
-    jvmArgs(
-        "--enable-native-access=com.hedera.common.nativesupport,com.hedera.cryptography.libsecp256k1,com.hedera.cryptography.libsodium"
-    )
-    jvmArgumentProviders.add(TestResourceArgumentsProvider())
-
-    // Pass a system property "KEY=VALUE" to the test JVM via "-PsysProp.KEY=VALUE"
-    providers.gradlePropertiesPrefixedBy("sysProp.").get().forEach { (k, v) ->
-        systemProperty(k.removePrefix("sysProp."), v)
+        // Configuration controlled by parameters
+        useJUnitPlatform {
+            if (ciDefaultTags == null) {
+                includeTags(defaultTags)
+            } else {
+                includeTags(
+                    if (ciTagExpression.isBlank()) defaultTags
+                    // We don't want to run stream or log validation for ISS or BLOCK_NODE cases
+                    else if (
+                        ciDefaultTagsWithoutStreamAndLogValidation != null &&
+                            (ciTagExpression.contains("ISS") ||
+                                ciTagExpression.contains("BLOCK_NODE"))
+                    )
+                        "(${ciTagExpression}${ciDefaultTagsWithoutStreamAndLogValidation})"
+                    else "(${ciTagExpression}${ciDefaultTags})"
+                )
+            }
+            if (excludeTags != null) {
+                excludeTags(excludeTags)
+            }
+        }
+        if (junitParallelMode != null) {
+            systemProperty("junit.jupiter.execution.parallel.enabled", true)
+            systemProperty("junit.jupiter.execution.parallel.mode.default", "concurrent")
+            systemProperty(
+                "junit.jupiter.execution.parallel.mode.classes.default",
+                junitParallelMode,
+            )
+            systemProperty(
+                "junit.jupiter.testclass.order.default",
+                "org.junit.jupiter.api.ClassOrderer\$OrderAnnotation",
+            )
+        }
+        if (junitFixedParallelism != null) {
+            systemProperty("junit.jupiter.execution.parallel.config.strategy", "fixed")
+            systemProperty(
+                "junit.jupiter.execution.parallel.config.fixed.parallelism",
+                "$junitFixedParallelism",
+            )
+        }
+        if (embeddedMode != null) {
+            systemProperty("hapi.spec.embedded.mode", embeddedMode)
+        }
+        if (initialPort != null) {
+            systemProperty("hapi.spec.initial.port", initialPort)
+        }
+        if (defaultShard != null) {
+            systemProperty("hapi.spec.default.shard", defaultShard)
+        }
+        if (defaultRealm != null) {
+            systemProperty("hapi.spec.default.realm", defaultRealm)
+        }
+        if (hapiSpecSubprocessConcurrent) {
+            systemProperty("hapi.spec.subprocess.concurrent", "true")
+        }
+        if (hapiSpecHintsThresholdDenominator != null) {
+            systemProperty("hapi.spec.hintsThresholdDenominator", hapiSpecHintsThresholdDenominator)
+        }
+        if (hapiSpecBlockStateproofVerificationOff) {
+            systemProperty("hapi.spec.block.stateproof.verification", "false")
+        }
+        if (hapiSpecRemote) {
+            systemProperty("hapi.spec.remote", "true")
+            // Support overriding a single remote target network for all executing specs
+            System.getenv("REMOTE_TARGET")?.let { systemProperty("hapi.spec.nodes.remoteYml", it) }
+        }
     }
 }
 


### PR DESCRIPTION
**Description**:

- Introduce a common `registerHapiTest` method to share common setup between hapi test tasks.
- Sort `build.gradle.kts`
  - standard config (dependencies) 
  - run and packaging config
  - test config
    - individual task/tag lists and parameters
    - technical code 
