### PR TITLE
fix: re-read last-used consensus time when externalizing the ledger id

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -14,6 +14,7 @@ import static com.hedera.node.app.state.logging.TransactionStateLogger.logStartU
 import static com.hedera.node.app.state.logging.TransactionStateLogger.logStartUserTransactionPreHandleResultP3;
 import static com.hedera.node.app.workflows.handle.TransactionType.ORDINARY_TRANSACTION;
 import static com.hedera.node.app.workflows.handle.TransactionType.POST_UPGRADE_TRANSACTION;
+import static com.hedera.node.app.workflows.handle.record.SystemTransactions.MAX_NANOS_PER_SYSTEM_DISPATCH;
 import static com.hedera.node.config.types.StreamMode.BLOCKS;
 import static com.hedera.node.config.types.StreamMode.RECORDS;
 import static com.swirlds.platform.system.InitTrigger.EVENT_STREAM_RECOVERY;
@@ -376,16 +377,17 @@ public class HandleWorkflow {
                         ? blockRecordManager.lastUsedConsensusTime()
                         : blockStreamManager.lastUsedConsensusTime())
                 : round.getConsensusTimestamp();
-        // Using the last used consensus time, we need to add 2ns, in case this triggers stake periods side effects
+        // Each of these dispatches takes the next free slot after the last used consensus time, where a slot is
+        // wide enough for the dispatch and a preceding NODE_STAKE_UPDATE if it triggers stake period side effects
         try {
-            transactionsDispatched |=
-                    nodeFeeManager.distributeFees(state, lastUsedConsTime.plusNanos(2), systemTransactions);
+            transactionsDispatched |= nodeFeeManager.distributeFees(
+                    state, lastUsedConsTime.plusNanos(MAX_NANOS_PER_SYSTEM_DISPATCH), systemTransactions);
         } catch (Exception e) {
             logger.error("{} Failed to pay node fees to nodes", ALERT_MESSAGE, e);
         }
         try {
-            transactionsDispatched |=
-                    nodeRewardManager.maybeRewardActiveNodes(state, lastUsedConsTime.plusNanos(4), systemTransactions);
+            transactionsDispatched |= nodeRewardManager.maybeRewardActiveNodes(
+                    state, lastUsedConsTime.plusNanos(2L * MAX_NANOS_PER_SYSTEM_DISPATCH), systemTransactions);
         } catch (Exception e) {
             logger.error("{} Failed to reward active nodes", ALERT_MESSAGE, e);
         }
@@ -399,11 +401,14 @@ public class HandleWorkflow {
                 try {
                     final var ctx = setLedgerIdContext.get();
                     logger.info("Externalizing ledger id {}", ctx.ledgerId().toHex());
-                    // Since we must have handled a TSS tx to trigger setting the ledger id, we
-                    // know the last-used consensus time has advanced since the last system tx
+                    // Re-read the last-used time, since handling this round's transactions has advanced it
+                    // past the snapshot the earlier system transactions were dispatched from
+                    final var ledgerIdConsTime = blockHashSigner.isReady()
+                            ? blockStreamManager.lastUsedConsensusTime()
+                            : round.getConsensusTimestamp();
                     systemTransactions.externalizeLedgerId(
                             state,
-                            lastUsedConsTime.plusNanos(2),
+                            ledgerIdConsTime.plusNanos(MAX_NANOS_PER_SYSTEM_DISPATCH),
                             ctx.ledgerId(),
                             ctx.proofKeys(),
                             ctx.targetNodeWeights(),

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
@@ -151,6 +151,14 @@ public class SystemTransactions {
 
     private static final Logger log = LogManager.getLogger(SystemTransactions.class);
 
+    /**
+     * The number of consensus times a single system transaction dispatch can consume when it applies stake period
+     * side effects; one for the dispatch itself, and an earlier one for a preceding {@code NODE_STAKE_UPDATE}. A
+     * caller choosing the first free time for such a dispatch must thus advance this many nanos past the last used
+     * consensus time.
+     */
+    public static final int MAX_NANOS_PER_SYSTEM_DISPATCH = 2;
+
     private static final int DEFAULT_GENESIS_WEIGHT = 500;
     private static final long FIRST_RESERVED_SYSTEM_CONTRACT = 350L;
     private static final long LAST_RESERVED_SYSTEM_CONTRACT = 399L;
@@ -834,7 +842,7 @@ public class SystemTransactions {
         final var remainingDispatches = new AtomicInteger(
                 useReserved
                         ? (int) java.time.Duration.between(firstConsTime, now).toNanos()
-                                / (applyStakePeriodSideEffects ? 2 : 1)
+                                / (applyStakePeriodSideEffects ? MAX_NANOS_PER_SYSTEM_DISPATCH : 1)
                         : 1);
         final AtomicReference<Instant> nextConsTime = new AtomicReference<>(firstConsTime);
         final var systemAdminId = idFactory.newAccountId(
@@ -919,7 +927,7 @@ public class SystemTransactions {
                 }
                 final boolean applyStakePeriodSideEffects =
                         triggerStakePeriodSideEffects == TriggerStakePeriodSideEffects.YES;
-                final int maxNanosUsed = applyStakePeriodSideEffects ? 2 : 1;
+                final int maxNanosUsed = applyStakePeriodSideEffects ? MAX_NANOS_PER_SYSTEM_DISPATCH : 1;
                 final var now = nextConsTime.getAndUpdate(then -> then.plusNanos(maxNanosUsed));
                 if (streamMode != BLOCKS) {
                     blockRecordManager.startUserTransaction(now, state);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -18,13 +18,16 @@ import static java.util.Collections.emptyList;
 import static org.hiero.consensus.platformstate.PlatformStateService.NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
@@ -37,13 +40,19 @@ import com.hedera.hapi.block.stream.input.EventHeader;
 import com.hedera.hapi.block.stream.input.ParentEventReference;
 import com.hedera.hapi.block.stream.output.StateChange;
 import com.hedera.hapi.block.stream.output.StateChanges;
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.FileID;
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.state.entity.EntityCounts;
 import com.hedera.hapi.node.state.file.File;
+import com.hedera.hapi.node.state.history.History;
+import com.hedera.hapi.node.state.history.HistoryProof;
+import com.hedera.hapi.node.state.history.HistoryProofConstruction;
 import com.hedera.hapi.node.state.token.NetworkStakingRewards;
 import com.hedera.hapi.platform.event.EventCore;
 import com.hedera.hapi.platform.event.EventDescriptor;
@@ -56,12 +65,18 @@ import com.hedera.node.app.blocks.impl.streaming.BlockBufferService;
 import com.hedera.node.app.fees.ExchangeRateManager;
 import com.hedera.node.app.hints.HintsService;
 import com.hedera.node.app.history.HistoryService;
+import com.hedera.node.app.history.WritableHistoryStore;
+import com.hedera.node.app.history.impl.OnProofFinished;
 import com.hedera.node.app.quiescence.QuiescenceController;
 import com.hedera.node.app.records.BlockRecordService;
 import com.hedera.node.app.records.impl.BlockRecordManagerImpl;
+import com.hedera.node.app.records.impl.WrappedRecordBlockHashMigration;
 import com.hedera.node.app.service.addressbook.AddressBookService;
+import com.hedera.node.app.service.entityid.EntityIdFactory;
 import com.hedera.node.app.service.entityid.EntityIdService;
 import com.hedera.node.app.service.file.FileService;
+import com.hedera.node.app.service.file.impl.FileServiceImpl;
+import com.hedera.node.app.service.roster.RosterService;
 import com.hedera.node.app.service.schedule.ExecutableTxnIterator;
 import com.hedera.node.app.service.schedule.ScheduleService;
 import com.hedera.node.app.service.token.TokenService;
@@ -69,14 +84,19 @@ import com.hedera.node.app.service.token.impl.handlers.staking.StakeInfoHelper;
 import com.hedera.node.app.service.token.impl.handlers.staking.StakePeriodManager;
 import com.hedera.node.app.services.NodeFeeManager;
 import com.hedera.node.app.services.NodeRewardManager;
+import com.hedera.node.app.services.ServicesRegistry;
+import com.hedera.node.app.spi.AppContext;
 import com.hedera.node.app.spi.fixtures.util.LogCaptor;
 import com.hedera.node.app.spi.info.NetworkInfo;
 import com.hedera.node.app.spi.info.NodeInfo;
+import com.hedera.node.app.spi.migrate.StartupNetworks;
+import com.hedera.node.app.spi.records.SelfNodeAccountIdManager;
 import com.hedera.node.app.state.HederaRecordCache;
 import com.hedera.node.app.throttle.CongestionMetrics;
 import com.hedera.node.app.throttle.ThrottleServiceManager;
 import com.hedera.node.app.workflows.OpWorkflowMetrics;
 import com.hedera.node.app.workflows.handle.cache.CacheWarmer;
+import com.hedera.node.app.workflows.handle.record.MigrationRootHashSubmissions;
 import com.hedera.node.app.workflows.handle.record.SystemTransactions;
 import com.hedera.node.app.workflows.handle.steps.HollowAccountCompletions;
 import com.hedera.node.app.workflows.handle.steps.ParentTxnFactory;
@@ -86,6 +106,7 @@ import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.node.config.types.BlockStreamWriterMode;
 import com.hedera.node.config.types.StreamMode;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.platform.system.InitTrigger;
 import com.swirlds.state.merkle.VirtualMapState;
 import com.swirlds.state.spi.CommittableWritableStates;
@@ -101,6 +122,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.logging.log4j.LogManager;
 import org.hiero.base.crypto.Hash;
@@ -227,6 +249,33 @@ class HandleWorkflowTest {
 
     @Mock
     private NodeFeeManager nodeFeeManager;
+
+    @Mock
+    private FileServiceImpl fileService;
+
+    @Mock
+    private ServicesRegistry servicesRegistry;
+
+    @Mock
+    private StartupNetworks startupNetworks;
+
+    @Mock
+    private SelfNodeAccountIdManager selfNodeAccountIdManager;
+
+    @Mock
+    private WrappedRecordBlockHashMigration wrappedRecordBlockHashMigration;
+
+    @Mock
+    private MigrationRootHashSubmissions migrationRootHashSubmissions;
+
+    @Mock
+    private AppContext appContext;
+
+    @Mock
+    private EntityIdFactory entityIdFactory;
+
+    @Mock
+    private NodeInfo creatorInfo;
 
     private HandleWorkflow subject;
 
@@ -932,5 +981,122 @@ class HandleWorkflowTest {
         verify(scheduleService).executableTxns(any(), any(), any());
         // But the loop body never entered — no scheduled txn was started
         verify(stakePeriodManager, never()).setCurrentStakePeriodFor(any());
+    }
+
+    @Test
+    void ledgerIdExternalizationDoesNotReuseTheNodeFeeConsensusTime() {
+        final var beforeEvents = Instant.ofEpochSecond(1_234_600L, 100);
+        final var afterEvents = beforeEvents.plusSeconds(1);
+        final var ledgerId = Bytes.wrap("LEDGER_ID");
+        final var proof = HistoryProof.newBuilder()
+                .targetHistory(History.newBuilder().addressBookHash(ledgerId).build())
+                .build();
+        final var construction = HistoryProofConstruction.newBuilder()
+                .constructionId(1L)
+                .targetProof(proof)
+                .build();
+        final var historyStore = mock(WritableHistoryStore.class);
+        given(historyStore.getActiveConstruction()).willReturn(construction);
+        // Stand in for a finished proof; in production the callback fires from the controller, either while
+        // reconciling TSS state or while handling the HistoryProofVote that completes the construction
+        willAnswer(invocation -> {
+                    invocation.<OnProofFinished>getArgument(0).onFinished(historyStore, construction, new TreeMap<>());
+                    return null;
+                })
+                .given(historyService)
+                .onFinishedConstruction(any());
+        given(historyService.historyProofVerificationKey()).willReturn(Bytes.EMPTY);
+        given(state.getReadableStates(RosterService.NAME)).willReturn(mock(ReadableStates.class));
+
+        final var creatorId = NodeId.of(0L);
+        given(round.iterator()).willAnswer(_ -> List.of(event).iterator());
+        given(event.getConsensusTimestamp()).willReturn(NOW);
+        given(event.allParentsIterator()).willReturn(emptyIterator());
+        given(event.getCreatorId()).willReturn(creatorId);
+        final var lastUsedConsTime = new AtomicReference<>(beforeEvents);
+        // Stands in for handling the round's transactions, which advances the last-used consensus time
+        given(event.consensusTransactionIterator()).willAnswer(invocation -> {
+            lastUsedConsTime.set(afterEvents);
+            return emptyIterator();
+        });
+        given(networkInfo.nodeInfo(creatorId.id())).willReturn(mock(NodeInfo.class));
+        given(blockHashSigner.isReady()).willReturn(true);
+        given(blockStreamManager.lastUsedConsensusTime()).willAnswer(invocation -> lastUsedConsTime.get());
+        given(blockStreamManager.lastIntervalProcessTime()).willReturn(NOW);
+
+        givenSubjectWith(
+                BLOCKS,
+                BlockStreamWriterMode.FILE,
+                emptyList(),
+                Map.of("tss.hintsEnabled", "true", "tss.historyEnabled", "true"));
+
+        // Both dispatches under test run through a real SystemTransactions, so each transaction is assigned the
+        // consensus time production would give it; the dispatch is then aborted, since carrying one out needs the
+        // entire handle stack
+        given(appContext.idFactory()).willReturn(entityIdFactory);
+        given(entityIdFactory.newAccountId(anyLong())).willReturn(AccountID.DEFAULT);
+        given(networkInfo.addressBook()).willReturn(List.of(creatorInfo));
+        final var realSystemTransactions = new SystemTransactions(
+                initTrigger,
+                parentTxnFactory,
+                fileService,
+                networkInfo,
+                configProvider,
+                dispatchProcessor,
+                appContext,
+                servicesRegistry,
+                blockRecordManager,
+                blockStreamManager,
+                exchangeRateManager,
+                recordCache,
+                startupNetworks,
+                stakePeriodChanges,
+                selfNodeAccountIdManager,
+                wrappedRecordBlockHashMigration,
+                migrationRootHashSubmissions);
+        final var assignedConsTimes = ArgumentCaptor.forClass(Instant.class);
+        given(parentTxnFactory.createSystemTxn(any(), any(), assignedConsTimes.capture(), any(), any(), any()))
+                .willThrow(new IllegalStateException("Aborting dispatch after its consensus time is assigned"));
+        // Mirrors NodeFeeManager.distributeFees(), which forwards its consensus time to dispatchNodePayments()
+        given(nodeFeeManager.distributeFees(any(), any(), any())).willAnswer(invocation -> {
+            realSystemTransactions.dispatchNodePayments(
+                    invocation.getArgument(0),
+                    invocation.getArgument(1),
+                    TransferList.newBuilder()
+                            .accountAmounts(AccountAmount.newBuilder()
+                                    .accountID(AccountID.DEFAULT)
+                                    .amount(1L)
+                                    .build())
+                            .build());
+            return true;
+        });
+        willAnswer(invocation -> {
+                    realSystemTransactions.externalizeLedgerId(
+                            invocation.getArgument(0),
+                            invocation.getArgument(1),
+                            invocation.getArgument(2),
+                            invocation.getArgument(3),
+                            invocation.getArgument(4),
+                            invocation.getArgument(5));
+                    return null;
+                })
+                .given(systemTransactions)
+                .externalizeLedgerId(any(), any(), any(), any(), any(), any());
+
+        subject.handleRound(state, round, txns -> {});
+
+        final var consTimes = assignedConsTimes.getAllValues();
+        assertEquals(2, consTimes.size(), "Expected the node fee payment and the ledger id publication to dispatch");
+        final var nodeFeeConsTime = consTimes.getFirst();
+        final var ledgerIdConsTime = consTimes.getLast();
+        assertNotEquals(
+                nodeFeeConsTime,
+                ledgerIdConsTime,
+                "The node fee payment and the ledger id publication were assigned the same consensus time, "
+                        + nodeFeeConsTime);
+        assertTrue(
+                ledgerIdConsTime.isAfter(afterEvents),
+                "The ledger id publication was assigned " + ledgerIdConsTime + ", which precedes the last transaction "
+                        + "handled in the round at " + afterEvents);
     }
 }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/LedgerIdPublicationTimestampTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/LedgerIdPublicationTimestampTest.java
@@ -1,13 +1,18 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.services.bdd.suites.regression.system;
 
+import static com.hedera.node.config.types.StreamMode.BOTH;
+import static com.hedera.node.config.types.StreamMode.RECORDS;
+import static com.hedera.services.bdd.junit.extensions.NetworkTargetingExtension.SHARED_NETWORK;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.streamMustIncludePassWithReplayFrom;
 import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.node.config.types.StreamMode;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.junit.support.translators.inputs.TransactionParts;
@@ -34,15 +39,27 @@ import org.junit.jupiter.api.DynamicTest;
  * block files to see it.
  */
 public class LedgerIdPublicationTimestampTest {
+    private static final String STREAM_MODE_PROPERTY = "blockStream.streamMode";
     private static final Duration PUBLICATION_TIMEOUT = Duration.ofMinutes(5);
 
     @HapiTest
     final Stream<DynamicTest> ledgerIdPublicationIsNotBackdatedWithinItsBlock() {
+        // TSS is deactivated and no blocks are written when streamMode=RECORDS, so nothing publishes a ledger id
+        assumeFalse(targetStreamMode() == RECORDS, "No block stream to check when streamMode=RECORDS");
         return hapiTest(
                 streamMustIncludePassWithReplayFrom(
                         spec -> new LedgerIdPublicationOrderAssertion(), PUBLICATION_TIMEOUT),
                 // Some traffic, in case the network is still finishing its genesis ceremony
                 cryptoCreate("a"));
+    }
+
+    /**
+     * Returns the stream mode of the network under test, defaulting to {@link StreamMode#BOTH} if it is not yet
+     * targeted.
+     */
+    private static StreamMode targetStreamMode() {
+        final var network = SHARED_NETWORK.get();
+        return network == null ? BOTH : network.startupProperties().getStreamMode(STREAM_MODE_PROPERTY);
     }
 
     /**

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/LedgerIdPublicationTimestampTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/LedgerIdPublicationTimestampTest.java
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.regression.system;
+
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.streamMustIncludePassWithReplayFrom;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.block.stream.Block;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.support.translators.inputs.TransactionParts;
+import com.hedera.services.bdd.spec.utilops.streams.assertions.BlockStreamAssertion;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+
+/**
+ * Asserts the synthetic {@code LedgerIdPublication} is externalized at a consensus time strictly after every
+ * transaction already streamed in its block.
+ *
+ * <p>{@code HandleWorkflow.handleRound()} snapshots the last-used consensus time <i>before</i> {@code handleEvents()}
+ * runs the round, then reuses that snapshot for the publication dispatch. Since the ceremony is finished by a
+ * {@code HistoryProofVote} handled inside {@code handleEvents()}, the publication is stamped with a time that
+ * precedes transactions already written to the block; the same snapshot (plus the same 2ns offset) is also handed to
+ * {@code NodeFeeManager.distributeFees()}, so in a staking-boundary round the two can share an instant.
+ *
+ * <p>Runs on the shared network, which publishes a ledger id during its genesis TSS ceremony since
+ * {@code tss.hintsEnabled} and {@code tss.historyEnabled} both default to true; the assertion replays existing
+ * block files to see it.
+ */
+public class LedgerIdPublicationTimestampTest {
+    private static final Duration PUBLICATION_TIMEOUT = Duration.ofMinutes(5);
+
+    @HapiTest
+    final Stream<DynamicTest> ledgerIdPublicationIsNotBackdatedWithinItsBlock() {
+        return hapiTest(
+                streamMustIncludePassWithReplayFrom(
+                        spec -> new LedgerIdPublicationOrderAssertion(), PUBLICATION_TIMEOUT),
+                // Some traffic, in case the network is still finishing its genesis ceremony
+                cryptoCreate("a"));
+    }
+
+    /**
+     * Passes as soon as a {@code LedgerIdPublication} result is seen at a consensus time strictly after the latest
+     * transaction result preceding it in the same block; fails if it is at or before that time.
+     */
+    private static class LedgerIdPublicationOrderAssertion implements BlockStreamAssertion {
+        @Override
+        public boolean test(@NonNull final Block block) throws AssertionError {
+            requireNonNull(block);
+            Timestamp latestSoFar = null;
+            boolean nextResultIsPublication = false;
+            for (final var item : block.items()) {
+                switch (item.item().kind()) {
+                    case SIGNED_TRANSACTION ->
+                        nextResultIsPublication = isLedgerIdPublication(item.signedTransactionOrThrow());
+                    case TRANSACTION_RESULT -> {
+                        final var at = item.transactionResultOrThrow().consensusTimestampOrThrow();
+                        if (nextResultIsPublication) {
+                            assertStrictlyAfter(at, latestSoFar);
+                            return true;
+                        }
+                        latestSoFar = latest(latestSoFar, at);
+                    }
+                    default -> {
+                        // Only transaction inputs and results carry the times under test
+                    }
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public String toString() {
+            return "LedgerIdPublicationOrder";
+        }
+    }
+
+    private static void assertStrictlyAfter(
+            @NonNull final Timestamp publishedAt, @Nullable final Timestamp latestSoFar) {
+        if (latestSoFar == null) {
+            throw new AssertionError("LedgerIdPublication was the first transaction result in its block, so its "
+                    + "ordering relative to the round's transactions could not be checked");
+        }
+        final var published = asInstant(publishedAt);
+        final var latest = asInstant(latestSoFar);
+        if (!published.isAfter(latest)) {
+            throw new AssertionError(String.format(
+                    "LedgerIdPublication externalized at %s, but the block already contained a transaction result at "
+                            + "%s (%s by %dns) - consensus times must be strictly increasing in the stream",
+                    published,
+                    latest,
+                    published.equals(latest) ? "duplicated" : "backdated",
+                    Duration.between(published, latest).toNanos()));
+        }
+    }
+
+    private static boolean isLedgerIdPublication(@NonNull final Bytes signedTransaction) {
+        try {
+            return TransactionParts.from(signedTransaction).body().hasLedgerIdPublication();
+        } catch (RuntimeException ignore) {
+            // Not every signed transaction item is a HAPI transaction body (e.g. state signatures)
+            return false;
+        }
+    }
+
+    private static Timestamp latest(@Nullable final Timestamp a, @NonNull final Timestamp b) {
+        return (a == null || asInstant(b).isAfter(asInstant(a))) ? b : a;
+    }
+
+    private static Instant asInstant(@NonNull final Timestamp timestamp) {
+        return Instant.ofEpochSecond(timestamp.seconds(), timestamp.nanos());
+    }
+}


### PR DESCRIPTION
### Problem

`handleRound()` dispatches the `LedgerIdPublication` with a consensus time snapshot taken
before `handleEvents()` runs the round. The publication is stamped ~180ms behind transactions
already written to its block, and can collide with the node fee dispatch, which shares that
snapshot and the same `+2ns` offset.

### Fix

- Re-read the last-used consensus time at the point of dispatch.
- Pull the repeated `+2`/`+4` offsets into `SystemTransactions.MAX_NANOS_PER_SYSTEM_DISPATCH`.
