### PR TITLE
fix: unblock the Solo 0.78 -> 0.79 cutover XTS panel

### DIFF
--- a/.github/workflows/103-user-solo-tests-adhoc.yaml
+++ b/.github/workflows/103-user-solo-tests-adhoc.yaml
@@ -64,7 +64,7 @@ on:
         type: string
         default: ""
       cutover-078-to-079-starting-tag:
-        description: "[078-to-079-cutover] Consensus-node release tag for the initial 0.78 network deploy. The 0.79 cutover always upgrades to the local build from the checked-out ref. Leave blank to default to v0.78.0-rc.2."
+        description: "[078-to-079-cutover] Consensus-node release tag for the initial 0.78 network deploy. The 0.79 cutover always upgrades to the local build from the checked-out ref. Leave blank to default to v0.78.0-rc.5."
         required: false
         type: string
         default: ""
@@ -784,7 +784,7 @@ jobs:
           timeout --signal=SIGINT --kill-after=5m 100m \
             env \
               BLOCK_NODE_REPO_PATH="${GITHUB_WORKSPACE}/hiero-block-node" \
-              DEPLOY_RELEASE_TAG="${{ inputs.cutover-078-to-079-starting-tag || 'v0.78.0-rc.2' }}" \
+              DEPLOY_RELEASE_TAG="${{ inputs.cutover-078-to-079-starting-tag || 'v0.78.0-rc.5' }}" \
             "${SCRIPT_PATH}" | tee "${RUNNER_TEMP}/078-to-079-cutover-script.log"
 
       - name: Collect Diagnostics On Failure

--- a/.github/workflows/826-call-solo-078-to-079-cutover.yaml
+++ b/.github/workflows/826-call-solo-078-to-079-cutover.yaml
@@ -20,14 +20,14 @@ on:
         required: false
         type: string
       starting-tag:
-        description: "Consensus-node release tag for the initial 0.78 network deploy. The 0.79 cutover always upgrades to the local build from the checked-out ref. Leave blank to default to v0.78.0-rc.2."
+        description: "Consensus-node release tag for the initial 0.78 network deploy. The 0.79 cutover always upgrades to the local build from the checked-out ref. Leave blank to default to v0.78.0-rc.5."
         required: false
         type: string
       block-node-ref:
         description: "hiero-block-node ref to checkout. Only used for the serverStatus/proto sources consumed by the grpcurl diagnostics; the deployed Block Node chart version is pinned inside the scenario script. Defaults to the tag matching that chart."
         required: false
         type: string
-        default: "v0.41.0-rc1"
+        default: "v0.41.0"
     outputs:
       failure-mode:
         description: "Failure Mode"
@@ -131,7 +131,7 @@ jobs:
       - name: Run 0.78 -> 0.79 BLOCKS Cutover Scenario
         id: run-cutover
         env:
-          DEPLOY_RELEASE_TAG: ${{ inputs.starting-tag || 'v0.78.0-rc.2' }}
+          DEPLOY_RELEASE_TAG: ${{ inputs.starting-tag || 'v0.78.0-rc.5' }}
         run: |
           set -eo pipefail
           SCRIPT_PATH="hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-078-to-079-cutover.sh"
@@ -152,8 +152,16 @@ jobs:
           kubectl get pods -A -o wide > "${OUT_DIR}/kubectl-pods.txt" 2>&1
           kubectl get svc -A > "${OUT_DIR}/kubectl-services.txt" 2>&1
           kubectl get events -A --sort-by=.lastTimestamp > "${OUT_DIR}/kubectl-events.txt" 2>&1
+          # The block node is rolled mid-scenario (seed + `block node upgrade`), so a plain `logs`
+          # returns nothing when the failure lands while the pod is still initializing. Capture the
+          # previous container's logs and the pod description too, otherwise a block node rejection
+          # (e.g. EndOfStream BAD_BLOCK_PROOF seen by the CN) cannot be attributed to a cause.
           kubectl -n "${SOLO_NAMESPACE}" logs "pod/block-node-1-0" --all-containers --tail=-1 \
             > "${OUT_DIR}/block-node-1-0.log" 2>&1
+          kubectl -n "${SOLO_NAMESPACE}" logs "pod/block-node-1-0" --all-containers --previous --tail=-1 \
+            > "${OUT_DIR}/block-node-1-0.previous.log" 2>&1
+          kubectl -n "${SOLO_NAMESPACE}" describe pod "block-node-1-0" \
+            > "${OUT_DIR}/block-node-1-0.describe.txt" 2>&1
 
           for node in node1 node2 node3 node4; do
             pod="network-${node}-0"

--- a/hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-078-to-079-cutover.sh
+++ b/hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-078-to-079-cutover.sh
@@ -70,6 +70,19 @@ WRAPS_SWAP_FILE_CONTAINER_PATH="${WRAPS_SWAP_FILE_CONTAINER_PATH:-${HAPI_PATH}/w
 
 SOLO_UPGRADE_TIMEOUT_SECS="${SOLO_UPGRADE_TIMEOUT_SECS:-1800}"
 
+# Every time Solo rewrites application.properties on the consensus nodes
+# (Helpers.copyBlockNodesJsonToConsensusNodes -> updateBlockStreamPropertiesForMode, added in Solo
+# v0.87.0) it force-sets blockStream.writerMode to constants.BLOCK_STREAM_WRITER_MODE. The sole call
+# site passes only the resolved streamMode, so that parameter always falls back to its default of
+# FILE_AND_GRPC and silently overwrites the writerMode=GRPC the 0.79 properties ask for.
+#
+# The upgrade itself is handled the way the 0.78 deploy handles Solo's property rewrites: stage it
+# with --skip-node-start and re-apply the properties before the JVMs start. `block node upgrade`
+# runs after the nodes are already up, though, so a re-apply there would not be picked up until the
+# next restart -- for that one command we use Solo's own environment override instead
+# (constants.ts: getEnvironmentVariable('BLOCK_STREAM_WRITER_MODE')).
+BLOCK_STREAM_WRITER_MODE_079="${BLOCK_STREAM_WRITER_MODE_079:-GRPC}"
+
 # When true (default), after the 0.79 upgrade we delete a CN pod to force an
 # event replay and assert it comes back ACTIVE without a SELF_ISS. This is the
 # actual failure mode observed in the full run (an OOMKilled node replayed past
@@ -1665,19 +1678,34 @@ upgrade_to_local_079() {
   # renders the per-node data ConfigMaps the block node deploy created out of band.
   adopt_node_data_config_maps_into_helm
 
+  # --skip-node-start stages the freeze upgrade and leaves the nodes CONFIGURED instead of started,
+  # which is the only point at which the properties Solo just rewrote can still be corrected. Same
+  # deploy -> re-apply -> start ordering deploy_078 uses.
   local upgrade_cmd=(
     solo consensus network upgrade
     --deployment "${SOLO_DEPLOYMENT}"
     --node-aliases "${NODE_ALIASES}"
     --local-build-path "${LOCAL_BUILD_PATH}"
     --application-properties "${APP_PROPS_079_FILE}"
+    --skip-node-start
     --quiet-mode
     --force
   )
   run_command_with_timeout "${SOLO_UPGRADE_TIMEOUT_SECS}" "${upgrade_cmd[@]}"
 
+  reapply_application_property_overrides "${APP_PROPS_079_FILE}"
+
+  solo consensus node start \
+    --deployment "${SOLO_DEPLOYMENT}" \
+    --node-aliases "${NODE_ALIASES}" \
+    --force-port-forward false
+
   log "--- 0.79 step: upgrade Block Node ${BLOCK_NODE_ID} to ${BLOCK_NODE_UPGRADE_VERSION} ---"
-  solo block node upgrade \
+  # `block node upgrade` rebuilds block-nodes.json through the same helper and runs after the nodes
+  # are already up, so re-applying the properties afterwards would not take effect until the next
+  # restart. Use Solo's environment override here so the on-disk file never drifts back.
+  env "BLOCK_STREAM_WRITER_MODE=${BLOCK_STREAM_WRITER_MODE_079}" \
+    solo block node upgrade \
     --deployment "${SOLO_DEPLOYMENT}" \
     --cluster-ref "kind-${SOLO_CLUSTER_NAME}" \
     --id "${BLOCK_NODE_ID}" \

--- a/hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-078-to-079-cutover.sh
+++ b/hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-078-to-079-cutover.sh
@@ -3,24 +3,24 @@
 #
 # Isolated reproducer for the 0.78 -> 0.79 BLOCKS cutover that deploys directly at the
 # published 0.78 release tag, verifies the 0.78 baseline, then upgrades the CN to the local 0.79
-# build and simultaneously upgrades the Block Node from v0.39.1 to v0.41.0-rc1.
+# build and simultaneously upgrades the Block Node from v0.41.0-rc1 to v0.41.0.
 #
-#   1. Deploy a CN network directly at the published v0.78.0-rc.2 release tag. The 0.78 genesis
+#   1. Deploy a CN network directly at the published v0.78.0-rc.5 release tag. The 0.78 genesis
 #      baseline uses dual-write streaming (streamMode=BOTH, writerMode=FILE_AND_GRPC) + mock TSS
 #      signatures, so genesis + staking complete without a block node (deployed mid-chain, step 3).
 #      The WRAPS env is injected before the JVMs start so all nodes initialize WRAPS in lockstep.
 #   2. Deploy a mirror node + explorer UI on the 0.78 network (importer reads blocks from the BN).
-#   3. Deploy a Block Node (v0.39.1) mid-chain; it verifies the real-TSS blocks streamed by the CN.
+#   3. Deploy a Block Node (v0.41.0-rc1) mid-chain; it verifies the real-TSS blocks streamed by the CN.
 #   4. Seed the Block Node with the network's TSS ledger id (published during 0.78) so it can
 #      verify blocks after the upgrade.
 #   5. Upgrade the CN in place to the local 0.79 build with
 #      resources/0.79/application-078-to-079.properties, and simultaneously upgrade the Block Node
-#      to v0.41.0-rc1. The mirror importer continues reading blocks from the upgraded BN.
+#      to v0.41.0. The mirror importer continues reading blocks from the upgraded BN.
 #
 # Verifications after the 0.79 upgrade:
 #   - local-build version on all consensus nodes
 #   - real (non-mock) WRAPS proof construction in hgcaa.log
-#   - Block Node (v0.41.0-rc1) verifies + persists the post-upgrade blocks (nextExpectedBlock
+#   - Block Node (v0.41.0) verifies + persists the post-upgrade blocks (nextExpectedBlock
 #     advances)
 #   - (optional) a node restart replays cleanly WITHOUT SELF_ISS. Enable with RESTART_REPLAY_CHECK=true.
 #
@@ -41,7 +41,7 @@ NODE_ALIASES="${NODE_ALIASES:-node1,node2,node3,node4}"
 # We deploy the network directly at the published 0.78 release tag (genesis at 0.78 with TSS +
 # WRAPS, dual-write + mock signatures — the pre-cutover baseline, no block node required), then
 # cut over to BLOCKS/GRPC/real-TSS at the local 0.79 upgrade.
-DEPLOY_RELEASE_TAG="${DEPLOY_RELEASE_TAG:-v0.78.0-rc.2}"
+DEPLOY_RELEASE_TAG="${DEPLOY_RELEASE_TAG:-v0.78.0-rc.5}"
 
 LOCAL_BUILD_PATH="${LOCAL_BUILD_PATH:-${REPO_ROOT}/hedera-node/data}"
 
@@ -86,15 +86,21 @@ OPERATOR_PRIVATE_KEY="${OPERATOR_PRIVATE_KEY:-302e020100300506032b65700422042091
 NUDGE_TX_COUNT="${NUDGE_TX_COUNT:-5}"
 
 # --- Block Node + TSS-ledger-id config (ported from the full e2e script) ---------------
-# The reproducer deploys a Block Node (v0.39.1) before the 0.78 step, seeds it with the network's
-# TSS ledger id before the 0.79 upgrade, and asserts the upgraded BN (v0.41.0-rc1) verifies +
+# The reproducer deploys a Block Node (v0.41.0-rc1) before the 0.78 step, seeds it with the
+# network's TSS ledger id before the 0.79 upgrade, and asserts the upgraded BN (v0.41.0) verifies +
 # persists the real-TSS-signed post-upgrade blocks.
+#
+# The baseline BN floor is v0.41.0-rc1, not something older: the block root tree the CN builds became
+# a fixed 16-slot merkle tree (#26919 on release/0.78, #26721 on main) and only BN v0.41.0-rc1+ feeds
+# 16 leaves to its Merkle Mountain Top hasher (hiero-block-node #3378). A v0.40.x-or-older BN rejects
+# every block a 0.78-with-that-rework CN produces with EndOfStream/BAD_BLOCK_PROOF, which saturates
+# the CN block buffer and wedges the handle thread on backpressure.
 MINIO_NAMESPACE="${MINIO_NAMESPACE:-${SOLO_NAMESPACE}}"
 MINIO_BUCKET="${MINIO_BUCKET:-solo-streams}"
 BLOCK_NODE_ID="${BLOCK_NODE_ID:-1}"
 BLOCK_NODE_REPO_PATH="${BLOCK_NODE_REPO_PATH:-${REPO_ROOT}/../hiero-block-node}"
-BLOCK_NODE_CHART_VERSION="${BLOCK_NODE_CHART_VERSION:-v0.39.1}"
-BLOCK_NODE_UPGRADE_VERSION="${BLOCK_NODE_UPGRADE_VERSION:-v0.41.0-rc1}"
+BLOCK_NODE_CHART_VERSION="${BLOCK_NODE_CHART_VERSION:-v0.41.0-rc1}"
+BLOCK_NODE_UPGRADE_VERSION="${BLOCK_NODE_UPGRADE_VERSION:-v0.41.0}"
 BLOCK_NODE_PRIORITY_MAPPING="${BLOCK_NODE_PRIORITY_MAPPING:-}"
 BLOCK_NODE_READY_TIMEOUT_SECS="${BLOCK_NODE_READY_TIMEOUT_SECS:-600}"
 BLOCK_NODE_GRPC_PORT="${BLOCK_NODE_GRPC_PORT:-40840}"
@@ -201,6 +207,38 @@ configured_wraps_artifacts_container_dir() {
   else
     printf '%s\n' "${WRAPS_ARTIFACTS_CONTAINER_DIR_DEFAULT}"
   fi
+}
+
+# Solo creates the per-node `network-<alias>-data-config-cm` ConfigMaps straight through the
+# Kubernetes API during `block node add` (Helpers.copyBlockNodesJsonToConsensusNodes), passing an
+# empty label map, so they carry no Helm ownership metadata. The solo-deployment chart templates the
+# same ConfigMaps, but only once `hedera.nodes[i].blockNodesJson` is set -- and `block node add` is
+# what sets it. So `consensus network deploy` renders none of them, Solo then creates them out of
+# band, and the next `helm upgrade` (driven by `consensus network upgrade`) aborts with "invalid
+# ownership metadata". Stamp the standard Helm adoption keys so Helm can take ownership instead.
+# Solo only merge-patches `.data` afterwards, so the metadata survives the later `block node upgrade`.
+adopt_node_data_config_maps_into_helm() {
+  # Solo's release name for the solo-deployment chart (constants.SOLO_DEPLOYMENT_CHART). This is NOT
+  # ${SOLO_DEPLOYMENT}, which is the Solo deployment name and defaults to something else entirely.
+  local helm_release="solo-deployment"
+  local node cm
+  local nodes=()
+
+  log "Stamping Helm ownership metadata on the per-node data ConfigMaps"
+  IFS=',' read -r -a nodes <<< "${NODE_ALIASES}"
+  for node in "${nodes[@]}"; do
+    cm="network-${node}-data-config-cm"
+    if ! kubectl -n "${SOLO_NAMESPACE}" get configmap "${cm}" >/dev/null 2>&1; then
+      echo "  ${cm}: absent, nothing to adopt"
+      continue
+    fi
+    kubectl -n "${SOLO_NAMESPACE}" label configmap "${cm}" \
+      "app.kubernetes.io/managed-by=Helm" --overwrite >/dev/null
+    kubectl -n "${SOLO_NAMESPACE}" annotate configmap "${cm}" \
+      "meta.helm.sh/release-name=${helm_release}" \
+      "meta.helm.sh/release-namespace=${SOLO_NAMESPACE}" --overwrite >/dev/null
+    echo "  ${cm}: adopted into Helm release ${helm_release}"
+  done
 }
 
 reapply_application_property_overrides() {
@@ -1622,6 +1660,10 @@ update_mirror_node_for_block_cutover() {
 
 upgrade_to_local_079() {
   log "=== 0.79 upgrade: upgrade CN to local build + upgrade BN to ${BLOCK_NODE_UPGRADE_VERSION} ==="
+
+  # `consensus network upgrade` re-runs `helm upgrade` on the solo-deployment release, which now
+  # renders the per-node data ConfigMaps the block node deploy created out of band.
+  adopt_node_data_config_maps_into_helm
 
   local upgrade_cmd=(
     solo consensus network upgrade

--- a/hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-078-to-079-cutover.sh
+++ b/hedera-node/test-clients/scripts/solo/e2e-block-stream-cutover/solo-078-to-079-cutover.sh
@@ -1711,6 +1711,13 @@ upgrade_to_local_079() {
     --id "${BLOCK_NODE_ID}" \
     --upgrade-version "${BLOCK_NODE_UPGRADE_VERSION}" \
     --quiet-mode
+  # Same StatefulSet race seed_block_node_tss_parameters documents: an in-place `block node upgrade`
+  # rolls the StatefulSet, and `wait --for=condition=ready pod/<name>` matches the OLD pod -- still
+  # Ready while it terminates -- so it returns before the upgraded pod exists. The script then races
+  # ahead and the post-cutover BN port-forward finds no ready endpoint behind svc/block-node-N.
+  # Block on the rollout first, then confirm the recreated pod.
+  kubectl -n "${SOLO_NAMESPACE}" rollout status "statefulset/block-node-${BLOCK_NODE_ID}" \
+    --timeout="${BLOCK_NODE_READY_TIMEOUT_SECS}s"
   kubectl -n "${SOLO_NAMESPACE}" wait --for=condition=ready "pod/block-node-${BLOCK_NODE_ID}-0" --timeout="${BLOCK_NODE_READY_TIMEOUT_SECS}s"
 
   log "--- 0.79 check 1/4: wait for consensus pods + haproxy + verify local-build version ---"


### PR DESCRIPTION
Unblocks the `Solo 0.78 -> 0.79 Cutover` XTS panel, which has failed on every run since it was enabled.

- Adopt the per-node `network-<alias>-data-config-cm` ConfigMaps into the `solo-deployment` Helm release before the upgrade. Solo creates them out of band, so `helm upgrade` aborted with `invalid ownership metadata`.
- Move the 0.78 baseline to `v0.78.0-rc.5` and the Block Node floor to `v0.41.0-rc1` (upgrading to `v0.41.0`), so both sides of the cutover agree on the fixed 16-slot block root tree. Older Block Nodes rejected every post-rework block with `BAD_BLOCK_PROOF`.
- Stage the upgrade with `--skip-node-start` and re-apply the 0.79 properties before the JVMs start, matching how `deploy_078` already handles Solo's property rewrites. Solo v0.87.0 force-sets `blockStream.writerMode` back to `FILE_AND_GRPC`.
- Wait on the Block Node StatefulSet rollout after `block node upgrade`; `wait --for=condition=ready pod/<name>` matched the old, terminating pod.
- Capture the Block Node's previous-container logs and pod description in the failure artifacts.