### PR TITLE
fix: 26969: (0.77) v0.77.0-rc.7: ISS reported despite 100% node agreement on state hash

### DIFF
--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/MerkleDbDataSource.java
@@ -334,8 +334,6 @@ public final class MerkleDbDataSource implements VirtualDataSource {
             throw new IllegalStateException("Initial capacity must be greater than 0, but was " + this.initialCapacity);
         }
 
-        saveMetadata(dbPaths);
-
         final boolean forceIndexRebuilding = merkleDbConfig.indexRebuildingEnforced();
 
         // Get the max number of keys is set in the MerkleDb config, then multiply it by
@@ -492,6 +490,18 @@ public final class MerkleDbDataSource implements VirtualDataSource {
         pathToKeyValueStoreScanner = new GarbageScanner(pathToDiskLocationLeafNodes, keyValueStore.getFileCollection());
         objectKeyToPathScanner =
                 new GarbageScanner(keyToPath.getBucketIndexToBucketLocation(), keyToPath.getFileCollection(), true);
+
+        // If this data source is restored from a snapshot, the storage dir may contain index files. They
+        // are no longer needed and can be deleted
+        Files.deleteIfExists(dbPaths.pathToDiskLocationLeafNodesFile);
+        Files.deleteIfExists(dbPaths.idToDiskLocationHashChunksFile);
+        // Also, delete the metadata file to make sure future metadata updates are in a new file, not the
+        // hard-linked file from the snapshot directory
+        Files.deleteIfExists(dbPaths.metadataFile);
+        // Write metadata to disk to have consistent set of files on disk at any given moment. This
+        // will create a new file, not reuse the hard-linked file shared with a snapshot dir
+        saveMetadata(dbPaths);
+
         COUNT_OF_OPEN_DATABASES.increment();
         logger.info(
                 MERKLE_DB.getMarker(),

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/DataFileCollection.java
@@ -249,15 +249,19 @@ public class DataFileCollection implements FileStatisticAware, Snapshotable {
         this.indexedObjectListConstructor = indexedObjectListConstructor;
 
         // check if exists, if so open existing files
-        if (Files.exists(storeDir)) {
+        if (Files.isDirectory(storeDir)) {
             loadedFromExistingFiles = tryLoadFromExistingStore(loadedDataCallback);
         } else {
             loadedFromExistingFiles = false;
             // create store dir
             Files.createDirectories(storeDir);
+        }
+        if (!loadedFromExistingFiles) {
             // next file will have index zero
             nextFileIndex.set(0);
         }
+
+        saveMetadata(storeDir);
     }
 
     @NonNull
@@ -419,6 +423,8 @@ public class DataFileCollection implements FileStatisticAware, Snapshotable {
                 dataReader.getIndex(),
                 dataWriter.getMetadata().getItemsCount(),
                 formatSizeBytes(dataReader.getSize()));
+
+        saveMetadata(storeDir);
 
         return dataReader;
     }
@@ -712,12 +718,9 @@ public class DataFileCollection implements FileStatisticAware, Snapshotable {
     }
 
     private boolean tryLoadFromExistingStore(final LoadedDataCallback loadedDataCallback) throws IOException {
-        if (!Files.isDirectory(storeDir)) {
-            throw new IOException("Tried to initialize DataFileCollection with a storage "
-                    + "directory that is not a directory. ["
-                    + storeDir.toAbsolutePath()
-                    + "]");
-        }
+        // Read metadata
+        final boolean metadataLoaded = loadMetadata();
+        // Check data files
         try (final Stream<Path> storePaths = Files.list(storeDir)) {
             final Path[] fullWrittenFilePaths = storePaths
                     .filter(path ->
@@ -741,24 +744,28 @@ public class DataFileCollection implements FileStatisticAware, Snapshotable {
                 // rethrow exception now that we have cleaned up
                 throw e;
             }
-            if (dataFileReaders.length > 0) {
+            if ((dataFileReaders.length > 0) && metadataLoaded) {
                 loadFromExistingFiles(dataFileReaders, loadedDataCallback);
                 return true;
-            } else {
-                // next file will have index zero as we did not find any files even though the
-                // directory existed
-                nextFileIndex.set(0);
+            }
+            if (dataFileReaders.length == 0) {
+                // Empty dir or empty data file collection
                 return false;
             }
+            logger.warn(
+                    EXCEPTION.getMarker(),
+                    "Can't load data file collection {} {}, either metadata or data files are missing in [{}]",
+                    dataFileReaders.length,
+                    metadataLoaded,
+                    storeDir.toAbsolutePath());
+            return false;
         }
     }
 
     private boolean loadMetadata() throws IOException {
-        boolean loadedLegacyMetadata = false;
         Path metadataFile = storeDir.resolve(storeName + METADATA_FILENAME_SUFFIX);
         if (!Files.exists(metadataFile)) {
             metadataFile = storeDir.resolve(legacyStoreName + METADATA_FILENAME_SUFFIX);
-            loadedLegacyMetadata = true;
         }
         if (!Files.exists(metadataFile)) {
             return false;
@@ -779,9 +786,7 @@ public class DataFileCollection implements FileStatisticAware, Snapshotable {
             }
             validKeyRange = new KeyRange(minValidKey, maxValidKey);
         }
-        if (loadedLegacyMetadata) {
-            Files.delete(metadataFile);
-        }
+        Files.delete(metadataFile);
         return true;
     }
 
@@ -792,13 +797,6 @@ public class DataFileCollection implements FileStatisticAware, Snapshotable {
                 "Loading existing set of [{}] data files for DataFileCollection [{}]",
                 dataFileReaders.length,
                 storeName);
-        // read metadata
-        if (!loadMetadata()) {
-            logger.warn(
-                    EXCEPTION.getMarker(),
-                    "Loading existing set of data files but no metadata file was found in [{}]",
-                    storeDir.toAbsolutePath());
-        }
         // create indexed file list
         dataFiles.set(indexedObjectListConstructor.apply(List.of(dataFileReaders)));
         // work out what the next index would be, the highest current index plus one

--- a/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
+++ b/platform-sdk/swirlds-merkledb/src/main/java/com/swirlds/merkledb/files/hashmap/HalfDiskHashMap.java
@@ -192,11 +192,9 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
         if (Files.exists(storeDir)) {
             // load metadata
             Path metaDataFile = storeDir.resolve(storeName + METADATA_FILENAME_SUFFIX);
-            boolean loadedLegacyMetadata = false;
             if (!Files.exists(metaDataFile)) {
                 metaDataFile = storeDir.resolve(legacyStoreName + METADATA_FILENAME_SUFFIX);
                 indexFile = storeDir.resolve(legacyStoreName + BUCKET_INDEX_FILENAME_SUFFIX);
-                loadedLegacyMetadata = true;
             }
             if (Files.exists(metaDataFile)) {
                 try (DataInputStream metaIn = new DataInputStream(Files.newInputStream(metaDataFile))) {
@@ -211,9 +209,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                     metaIn.readInt(); // backwards compatibility, was: minimumBuckets
                     setNumberOfBuckets(metaIn.readInt());
                 }
-                if (loadedLegacyMetadata) {
-                    Files.delete(metaDataFile);
-                }
+                Files.delete(metaDataFile);
             } else {
                 logger.error(
                         EXCEPTION.getMarker(),
@@ -241,6 +237,8 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                     bucketIndexToBucketLocation.put(bucket.getBucketIndex(), dataLocation);
                 };
             }
+            // The bucket index file is no longer needed and should be deleted
+            Files.deleteIfExists(indexFile);
         } else {
             // create store dir
             Files.createDirectories(storeDir);
@@ -254,8 +252,6 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                     : new LongListSegment(bucketIndexCapacity, config);
             // we are new, so no need for a loadedDataCallback
             loadedDataCallback = null;
-            // write metadata
-            writeMetadata(storeDir);
             logger.info(
                     MERKLE_DB.getMarker(),
                     "HalfDiskHashMap [{}] created with minimumBuckets={} and numOfBuckets={}",
@@ -269,6 +265,7 @@ public class HalfDiskHashMap implements AutoCloseable, Snapshotable, FileStatist
                 // Need: propagate MerkleDb merkleDbConfig from the database
                 config, storeDir, storeName, legacyStoreName, loadedDataCallback);
         fileCollection.updateValidKeyRange(0, numOfBuckets.get() - 1);
+        writeMetadata(storeDir);
     }
 
     private void writeMetadata(final Path dir) throws IOException {

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/MerkleDbBuilderTest.java
@@ -4,6 +4,7 @@ package com.swirlds.merkledb;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.DEFAULT_CONFIGURATION;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.assertAllDatabasesClosed;
 import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createDataSource;
+import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.createHashChunkStream;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -14,6 +15,9 @@ import com.swirlds.virtualmap.datasource.VirtualDataSource;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.hiero.base.constructable.ConstructableRegistryException;
 import org.hiero.base.utility.test.fixtures.file.AbstractFileManagerAwareTest;
@@ -168,5 +172,58 @@ class MerkleDbBuilderTest extends AbstractFileManagerAwareTest {
         } finally {
             dataSource2.close();
         }
+    }
+
+    @Test
+    void snapshotMetadataMustNotBeCorrupted() throws Exception {
+        final String LABEL = "state";
+        final MerkleDbDataSourceBuilder builder = new MerkleDbDataSourceBuilder(
+                "snapshotMetadataMustNotBeCorrupted", DEFAULT_CONFIGURATION, fileSystemManager, 100);
+
+        final VirtualDataSource original = builder.build(LABEL, null, false, false);
+        original.saveRecords(42, 84, createHashChunkStream(84, 2), Stream.of(), Stream.of(), false);
+        final Path snapshotPath = fileSystemManager.resolveNewTemp("merkledb-snapshotMetadataMustNotBeCorrupted");
+        builder.snapshot(snapshotPath, original);
+        original.close();
+
+        final Map<Path, byte[]> snapshotMetadataFiles = collectMetadataFiles(snapshotPath);
+
+        final VirtualDataSource restored1 = builder.build(LABEL, snapshotPath, false, false);
+        final long firstLeafPath = restored1.getFirstLeafPath();
+        final long lastLeafPath = restored1.getLastLeafPath();
+        restored1.saveRecords(85, 170, createHashChunkStream(170, 2), Stream.of(), Stream.of(), false);
+        restored1.close();
+
+        for (final Map.Entry<Path, byte[]> e : snapshotMetadataFiles.entrySet()) {
+            final Path path = e.getKey();
+            final byte[] wasContent = e.getValue();
+            final byte[] nowContent = Files.readAllBytes(path);
+            Assertions.assertArrayEquals(
+                    wasContent, nowContent, "File must not be changed: " + snapshotPath.relativize(path));
+        }
+
+        // Restore from the same snapshot path. DB metadata must not be affected by restored1.saveRecords() above
+        final VirtualDataSource restored2 = builder.build(LABEL, snapshotPath, false, false);
+        try {
+            Assertions.assertEquals(firstLeafPath, restored2.getFirstLeafPath());
+            Assertions.assertEquals(lastLeafPath, restored2.getLastLeafPath());
+        } finally {
+            restored2.close();
+        }
+    }
+
+    private static Map<Path, byte[]> collectMetadataFiles(final Path dataSourcePath) throws IOException {
+        final Map<Path, byte[]> metadata = new HashMap<>();
+        try (final Stream<Path> files = Files.walk(dataSourcePath)) {
+            final List<Path> filesList = files.filter(Files::isRegularFile)
+                    .filter(path -> path.getFileName().toString().contains("metadata"))
+                    .toList();
+            for (final Path file : filesList) {
+                metadata.put(file, Files.readAllBytes(file));
+            }
+        }
+        // table metadata + 3 DataFileCollection metadata + HDHM metadata
+        assertEquals(5, metadata.size(), "All metadata files must exist");
+        return metadata;
     }
 }

--- a/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
+++ b/platform-sdk/swirlds-merkledb/src/test/java/com/swirlds/merkledb/files/DataFileCollectionTest.java
@@ -145,9 +145,11 @@ class DataFileCollectionTest {
         // check 10 files were created
         int filesCount;
         try (Stream<Path> list = Files.list(tempFileDir.resolve(testType.name()))) {
-            filesCount = (int) list.count();
+            filesCount = (int) list.filter(p -> p.getFileName().toString().endsWith(".pbj"))
+                    .count();
         }
-        assertEquals(10, filesCount, "unexpected file count");
+        // 10 data files + metadata
+        assertEquals(11, filesCount, "unexpected file count");
     }
 
     @Order(3)
@@ -621,10 +623,10 @@ class DataFileCollectionTest {
         // check 10 files were created and data is correct
         try (Stream<Path> list = Files.list(dbDir)) {
             assertEquals(
-                    10,
+                    11, // 10 data files + metadata
                     list.filter(file -> file.getFileName().toString().startsWith(storeName))
                             .count(),
-                    "expected 10 db files");
+                    "expected 10 db files + metadata file");
         }
         assertSame(10, fileCollection.getAllCompletedFiles().size(), "Should be 10 files");
         checkData(fileCollectionMap.get(testType), storedOffsetsMap.get(testType), testType, 0, 1000, 10_000);


### PR DESCRIPTION
Fix summary: backport of https://github.com/hiero-ledger/hiero-consensus-node/issues/26969 to the `release/0.77` branch, except changes to `swirlds-cli` and `swirlds-platform-code` modules as these changes are not applicable to this release.

Fixes: https://github.com/hiero-ledger/hiero-consensus-node/issues/26969
Signed-off-by: Artem Ananev <artem.ananev@hashgraph.com>

