### PR TITLE
fix: install WRAPS proving keys atomically and gate prover readiness on a verified key

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/HistoryLibrary.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/HistoryLibrary.java
@@ -276,9 +276,16 @@ public interface HistoryLibrary {
             @NonNull Set<Long> signers);
 
     /**
-     * Returns whether the library is ready to be used.
+     * Returns whether the library is ready to construct WRAPS proofs; that is, whether the proving key
+     * artifacts installed in {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} are complete and verified against the
+     * given archive hash. Callers must pass {@code tss.wrapsProvingKeyHash} from the configuration the
+     * current construction is running under, so that readiness is judged against the same proving key
+     * the network agreed on.
+     *
+     * @param expectedProvingKeyHashHex the expected proving key archive hash, as bare hex
+     * @return whether recursive proof construction may safely map the installed artifacts
      */
-    boolean wrapsProverReady();
+    boolean wrapsProverReady(@NonNull String expectedProvingKeyHashHex);
 
     /**
      * Verifies whether a compressed proof establishes the given metadata in the chain of trust of the given ledger id.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
@@ -95,6 +95,22 @@ public class WrapsProvingKeyVerification {
     static final Set<String> REQUIRED_ARTIFACT_FILES =
             Set.of("decider_pp.bin", "decider_vp.bin", "nova_pp.bin", "nova_vp.bin");
 
+    /**
+     * Outcome of an install attempt, which decides whether a retry is worth scheduling.
+     */
+    private enum InstallOutcome {
+        /** The artifacts directory now passes {@link #installationDefect}. */
+        INSTALLED,
+        /**
+         * Retrying cannot help. The archive's SHA-384 matched {@code tss.wrapsProvingKeyHash}, so its contents
+         * are fixed; if it did not yield the required artifacts, no later attempt on the same configured hash
+         * ever will. Also covers an unset artifacts path.
+         */
+        PERMANENTLY_BLOCKED,
+        /** An environmental failure (I/O error, permissions, disk space); a later attempt may succeed. */
+        RETRYABLE
+    }
+
     private final Executor downloadExecutor;
 
     @Nullable
@@ -285,8 +301,10 @@ public class WrapsProvingKeyVerification {
             asyncDownloadAndVerify(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
             return;
         }
-        // Hash matches - extract the archive
-        tryExtractTarGz(provingKeyPath, expectedHash.toHex());
+        // Hash matches - install the archive, retrying only if a later attempt could succeed
+        if (tryExtractTarGz(provingKeyPath, expectedHash.toHex()) == InstallOutcome.RETRYABLE) {
+            scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
+        }
     }
 
     private void asyncDownloadAndVerify(
@@ -313,8 +331,14 @@ public class WrapsProvingKeyVerification {
                                 scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
                                 return;
                             }
-                            tryExtractTarGz(provingKeyPath, expectedHash.toHex());
-                            log.info("Successfully downloaded and verified WRAPS proving key (hash={})", expectedHash);
+                            final var outcome = tryExtractTarGz(provingKeyPath, expectedHash.toHex());
+                            if (outcome == InstallOutcome.INSTALLED) {
+                                log.info(
+                                        "Successfully downloaded and verified WRAPS proving key (hash={})",
+                                        expectedHash);
+                            } else if (outcome == InstallOutcome.RETRYABLE) {
+                                scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
+                            }
                         } catch (final Throwable t) {
                             log.error(
                                     "Failed to initiate async download of WRAPS proving key (from URL {}):",
@@ -352,20 +376,36 @@ public class WrapsProvingKeyVerification {
                         return;
                     }
                     try {
-                        log.info("Retrying WRAPS proving key download from {}", downloadUrl);
-                        downloader.download(downloadUrl, provingKeyPath);
-                        final Bytes downloadedHash = hashFile(provingKeyPath);
-                        if (downloadedHash.equals(expectedHash)) {
-                            tryExtractTarGz(provingKeyPath, expectedHash.toHex());
+                        // A retry may be here only because the install failed, not the download. Re-pulling a
+                        // multi-gigabyte archive that is already on disk and still verifies wastes bandwidth
+                        // every interval, so re-run the install directly in that case.
+                        if (archiveAlreadyVerifies(provingKeyPath, expectedHash)) {
+                            log.info(
+                                    "WRAPS proving key archive at {} still matches the expected hash; retrying the "
+                                            + "install without re-downloading",
+                                    provingKeyPath);
+                        } else {
+                            log.info("Retrying WRAPS proving key download from {}", downloadUrl);
+                            downloader.download(downloadUrl, provingKeyPath);
+                            final Bytes downloadedHash = hashFile(provingKeyPath);
+                            if (!downloadedHash.equals(expectedHash)) {
+                                log.error(
+                                        "Downloaded WRAPS proving key hash mismatch on retry: expected={}, actual={}",
+                                        expectedHash,
+                                        downloadedHash);
+                                return;
+                            }
+                        }
+                        final var outcome = tryExtractTarGz(provingKeyPath, expectedHash.toHex());
+                        if (outcome == InstallOutcome.INSTALLED) {
                             log.info(
                                     "Successfully downloaded and verified WRAPS proving key on retry (hash={})",
                                     expectedHash);
                             cancelRetry();
-                        } else {
-                            log.error(
-                                    "Downloaded WRAPS proving key hash mismatch on retry: expected={}, actual={}",
-                                    expectedHash,
-                                    downloadedHash);
+                        } else if (outcome == InstallOutcome.PERMANENTLY_BLOCKED) {
+                            // Nothing a later attempt can change; stop burning I/O re-running it every interval
+                            log.error("Giving up on WRAPS proving key retries; see the error above for the cause");
+                            cancelRetry();
                         }
                     } catch (final Throwable e) {
                         log.error("Failed to download WRAPS proving key on retry", e);
@@ -376,6 +416,23 @@ public class WrapsProvingKeyVerification {
                 retryInterval.toMillis(),
                 retryInterval.toMillis(),
                 TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Returns whether the archive already on disk matches the expected hash, in which case a retry only needs
+     * to re-run the install. A read failure is reported as "does not verify" so the retry falls back to
+     * downloading.
+     */
+    private static boolean archiveAlreadyVerifies(@NonNull final Path provingKeyPath, @NonNull final Bytes expected) {
+        if (!Files.exists(provingKeyPath)) {
+            return false;
+        }
+        try {
+            return hashFile(provingKeyPath).equals(expected);
+        } catch (final UncheckedIOException e) {
+            log.warn("Failed to read WRAPS proving key archive at {} on retry; will re-download", provingKeyPath, e);
+            return false;
+        }
     }
 
     private void cancelRetry() {
@@ -426,13 +483,14 @@ public class WrapsProvingKeyVerification {
 
     // --- Tar.gz extraction ---
 
-    private static void tryExtractTarGz(@NonNull final Path tarGzPath, @NonNull final String expectedHashHex) {
+    private static InstallOutcome tryExtractTarGz(
+            @NonNull final Path tarGzPath, @NonNull final String expectedHashHex) {
         final var envArtifactsPath = System.getenv(WRAPS_ARTIFACTS_ENV_VAR);
         if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
             log.warn(
                     "Cannot extract WRAPS proving key archive; {} environment variable is not set",
                     WRAPS_ARTIFACTS_ENV_VAR);
-            return;
+            return InstallOutcome.PERMANENTLY_BLOCKED;
         }
         final var extractionDir = Paths.get(envArtifactsPath);
         final var stagingDir = extractionDir.resolve(STAGING_DIR_NAME);
@@ -447,18 +505,36 @@ public class WrapsProvingKeyVerification {
                     .toList();
             if (!missingArtifacts.isEmpty()) {
                 log.error(
-                        "WRAPS proving key archive {} did not yield required artifacts {}; leaving the "
-                                + "installed artifacts in {} untouched",
+                        "WRAPS proving key archive {} verified against configured hash {} but did not yield "
+                                + "required artifacts {}; the installed artifacts in {} are left untouched and "
+                                + "WRAPS proving stays disabled. Retrying cannot help - the hash matches, so the "
+                                + "archive contents are fixed. Correct tss.wrapsProvingKeyHash (or the published "
+                                + "archive it names) and restart.",
                         tarGzPath,
+                        expectedHashHex,
                         missingArtifacts,
                         extractionDir);
-                return;
+                return InstallOutcome.PERMANENTLY_BLOCKED;
             }
             publishStagedArtifacts(stagingDir, extractionDir, expectedHashHex);
-            log.info("Installed WRAPS proving key artifacts from {} into {}", tarGzPath, extractionDir);
             verifyArtifactsDirectoryExists();
+            // The only credible evidence of a complete install is that the artifacts directory now passes
+            // the same check the prover readiness gate applies. Writing the markers is best-effort, so a
+            // clean return from the steps above does not by itself mean the install landed.
+            final var defect = installationDefect(envArtifactsPath, expectedHashHex);
+            if (defect != null) {
+                log.error(
+                        "WRAPS proving key install from {} did not complete: {}; proving stays disabled until "
+                                + "a later attempt succeeds",
+                        tarGzPath,
+                        defect);
+                return InstallOutcome.RETRYABLE;
+            }
+            log.info("Installed WRAPS proving key artifacts from {} into {}", tarGzPath, extractionDir);
+            return InstallOutcome.INSTALLED;
         } catch (final IOException e) {
             log.error("Failed to install WRAPS proving key archive {}", tarGzPath, e);
+            return InstallOutcome.RETRYABLE;
         } finally {
             try {
                 deleteRecursively(stagingDir);
@@ -520,8 +596,9 @@ public class WrapsProvingKeyVerification {
     /**
      * Writes the hash file ({@value #WRAPS_HASH_FILE_NAME}) into the artifacts directory so that
      * subsequent startups can detect the artifacts are already present and skip the download/extraction.
-     * A failure to write (e.g. a read-only mount) is logged but is non-fatal: the extracted artifacts
-     * remain usable.
+     * A failure to write (e.g. a read-only mount) is logged rather than thrown, but it is not harmless:
+     * without this file the install does not pass {@link #installationDefect} and the prover stays
+     * disabled, so the caller treats it as a failed install and retries.
      *
      * @param extractionDir the directory the artifacts were extracted into
      * @param hashHex the archive hash (bare hex) to record

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
@@ -15,12 +15,9 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.time.Duration;
-import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -48,11 +45,6 @@ import org.apache.logging.log4j.Logger;
  * <p>After successful hash verification, the proving key archive (.tar.gz) is extracted
  * to the directory specified by the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} environment variable.
  * The {@code tss.wrapsProvingKeyPath} config controls only where the archive file is stored on disk.
- *
- * <p>The archive is extracted into a staging subdirectory first and only then published onto the
- * artifacts directory, one atomic rename per file. The native library maps these artifacts, and
- * rewriting one in place truncates an inode a running proof may already have mapped, which faults
- * with {@code SIGBUS}; a rename leaves that inode intact.
  *
  * <p>To avoid re-downloading and re-extracting the multi-gigabyte archive on every startup when the
  * extracted artifacts are already present (e.g. mounted from the published data-only image), a
@@ -84,32 +76,9 @@ public class WrapsProvingKeyVerification {
      */
     static final String WRAPS_ARTIFACTS_MANIFEST_FILE_NAME = "wraps-artifacts.sha384";
 
-    /**
-     * Name of the staging subdirectory the archive is extracted into before its contents are published
-     * onto the artifacts directory. Kept inside the artifacts directory so that publishing is a
-     * same-filesystem rename; a sibling directory could land on a different mount.
-     */
-    static final String STAGING_DIR_NAME = ".wraps-staging";
-
     public static final int READ_BUFFER_SIZE = 50 * 1024 * 1024; // ~50 MB
     static final Set<String> REQUIRED_ARTIFACT_FILES =
             Set.of("decider_pp.bin", "decider_vp.bin", "nova_pp.bin", "nova_vp.bin");
-
-    /**
-     * Outcome of an install attempt, which decides whether a retry is worth scheduling.
-     */
-    private enum InstallOutcome {
-        /** The artifacts directory now passes {@link #installationDefect}. */
-        INSTALLED,
-        /**
-         * Retrying cannot help. The archive's SHA-384 matched {@code tss.wrapsProvingKeyHash}, so its contents
-         * are fixed; if it did not yield the required artifacts, no later attempt on the same configured hash
-         * ever will. Also covers an unset artifacts path.
-         */
-        PERMANENTLY_BLOCKED,
-        /** An environmental failure (I/O error, permissions, disk space); a later attempt may succeed. */
-        RETRYABLE
-    }
 
     private final Executor downloadExecutor;
 
@@ -191,8 +160,9 @@ public class WrapsProvingKeyVerification {
 
     /**
      * Determines whether the extracted WRAPS artifacts are already present in the artifacts directory
-     * and up to date, so that the archive download and extraction can be skipped. Logs the reason when
-     * they are not.
+     * and up to date, so that the archive download and extraction can be skipped. This is the case when
+     * the hash file ({@value #WRAPS_HASH_FILE_NAME}) exists, its contents match the expected
+     * archive hash from config, and all {@link #REQUIRED_ARTIFACT_FILES} are present.
      *
      * @param envArtifactsPath the artifacts directory path, or null/blank if unset
      * @param expectedHashHex the expected archive hash (bare hex) from {@code tss.wrapsProvingKeyHash}
@@ -200,70 +170,51 @@ public class WrapsProvingKeyVerification {
      */
     static boolean artifactsAlreadyPresent(
             @Nullable final String envArtifactsPath, @NonNull final String expectedHashHex) {
-        final var defect = installationDefect(envArtifactsPath, expectedHashHex);
-        if (defect != null) {
-            log.info("Not skipping WRAPS download and extraction for {}: {}", envArtifactsPath, defect);
-            return false;
-        }
-        return true;
-    }
-
-    /**
-     * Returns whether the WRAPS artifacts installed in {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} are complete
-     * and verified against the given archive hash, so that native code may safely map them.
-     *
-     * <p>This holds the installation to the same bar as {@link #artifactsAlreadyPresent}: merely finding
-     * the four {@code *.bin} filenames is not enough, because they may be a different proving key, or the
-     * partially published output of an install still in flight. Unlike {@code artifactsAlreadyPresent}
-     * this is quiet, since it is consulted once per consensus round.
-     *
-     * @param expectedHashHex the expected archive hash (bare hex) from {@code tss.wrapsProvingKeyHash}
-     * @return true if the installed artifacts are complete and match the expected hash
-     */
-    public static boolean artifactsInstalledAndVerified(@NonNull final String expectedHashHex) {
-        requireNonNull(expectedHashHex);
-        return installationDefect(System.getenv(WRAPS_ARTIFACTS_ENV_VAR), expectedHashHex) == null;
-    }
-
-    /**
-     * Returns a human-readable description of why the artifacts directory does not hold a complete
-     * installation of the expected proving key, or null if it does.
-     */
-    @Nullable
-    private static String installationDefect(
-            @Nullable final String envArtifactsPath, @NonNull final String expectedHashHex) {
         if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
-            return WRAPS_ARTIFACTS_ENV_VAR + " is not set";
+            return false;
         }
         final var artifactsDir = Paths.get(envArtifactsPath);
         final var hashFile = artifactsDir.resolve(WRAPS_HASH_FILE_NAME);
         if (!Files.isRegularFile(hashFile)) {
-            return "hash file " + hashFile + " is missing";
+            return false;
         }
         final String storedHash;
         try {
             storedHash = Files.readString(hashFile).trim();
         } catch (final IOException e) {
-            return "hash file " + hashFile + " could not be read (" + e.getMessage() + ")";
+            log.warn("Failed to read WRAPS hash file {}; will verify the archive instead", hashFile, e);
+            return false;
         }
         if (!storedHash.equalsIgnoreCase(expectedHashHex.trim())) {
-            return "hash file " + hashFile + " (" + storedHash + ") does not match the configured hash ("
-                    + expectedHashHex + ")";
+            log.info(
+                    "WRAPS hash file {} ({}) does not match configured hash ({}); will download and extract",
+                    hashFile,
+                    storedHash,
+                    expectedHashHex);
+            return false;
         }
         final var missingArtifacts = REQUIRED_ARTIFACT_FILES.stream()
                 .filter(name -> !Files.isRegularFile(artifactsDir.resolve(name)))
                 .toList();
         if (!missingArtifacts.isEmpty()) {
-            return "artifacts " + missingArtifacts + " are missing from " + artifactsDir;
+            log.warn(
+                    "WRAPS hash file {} matches config but artifacts {} are missing in {}; will download and extract",
+                    hashFile,
+                    missingArtifacts,
+                    artifactsDir);
+            return false;
         }
         // If a manifest is present, verify it lists all required artifacts. An absent manifest is
         // accepted (e.g. an older image without the manifest file) to preserve backwards compatibility
         // with read-only mounts that cannot be updated.
         final var manifestFile = artifactsDir.resolve(WRAPS_ARTIFACTS_MANIFEST_FILE_NAME);
         if (Files.isRegularFile(manifestFile) && !manifestListsAllArtifacts(manifestFile)) {
-            return "artifacts manifest " + manifestFile + " is incomplete or unreadable";
+            log.warn(
+                    "WRAPS artifacts manifest {} is incomplete or unreadable; will re-download and extract",
+                    manifestFile);
+            return false;
         }
-        return null;
+        return true;
     }
 
     private void verifyFileAndDownloadIfNeeded(
@@ -301,10 +252,8 @@ public class WrapsProvingKeyVerification {
             asyncDownloadAndVerify(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
             return;
         }
-        // Hash matches - install the archive, retrying only if a later attempt could succeed
-        if (tryExtractTarGz(provingKeyPath, expectedHash.toHex()) == InstallOutcome.RETRYABLE) {
-            scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
-        }
+        // Hash matches - extract the archive
+        tryExtractTarGz(provingKeyPath, expectedHash.toHex());
     }
 
     private void asyncDownloadAndVerify(
@@ -331,14 +280,8 @@ public class WrapsProvingKeyVerification {
                                 scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
                                 return;
                             }
-                            final var outcome = tryExtractTarGz(provingKeyPath, expectedHash.toHex());
-                            if (outcome == InstallOutcome.INSTALLED) {
-                                log.info(
-                                        "Successfully downloaded and verified WRAPS proving key (hash={})",
-                                        expectedHash);
-                            } else if (outcome == InstallOutcome.RETRYABLE) {
-                                scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
-                            }
+                            tryExtractTarGz(provingKeyPath, expectedHash.toHex());
+                            log.info("Successfully downloaded and verified WRAPS proving key (hash={})", expectedHash);
                         } catch (final Throwable t) {
                             log.error(
                                     "Failed to initiate async download of WRAPS proving key (from URL {}):",
@@ -376,36 +319,20 @@ public class WrapsProvingKeyVerification {
                         return;
                     }
                     try {
-                        // A retry may be here only because the install failed, not the download. Re-pulling a
-                        // multi-gigabyte archive that is already on disk and still verifies wastes bandwidth
-                        // every interval, so re-run the install directly in that case.
-                        if (archiveAlreadyVerifies(provingKeyPath, expectedHash)) {
-                            log.info(
-                                    "WRAPS proving key archive at {} still matches the expected hash; retrying the "
-                                            + "install without re-downloading",
-                                    provingKeyPath);
-                        } else {
-                            log.info("Retrying WRAPS proving key download from {}", downloadUrl);
-                            downloader.download(downloadUrl, provingKeyPath);
-                            final Bytes downloadedHash = hashFile(provingKeyPath);
-                            if (!downloadedHash.equals(expectedHash)) {
-                                log.error(
-                                        "Downloaded WRAPS proving key hash mismatch on retry: expected={}, actual={}",
-                                        expectedHash,
-                                        downloadedHash);
-                                return;
-                            }
-                        }
-                        final var outcome = tryExtractTarGz(provingKeyPath, expectedHash.toHex());
-                        if (outcome == InstallOutcome.INSTALLED) {
+                        log.info("Retrying WRAPS proving key download from {}", downloadUrl);
+                        downloader.download(downloadUrl, provingKeyPath);
+                        final Bytes downloadedHash = hashFile(provingKeyPath);
+                        if (downloadedHash.equals(expectedHash)) {
+                            tryExtractTarGz(provingKeyPath, expectedHash.toHex());
                             log.info(
                                     "Successfully downloaded and verified WRAPS proving key on retry (hash={})",
                                     expectedHash);
                             cancelRetry();
-                        } else if (outcome == InstallOutcome.PERMANENTLY_BLOCKED) {
-                            // Nothing a later attempt can change; stop burning I/O re-running it every interval
-                            log.error("Giving up on WRAPS proving key retries; see the error above for the cause");
-                            cancelRetry();
+                        } else {
+                            log.error(
+                                    "Downloaded WRAPS proving key hash mismatch on retry: expected={}, actual={}",
+                                    expectedHash,
+                                    downloadedHash);
                         }
                     } catch (final Throwable e) {
                         log.error("Failed to download WRAPS proving key on retry", e);
@@ -416,23 +343,6 @@ public class WrapsProvingKeyVerification {
                 retryInterval.toMillis(),
                 retryInterval.toMillis(),
                 TimeUnit.MILLISECONDS);
-    }
-
-    /**
-     * Returns whether the archive already on disk matches the expected hash, in which case a retry only needs
-     * to re-run the install. A read failure is reported as "does not verify" so the retry falls back to
-     * downloading.
-     */
-    private static boolean archiveAlreadyVerifies(@NonNull final Path provingKeyPath, @NonNull final Bytes expected) {
-        if (!Files.exists(provingKeyPath)) {
-            return false;
-        }
-        try {
-            return hashFile(provingKeyPath).equals(expected);
-        } catch (final UncheckedIOException e) {
-            log.warn("Failed to read WRAPS proving key archive at {} on retry; will re-download", provingKeyPath, e);
-            return false;
-        }
     }
 
     private void cancelRetry() {
@@ -483,122 +393,32 @@ public class WrapsProvingKeyVerification {
 
     // --- Tar.gz extraction ---
 
-    private static InstallOutcome tryExtractTarGz(
-            @NonNull final Path tarGzPath, @NonNull final String expectedHashHex) {
+    private static void tryExtractTarGz(@NonNull final Path tarGzPath, @NonNull final String expectedHashHex) {
         final var envArtifactsPath = System.getenv(WRAPS_ARTIFACTS_ENV_VAR);
         if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
             log.warn(
                     "Cannot extract WRAPS proving key archive; {} environment variable is not set",
                     WRAPS_ARTIFACTS_ENV_VAR);
-            return InstallOutcome.PERMANENTLY_BLOCKED;
-        }
-        final var extractionDir = Paths.get(envArtifactsPath);
-        final var stagingDir = extractionDir.resolve(STAGING_DIR_NAME);
-        try {
-            Files.createDirectories(extractionDir);
-            deleteRecursively(stagingDir);
-            Files.createDirectories(stagingDir);
-            TarGzExtractor.extract(tarGzPath, stagingDir);
-            log.info("Extracted WRAPS proving key archive {} to staging directory {}", tarGzPath, stagingDir);
-            final var missingArtifacts = REQUIRED_ARTIFACT_FILES.stream()
-                    .filter(name -> !Files.isRegularFile(stagingDir.resolve(name)))
-                    .toList();
-            if (!missingArtifacts.isEmpty()) {
-                log.error(
-                        "WRAPS proving key archive {} verified against configured hash {} but did not yield "
-                                + "required artifacts {}; the installed artifacts in {} are left untouched and "
-                                + "WRAPS proving stays disabled. Retrying cannot help - the hash matches, so the "
-                                + "archive contents are fixed. Correct tss.wrapsProvingKeyHash (or the published "
-                                + "archive it names) and restart.",
-                        tarGzPath,
-                        expectedHashHex,
-                        missingArtifacts,
-                        extractionDir);
-                return InstallOutcome.PERMANENTLY_BLOCKED;
-            }
-            publishStagedArtifacts(stagingDir, extractionDir, expectedHashHex);
-            verifyArtifactsDirectoryExists();
-            // The only credible evidence of a complete install is that the artifacts directory now passes
-            // the same check the prover readiness gate applies. Writing the markers is best-effort, so a
-            // clean return from the steps above does not by itself mean the install landed.
-            final var defect = installationDefect(envArtifactsPath, expectedHashHex);
-            if (defect != null) {
-                log.error(
-                        "WRAPS proving key install from {} did not complete: {}; proving stays disabled until "
-                                + "a later attempt succeeds",
-                        tarGzPath,
-                        defect);
-                return InstallOutcome.RETRYABLE;
-            }
-            log.info("Installed WRAPS proving key artifacts from {} into {}", tarGzPath, extractionDir);
-            return InstallOutcome.INSTALLED;
-        } catch (final IOException e) {
-            log.error("Failed to install WRAPS proving key archive {}", tarGzPath, e);
-            return InstallOutcome.RETRYABLE;
-        } finally {
-            try {
-                deleteRecursively(stagingDir);
-            } catch (final IOException e) {
-                log.warn("Failed to clean up WRAPS staging directory {}", stagingDir, e);
-            }
-        }
-    }
-
-    /**
-     * Publishes freshly extracted artifacts from the staging directory onto the live artifacts directory.
-     *
-     * <p>Each file is moved with {@link StandardCopyOption#ATOMIC_MOVE}, which replaces the directory entry
-     * without touching the previous inode. A proof already running against the old artifacts therefore keeps
-     * a valid mapping, rather than faulting with {@code SIGBUS} the way an in-place rewrite does when it
-     * truncates a file the native library has mapped.
-     *
-     * <p>The readiness markers are removed first: while the moves are in flight the directory holds a mix of
-     * old and new files, and {@code HistoryLibrary.wrapsProverReady} must not admit a proof against it. The
-     * hash file is written last, so its presence implies a complete installation.
-     */
-    private static void publishStagedArtifacts(
-            @NonNull final Path stagingDir, @NonNull final Path extractionDir, @NonNull final String expectedHashHex)
-            throws IOException {
-        Files.deleteIfExists(extractionDir.resolve(WRAPS_HASH_FILE_NAME));
-        Files.deleteIfExists(extractionDir.resolve(WRAPS_ARTIFACTS_MANIFEST_FILE_NAME));
-        final List<Path> stagedFiles;
-        try (final var paths = Files.walk(stagingDir)) {
-            stagedFiles = paths.filter(Files::isRegularFile).toList();
-        }
-        for (final var source : stagedFiles) {
-            final var target = extractionDir.resolve(stagingDir.relativize(source));
-            final var targetParent = target.getParent();
-            if (targetParent != null) {
-                Files.createDirectories(targetParent);
-            }
-            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
-        }
-        writeArtifactsManifest(extractionDir);
-        writeHashFile(extractionDir, expectedHashHex);
-    }
-
-    /**
-     * Deletes the given directory tree if it exists, deepest entries first.
-     */
-    private static void deleteRecursively(@NonNull final Path dir) throws IOException {
-        if (!Files.exists(dir)) {
             return;
         }
-        final List<Path> entries;
-        try (final var paths = Files.walk(dir)) {
-            entries = paths.sorted(Comparator.reverseOrder()).toList();
-        }
-        for (final var entry : entries) {
-            Files.deleteIfExists(entry);
+        final var extractionDir = Paths.get(envArtifactsPath);
+        try {
+            Files.createDirectories(extractionDir);
+            TarGzExtractor.extract(tarGzPath, extractionDir);
+            log.info("Extracted WRAPS proving key archive {} to {}", tarGzPath, extractionDir);
+            verifyArtifactsDirectoryExists();
+            writeHashFile(extractionDir, expectedHashHex);
+            writeArtifactsManifest(extractionDir);
+        } catch (final IOException e) {
+            log.error("Failed to extract WRAPS proving key archive {}", tarGzPath, e);
         }
     }
 
     /**
      * Writes the hash file ({@value #WRAPS_HASH_FILE_NAME}) into the artifacts directory so that
      * subsequent startups can detect the artifacts are already present and skip the download/extraction.
-     * A failure to write (e.g. a read-only mount) is logged rather than thrown, but it is not harmless:
-     * without this file the install does not pass {@link #installationDefect} and the prover stays
-     * disabled, so the caller treats it as a failed install and retries.
+     * A failure to write (e.g. a read-only mount) is logged but is non-fatal: the extracted artifacts
+     * remain usable.
      *
      * @param extractionDir the directory the artifacts were extracted into
      * @param hashHex the archive hash (bare hex) to record

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
@@ -15,9 +15,12 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -45,6 +48,11 @@ import org.apache.logging.log4j.Logger;
  * <p>After successful hash verification, the proving key archive (.tar.gz) is extracted
  * to the directory specified by the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} environment variable.
  * The {@code tss.wrapsProvingKeyPath} config controls only where the archive file is stored on disk.
+ *
+ * <p>The archive is extracted into a staging subdirectory first and only then published onto the
+ * artifacts directory, one atomic rename per file. The native library maps these artifacts, and
+ * rewriting one in place truncates an inode a running proof may already have mapped, which faults
+ * with {@code SIGBUS}; a rename leaves that inode intact.
  *
  * <p>To avoid re-downloading and re-extracting the multi-gigabyte archive on every startup when the
  * extracted artifacts are already present (e.g. mounted from the published data-only image), a
@@ -75,6 +83,13 @@ public class WrapsProvingKeyVerification {
      * incomplete installation.
      */
     static final String WRAPS_ARTIFACTS_MANIFEST_FILE_NAME = "wraps-artifacts.sha384";
+
+    /**
+     * Name of the staging subdirectory the archive is extracted into before its contents are published
+     * onto the artifacts directory. Kept inside the artifacts directory so that publishing is a
+     * same-filesystem rename; a sibling directory could land on a different mount.
+     */
+    static final String STAGING_DIR_NAME = ".wraps-staging";
 
     public static final int READ_BUFFER_SIZE = 50 * 1024 * 1024; // ~50 MB
     static final Set<String> REQUIRED_ARTIFACT_FILES =
@@ -160,9 +175,8 @@ public class WrapsProvingKeyVerification {
 
     /**
      * Determines whether the extracted WRAPS artifacts are already present in the artifacts directory
-     * and up to date, so that the archive download and extraction can be skipped. This is the case when
-     * the hash file ({@value #WRAPS_HASH_FILE_NAME}) exists, its contents match the expected
-     * archive hash from config, and all {@link #REQUIRED_ARTIFACT_FILES} are present.
+     * and up to date, so that the archive download and extraction can be skipped. Logs the reason when
+     * they are not.
      *
      * @param envArtifactsPath the artifacts directory path, or null/blank if unset
      * @param expectedHashHex the expected archive hash (bare hex) from {@code tss.wrapsProvingKeyHash}
@@ -170,51 +184,70 @@ public class WrapsProvingKeyVerification {
      */
     static boolean artifactsAlreadyPresent(
             @Nullable final String envArtifactsPath, @NonNull final String expectedHashHex) {
-        if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
+        final var defect = installationDefect(envArtifactsPath, expectedHashHex);
+        if (defect != null) {
+            log.info("Not skipping WRAPS download and extraction for {}: {}", envArtifactsPath, defect);
             return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns whether the WRAPS artifacts installed in {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} are complete
+     * and verified against the given archive hash, so that native code may safely map them.
+     *
+     * <p>This holds the installation to the same bar as {@link #artifactsAlreadyPresent}: merely finding
+     * the four {@code *.bin} filenames is not enough, because they may be a different proving key, or the
+     * partially published output of an install still in flight. Unlike {@code artifactsAlreadyPresent}
+     * this is quiet, since it is consulted once per consensus round.
+     *
+     * @param expectedHashHex the expected archive hash (bare hex) from {@code tss.wrapsProvingKeyHash}
+     * @return true if the installed artifacts are complete and match the expected hash
+     */
+    public static boolean artifactsInstalledAndVerified(@NonNull final String expectedHashHex) {
+        requireNonNull(expectedHashHex);
+        return installationDefect(System.getenv(WRAPS_ARTIFACTS_ENV_VAR), expectedHashHex) == null;
+    }
+
+    /**
+     * Returns a human-readable description of why the artifacts directory does not hold a complete
+     * installation of the expected proving key, or null if it does.
+     */
+    @Nullable
+    private static String installationDefect(
+            @Nullable final String envArtifactsPath, @NonNull final String expectedHashHex) {
+        if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
+            return WRAPS_ARTIFACTS_ENV_VAR + " is not set";
         }
         final var artifactsDir = Paths.get(envArtifactsPath);
         final var hashFile = artifactsDir.resolve(WRAPS_HASH_FILE_NAME);
         if (!Files.isRegularFile(hashFile)) {
-            return false;
+            return "hash file " + hashFile + " is missing";
         }
         final String storedHash;
         try {
             storedHash = Files.readString(hashFile).trim();
         } catch (final IOException e) {
-            log.warn("Failed to read WRAPS hash file {}; will verify the archive instead", hashFile, e);
-            return false;
+            return "hash file " + hashFile + " could not be read (" + e.getMessage() + ")";
         }
         if (!storedHash.equalsIgnoreCase(expectedHashHex.trim())) {
-            log.info(
-                    "WRAPS hash file {} ({}) does not match configured hash ({}); will download and extract",
-                    hashFile,
-                    storedHash,
-                    expectedHashHex);
-            return false;
+            return "hash file " + hashFile + " (" + storedHash + ") does not match the configured hash ("
+                    + expectedHashHex + ")";
         }
         final var missingArtifacts = REQUIRED_ARTIFACT_FILES.stream()
                 .filter(name -> !Files.isRegularFile(artifactsDir.resolve(name)))
                 .toList();
         if (!missingArtifacts.isEmpty()) {
-            log.warn(
-                    "WRAPS hash file {} matches config but artifacts {} are missing in {}; will download and extract",
-                    hashFile,
-                    missingArtifacts,
-                    artifactsDir);
-            return false;
+            return "artifacts " + missingArtifacts + " are missing from " + artifactsDir;
         }
         // If a manifest is present, verify it lists all required artifacts. An absent manifest is
         // accepted (e.g. an older image without the manifest file) to preserve backwards compatibility
         // with read-only mounts that cannot be updated.
         final var manifestFile = artifactsDir.resolve(WRAPS_ARTIFACTS_MANIFEST_FILE_NAME);
         if (Files.isRegularFile(manifestFile) && !manifestListsAllArtifacts(manifestFile)) {
-            log.warn(
-                    "WRAPS artifacts manifest {} is incomplete or unreadable; will re-download and extract",
-                    manifestFile);
-            return false;
+            return "artifacts manifest " + manifestFile + " is incomplete or unreadable";
         }
-        return true;
+        return null;
     }
 
     private void verifyFileAndDownloadIfNeeded(
@@ -402,15 +435,85 @@ public class WrapsProvingKeyVerification {
             return;
         }
         final var extractionDir = Paths.get(envArtifactsPath);
+        final var stagingDir = extractionDir.resolve(STAGING_DIR_NAME);
         try {
             Files.createDirectories(extractionDir);
-            TarGzExtractor.extract(tarGzPath, extractionDir);
-            log.info("Extracted WRAPS proving key archive {} to {}", tarGzPath, extractionDir);
+            deleteRecursively(stagingDir);
+            Files.createDirectories(stagingDir);
+            TarGzExtractor.extract(tarGzPath, stagingDir);
+            log.info("Extracted WRAPS proving key archive {} to staging directory {}", tarGzPath, stagingDir);
+            final var missingArtifacts = REQUIRED_ARTIFACT_FILES.stream()
+                    .filter(name -> !Files.isRegularFile(stagingDir.resolve(name)))
+                    .toList();
+            if (!missingArtifacts.isEmpty()) {
+                log.error(
+                        "WRAPS proving key archive {} did not yield required artifacts {}; leaving the "
+                                + "installed artifacts in {} untouched",
+                        tarGzPath,
+                        missingArtifacts,
+                        extractionDir);
+                return;
+            }
+            publishStagedArtifacts(stagingDir, extractionDir, expectedHashHex);
+            log.info("Installed WRAPS proving key artifacts from {} into {}", tarGzPath, extractionDir);
             verifyArtifactsDirectoryExists();
-            writeHashFile(extractionDir, expectedHashHex);
-            writeArtifactsManifest(extractionDir);
         } catch (final IOException e) {
-            log.error("Failed to extract WRAPS proving key archive {}", tarGzPath, e);
+            log.error("Failed to install WRAPS proving key archive {}", tarGzPath, e);
+        } finally {
+            try {
+                deleteRecursively(stagingDir);
+            } catch (final IOException e) {
+                log.warn("Failed to clean up WRAPS staging directory {}", stagingDir, e);
+            }
+        }
+    }
+
+    /**
+     * Publishes freshly extracted artifacts from the staging directory onto the live artifacts directory.
+     *
+     * <p>Each file is moved with {@link StandardCopyOption#ATOMIC_MOVE}, which replaces the directory entry
+     * without touching the previous inode. A proof already running against the old artifacts therefore keeps
+     * a valid mapping, rather than faulting with {@code SIGBUS} the way an in-place rewrite does when it
+     * truncates a file the native library has mapped.
+     *
+     * <p>The readiness markers are removed first: while the moves are in flight the directory holds a mix of
+     * old and new files, and {@code HistoryLibrary.wrapsProverReady} must not admit a proof against it. The
+     * hash file is written last, so its presence implies a complete installation.
+     */
+    private static void publishStagedArtifacts(
+            @NonNull final Path stagingDir, @NonNull final Path extractionDir, @NonNull final String expectedHashHex)
+            throws IOException {
+        Files.deleteIfExists(extractionDir.resolve(WRAPS_HASH_FILE_NAME));
+        Files.deleteIfExists(extractionDir.resolve(WRAPS_ARTIFACTS_MANIFEST_FILE_NAME));
+        final List<Path> stagedFiles;
+        try (final var paths = Files.walk(stagingDir)) {
+            stagedFiles = paths.filter(Files::isRegularFile).toList();
+        }
+        for (final var source : stagedFiles) {
+            final var target = extractionDir.resolve(stagingDir.relativize(source));
+            final var targetParent = target.getParent();
+            if (targetParent != null) {
+                Files.createDirectories(targetParent);
+            }
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+        }
+        writeArtifactsManifest(extractionDir);
+        writeHashFile(extractionDir, expectedHashHex);
+    }
+
+    /**
+     * Deletes the given directory tree if it exists, deepest entries first.
+     */
+    private static void deleteRecursively(@NonNull final Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            return;
+        }
+        final List<Path> entries;
+        try (final var paths = Files.walk(dir)) {
+            entries = paths.sorted(Comparator.reverseOrder()).toList();
+        }
+        for (final var entry : entries) {
+            Files.deleteIfExists(entry);
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/WrapsProvingKeyVerification.java
@@ -15,9 +15,12 @@ import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
 import java.security.MessageDigest;
 import java.time.Duration;
+import java.util.Comparator;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
@@ -45,6 +48,11 @@ import org.apache.logging.log4j.Logger;
  * <p>After successful hash verification, the proving key archive (.tar.gz) is extracted
  * to the directory specified by the {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} environment variable.
  * The {@code tss.wrapsProvingKeyPath} config controls only where the archive file is stored on disk.
+ *
+ * <p>The archive is extracted into a staging subdirectory first and only then published onto the
+ * artifacts directory, one atomic rename per file. The native library maps these artifacts, and
+ * rewriting one in place truncates an inode a running proof may already have mapped, which faults
+ * with {@code SIGBUS}; a rename leaves that inode intact.
  *
  * <p>To avoid re-downloading and re-extracting the multi-gigabyte archive on every startup when the
  * extracted artifacts are already present (e.g. mounted from the published data-only image), a
@@ -76,9 +84,32 @@ public class WrapsProvingKeyVerification {
      */
     static final String WRAPS_ARTIFACTS_MANIFEST_FILE_NAME = "wraps-artifacts.sha384";
 
+    /**
+     * Name of the staging subdirectory the archive is extracted into before its contents are published
+     * onto the artifacts directory. Kept inside the artifacts directory so that publishing is a
+     * same-filesystem rename; a sibling directory could land on a different mount.
+     */
+    static final String STAGING_DIR_NAME = ".wraps-staging";
+
     public static final int READ_BUFFER_SIZE = 50 * 1024 * 1024; // ~50 MB
     static final Set<String> REQUIRED_ARTIFACT_FILES =
             Set.of("decider_pp.bin", "decider_vp.bin", "nova_pp.bin", "nova_vp.bin");
+
+    /**
+     * Outcome of an install attempt, which decides whether a retry is worth scheduling.
+     */
+    private enum InstallOutcome {
+        /** The artifacts directory now passes {@link #installationDefect}. */
+        INSTALLED,
+        /**
+         * Retrying cannot help. The archive's SHA-384 matched {@code tss.wrapsProvingKeyHash}, so its contents
+         * are fixed; if it did not yield the required artifacts, no later attempt on the same configured hash
+         * ever will. Also covers an unset artifacts path.
+         */
+        PERMANENTLY_BLOCKED,
+        /** An environmental failure (I/O error, permissions, disk space); a later attempt may succeed. */
+        RETRYABLE
+    }
 
     private final Executor downloadExecutor;
 
@@ -89,11 +120,13 @@ public class WrapsProvingKeyVerification {
     private volatile ScheduledFuture<?> retryFuture;
 
     /**
-     * Guards against more than one acquisition attempt at a time, covering both the download and the extraction
-     * that follows it. {@link #ensureProvingKey} runs on every init trigger, so without this a node that keeps
-     * reconnecting while the archive is unavailable stacks a download per reconnect on the shared
-     * {@link ForkJoinPool#commonPool()}, and the concurrent attempts truncate each other's output at
-     * {@code provingKeyPath}.
+     * Guards against more than one acquisition attempt at a time, covering the archive hashing, the download
+     * and the install that follows, on both the synchronous and asynchronous paths. {@link #ensureProvingKey}
+     * runs on every init trigger, so without this a node that keeps reconnecting while the archive is
+     * unavailable stacks a download per reconnect on the shared {@link ForkJoinPool#commonPool()}, and the
+     * concurrent attempts truncate each other's output at {@code provingKeyPath}. It also keeps a scheduled
+     * retry from installing concurrently with a synchronous attempt: they share one staging directory, and
+     * interleaved extraction and publication could hand the prover a partially written artifact.
      */
     private final AtomicBoolean downloadInFlight = new AtomicBoolean();
 
@@ -160,9 +193,8 @@ public class WrapsProvingKeyVerification {
 
     /**
      * Determines whether the extracted WRAPS artifacts are already present in the artifacts directory
-     * and up to date, so that the archive download and extraction can be skipped. This is the case when
-     * the hash file ({@value #WRAPS_HASH_FILE_NAME}) exists, its contents match the expected
-     * archive hash from config, and all {@link #REQUIRED_ARTIFACT_FILES} are present.
+     * and up to date, so that the archive download and extraction can be skipped. Logs the reason when
+     * they are not.
      *
      * @param envArtifactsPath the artifacts directory path, or null/blank if unset
      * @param expectedHashHex the expected archive hash (bare hex) from {@code tss.wrapsProvingKeyHash}
@@ -170,51 +202,70 @@ public class WrapsProvingKeyVerification {
      */
     static boolean artifactsAlreadyPresent(
             @Nullable final String envArtifactsPath, @NonNull final String expectedHashHex) {
-        if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
+        final var defect = installationDefect(envArtifactsPath, expectedHashHex);
+        if (defect != null) {
+            log.info("Not skipping WRAPS download and extraction for {}: {}", envArtifactsPath, defect);
             return false;
+        }
+        return true;
+    }
+
+    /**
+     * Returns whether the WRAPS artifacts installed in {@code TSS_LIB_WRAPS_ARTIFACTS_PATH} are complete
+     * and verified against the given archive hash, so that native code may safely map them.
+     *
+     * <p>This holds the installation to the same bar as {@link #artifactsAlreadyPresent}: merely finding
+     * the four {@code *.bin} filenames is not enough, because they may be a different proving key, or the
+     * partially published output of an install still in flight. Unlike {@code artifactsAlreadyPresent}
+     * this is quiet, since it is consulted once per consensus round.
+     *
+     * @param expectedHashHex the expected archive hash (bare hex) from {@code tss.wrapsProvingKeyHash}
+     * @return true if the installed artifacts are complete and match the expected hash
+     */
+    public static boolean artifactsInstalledAndVerified(@NonNull final String expectedHashHex) {
+        requireNonNull(expectedHashHex);
+        return installationDefect(System.getenv(WRAPS_ARTIFACTS_ENV_VAR), expectedHashHex) == null;
+    }
+
+    /**
+     * Returns a human-readable description of why the artifacts directory does not hold a complete
+     * installation of the expected proving key, or null if it does.
+     */
+    @Nullable
+    private static String installationDefect(
+            @Nullable final String envArtifactsPath, @NonNull final String expectedHashHex) {
+        if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
+            return WRAPS_ARTIFACTS_ENV_VAR + " is not set";
         }
         final var artifactsDir = Paths.get(envArtifactsPath);
         final var hashFile = artifactsDir.resolve(WRAPS_HASH_FILE_NAME);
         if (!Files.isRegularFile(hashFile)) {
-            return false;
+            return "hash file " + hashFile + " is missing";
         }
         final String storedHash;
         try {
             storedHash = Files.readString(hashFile).trim();
         } catch (final IOException e) {
-            log.warn("Failed to read WRAPS hash file {}; will verify the archive instead", hashFile, e);
-            return false;
+            return "hash file " + hashFile + " could not be read (" + e.getMessage() + ")";
         }
         if (!storedHash.equalsIgnoreCase(expectedHashHex.trim())) {
-            log.info(
-                    "WRAPS hash file {} ({}) does not match configured hash ({}); will download and extract",
-                    hashFile,
-                    storedHash,
-                    expectedHashHex);
-            return false;
+            return "hash file " + hashFile + " (" + storedHash + ") does not match the configured hash ("
+                    + expectedHashHex + ")";
         }
         final var missingArtifacts = REQUIRED_ARTIFACT_FILES.stream()
                 .filter(name -> !Files.isRegularFile(artifactsDir.resolve(name)))
                 .toList();
         if (!missingArtifacts.isEmpty()) {
-            log.warn(
-                    "WRAPS hash file {} matches config but artifacts {} are missing in {}; will download and extract",
-                    hashFile,
-                    missingArtifacts,
-                    artifactsDir);
-            return false;
+            return "artifacts " + missingArtifacts + " are missing from " + artifactsDir;
         }
         // If a manifest is present, verify it lists all required artifacts. An absent manifest is
         // accepted (e.g. an older image without the manifest file) to preserve backwards compatibility
         // with read-only mounts that cannot be updated.
         final var manifestFile = artifactsDir.resolve(WRAPS_ARTIFACTS_MANIFEST_FILE_NAME);
         if (Files.isRegularFile(manifestFile) && !manifestListsAllArtifacts(manifestFile)) {
-            log.warn(
-                    "WRAPS artifacts manifest {} is incomplete or unreadable; will re-download and extract",
-                    manifestFile);
-            return false;
+            return "artifacts manifest " + manifestFile + " is incomplete or unreadable";
         }
-        return true;
+        return null;
     }
 
     private void verifyFileAndDownloadIfNeeded(
@@ -223,49 +274,66 @@ public class WrapsProvingKeyVerification {
             @NonNull final String downloadUrl,
             @NonNull final HttpWrapsProvingKeyDownloader downloader,
             @NonNull final Duration retryInterval) {
-        // An in-flight attempt verifies and extracts the archive itself, so there is nothing to do here. Checked
-        // before hashing, which reads a multi-gigabyte file on the init thread.
-        if (downloadInFlight.get()) {
+        // Claim the guard for the WHOLE attempt, not just the download. The synchronous branch below hashes a
+        // multi-gigabyte archive and then installs it, and the scheduled retry acquires the same guard; without
+        // holding it here the two could extract into the same staging directory and delete each other's files,
+        // or publish a staging inode that the other extractor still has open and is still writing to.
+        if (!downloadInFlight.compareAndSet(false, true)) {
             log.info("A WRAPS proving key acquisition is already in progress, skipping this check");
             return;
         }
-        final var expectedHash = Bytes.fromHex(bootstrapHash);
-        if (!Files.exists(provingKeyPath)) {
-            log.info("WRAPS proving key file not found at {}. Initiating download", provingKeyPath);
-            asyncDownloadAndVerify(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
-            return;
-        }
-        final Bytes fileHash;
+        // Set once the guard has been handed to the async task, which releases it when it finishes
+        boolean handedOff = false;
         try {
-            fileHash = hashFile(provingKeyPath);
-        } catch (final UncheckedIOException e) {
-            log.warn("Failed to read WRAPS proving key file at {}; initiating download", provingKeyPath, e);
-            asyncDownloadAndVerify(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
-            return;
+            final var expectedHash = Bytes.fromHex(bootstrapHash);
+            if (!Files.exists(provingKeyPath)) {
+                log.info("WRAPS proving key file not found at {}. Initiating download", provingKeyPath);
+                asyncDownloadAndVerify(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
+                handedOff = true;
+                return;
+            }
+            final Bytes fileHash;
+            try {
+                fileHash = hashFile(provingKeyPath);
+            } catch (final UncheckedIOException e) {
+                log.warn("Failed to read WRAPS proving key file at {}; initiating download", provingKeyPath, e);
+                asyncDownloadAndVerify(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
+                handedOff = true;
+                return;
+            }
+            if (!fileHash.equals(expectedHash)) {
+                log.warn(
+                        "WRAPS proving key hash mismatch at {} (expected={}, actual={}), initiating download",
+                        provingKeyPath,
+                        expectedHash,
+                        fileHash);
+                asyncDownloadAndVerify(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
+                handedOff = true;
+                return;
+            }
+            // Hash matches - install the archive, retrying only if a later attempt could succeed
+            if (tryExtractTarGz(provingKeyPath, expectedHash.toHex()) == InstallOutcome.RETRYABLE) {
+                scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
+            }
+        } finally {
+            // A leaked guard would block every later acquisition for the life of the process
+            if (!handedOff) {
+                downloadInFlight.set(false);
+            }
         }
-        if (!fileHash.equals(expectedHash)) {
-            log.warn(
-                    "WRAPS proving key hash mismatch at {} (expected={}, actual={}), initiating download",
-                    provingKeyPath,
-                    expectedHash,
-                    fileHash);
-            asyncDownloadAndVerify(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
-            return;
-        }
-        // Hash matches - extract the archive
-        tryExtractTarGz(provingKeyPath, expectedHash.toHex());
     }
 
+    /**
+     * Downloads, verifies and installs the archive off the calling thread. The caller must already hold
+     * {@link #downloadInFlight}; this method takes ownership of it and releases it when the async task
+     * finishes, or immediately if the task could not be submitted.
+     */
     private void asyncDownloadAndVerify(
             @NonNull final Path provingKeyPath,
             @NonNull final Bytes expectedHash,
             @NonNull final String downloadUrl,
             @NonNull final HttpWrapsProvingKeyDownloader downloader,
             @NonNull final Duration retryInterval) {
-        if (!downloadInFlight.compareAndSet(false, true)) {
-            log.info("A WRAPS proving key download is already in progress, not starting another");
-            return;
-        }
         try {
             CompletableFuture.runAsync(
                     () -> {
@@ -280,8 +348,14 @@ public class WrapsProvingKeyVerification {
                                 scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
                                 return;
                             }
-                            tryExtractTarGz(provingKeyPath, expectedHash.toHex());
-                            log.info("Successfully downloaded and verified WRAPS proving key (hash={})", expectedHash);
+                            final var outcome = tryExtractTarGz(provingKeyPath, expectedHash.toHex());
+                            if (outcome == InstallOutcome.INSTALLED) {
+                                log.info(
+                                        "Successfully downloaded and verified WRAPS proving key (hash={})",
+                                        expectedHash);
+                            } else if (outcome == InstallOutcome.RETRYABLE) {
+                                scheduleRetry(provingKeyPath, expectedHash, downloadUrl, downloader, retryInterval);
+                            }
                         } catch (final Throwable t) {
                             log.error(
                                     "Failed to initiate async download of WRAPS proving key (from URL {}):",
@@ -319,20 +393,36 @@ public class WrapsProvingKeyVerification {
                         return;
                     }
                     try {
-                        log.info("Retrying WRAPS proving key download from {}", downloadUrl);
-                        downloader.download(downloadUrl, provingKeyPath);
-                        final Bytes downloadedHash = hashFile(provingKeyPath);
-                        if (downloadedHash.equals(expectedHash)) {
-                            tryExtractTarGz(provingKeyPath, expectedHash.toHex());
+                        // A retry may be here only because the install failed, not the download. Re-pulling a
+                        // multi-gigabyte archive that is already on disk and still verifies wastes bandwidth
+                        // every interval, so re-run the install directly in that case.
+                        if (archiveAlreadyVerifies(provingKeyPath, expectedHash)) {
+                            log.info(
+                                    "WRAPS proving key archive at {} still matches the expected hash; retrying the "
+                                            + "install without re-downloading",
+                                    provingKeyPath);
+                        } else {
+                            log.info("Retrying WRAPS proving key download from {}", downloadUrl);
+                            downloader.download(downloadUrl, provingKeyPath);
+                            final Bytes downloadedHash = hashFile(provingKeyPath);
+                            if (!downloadedHash.equals(expectedHash)) {
+                                log.error(
+                                        "Downloaded WRAPS proving key hash mismatch on retry: expected={}, actual={}",
+                                        expectedHash,
+                                        downloadedHash);
+                                return;
+                            }
+                        }
+                        final var outcome = tryExtractTarGz(provingKeyPath, expectedHash.toHex());
+                        if (outcome == InstallOutcome.INSTALLED) {
                             log.info(
                                     "Successfully downloaded and verified WRAPS proving key on retry (hash={})",
                                     expectedHash);
                             cancelRetry();
-                        } else {
-                            log.error(
-                                    "Downloaded WRAPS proving key hash mismatch on retry: expected={}, actual={}",
-                                    expectedHash,
-                                    downloadedHash);
+                        } else if (outcome == InstallOutcome.PERMANENTLY_BLOCKED) {
+                            // Nothing a later attempt can change; stop burning I/O re-running it every interval
+                            log.error("Giving up on WRAPS proving key retries; see the error above for the cause");
+                            cancelRetry();
                         }
                     } catch (final Throwable e) {
                         log.error("Failed to download WRAPS proving key on retry", e);
@@ -343,6 +433,23 @@ public class WrapsProvingKeyVerification {
                 retryInterval.toMillis(),
                 retryInterval.toMillis(),
                 TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Returns whether the archive already on disk matches the expected hash, in which case a retry only needs
+     * to re-run the install. A read failure is reported as "does not verify" so the retry falls back to
+     * downloading.
+     */
+    private static boolean archiveAlreadyVerifies(@NonNull final Path provingKeyPath, @NonNull final Bytes expected) {
+        if (!Files.exists(provingKeyPath)) {
+            return false;
+        }
+        try {
+            return hashFile(provingKeyPath).equals(expected);
+        } catch (final UncheckedIOException e) {
+            log.warn("Failed to read WRAPS proving key archive at {} on retry; will re-download", provingKeyPath, e);
+            return false;
+        }
     }
 
     private void cancelRetry() {
@@ -393,32 +500,122 @@ public class WrapsProvingKeyVerification {
 
     // --- Tar.gz extraction ---
 
-    private static void tryExtractTarGz(@NonNull final Path tarGzPath, @NonNull final String expectedHashHex) {
+    private static InstallOutcome tryExtractTarGz(
+            @NonNull final Path tarGzPath, @NonNull final String expectedHashHex) {
         final var envArtifactsPath = System.getenv(WRAPS_ARTIFACTS_ENV_VAR);
         if (envArtifactsPath == null || envArtifactsPath.isBlank()) {
             log.warn(
                     "Cannot extract WRAPS proving key archive; {} environment variable is not set",
                     WRAPS_ARTIFACTS_ENV_VAR);
-            return;
+            return InstallOutcome.PERMANENTLY_BLOCKED;
         }
         final var extractionDir = Paths.get(envArtifactsPath);
+        final var stagingDir = extractionDir.resolve(STAGING_DIR_NAME);
         try {
             Files.createDirectories(extractionDir);
-            TarGzExtractor.extract(tarGzPath, extractionDir);
-            log.info("Extracted WRAPS proving key archive {} to {}", tarGzPath, extractionDir);
+            deleteRecursively(stagingDir);
+            Files.createDirectories(stagingDir);
+            TarGzExtractor.extract(tarGzPath, stagingDir);
+            log.info("Extracted WRAPS proving key archive {} to staging directory {}", tarGzPath, stagingDir);
+            final var missingArtifacts = REQUIRED_ARTIFACT_FILES.stream()
+                    .filter(name -> !Files.isRegularFile(stagingDir.resolve(name)))
+                    .toList();
+            if (!missingArtifacts.isEmpty()) {
+                log.error(
+                        "WRAPS proving key archive {} verified against configured hash {} but did not yield "
+                                + "required artifacts {}; the installed artifacts in {} are left untouched and "
+                                + "WRAPS proving stays disabled. Retrying cannot help - the hash matches, so the "
+                                + "archive contents are fixed. Correct tss.wrapsProvingKeyHash (or the published "
+                                + "archive it names) and restart.",
+                        tarGzPath,
+                        expectedHashHex,
+                        missingArtifacts,
+                        extractionDir);
+                return InstallOutcome.PERMANENTLY_BLOCKED;
+            }
+            publishStagedArtifacts(stagingDir, extractionDir, expectedHashHex);
             verifyArtifactsDirectoryExists();
-            writeHashFile(extractionDir, expectedHashHex);
-            writeArtifactsManifest(extractionDir);
+            // The only credible evidence of a complete install is that the artifacts directory now passes
+            // the same check the prover readiness gate applies. Writing the markers is best-effort, so a
+            // clean return from the steps above does not by itself mean the install landed.
+            final var defect = installationDefect(envArtifactsPath, expectedHashHex);
+            if (defect != null) {
+                log.error(
+                        "WRAPS proving key install from {} did not complete: {}; proving stays disabled until "
+                                + "a later attempt succeeds",
+                        tarGzPath,
+                        defect);
+                return InstallOutcome.RETRYABLE;
+            }
+            log.info("Installed WRAPS proving key artifacts from {} into {}", tarGzPath, extractionDir);
+            return InstallOutcome.INSTALLED;
         } catch (final IOException e) {
-            log.error("Failed to extract WRAPS proving key archive {}", tarGzPath, e);
+            log.error("Failed to install WRAPS proving key archive {}", tarGzPath, e);
+            return InstallOutcome.RETRYABLE;
+        } finally {
+            try {
+                deleteRecursively(stagingDir);
+            } catch (final IOException e) {
+                log.warn("Failed to clean up WRAPS staging directory {}", stagingDir, e);
+            }
+        }
+    }
+
+    /**
+     * Publishes freshly extracted artifacts from the staging directory onto the live artifacts directory.
+     *
+     * <p>Each file is moved with {@link StandardCopyOption#ATOMIC_MOVE}, which replaces the directory entry
+     * without touching the previous inode. A proof already running against the old artifacts therefore keeps
+     * a valid mapping, rather than faulting with {@code SIGBUS} the way an in-place rewrite does when it
+     * truncates a file the native library has mapped.
+     *
+     * <p>The readiness markers are removed first: while the moves are in flight the directory holds a mix of
+     * old and new files, and {@code HistoryLibrary.wrapsProverReady} must not admit a proof against it. The
+     * hash file is written last, so its presence implies a complete installation.
+     */
+    private static void publishStagedArtifacts(
+            @NonNull final Path stagingDir, @NonNull final Path extractionDir, @NonNull final String expectedHashHex)
+            throws IOException {
+        Files.deleteIfExists(extractionDir.resolve(WRAPS_HASH_FILE_NAME));
+        Files.deleteIfExists(extractionDir.resolve(WRAPS_ARTIFACTS_MANIFEST_FILE_NAME));
+        final List<Path> stagedFiles;
+        try (final var paths = Files.walk(stagingDir)) {
+            stagedFiles = paths.filter(Files::isRegularFile).toList();
+        }
+        for (final var source : stagedFiles) {
+            final var target = extractionDir.resolve(stagingDir.relativize(source));
+            final var targetParent = target.getParent();
+            if (targetParent != null) {
+                Files.createDirectories(targetParent);
+            }
+            Files.move(source, target, StandardCopyOption.ATOMIC_MOVE);
+        }
+        writeArtifactsManifest(extractionDir);
+        writeHashFile(extractionDir, expectedHashHex);
+    }
+
+    /**
+     * Deletes the given directory tree if it exists, deepest entries first.
+     */
+    private static void deleteRecursively(@NonNull final Path dir) throws IOException {
+        if (!Files.exists(dir)) {
+            return;
+        }
+        final List<Path> entries;
+        try (final var paths = Files.walk(dir)) {
+            entries = paths.sorted(Comparator.reverseOrder()).toList();
+        }
+        for (final var entry : entries) {
+            Files.deleteIfExists(entry);
         }
     }
 
     /**
      * Writes the hash file ({@value #WRAPS_HASH_FILE_NAME}) into the artifacts directory so that
      * subsequent startups can detect the artifacts are already present and skip the download/extraction.
-     * A failure to write (e.g. a read-only mount) is logged but is non-fatal: the extracted artifacts
-     * remain usable.
+     * A failure to write (e.g. a read-only mount) is logged rather than thrown, but it is not harmless:
+     * without this file the install does not pass {@link #installationDefect} and the prover stays
+     * disabled, so the caller treats it as a failed install and retries.
      *
      * @param extractionDir the directory the artifacts were extracted into
      * @param hashHex the archive hash (bare hex) to record

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/HistoryLibraryImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/HistoryLibraryImpl.java
@@ -12,6 +12,7 @@ import com.hedera.cryptography.wraps.SchnorrKeys;
 import com.hedera.cryptography.wraps.WRAPSLibraryBridge;
 import com.hedera.cryptography.wraps.WRAPSVerificationKey;
 import com.hedera.node.app.history.HistoryLibrary;
+import com.hedera.node.app.history.WrapsProvingKeyVerification;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.security.SecureRandom;
 import java.util.Set;
@@ -237,8 +238,12 @@ public class HistoryLibraryImpl implements HistoryLibrary {
     }
 
     @Override
-    public boolean wrapsProverReady() {
-        return WRAPSLibraryBridge.isProofSupported();
+    public boolean wrapsProverReady(@NonNull final String expectedProvingKeyHashHex) {
+        requireNonNull(expectedProvingKeyHashHex);
+        // isProofSupported() only checks the four artifact filenames exist, which is also true of a
+        // different proving key and of an install still publishing its files.
+        return WRAPSLibraryBridge.isProofSupported()
+                && WrapsProvingKeyVerification.artifactsInstalledAndVerified(expectedProvingKeyHashHex);
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
@@ -485,7 +485,7 @@ public class WrapsHistoryProver implements HistoryProver {
         // Skip building sourceBook/proofKeyList/chained futures while the WRAPS library is still loading.
         final boolean needsWrapsForOutput =
                 phase == POST_AGGREGATION || (phase == AGGREGATE && sourceProof != null && tssConfig.wrapsEnabled());
-        if (needsWrapsForOutput && !historyLibrary.wrapsProverReady()) {
+        if (needsWrapsForOutput && !historyLibrary.wrapsProverReady(tssConfig.wrapsProvingKeyHash())) {
             if (isWrapsReadinessRetry) {
                 log.debug(
                         "Deferring {} output for construction #{}: WRAPS library is not ready", phase, constructionId);
@@ -781,7 +781,7 @@ public class WrapsHistoryProver implements HistoryProver {
                             yield new AggregatePhaseOutput(
                                     signature, signers.stream().toList());
                         } else {
-                            if (!historyLibrary.wrapsProverReady()) {
+                            if (!historyLibrary.wrapsProverReady(tssConfig.wrapsProvingKeyHash())) {
                                 yield new NoopOutput(WRAPS_NOT_READY_FAILURE_PREFIX);
                             }
                             final var isValid = historyLibrary.verifyAggregateSignature(
@@ -833,7 +833,7 @@ public class WrapsHistoryProver implements HistoryProver {
                         }
                     }
                     case POST_AGGREGATION -> {
-                        if (!historyLibrary.wrapsProverReady()) {
+                        if (!historyLibrary.wrapsProverReady(tssConfig.wrapsProvingKeyHash())) {
                             yield new NoopOutput(WRAPS_NOT_READY_FAILURE_PREFIX);
                         }
                         final var signature = requireNonNull(aggregatedSignatureProof)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
@@ -485,7 +485,7 @@ public class WrapsHistoryProver implements HistoryProver {
         // Skip building sourceBook/proofKeyList/chained futures while the WRAPS library is still loading.
         final boolean needsWrapsForOutput =
                 phase == POST_AGGREGATION || (phase == AGGREGATE && sourceProof != null && tssConfig.wrapsEnabled());
-        if (needsWrapsForOutput && !historyLibrary.wrapsProverReady(tssConfig.wrapsProvingKeyHash())) {
+        if (needsWrapsForOutput && !historyLibrary.wrapsProverReady()) {
             if (isWrapsReadinessRetry) {
                 log.debug(
                         "Deferring {} output for construction #{}: WRAPS library is not ready", phase, constructionId);
@@ -781,7 +781,7 @@ public class WrapsHistoryProver implements HistoryProver {
                             yield new AggregatePhaseOutput(
                                     signature, signers.stream().toList());
                         } else {
-                            if (!historyLibrary.wrapsProverReady(tssConfig.wrapsProvingKeyHash())) {
+                            if (!historyLibrary.wrapsProverReady()) {
                                 yield new NoopOutput(WRAPS_NOT_READY_FAILURE_PREFIX);
                             }
                             final var isValid = historyLibrary.verifyAggregateSignature(
@@ -833,7 +833,7 @@ public class WrapsHistoryProver implements HistoryProver {
                         }
                     }
                     case POST_AGGREGATION -> {
-                        if (!historyLibrary.wrapsProverReady(tssConfig.wrapsProvingKeyHash())) {
+                        if (!historyLibrary.wrapsProverReady()) {
                             yield new NoopOutput(WRAPS_NOT_READY_FAILURE_PREFIX);
                         }
                         final var signature = requireNonNull(aggregatedSignatureProof)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/impl/WrapsHistoryProver.java
@@ -59,6 +59,7 @@ public class WrapsHistoryProver implements HistoryProver {
     private static final Logger log = LogManager.getLogger(WrapsHistoryProver.class);
     public static final String MISSING_MESSAGES_FAILURE_PREFIX = "Still missing messages from R1 nodes ";
     public static final String WRAPS_NOT_READY_FAILURE_PREFIX = "WRAPS library is not ready";
+    public static final String LEDGER_ID_NOT_READY_FAILURE_PREFIX = "Ledger id is not yet available";
 
     private final long selfId;
     private final Duration wrapsMessageGracePeriod;
@@ -485,15 +486,27 @@ public class WrapsHistoryProver implements HistoryProver {
         // Skip building sourceBook/proofKeyList/chained futures while the WRAPS library is still loading.
         final boolean needsWrapsForOutput =
                 phase == POST_AGGREGATION || (phase == AGGREGATE && sourceProof != null && tssConfig.wrapsEnabled());
-        if (needsWrapsForOutput && !historyLibrary.wrapsProverReady()) {
+        // The genesis proof also needs the ledger id, which is not established at the instant the library
+        // becomes ready; without this the phase proceeds and dereferences a null ledgerId.
+        final String notReadyReason;
+        if (!needsWrapsForOutput) {
+            notReadyReason = null;
+        } else if (!historyLibrary.wrapsProverReady(tssConfig.wrapsProvingKeyHash())) {
+            notReadyReason = "WRAPS library is not ready";
+        } else if (phase == POST_AGGREGATION && ledgerId == null) {
+            notReadyReason = "ledger id is not yet available";
+        } else {
+            notReadyReason = null;
+        }
+        if (notReadyReason != null) {
             if (isWrapsReadinessRetry) {
-                log.debug(
-                        "Deferring {} output for construction #{}: WRAPS library is not ready", phase, constructionId);
+                log.debug("Deferring {} output for construction #{}: {}", phase, constructionId, notReadyReason);
             } else {
                 log.info(
-                        "Deferring {} output for construction #{}: WRAPS library is not ready (will retry each consensus round until ready)",
+                        "Deferring {} output for construction #{}: {} (will retry each consensus round until ready)",
                         phase,
-                        constructionId);
+                        constructionId,
+                        notReadyReason);
             }
             phaseNeedingWrapsReadinessRetry = phase;
             return;
@@ -579,7 +592,9 @@ public class WrapsHistoryProver implements HistoryProver {
                                                 scheduleVoteWithJitter(constructionId, tssConfig, proof);
                                             }
                                             case NoopOutput noopOutput -> {
-                                                if (WRAPS_NOT_READY_FAILURE_PREFIX.equals(noopOutput.reason())) {
+                                                if (WRAPS_NOT_READY_FAILURE_PREFIX.equals(noopOutput.reason())
+                                                        || LEDGER_ID_NOT_READY_FAILURE_PREFIX.equals(
+                                                                noopOutput.reason())) {
                                                     // Flag instead of clearing voteFuture inline; the outer accept()
                                                     // hasn't returned yet.
                                                     log.debug(
@@ -781,7 +796,7 @@ public class WrapsHistoryProver implements HistoryProver {
                             yield new AggregatePhaseOutput(
                                     signature, signers.stream().toList());
                         } else {
-                            if (!historyLibrary.wrapsProverReady()) {
+                            if (!historyLibrary.wrapsProverReady(tssConfig.wrapsProvingKeyHash())) {
                                 yield new NoopOutput(WRAPS_NOT_READY_FAILURE_PREFIX);
                             }
                             final var isValid = historyLibrary.verifyAggregateSignature(
@@ -833,8 +848,11 @@ public class WrapsHistoryProver implements HistoryProver {
                         }
                     }
                     case POST_AGGREGATION -> {
-                        if (!historyLibrary.wrapsProverReady()) {
+                        if (!historyLibrary.wrapsProverReady(tssConfig.wrapsProvingKeyHash())) {
                             yield new NoopOutput(WRAPS_NOT_READY_FAILURE_PREFIX);
+                        }
+                        if (ledgerId == null) {
+                            yield new NoopOutput(LEDGER_ID_NOT_READY_FAILURE_PREFIX);
                         }
                         final var signature = requireNonNull(aggregatedSignatureProof)
                                 .chainOfTrustProofOrThrow()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
@@ -3,19 +3,23 @@ package com.hedera.node.app.history;
 
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.node.app.history.WrapsProvingKeyVerification.artifactsAlreadyPresent;
+import static com.hedera.node.app.history.WrapsProvingKeyVerification.artifactsInstalledAndVerified;
 import static com.hedera.node.app.history.WrapsProvingKeyVerification.validateArtifactsPathConsistency;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -26,10 +30,12 @@ import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -413,9 +419,18 @@ class WrapsProvingKeyVerificationTest {
     @SuppressWarnings("unchecked")
     @Test
     void retrySucceedsAndCancelsScheduledFuture(final EnvironmentVariables environment) throws Exception {
+        // The retry only counts as successful once a complete, verified install has landed, so the
+        // archive the retry fetches must be a real one containing every required artifact.
+        final byte[] validArchive = createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
+        final var validHash = noThrowSha384HashOf(Bytes.wrap(validArchive)).toHex();
+
         final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
         final var path = tempDir.resolve("key.tar.gz");
-        givenConfigWithHashAndPath(HASH_A.toHex(), path);
+        givenConfigWithHashAndPath(validHash, path);
         givenDownloaderWritesContent(path, CONTENT_B);
         setArtifactsEnvVar(environment);
 
@@ -425,11 +440,12 @@ class WrapsProvingKeyVerificationTest {
 
         subject.ensureProvingKey(configuration, downloader);
 
-        // Re-stub downloader to return correct content for the retry
-        givenDownloaderWritesContent(path, CONTENT_A);
+        // Re-stub downloader to return a valid archive for the retry
+        givenDownloaderWritesContent(path, validArchive);
         retryCaptor.getValue().run();
 
         verify(scheduledFuture).cancel(false);
+        assertTrue(artifactsInstalledAndVerified(validHash));
     }
 
     @SuppressWarnings("unchecked")
@@ -604,6 +620,306 @@ class WrapsProvingKeyVerificationTest {
         assertEquals(archiveHash, Files.readString(hashFile).trim());
     }
 
+    // ===== proving key readiness (SIGBUS / wrong-key guard) =====
+
+    @Test
+    void notInstalledWhenHashFileIsMissingEvenThoughEveryArtifactIsPresent(final EnvironmentVariables environment)
+            throws IOException {
+        // The provisioning shape that caused the crash: the four bins copied in without wraps.sha384,
+        // which leaves WRAPSLibraryBridge.isProofSupported() true while a download/extract is still due.
+        writeRequiredArtifacts(tempDir);
+        setArtifactsEnvVar(environment);
+
+        assertTrue(WRAPSLibraryBridge.isProofSupported());
+        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
+    }
+
+    @Test
+    void notInstalledWhenHashFileIsForADifferentProvingKey(final EnvironmentVariables environment) throws IOException {
+        writeRequiredArtifacts(tempDir);
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), "bb".repeat(48));
+        setArtifactsEnvVar(environment);
+
+        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
+    }
+
+    @Test
+    void installedOnlyOnceAMatchingHashFileIsInPlace(final EnvironmentVariables environment) throws IOException {
+        writeRequiredArtifacts(tempDir);
+        setArtifactsEnvVar(environment);
+        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
+
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
+
+        assertTrue(artifactsInstalledAndVerified(HASH_A.toHex()));
+    }
+
+    @Test
+    void notInstalledWhenArtifactsPathIsUnset() {
+        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
+    }
+
+    // ===== staged install =====
+
+    @Test
+    void installingOverAMappedArtifactLeavesTheExistingMappingIntact(final EnvironmentVariables environment)
+            throws Exception {
+        // Both contents are the same length on purpose. An in-place extract truncates the mapped inode and
+        // regrows it, so a regression shows up as this mapping reading the *new* bytes rather than as a
+        // SIGBUS that would take the test JVM down with it.
+        final byte[] installedContent = "pp-installed".getBytes(StandardCharsets.UTF_8);
+        final byte[] replacementContent = "pp-replaced!".getBytes(StandardCharsets.UTF_8);
+        assertEquals(installedContent.length, replacementContent.length);
+
+        final var extractionDir = tempDir.resolve("extracted");
+        Files.createDirectories(extractionDir);
+        writeRequiredArtifacts(extractionDir);
+        final var deciderPp = extractionDir.resolve("decider_pp.bin");
+        Files.write(deciderPp, installedContent);
+
+        final byte[] archiveBytes = createTarGz(
+                entry("decider_pp.bin", replacementContent),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, archiveBytes);
+        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
+
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        try (final var channel = FileChannel.open(deciderPp, StandardOpenOption.READ)) {
+            final var mapping = channel.map(FileChannel.MapMode.READ_ONLY, 0, installedContent.length);
+
+            subject.ensureProvingKey(configuration, downloader);
+
+            final var seenThroughMapping = new byte[installedContent.length];
+            mapping.get(0, seenThroughMapping);
+            assertArrayEquals(
+                    installedContent,
+                    seenThroughMapping,
+                    "the install rewrote the inode a native proof had mapped instead of replacing the directory entry");
+        }
+        assertArrayEquals(replacementContent, Files.readAllBytes(deciderPp), "the new artifact was not published");
+    }
+
+    @Test
+    void leavesNoStagingDirectoryBehindAfterInstalling(final EnvironmentVariables environment) throws Exception {
+        final byte[] archiveBytes = createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, archiveBytes);
+        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
+        final var extractionDir = tempDir.resolve("extracted");
+
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        assertFalse(
+                Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.STAGING_DIR_NAME)),
+                "staging directory was not cleaned up");
+        assertTrue(artifactsInstalledAndVerified(archiveHash));
+    }
+
+    @Test
+    void leavesInstalledArtifactsUntouchedWhenTheArchiveIsIncomplete(final EnvironmentVariables environment)
+            throws Exception {
+        final var extractionDir = tempDir.resolve("extracted");
+        Files.createDirectories(extractionDir);
+        writeRequiredArtifacts(extractionDir);
+
+        // Missing nova_vp.bin, so the staged tree must never be published
+        final byte[] archiveBytes = createTarGz(
+                entry("decider_pp.bin", "new-pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)));
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, archiveBytes);
+        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
+
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        assertArrayEquals(
+                "decider_pp.bin".getBytes(StandardCharsets.UTF_8),
+                Files.readAllBytes(extractionDir.resolve("decider_pp.bin")));
+        assertFalse(Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME)));
+        assertFalse(Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.STAGING_DIR_NAME)));
+    }
+
+    // ===== install failure handling =====
+
+    @Test
+    void doesNotRetryWhenTheVerifiedArchiveIsMissingRequiredArtifacts(final EnvironmentVariables environment)
+            throws Exception {
+        // The archive matches the configured hash, so its contents are fixed: if it yields only 3 of the 4
+        // artifacts it always will. Retrying re-runs a multi-gigabyte install to reach the same result.
+        final byte[] archiveBytes = createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)));
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, archiveBytes);
+        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
+        final var extractionDir = tempDir.resolve("extracted");
+
+        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        verifyNoInteractions(retryScheduler);
+        assertFalse(artifactsInstalledAndVerified(archiveHash));
+    }
+
+    @Test
+    void schedulesRetryWhenTheInstallFailsForAnEnvironmentalReason(final EnvironmentVariables environment)
+            throws Exception {
+        final var extractionDir = tempDir.resolve("extracted");
+        // A non-empty directory where decider_pp.bin belongs makes the publishing rename fail with an
+        // IOException. Unlike a chmod-based setup this still fails when the tests run as root.
+        Files.createDirectories(extractionDir.resolve("decider_pp.bin"));
+        Files.writeString(extractionDir.resolve("decider_pp.bin").resolve("blocker"), "x");
+
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, completeArchiveBytes());
+        final var archiveHash =
+                noThrowSha384HashOf(Bytes.wrap(completeArchiveBytes())).toHex();
+
+        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        verify(retryScheduler).scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+        assertFalse(artifactsInstalledAndVerified(archiveHash));
+    }
+
+    @Test
+    void retrySkipsTheDownloadWhenTheArchiveOnDiskStillVerifies(final EnvironmentVariables environment)
+            throws Exception {
+        final var extractionDir = tempDir.resolve("extracted");
+        Files.createDirectories(extractionDir.resolve("decider_pp.bin"));
+        Files.writeString(extractionDir.resolve("decider_pp.bin").resolve("blocker"), "x");
+
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, completeArchiveBytes());
+        final var archiveHash =
+                noThrowSha384HashOf(Bytes.wrap(completeArchiveBytes())).toHex();
+
+        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        final ArgumentCaptor<Runnable> retryCaptor = ArgumentCaptor.forClass(Runnable.class);
+        given(retryScheduler.scheduleWithFixedDelay(retryCaptor.capture(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .willReturn(scheduledFuture);
+
+        subject.ensureProvingKey(configuration, downloader);
+        retryCaptor.getValue().run();
+
+        // The archive on disk still matches, so the multi-gigabyte download must be skipped entirely
+        verifyNoInteractions(downloader);
+        // ... and the retry stays armed, because an environmental failure may still clear
+        verify(scheduledFuture, never()).cancel(anyBoolean());
+    }
+
+    // ===== the in-flight guard covers the synchronous install too =====
+
+    @Test
+    void releasesTheGuardAfterASuccessfulSynchronousInstall(final EnvironmentVariables environment) throws Exception {
+        final var extractionDir = tempDir.resolve("extracted");
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
+
+        final var first = tempDir.resolve("first.tar.gz");
+        Files.write(first, completeArchiveBytes());
+        final var firstHash =
+                noThrowSha384HashOf(Bytes.wrap(completeArchiveBytes())).toHex();
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(firstHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(first.toString());
+        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
+
+        subject.ensureProvingKey(configuration, downloader);
+        assertTrue(artifactsInstalledAndVerified(firstHash));
+
+        // A second acquisition must not be turned away by a guard the first attempt forgot to release
+        final byte[] secondBytes = createTarGz(
+                entry("decider_pp.bin", "pp2".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp2".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp2".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp2".getBytes(StandardCharsets.UTF_8)));
+        final var second = tempDir.resolve("second.tar.gz");
+        Files.write(second, secondBytes);
+        final var secondHash = noThrowSha384HashOf(Bytes.wrap(secondBytes)).toHex();
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(secondHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(second.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        assertTrue(artifactsInstalledAndVerified(secondHash), "guard was not released after the first install");
+    }
+
+    @Test
+    void releasesTheGuardAfterAFailedSynchronousInstall(final EnvironmentVariables environment) throws Exception {
+        final var extractionDir = tempDir.resolve("extracted");
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
+
+        // An archive that can never install: verified, but only 3 of the 4 artifacts
+        final byte[] incomplete = createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)));
+        final var bad = tempDir.resolve("bad.tar.gz");
+        Files.write(bad, incomplete);
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash())
+                .willReturn(noThrowSha384HashOf(Bytes.wrap(incomplete)).toHex());
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(bad.toString());
+        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        // The failure path must release the guard too, or the fixed config could never be installed
+        final var good = tempDir.resolve("good.tar.gz");
+        Files.write(good, completeArchiveBytes());
+        final var goodHash =
+                noThrowSha384HashOf(Bytes.wrap(completeArchiveBytes())).toHex();
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(goodHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(good.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        assertTrue(artifactsInstalledAndVerified(goodHash), "guard was not released after the failed install");
+    }
+
     // ===== helpers =====
 
     private void givenConfigWithHashAndPath(final String bootstrapHash, final Path provingKeyPath) {
@@ -627,6 +943,14 @@ class WrapsProvingKeyVerificationTest {
 
     private void setArtifactsEnvVar(final EnvironmentVariables environment) {
         environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, tempDir.toString());
+    }
+
+    private static byte[] completeArchiveBytes() throws IOException {
+        return createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
     }
 
     private static void writeRequiredArtifacts(final Path dir) throws IOException {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
@@ -3,23 +3,19 @@ package com.hedera.node.app.history;
 
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.node.app.history.WrapsProvingKeyVerification.artifactsAlreadyPresent;
-import static com.hedera.node.app.history.WrapsProvingKeyVerification.artifactsInstalledAndVerified;
 import static com.hedera.node.app.history.WrapsProvingKeyVerification.validateArtifactsPathConsistency;
-import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -30,12 +26,10 @@ import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -419,18 +413,9 @@ class WrapsProvingKeyVerificationTest {
     @SuppressWarnings("unchecked")
     @Test
     void retrySucceedsAndCancelsScheduledFuture(final EnvironmentVariables environment) throws Exception {
-        // The retry only counts as successful once a complete, verified install has landed, so the
-        // archive the retry fetches must be a real one containing every required artifact.
-        final byte[] validArchive = createTarGz(
-                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
-                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
-        final var validHash = noThrowSha384HashOf(Bytes.wrap(validArchive)).toHex();
-
         final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
         final var path = tempDir.resolve("key.tar.gz");
-        givenConfigWithHashAndPath(validHash, path);
+        givenConfigWithHashAndPath(HASH_A.toHex(), path);
         givenDownloaderWritesContent(path, CONTENT_B);
         setArtifactsEnvVar(environment);
 
@@ -440,12 +425,11 @@ class WrapsProvingKeyVerificationTest {
 
         subject.ensureProvingKey(configuration, downloader);
 
-        // Re-stub downloader to return a valid archive for the retry
-        givenDownloaderWritesContent(path, validArchive);
+        // Re-stub downloader to return correct content for the retry
+        givenDownloaderWritesContent(path, CONTENT_A);
         retryCaptor.getValue().run();
 
         verify(scheduledFuture).cancel(false);
-        assertTrue(artifactsInstalledAndVerified(validHash));
     }
 
     @SuppressWarnings("unchecked")
@@ -620,235 +604,6 @@ class WrapsProvingKeyVerificationTest {
         assertEquals(archiveHash, Files.readString(hashFile).trim());
     }
 
-    // ===== proving key readiness (SIGBUS / wrong-key guard) =====
-
-    @Test
-    void notInstalledWhenHashFileIsMissingEvenThoughEveryArtifactIsPresent(final EnvironmentVariables environment)
-            throws IOException {
-        // The provisioning shape that caused the crash: the four bins copied in without wraps.sha384,
-        // which leaves WRAPSLibraryBridge.isProofSupported() true while a download/extract is still due.
-        writeRequiredArtifacts(tempDir);
-        setArtifactsEnvVar(environment);
-
-        assertTrue(WRAPSLibraryBridge.isProofSupported());
-        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
-    }
-
-    @Test
-    void notInstalledWhenHashFileIsForADifferentProvingKey(final EnvironmentVariables environment) throws IOException {
-        writeRequiredArtifacts(tempDir);
-        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), "bb".repeat(48));
-        setArtifactsEnvVar(environment);
-
-        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
-    }
-
-    @Test
-    void installedOnlyOnceAMatchingHashFileIsInPlace(final EnvironmentVariables environment) throws IOException {
-        writeRequiredArtifacts(tempDir);
-        setArtifactsEnvVar(environment);
-        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
-
-        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
-
-        assertTrue(artifactsInstalledAndVerified(HASH_A.toHex()));
-    }
-
-    @Test
-    void notInstalledWhenArtifactsPathIsUnset() {
-        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
-    }
-
-    // ===== staged install =====
-
-    @Test
-    void installingOverAMappedArtifactLeavesTheExistingMappingIntact(final EnvironmentVariables environment)
-            throws Exception {
-        // Both contents are the same length on purpose. An in-place extract truncates the mapped inode and
-        // regrows it, so a regression shows up as this mapping reading the *new* bytes rather than as a
-        // SIGBUS that would take the test JVM down with it.
-        final byte[] installedContent = "pp-installed".getBytes(StandardCharsets.UTF_8);
-        final byte[] replacementContent = "pp-replaced!".getBytes(StandardCharsets.UTF_8);
-        assertEquals(installedContent.length, replacementContent.length);
-
-        final var extractionDir = tempDir.resolve("extracted");
-        Files.createDirectories(extractionDir);
-        writeRequiredArtifacts(extractionDir);
-        final var deciderPp = extractionDir.resolve("decider_pp.bin");
-        Files.write(deciderPp, installedContent);
-
-        final byte[] archiveBytes = createTarGz(
-                entry("decider_pp.bin", replacementContent),
-                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
-        final var archivePath = tempDir.resolve("wraps.tar.gz");
-        Files.write(archivePath, archiveBytes);
-        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
-
-        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
-        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
-        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
-        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
-
-        try (final var channel = FileChannel.open(deciderPp, StandardOpenOption.READ)) {
-            final var mapping = channel.map(FileChannel.MapMode.READ_ONLY, 0, installedContent.length);
-
-            subject.ensureProvingKey(configuration, downloader);
-
-            final var seenThroughMapping = new byte[installedContent.length];
-            mapping.get(0, seenThroughMapping);
-            assertArrayEquals(
-                    installedContent,
-                    seenThroughMapping,
-                    "the install rewrote the inode a native proof had mapped instead of replacing the directory entry");
-        }
-        assertArrayEquals(replacementContent, Files.readAllBytes(deciderPp), "the new artifact was not published");
-    }
-
-    @Test
-    void leavesNoStagingDirectoryBehindAfterInstalling(final EnvironmentVariables environment) throws Exception {
-        final byte[] archiveBytes = createTarGz(
-                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
-                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
-        final var archivePath = tempDir.resolve("wraps.tar.gz");
-        Files.write(archivePath, archiveBytes);
-        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
-        final var extractionDir = tempDir.resolve("extracted");
-
-        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
-        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
-        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
-        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
-
-        subject.ensureProvingKey(configuration, downloader);
-
-        assertFalse(
-                Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.STAGING_DIR_NAME)),
-                "staging directory was not cleaned up");
-        assertTrue(artifactsInstalledAndVerified(archiveHash));
-    }
-
-    @Test
-    void leavesInstalledArtifactsUntouchedWhenTheArchiveIsIncomplete(final EnvironmentVariables environment)
-            throws Exception {
-        final var extractionDir = tempDir.resolve("extracted");
-        Files.createDirectories(extractionDir);
-        writeRequiredArtifacts(extractionDir);
-
-        // Missing nova_vp.bin, so the staged tree must never be published
-        final byte[] archiveBytes = createTarGz(
-                entry("decider_pp.bin", "new-pp".getBytes(StandardCharsets.UTF_8)),
-                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)));
-        final var archivePath = tempDir.resolve("wraps.tar.gz");
-        Files.write(archivePath, archiveBytes);
-        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
-
-        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
-        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
-        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
-        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
-
-        subject.ensureProvingKey(configuration, downloader);
-
-        assertArrayEquals(
-                "decider_pp.bin".getBytes(StandardCharsets.UTF_8),
-                Files.readAllBytes(extractionDir.resolve("decider_pp.bin")));
-        assertFalse(Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME)));
-        assertFalse(Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.STAGING_DIR_NAME)));
-    }
-
-    // ===== install failure handling =====
-
-    @Test
-    void doesNotRetryWhenTheVerifiedArchiveIsMissingRequiredArtifacts(final EnvironmentVariables environment)
-            throws Exception {
-        // The archive matches the configured hash, so its contents are fixed: if it yields only 3 of the 4
-        // artifacts it always will. Retrying re-runs a multi-gigabyte install to reach the same result.
-        final byte[] archiveBytes = createTarGz(
-                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
-                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)));
-        final var archivePath = tempDir.resolve("wraps.tar.gz");
-        Files.write(archivePath, archiveBytes);
-        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
-        final var extractionDir = tempDir.resolve("extracted");
-
-        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
-        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
-        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
-        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
-        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
-        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
-
-        subject.ensureProvingKey(configuration, downloader);
-
-        verifyNoInteractions(retryScheduler);
-        assertFalse(artifactsInstalledAndVerified(archiveHash));
-    }
-
-    @Test
-    void schedulesRetryWhenTheInstallFailsForAnEnvironmentalReason(final EnvironmentVariables environment)
-            throws Exception {
-        final var extractionDir = tempDir.resolve("extracted");
-        // A non-empty directory where decider_pp.bin belongs makes the publishing rename fail with an
-        // IOException. Unlike a chmod-based setup this still fails when the tests run as root.
-        Files.createDirectories(extractionDir.resolve("decider_pp.bin"));
-        Files.writeString(extractionDir.resolve("decider_pp.bin").resolve("blocker"), "x");
-
-        final var archivePath = tempDir.resolve("wraps.tar.gz");
-        Files.write(archivePath, completeArchiveBytes());
-        final var archiveHash =
-                noThrowSha384HashOf(Bytes.wrap(completeArchiveBytes())).toHex();
-
-        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
-        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
-        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
-        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
-        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
-        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
-
-        subject.ensureProvingKey(configuration, downloader);
-
-        verify(retryScheduler).scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
-        assertFalse(artifactsInstalledAndVerified(archiveHash));
-    }
-
-    @Test
-    void retrySkipsTheDownloadWhenTheArchiveOnDiskStillVerifies(final EnvironmentVariables environment)
-            throws Exception {
-        final var extractionDir = tempDir.resolve("extracted");
-        Files.createDirectories(extractionDir.resolve("decider_pp.bin"));
-        Files.writeString(extractionDir.resolve("decider_pp.bin").resolve("blocker"), "x");
-
-        final var archivePath = tempDir.resolve("wraps.tar.gz");
-        Files.write(archivePath, completeArchiveBytes());
-        final var archiveHash =
-                noThrowSha384HashOf(Bytes.wrap(completeArchiveBytes())).toHex();
-
-        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
-        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
-        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
-        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
-        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
-        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
-
-        final ArgumentCaptor<Runnable> retryCaptor = ArgumentCaptor.forClass(Runnable.class);
-        given(retryScheduler.scheduleWithFixedDelay(retryCaptor.capture(), anyLong(), anyLong(), any(TimeUnit.class)))
-                .willReturn(scheduledFuture);
-
-        subject.ensureProvingKey(configuration, downloader);
-        retryCaptor.getValue().run();
-
-        // The archive on disk still matches, so the multi-gigabyte download must be skipped entirely
-        verifyNoInteractions(downloader);
-        // ... and the retry stays armed, because an environmental failure may still clear
-        verify(scheduledFuture, never()).cancel(anyBoolean());
-    }
-
     // ===== helpers =====
 
     private void givenConfigWithHashAndPath(final String bootstrapHash, final Path provingKeyPath) {
@@ -872,14 +627,6 @@ class WrapsProvingKeyVerificationTest {
 
     private void setArtifactsEnvVar(final EnvironmentVariables environment) {
         environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, tempDir.toString());
-    }
-
-    private static byte[] completeArchiveBytes() throws IOException {
-        return createTarGz(
-                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
-                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
-                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
     }
 
     private static void writeRequiredArtifacts(final Path dir) throws IOException {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
@@ -12,12 +12,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 
@@ -417,9 +419,18 @@ class WrapsProvingKeyVerificationTest {
     @SuppressWarnings("unchecked")
     @Test
     void retrySucceedsAndCancelsScheduledFuture(final EnvironmentVariables environment) throws Exception {
+        // The retry only counts as successful once a complete, verified install has landed, so the
+        // archive the retry fetches must be a real one containing every required artifact.
+        final byte[] validArchive = createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
+        final var validHash = noThrowSha384HashOf(Bytes.wrap(validArchive)).toHex();
+
         final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
         final var path = tempDir.resolve("key.tar.gz");
-        givenConfigWithHashAndPath(HASH_A.toHex(), path);
+        givenConfigWithHashAndPath(validHash, path);
         givenDownloaderWritesContent(path, CONTENT_B);
         setArtifactsEnvVar(environment);
 
@@ -429,11 +440,12 @@ class WrapsProvingKeyVerificationTest {
 
         subject.ensureProvingKey(configuration, downloader);
 
-        // Re-stub downloader to return correct content for the retry
-        givenDownloaderWritesContent(path, CONTENT_A);
+        // Re-stub downloader to return a valid archive for the retry
+        givenDownloaderWritesContent(path, validArchive);
         retryCaptor.getValue().run();
 
         verify(scheduledFuture).cancel(false);
+        assertTrue(artifactsInstalledAndVerified(validHash));
     }
 
     @SuppressWarnings("unchecked")
@@ -749,6 +761,94 @@ class WrapsProvingKeyVerificationTest {
         assertFalse(Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.STAGING_DIR_NAME)));
     }
 
+    // ===== install failure handling =====
+
+    @Test
+    void doesNotRetryWhenTheVerifiedArchiveIsMissingRequiredArtifacts(final EnvironmentVariables environment)
+            throws Exception {
+        // The archive matches the configured hash, so its contents are fixed: if it yields only 3 of the 4
+        // artifacts it always will. Retrying re-runs a multi-gigabyte install to reach the same result.
+        final byte[] archiveBytes = createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)));
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, archiveBytes);
+        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
+        final var extractionDir = tempDir.resolve("extracted");
+
+        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        verifyNoInteractions(retryScheduler);
+        assertFalse(artifactsInstalledAndVerified(archiveHash));
+    }
+
+    @Test
+    void schedulesRetryWhenTheInstallFailsForAnEnvironmentalReason(final EnvironmentVariables environment)
+            throws Exception {
+        final var extractionDir = tempDir.resolve("extracted");
+        // A non-empty directory where decider_pp.bin belongs makes the publishing rename fail with an
+        // IOException. Unlike a chmod-based setup this still fails when the tests run as root.
+        Files.createDirectories(extractionDir.resolve("decider_pp.bin"));
+        Files.writeString(extractionDir.resolve("decider_pp.bin").resolve("blocker"), "x");
+
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, completeArchiveBytes());
+        final var archiveHash =
+                noThrowSha384HashOf(Bytes.wrap(completeArchiveBytes())).toHex();
+
+        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        verify(retryScheduler).scheduleWithFixedDelay(any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+        assertFalse(artifactsInstalledAndVerified(archiveHash));
+    }
+
+    @Test
+    void retrySkipsTheDownloadWhenTheArchiveOnDiskStillVerifies(final EnvironmentVariables environment)
+            throws Exception {
+        final var extractionDir = tempDir.resolve("extracted");
+        Files.createDirectories(extractionDir.resolve("decider_pp.bin"));
+        Files.writeString(extractionDir.resolve("decider_pp.bin").resolve("blocker"), "x");
+
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, completeArchiveBytes());
+        final var archiveHash =
+                noThrowSha384HashOf(Bytes.wrap(completeArchiveBytes())).toHex();
+
+        final var subject = new WrapsProvingKeyVerification(Runnable::run, retryScheduler);
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        Mockito.lenient().when(tssConfig.wrapsProvingKeyDownloadUrl()).thenReturn(DOWNLOAD_URL);
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        final ArgumentCaptor<Runnable> retryCaptor = ArgumentCaptor.forClass(Runnable.class);
+        given(retryScheduler.scheduleWithFixedDelay(retryCaptor.capture(), anyLong(), anyLong(), any(TimeUnit.class)))
+                .willReturn(scheduledFuture);
+
+        subject.ensureProvingKey(configuration, downloader);
+        retryCaptor.getValue().run();
+
+        // The archive on disk still matches, so the multi-gigabyte download must be skipped entirely
+        verifyNoInteractions(downloader);
+        // ... and the retry stays armed, because an environmental failure may still clear
+        verify(scheduledFuture, never()).cancel(anyBoolean());
+    }
+
     // ===== helpers =====
 
     private void givenConfigWithHashAndPath(final String bootstrapHash, final Path provingKeyPath) {
@@ -772,6 +872,14 @@ class WrapsProvingKeyVerificationTest {
 
     private void setArtifactsEnvVar(final EnvironmentVariables environment) {
         environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, tempDir.toString());
+    }
+
+    private static byte[] completeArchiveBytes() throws IOException {
+        return createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
     }
 
     private static void writeRequiredArtifacts(final Path dir) throws IOException {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/WrapsProvingKeyVerificationTest.java
@@ -3,7 +3,9 @@ package com.hedera.node.app.history;
 
 import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
 import static com.hedera.node.app.history.WrapsProvingKeyVerification.artifactsAlreadyPresent;
+import static com.hedera.node.app.history.WrapsProvingKeyVerification.artifactsInstalledAndVerified;
 import static com.hedera.node.app.history.WrapsProvingKeyVerification.validateArtifactsPathConsistency;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -26,10 +28,12 @@ import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
 import java.time.Duration;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executor;
@@ -602,6 +606,147 @@ class WrapsProvingKeyVerificationTest {
         final var hashFile = extractionDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME);
         assertTrue(Files.isRegularFile(hashFile), "hash file was not written");
         assertEquals(archiveHash, Files.readString(hashFile).trim());
+    }
+
+    // ===== proving key readiness (SIGBUS / wrong-key guard) =====
+
+    @Test
+    void notInstalledWhenHashFileIsMissingEvenThoughEveryArtifactIsPresent(final EnvironmentVariables environment)
+            throws IOException {
+        // The provisioning shape that caused the crash: the four bins copied in without wraps.sha384,
+        // which leaves WRAPSLibraryBridge.isProofSupported() true while a download/extract is still due.
+        writeRequiredArtifacts(tempDir);
+        setArtifactsEnvVar(environment);
+
+        assertTrue(WRAPSLibraryBridge.isProofSupported());
+        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
+    }
+
+    @Test
+    void notInstalledWhenHashFileIsForADifferentProvingKey(final EnvironmentVariables environment) throws IOException {
+        writeRequiredArtifacts(tempDir);
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), "bb".repeat(48));
+        setArtifactsEnvVar(environment);
+
+        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
+    }
+
+    @Test
+    void installedOnlyOnceAMatchingHashFileIsInPlace(final EnvironmentVariables environment) throws IOException {
+        writeRequiredArtifacts(tempDir);
+        setArtifactsEnvVar(environment);
+        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
+
+        Files.writeString(tempDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME), HASH_A.toHex());
+
+        assertTrue(artifactsInstalledAndVerified(HASH_A.toHex()));
+    }
+
+    @Test
+    void notInstalledWhenArtifactsPathIsUnset() {
+        assertFalse(artifactsInstalledAndVerified(HASH_A.toHex()));
+    }
+
+    // ===== staged install =====
+
+    @Test
+    void installingOverAMappedArtifactLeavesTheExistingMappingIntact(final EnvironmentVariables environment)
+            throws Exception {
+        // Both contents are the same length on purpose. An in-place extract truncates the mapped inode and
+        // regrows it, so a regression shows up as this mapping reading the *new* bytes rather than as a
+        // SIGBUS that would take the test JVM down with it.
+        final byte[] installedContent = "pp-installed".getBytes(StandardCharsets.UTF_8);
+        final byte[] replacementContent = "pp-replaced!".getBytes(StandardCharsets.UTF_8);
+        assertEquals(installedContent.length, replacementContent.length);
+
+        final var extractionDir = tempDir.resolve("extracted");
+        Files.createDirectories(extractionDir);
+        writeRequiredArtifacts(extractionDir);
+        final var deciderPp = extractionDir.resolve("decider_pp.bin");
+        Files.write(deciderPp, installedContent);
+
+        final byte[] archiveBytes = createTarGz(
+                entry("decider_pp.bin", replacementContent),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, archiveBytes);
+        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
+
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        try (final var channel = FileChannel.open(deciderPp, StandardOpenOption.READ)) {
+            final var mapping = channel.map(FileChannel.MapMode.READ_ONLY, 0, installedContent.length);
+
+            subject.ensureProvingKey(configuration, downloader);
+
+            final var seenThroughMapping = new byte[installedContent.length];
+            mapping.get(0, seenThroughMapping);
+            assertArrayEquals(
+                    installedContent,
+                    seenThroughMapping,
+                    "the install rewrote the inode a native proof had mapped instead of replacing the directory entry");
+        }
+        assertArrayEquals(replacementContent, Files.readAllBytes(deciderPp), "the new artifact was not published");
+    }
+
+    @Test
+    void leavesNoStagingDirectoryBehindAfterInstalling(final EnvironmentVariables environment) throws Exception {
+        final byte[] archiveBytes = createTarGz(
+                entry("decider_pp.bin", "pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_vp.bin", "nvp".getBytes(StandardCharsets.UTF_8)));
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, archiveBytes);
+        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
+        final var extractionDir = tempDir.resolve("extracted");
+
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        assertFalse(
+                Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.STAGING_DIR_NAME)),
+                "staging directory was not cleaned up");
+        assertTrue(artifactsInstalledAndVerified(archiveHash));
+    }
+
+    @Test
+    void leavesInstalledArtifactsUntouchedWhenTheArchiveIsIncomplete(final EnvironmentVariables environment)
+            throws Exception {
+        final var extractionDir = tempDir.resolve("extracted");
+        Files.createDirectories(extractionDir);
+        writeRequiredArtifacts(extractionDir);
+
+        // Missing nova_vp.bin, so the staged tree must never be published
+        final byte[] archiveBytes = createTarGz(
+                entry("decider_pp.bin", "new-pp".getBytes(StandardCharsets.UTF_8)),
+                entry("decider_vp.bin", "vp".getBytes(StandardCharsets.UTF_8)),
+                entry("nova_pp.bin", "npp".getBytes(StandardCharsets.UTF_8)));
+        final var archivePath = tempDir.resolve("wraps.tar.gz");
+        Files.write(archivePath, archiveBytes);
+        final var archiveHash = noThrowSha384HashOf(Bytes.wrap(archiveBytes)).toHex();
+
+        given(tssConfig.wrapsProvingKeyDownloadEnabled()).willReturn(true);
+        given(tssConfig.wrapsProvingKeyHash()).willReturn(archiveHash);
+        given(tssConfig.wrapsProvingKeyPath()).willReturn(archivePath.toString());
+        environment.set(WrapsProvingKeyVerification.WRAPS_ARTIFACTS_ENV_VAR, extractionDir.toString());
+
+        subject.ensureProvingKey(configuration, downloader);
+
+        assertArrayEquals(
+                "decider_pp.bin".getBytes(StandardCharsets.UTF_8),
+                Files.readAllBytes(extractionDir.resolve("decider_pp.bin")));
+        assertFalse(Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.WRAPS_HASH_FILE_NAME)));
+        assertFalse(Files.exists(extractionDir.resolve(WrapsProvingKeyVerification.STAGING_DIR_NAME)));
     }
 
     // ===== helpers =====

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/HistoryLibraryImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/HistoryLibraryImplTest.java
@@ -223,6 +223,6 @@ class HistoryLibraryImplTest {
 
     @Test
     void wrapsLibraryBridgeIsNotReady() {
-        assertFalse(subject.wrapsProverReady());
+        assertFalse(subject.wrapsProverReady("ab".repeat(48)));
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
@@ -600,7 +600,7 @@ class WrapsHistoryProverTest {
                 new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray());
         given(historyLibrary.constructIncrementalWrapsProof(any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(incremental);
-        given(historyLibrary.wrapsProverReady()).willReturn(true);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(true);
         given(historyLibrary.verifyAggregateSignature(any(), any(), any(), any(), any()))
                 .willReturn(true);
 
@@ -988,7 +988,7 @@ class WrapsHistoryProverTest {
                 new WrapsMpcStateMachine());
         given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
         given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
-        given(historyLibrary.wrapsProverReady()).willReturn(true);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(true);
         given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
                 .willReturn(
                         new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
@@ -1044,7 +1044,7 @@ class WrapsHistoryProverTest {
         given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
         given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
         // Not ready on the first advance() (download still in flight); ready on the second.
-        given(historyLibrary.wrapsProverReady()).willReturn(false, true);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(false, true);
         given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
                 .willReturn(
                         new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
@@ -1111,7 +1111,7 @@ class WrapsHistoryProverTest {
         // First call (publishIfNeeded early-exit guard): true -> skips early-exit.
         // Second call (inside outputFuture supplier): false -> NoopOutput.
         // Third call (next-round retry early-exit guard): true -> proceeds to publish.
-        given(historyLibrary.wrapsProverReady()).willReturn(true, false, true);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(true, false, true);
         given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
                 .willReturn(
                         new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
@@ -1152,6 +1152,51 @@ class WrapsHistoryProverTest {
     }
 
     @Test
+    void postAggregationDefersWhenTheLedgerIdIsNotYetAvailable() {
+        // The library can be ready before the ledger id has been established at genesis. Proceeding then
+        // dereferenced a null ledgerId and killed the publication with an NPE; it must defer and retry.
+        subject = new WrapsHistoryProver(
+                SELF_ID,
+                GRACE_PERIOD,
+                KEY_PAIR,
+                null,
+                weights,
+                proofKeys,
+                delayer,
+                Runnable::run,
+                historyLibrary,
+                submissions,
+                new WrapsMpcStateMachine());
+        given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
+        given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
+        // Library IS ready; only the ledger id is missing
+        given(historyLibrary.wrapsProverReady(any())).willReturn(true);
+
+        final var aggregatedSignatureProof = HistoryProof.newBuilder()
+                .chainOfTrustProof(ChainOfTrustProof.newBuilder()
+                        .aggregatedNodeSignatures(new AggregatedNodeSignatures(
+                                AGG_SIG, new ArrayList<>(List.of(SELF_ID, OTHER_NODE_ID)), TARGET_METADATA)))
+                .build();
+        final var construction = HistoryProofConstruction.newBuilder()
+                .constructionId(CONSTRUCTION_ID)
+                .wrapsSigningState(
+                        WrapsSigningState.newBuilder().phase(AGGREGATE).build())
+                .targetProof(aggregatedSignatureProof)
+                .build();
+
+        final var outcome =
+                subject.advance(EPOCH, construction, TARGET_METADATA, targetProofKeys, tssConfig, null, true);
+
+        assertSame(HistoryProver.Outcome.InProgress.INSTANCE, outcome);
+        assertSame(
+                WrapsPhase.POST_AGGREGATION,
+                getField("phaseNeedingWrapsReadinessRetry"),
+                "phase must stay flagged so the genesis proof is retried once the ledger id exists");
+        verify(historyLibrary, never()).constructGenesisWrapsProof(any(), any(), any(), any(), any());
+        verifyNoInteractions(submissions);
+    }
+
+    @Test
     void postAggregationKeepsRetryFlagAcrossMultipleStillNotReadyRounds() {
         // Covers the case where the next consensus round arrives but WRAPS is still
         // loading: isWrapsReadinessRetry=true at the top of publishIfNeeded clears the
@@ -1172,7 +1217,7 @@ class WrapsHistoryProverTest {
         given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
         given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
         // Stays false across every advance() — exercises the retry loop while the library is still loading.
-        given(historyLibrary.wrapsProverReady()).willReturn(false);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(false);
 
         final var aggregatedSignatureProof = HistoryProof.newBuilder()
                 .chainOfTrustProof(ChainOfTrustProof.newBuilder()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
@@ -600,7 +600,7 @@ class WrapsHistoryProverTest {
                 new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray());
         given(historyLibrary.constructIncrementalWrapsProof(any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(incremental);
-        given(historyLibrary.wrapsProverReady()).willReturn(true);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(true);
         given(historyLibrary.verifyAggregateSignature(any(), any(), any(), any(), any()))
                 .willReturn(true);
 
@@ -988,7 +988,7 @@ class WrapsHistoryProverTest {
                 new WrapsMpcStateMachine());
         given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
         given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
-        given(historyLibrary.wrapsProverReady()).willReturn(true);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(true);
         given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
                 .willReturn(
                         new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
@@ -1044,7 +1044,7 @@ class WrapsHistoryProverTest {
         given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
         given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
         // Not ready on the first advance() (download still in flight); ready on the second.
-        given(historyLibrary.wrapsProverReady()).willReturn(false, true);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(false, true);
         given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
                 .willReturn(
                         new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
@@ -1111,7 +1111,7 @@ class WrapsHistoryProverTest {
         // First call (publishIfNeeded early-exit guard): true -> skips early-exit.
         // Second call (inside outputFuture supplier): false -> NoopOutput.
         // Third call (next-round retry early-exit guard): true -> proceeds to publish.
-        given(historyLibrary.wrapsProverReady()).willReturn(true, false, true);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(true, false, true);
         given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
                 .willReturn(
                         new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
@@ -1172,7 +1172,7 @@ class WrapsHistoryProverTest {
         given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
         given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
         // Stays false across every advance() — exercises the retry loop while the library is still loading.
-        given(historyLibrary.wrapsProverReady()).willReturn(false);
+        given(historyLibrary.wrapsProverReady(any())).willReturn(false);
 
         final var aggregatedSignatureProof = HistoryProof.newBuilder()
                 .chainOfTrustProof(ChainOfTrustProof.newBuilder()

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
@@ -600,7 +600,7 @@ class WrapsHistoryProverTest {
                 new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray());
         given(historyLibrary.constructIncrementalWrapsProof(any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(incremental);
-        given(historyLibrary.wrapsProverReady(any())).willReturn(true);
+        given(historyLibrary.wrapsProverReady()).willReturn(true);
         given(historyLibrary.verifyAggregateSignature(any(), any(), any(), any(), any()))
                 .willReturn(true);
 
@@ -988,7 +988,7 @@ class WrapsHistoryProverTest {
                 new WrapsMpcStateMachine());
         given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
         given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
-        given(historyLibrary.wrapsProverReady(any())).willReturn(true);
+        given(historyLibrary.wrapsProverReady()).willReturn(true);
         given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
                 .willReturn(
                         new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
@@ -1044,7 +1044,7 @@ class WrapsHistoryProverTest {
         given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
         given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
         // Not ready on the first advance() (download still in flight); ready on the second.
-        given(historyLibrary.wrapsProverReady(any())).willReturn(false, true);
+        given(historyLibrary.wrapsProverReady()).willReturn(false, true);
         given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
                 .willReturn(
                         new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
@@ -1111,7 +1111,7 @@ class WrapsHistoryProverTest {
         // First call (publishIfNeeded early-exit guard): true -> skips early-exit.
         // Second call (inside outputFuture supplier): false -> NoopOutput.
         // Third call (next-round retry early-exit guard): true -> proceeds to publish.
-        given(historyLibrary.wrapsProverReady(any())).willReturn(true, false, true);
+        given(historyLibrary.wrapsProverReady()).willReturn(true, false, true);
         given(historyLibrary.constructGenesisWrapsProof(any(), any(), any(), any(), any()))
                 .willReturn(
                         new com.hedera.cryptography.wraps.Proof(UNCOMPRESSED.toByteArray(), COMPRESSED.toByteArray()));
@@ -1172,7 +1172,7 @@ class WrapsHistoryProverTest {
         given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
         given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
         // Stays false across every advance() — exercises the retry loop while the library is still loading.
-        given(historyLibrary.wrapsProverReady(any())).willReturn(false);
+        given(historyLibrary.wrapsProverReady()).willReturn(false);
 
         final var aggregatedSignatureProof = HistoryProof.newBuilder()
                 .chainOfTrustProof(ChainOfTrustProof.newBuilder()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
@@ -111,7 +111,9 @@ public class HgcaaLogValidator {
                 List.of("Restarted WRAPS signing"),
                 // Expected as part of WRAPS proving key verification tests
                 List.of("WRAPS proving key hash mismatch at"),
+                // Pre-0.79 nodes log "extract"; the staged install logs "install"
                 List.of("Failed to extract WRAPS proving key archive"),
+                List.of("Failed to install WRAPS proving key archive"),
                 List.of("Failed to download WRAPS proving key"),
                 List.of("WRAPS proving key download failed"),
                 List.of("Downloaded WRAPS proving key hash mismatch"),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/HgcaaLogValidator.java
@@ -111,8 +111,6 @@ public class HgcaaLogValidator {
                 List.of("Restarted WRAPS signing"),
                 // Expected as part of WRAPS proving key verification tests
                 List.of("WRAPS proving key hash mismatch at"),
-                // Pre-0.79 nodes log "extract"; the staged install logs "install"
-                List.of("Failed to extract WRAPS proving key archive"),
                 List.of("Failed to install WRAPS proving key archive"),
                 List.of("Failed to download WRAPS proving key"),
                 List.of("WRAPS proving key download failed"),


### PR DESCRIPTION
## Problem

WRAPS proof construction can `SIGBUS` in native `constructWrapsProofImpl` when Services extracts a
downloaded `wraps.tar.gz` on top of `decider_pp.bin` that the native library has already mmap'd —
`TarGzExtractor` truncates the mapped inode in place.

`wrapsProverReady()` only checked the four `*.bin` filenames exist, while `artifactsAlreadyPresent()`
also requires a matching `wraps.sha384`. Provisioning that copies only the bins makes both true at
once: prove from the live bins *and* overwrite them. The same gap let a node mmap the **wrong**
proving key.

## Fix

Both parts are needed; either alone is insufficient.

1. **Atomic install** — extract to `.wraps-staging`, verify, then publish each file with
   `Files.move(..., ATOMIC_MOVE)`, leaving the previous inode intact for any running proof.
2. **Tightened readiness** — `wrapsProverReady(String expectedProvingKeyHashHex)` now requires a
   `wraps.sha384` matching `tss.wrapsProvingKeyHash`. R1–R3 and aggregation are unaffected; only
   native proof construction defers, retrying each round.

**Operational note:** provisioning that copies only the four bins must now also supply
`wraps.sha384`. The published proving-key image already does.

Follow-ups found while testing, each with its own commit:

3. **Failed installs are retried** — `tryExtractTarGz` reports a definitive outcome instead of
   swallowing errors, so a silently failed install no longer leaves the prover deferring forever. An
   archive that verifies but lacks required artifacts is terminal (its contents are fixed by the
   matching hash), logged loudly, and not retried.
4. **The in-flight guard covers the synchronous install**, not just the download — otherwise a
   scheduled retry could extract into the same staging directory concurrently and publish a
   half-written artifact.
5. **`POST_AGGREGATION` defers when the ledger id is not yet available**, rather than dereferencing
   it once the library becomes ready.

## Testing

- Reproduced the fault directly against the shipped classes: with a live mmap over a 512 MiB
  `decider_pp.bin`, the pre-fix in-place extract faults on the mapping; the staged install leaves it
  intact and still publishes the new key.
- New unit tests, each verified to fail without its fix — the staged install preserves a live mapping
  (`installingOverAMappedArtifactLeavesTheExistingMappingIntact`), the acquisition guard is released
  on every exit path, and `POST_AGGREGATION` defers when the ledger id is not yet available.
- 264 `*history*` unit tests pass.
- `hapiTestWrapsDownload`: 9/9 WRAPS specs green. The ledger-id race actually occurred during the run
  and was deferred and retried instead of throwing (3 x `ledger id is not yet available`), so that
  path is exercised rather than merely absent. `LogValidationTest` fails on this branch and on `main`
  alike, with the same single `DefaultBranchReporter` branching problem in `swirlds.log` - verified
  by running the same task from a worktree at `main` (`e723f02cde7`).
- XTS dry run on this branch: 35 jobs passed, 15 skipped, 1 failed - `Solo 0.78 -> 0.79 Cutover`,
  which fails identically on `main` (Helm ConfigMap ownership, run 32939258001).

Fixes #26965
