### PR TITLE
chore: bump CITR/adhoc Solo version to v0.87.1

### DIFF
--- a/.github/workflows/support/citr/.citr-env
+++ b/.github/workflows/support/citr/.citr-env
@@ -1,7 +1,7 @@
 citr-solo-version=v0.87.1
 adhoc-solo-version=v0.87.1
-adhoc-xts-solo-version=0.84.1
-cutover-solo-version=0.84.1
+adhoc-xts-solo-version=v0.87.1
+cutover-solo-version=v0.87.1
 citr-mirror-node-version=0.162.0-rc1
 tck-version=v0.12.4
 js-sdk-version=v2.87.0

--- a/.github/workflows/support/citr/.citr-env
+++ b/.github/workflows/support/citr/.citr-env
@@ -1,5 +1,5 @@
-citr-solo-version=0.79.1
-adhoc-solo-version=0.79.1
+citr-solo-version=v0.87.1
+adhoc-solo-version=v0.87.1
 adhoc-xts-solo-version=0.84.1
 cutover-solo-version=0.84.1
 citr-mirror-node-version=0.162.0-rc1


### PR DESCRIPTION
## Summary
- Bump
`citr-solo-version=v0.87.1`
`adhoc-solo-version=v0.87.1`
`adhoc-xts-solo-version=0.87.1`
`cutover-solo-version=0.87.1`
in `.github/workflows/support/citr/.citr-env` 
## Test plan
-  Run the entire [XTS dryrun test suite](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/32798515949)