### PR TITLE
ci(citr): add per-suite Otter test workflows (847-849)

### DIFF
--- a/.github/workflows/847-call-execute-otter-fast.yaml
+++ b/.github/workflows/847-call-execute-otter-fast.yaml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "847: [CALL] Exec Fast Otter Tests"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.fast-otter.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  fast-otter:
+    name: "Fast Otter Tests"
+    runs-on: hl-cn-otter-fast-lin
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: ${{ inputs.ref || '' }}
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: Fast Otter Testing
+        id: gradle-fast-otter-tests
+        if: ${{ !cancelled() }}
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: ${GRADLE_EXEC} :consensus-otter-tests:testOtter
+
+      - name: Publish Fast Otter Testing Report
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        if: ${{ !cancelled() }}
+        with:
+          check_name: "Node: Fast Otter Tests Results"
+          json_thousands_separator: ","
+          junit_files: "**/consensus-otter-tests/build/test-results/testOtter/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload Fast Otter Tests Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() }}
+        with:
+          name: Fast Otter Tests Report
+          path: "**/consensus-otter-tests/build/test-results/testOtter/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload Fast Otter Tests Turtle Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-fast-otter-tests.conclusion == 'failure' && !cancelled() }}
+        with:
+          name: Fast Otter Tests Turtle Logs
+          path: platform-sdk/consensus-otter-tests/build/turtle
+          retention-days: 7
+
+      - name: Upload Fast Otter Tests Container Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-fast-otter-tests.conclusion == 'failure' && !cancelled() }}
+        with:
+          name: Fast Otter Tests Container Logs
+          path: platform-sdk/consensus-otter-tests/build/container
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-fast-otter-tests.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-fast-otter-tests.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-fast-otter-tests.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/848-call-execute-otter-full.yaml
+++ b/.github/workflows/848-call-execute-otter-full.yaml
@@ -1,0 +1,129 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "848: [CALL] Exec Full Otter Tests"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.full-otter.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  full-otter:
+    name: "Full Otter Tests"
+    runs-on: hl-cn-otter-full-lin
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: ${{ inputs.ref || '' }}
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: Full Otter Testing
+        id: gradle-full-otter-tests
+        if: ${{ !cancelled() }}
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: ${GRADLE_EXEC} :consensus-otter-tests:testContainer
+
+      - name: Publish Full Otter Testing Report
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        if: ${{ !cancelled() }}
+        with:
+          check_name: "Node: Full Otter Tests Results"
+          json_thousands_separator: ","
+          junit_files: "**/consensus-otter-tests/build/test-results/testContainer/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload Full Otter Tests Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() }}
+        with:
+          name: Full Otter Tests Report
+          path: "**/consensus-otter-tests/build/test-results/testContainer/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload Full Otter Tests Container Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-full-otter-tests.conclusion == 'failure' && !cancelled() }}
+        with:
+          name: Full Otter Tests Container Logs
+          path: platform-sdk/consensus-otter-tests/build/container
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-full-otter-tests.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-full-otter-tests.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-full-otter-tests.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/849-call-execute-otter-chaos.yaml
+++ b/.github/workflows/849-call-execute-otter-chaos.yaml
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "849: [CALL] Exec Chaos Otter Tests"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.chaos-otter.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  chaos-otter:
+    name: "Chaos Otter Tests"
+    runs-on: hl-cn-otter-chaos-lin
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: ${{ inputs.ref || '' }}
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: Chaos Otter Testing
+        id: gradle-chaos-otter-tests
+        if: ${{ !cancelled() }}
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: ${GRADLE_EXEC} :consensus-otter-tests:testChaos
+
+      - name: Publish Chaos Otter Testing Report
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        if: ${{ !cancelled() }}
+        with:
+          check_name: "Node: Chaos Otter Tests Results"
+          json_thousands_separator: ","
+          junit_files: "**/consensus-otter-tests/build/test-results/testChaos/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload Chaos Otter Test Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() }}
+        with:
+          name: Chaos Otter Tests Report
+          path: "**/consensus-otter-tests/build/test-results/testChaos/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload Chaos Otter Tests Turtle Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-chaos-otter-tests.conclusion == 'failure' && !cancelled() }}
+        with:
+          name: Chaos Otter Tests Turtle Logs
+          path: platform-sdk/consensus-otter-tests/build/turtle
+          retention-days: 7
+
+      - name: Upload Chaos Otter Tests Container Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ inputs.enable-network-log-capture && steps.gradle-chaos-otter-tests.conclusion == 'failure' && !cancelled() }}
+        with:
+          name: Chaos Otter Tests Container Logs
+          path: platform-sdk/consensus-otter-tests/build/container
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-chaos-otter-tests.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-chaos-otter-tests.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-chaos-otter-tests.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi


### PR DESCRIPTION
Extract each job in 808-call-execute-otter-tests.yaml into its own reusable
workflow_call workflow:

  847-call-execute-otter-fast.yaml   :consensus-otter-tests:testOtter
  848-call-execute-otter-full.yaml   :consensus-otter-tests:testContainer
  849-call-execute-otter-chaos.yaml  :consensus-otter-tests:testChaos

Steps are copied verbatim; the only deltas are the removed job-level enable
toggle (gating moves up to the driver) and the reporting renames below.

fast-otter and full-otter previously published under the SAME check_name
("Node: Otter Tests Results") and shared the "Otter Tests Report" and
"Otter Tests Container Logs" artifact names, so whichever finished second
overwrote the first. Each suite now gets a distinct check and artifact name.
Chaos is normalised to match ("Result" -> "Results", "Test Report" ->
"Tests Report").

These are additive: nothing references them yet.

Refs: #26978

Signed-off-by: Roger Barker <roger.barker@swirldslabs.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
