### PR TITLE
feat: increase max number of topics from 1,000,000 to 2,000,000

### DIFF
--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/UtilizationScaledThrottleMultiplierTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/congestion/UtilizationScaledThrottleMultiplierTest.java
@@ -12,6 +12,7 @@ import static com.hedera.hapi.node.base.HederaFunctionality.TOKEN_CREATE;
 import static com.hedera.hapi.node.base.HederaFunctionality.TOKEN_MINT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -39,6 +40,7 @@ import com.hedera.hapi.node.transaction.TransactionBody;
 import com.hedera.hapi.platform.state.NodeId;
 import com.hedera.node.app.fixtures.state.FakeState;
 import com.hedera.node.app.service.consensus.ConsensusService;
+import com.hedera.node.app.service.consensus.ReadableTopicStore;
 import com.hedera.node.app.service.consensus.impl.schemas.V0490ConsensusSchema;
 import com.hedera.node.app.service.contract.ContractService;
 import com.hedera.node.app.service.contract.impl.schemas.V0490ContractSchema;
@@ -51,6 +53,7 @@ import com.hedera.node.app.service.file.impl.schemas.V0490FileSchema;
 import com.hedera.node.app.service.token.TokenService;
 import com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema;
 import com.hedera.node.app.service.token.impl.schemas.V0530TokenSchema;
+import com.hedera.node.app.spi.store.ReadableStoreFactory;
 import com.hedera.node.app.store.ReadableStoreFactoryImpl;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.config.ConfigProvider;
@@ -472,6 +475,48 @@ class UtilizationScaledThrottleMultiplierTest {
         long multiplier = utilizationScaledThrottleMultiplier.currentMultiplier(txnInfo, storeFactory);
 
         assertEquals(SOME_MULTIPLIER * ENTITY_SCALE_FACTOR, multiplier);
+    }
+
+    @Test
+    void testCurrentMultiplierConsensusCreateTopicBelowFirstTierAtNewCeiling() {
+        given(configProvider.getConfiguration()).willReturn(configuration);
+        given(configuration.getConfigData(FeesConfig.class)).willReturn(feesConfig);
+        given(feesConfig.percentUtilizationScaleFactors()).willReturn(entityScaleFactors);
+        given(configuration.getConfigData(TopicsConfig.class)).willReturn(topicsConfig);
+        given(topicsConfig.maxNumber()).willReturn(2_000_000L);
+
+        when(txnInfo.functionality()).thenReturn(CONSENSUS_CREATE_TOPIC);
+        when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
+
+        final var topicStore = mock(ReadableTopicStore.class);
+        when(topicStore.sizeOfState()).thenReturn(19_999L);
+        final var storeFactory = mock(ReadableStoreFactory.class);
+        when(storeFactory.readableStore(ReadableTopicStore.class)).thenReturn(topicStore);
+
+        long multiplier = utilizationScaledThrottleMultiplier.currentMultiplier(txnInfo, storeFactory);
+
+        assertEquals(SOME_MULTIPLIER, multiplier);
+    }
+
+    @Test
+    void testCurrentMultiplierConsensusCreateTopicCrossesTiersAtNewCeiling() {
+        given(configProvider.getConfiguration()).willReturn(configuration);
+        given(configuration.getConfigData(FeesConfig.class)).willReturn(feesConfig);
+        given(feesConfig.percentUtilizationScaleFactors()).willReturn(entityScaleFactors);
+        given(configuration.getConfigData(TopicsConfig.class)).willReturn(topicsConfig);
+        given(topicsConfig.maxNumber()).willReturn(2_000_000L);
+
+        when(txnInfo.functionality()).thenReturn(CONSENSUS_CREATE_TOPIC);
+        when(delegate.currentMultiplier()).thenReturn(SOME_MULTIPLIER);
+
+        final var topicStore = mock(ReadableTopicStore.class);
+        when(topicStore.sizeOfState()).thenReturn(1_000_000L);
+        final var storeFactory = mock(ReadableStoreFactory.class);
+        when(storeFactory.readableStore(ReadableTopicStore.class)).thenReturn(topicStore);
+
+        long multiplier = utilizationScaledThrottleMultiplier.currentMultiplier(txnInfo, storeFactory);
+
+        assertEquals(SOME_MULTIPLIER * 25L, multiplier);
     }
 
     @Test

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TopicsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TopicsConfig.java
@@ -7,6 +7,11 @@ import com.swirlds.config.api.ConfigProperty;
 
 @ConfigData("topics")
 public record TopicsConfig(
-        @ConfigProperty(defaultValue = "2000000") @NetworkProperty long maxNumber,
-        @ConfigProperty(defaultValue = "10") @NetworkProperty int maxCustomFeeEntriesForTopics,
-        @ConfigProperty(defaultValue = "10") @NetworkProperty int maxEntriesForFeeExemptKeyList) {}
+        @ConfigProperty(defaultValue = "2000000") @NetworkProperty
+        long maxNumber,
+
+        @ConfigProperty(defaultValue = "10") @NetworkProperty
+        int maxCustomFeeEntriesForTopics,
+
+        @ConfigProperty(defaultValue = "10") @NetworkProperty
+        int maxEntriesForFeeExemptKeyList) {}

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TopicsConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/TopicsConfig.java
@@ -7,6 +7,6 @@ import com.swirlds.config.api.ConfigProperty;
 
 @ConfigData("topics")
 public record TopicsConfig(
-        @ConfigProperty(defaultValue = "1000000") @NetworkProperty long maxNumber,
+        @ConfigProperty(defaultValue = "2000000") @NetworkProperty long maxNumber,
         @ConfigProperty(defaultValue = "10") @NetworkProperty int maxCustomFeeEntriesForTopics,
         @ConfigProperty(defaultValue = "10") @NetworkProperty int maxEntriesForFeeExemptKeyList) {}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/UtilScalePricingCheck.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/UtilScalePricingCheck.java
@@ -4,6 +4,7 @@ package com.hedera.services.bdd.suites.regression;
 import static com.hedera.services.bdd.junit.EmbeddedReason.NEEDS_STATE_ACCESS;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.createTopic;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
@@ -79,10 +80,53 @@ public class UtilScalePricingCheck {
                         .toArray(HapiSpecOperation[]::new)));
     }
 
-    private long expectedMultiplier(final int mintNo) {
-        if (mintNo <= 5) {
+    @LeakyEmbeddedHapiTest(
+            reason = NEEDS_STATE_ACCESS,
+            overrides = {"topics.maxNumber", "fees.percentUtilizationScaleFactors"})
+    final Stream<DynamicTest> topicPriceScalesWithUtilization() {
+        final var civilian = "topicCivilian";
+        final var maxAllowed = 10;
+        final IntFunction<String> createOp = i -> "createTopic" + i;
+        final AtomicLong baseFee = new AtomicLong();
+        return hapiTest(
+                overridingTwo(
+                        "topics.maxNumber",
+                        "" + maxAllowed,
+                        "fees.percentUtilizationScaleFactors",
+                        "TOPIC(0,1:1,50,5:1,90,50:1)"),
+                cryptoCreate(civilian).balance(ONE_MILLION_HBARS),
+                blockingOrder(IntStream.range(1, maxAllowed + 1)
+                        .mapToObj(i -> createTopic("topic" + i)
+                                .payingWith(civilian)
+                                .blankMemo()
+                                .fee(1000 * ONE_HUNDRED_HBARS)
+                                .via(createOp.apply(i)))
+                        .toArray(HapiSpecOperation[]::new)),
+                blockingOrder(IntStream.range(1, maxAllowed + 1)
+                        .mapToObj(i -> getTxnRecord(createOp.apply(i))
+                                .noLogging()
+                                .loggingOnlyFee()
+                                .exposingTo(createRecord -> {
+                                    if (i == 1) {
+                                        baseFee.set(createRecord.getTransactionFee());
+                                    } else {
+                                        final var multiplier = expectedMultiplier(i);
+                                        final var expected = multiplier * baseFee.get();
+                                        assertCloseEnough(
+                                                expected,
+                                                createRecord.getTransactionFee(),
+                                                0.1,
+                                                "transaction fee",
+                                                multiplier + "x multiplier should be in effect at " + i + " topics");
+                                    }
+                                }))
+                        .toArray(HapiSpecOperation[]::new)));
+    }
+
+    private long expectedMultiplier(final int usageNo) {
+        if (usageNo <= 5) {
             return 1;
-        } else if (mintNo <= 9) {
+        } else if (usageNo <= 9) {
             return 5;
         } else {
             return 50;


### PR DESCRIPTION
## Summary
- Raise the default `topics.maxNumber` config property in `TopicsConfig.java` from `1,000,000` to `2,000,000` to allow more HCS topics to be created on the network.
- Add test coverage confirming congestion-pricing scaling behaves correctly at the new ceiling: a unit test in `UtilizationScaledThrottleMultiplierTest` exercising the real `2,000,000` default (below first tier, and crossing tiers), and a new HAPI test `UtilScalePricingCheck#topicPriceScalesWithUtilization` confirming `CONSENSUS_CREATE_TOPIC` fees scale with topic utilization end-to-end (modeled on the existing NFT congestion-pricing check).

Closes #26955

## Test plan
- [x] `ConsensusCreateTopicHandlerTest` passes (parametrizes the limit rather than hardcoding it)
- [x] Confirm throttle/congestion-pricing scaling (`UtilizationScaledThrottleMultiplier`) behaves correctly at the new ceiling — covered by new unit test cases and `UtilScalePricingCheck#topicPriceScalesWithUtilization` (`./gradlew hapiTestMiscEmbedded testEmbedded --tests "*UtilScalePricingCheck*"`, 2 passing)
- [x] Confirm whether a network dynamic-property update (FileUpdate on `0.0.121`) is also needed to raise the limit on already-running networks, since `maxNumber` is a `@NetworkProperty`