### PR TITLE
ci(citr): add per-suite MATS HAPI test workflows (836-843)

### DIFF
--- a/.github/workflows/836-call-execute-hapi-misc.yaml
+++ b/.github/workflows/836-call-execute-hapi-misc.yaml
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "836: [CALL] Exec HAPI Misc"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.hapi-tests-misc.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  hapi-tests-misc:
+    name: "HAPI Tests (Misc)"
+    runs-on: hl-cn-hapi-lin-lg
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: HAPI Testing (Misc)
+        id: gradle-hapi-misc
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        # Run each task in isolation with clean builds because we dynamically reconfigure Log4j for each mode
+        run: |
+          status=0
+          run_subtask() {
+            local t=$1
+            echo "::group::$t"
+            if ${GRADLE_EXEC} "$t" --no-daemon; then
+              echo "::endgroup::"
+              return 0
+            fi
+            echo "::endgroup::"
+            status=1
+            echo "::error::$t failed"
+            echo "❌ $t FAILED — expand group above for details"
+          }
+          run_subtask hapiTestMisc
+          run_subtask hapiTestMiscEmbedded
+          run_subtask hapiTestMiscRepeatable
+          exit $status
+
+      - name: YahCLI Subprocess Regression Tests
+        id: gradle-yahcli-misc
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: ${GRADLE_EXEC} :yahcli:testSubprocess --no-daemon
+
+      - name: Publish HAPI Test (Misc) Reports
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        with:
+          check_name: "Node: HAPI Test (Misc) Results"
+          json_thousands_separator: ","
+          junit_files: |
+            **/test-clients/build/test-results/**/TEST-*.xml
+            **/yahcli/build/test-results/**/TEST-*.xml
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload HAPI Test (Misc) Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: HAPI Test (Misc) Reports
+          path: |
+            **/test-clients/build/test-results/**/TEST-*.xml
+            **/yahcli/build/test-results/**/TEST-*.xml
+          retention-days: 7
+
+      - name: Upload HAPI Test (Misc) Network Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && inputs.enable-network-log-capture && (steps.gradle-hapi-misc.conclusion == 'failure' || steps.gradle-yahcli-misc.conclusion == 'failure') }}
+        with:
+          name: HAPI Test (Misc) Network Logs
+          path: |
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
+            hedera-node/test-clients/output/**
+            hedera-node/yahcli/build/hapi-test/**/output/**
+            hedera-node/yahcli/build/hapi-test/**/*.log
+          retention-days: 7
+
+      - name: Upload HAPI Test (Misc) Failure Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && (steps.gradle-hapi-misc.conclusion == 'failure' || steps.gradle-yahcli-misc.conclusion == 'failure') }}
+        with:
+          name: HAPI Test (Misc) Failure Artifacts
+          path: |
+            hedera-node/test-clients/build/**/*.blk.gz
+            hedera-node/test-clients/build/**/*.rcd.gz
+            hedera-node/test-clients/build/**/*.pb
+            hedera-node/test-clients/build/**/*.pces
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
+            hedera-node/test-clients/output/**
+            hedera-node/yahcli/build/**/*.blk.gz
+            hedera-node/yahcli/build/**/*.rcd.gz
+            hedera-node/yahcli/build/**/*.pb
+            hedera-node/yahcli/build/**/*.pces
+            hedera-node/yahcli/build/reports/tests/testSubprocess/**
+            hedera-node/yahcli/build/hapi-test/**/output/**
+            hedera-node/yahcli/build/hapi-test/**/*.log
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-hapi-misc.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-hapi-misc.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-hapi-misc.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/837-call-execute-hapi-misc-records-crypto.yaml
+++ b/.github/workflows/837-call-execute-hapi-misc-records-crypto.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "837: [CALL] Exec HAPI Rec/Crypto"
+name: "837: [CALL] Exec HAPI Rec Crypto"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/837-call-execute-hapi-misc-records-crypto.yaml
+++ b/.github/workflows/837-call-execute-hapi-misc-records-crypto.yaml
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "837: [CALL] Exec HAPI Rec/Crypto"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.hapi-tests-misc-records-crypto-and-serial.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  hapi-tests-misc-records-crypto-and-serial:
+    name: "HAPI Tests (Misc Records, Crypto & Misc Serial)"
+    runs-on: hl-cn-hapi-lin-lg
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: HAPI Testing (Misc Records, Crypto & Misc Serial)
+        id: gradle-hapi-misc-records-crypto-and-serial
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: |
+          status=0
+          run_subtask() {
+            local t=$1
+            echo "::group::$t"
+            if ${GRADLE_EXEC} "$t" --no-daemon; then
+              echo "::endgroup::"
+              return 0
+            fi
+            echo "::endgroup::"
+            status=1
+            echo "::error::$t failed"
+            echo "❌ $t FAILED — expand group above for details"
+          }
+          run_subtask hapiTestMiscRecords
+          run_subtask hapiTestMiscRecordsSerial
+          run_subtask hapiTestCrypto
+          run_subtask hapiTestCryptoEmbedded
+          run_subtask hapiTestCryptoSerial
+          run_subtask hapiTestMiscSerial
+          exit $status
+
+      - name: Publish HAPI Test (Misc Records, Crypto & Misc Serial) Reports
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        with:
+          check_name: "Node: HAPI Test (Misc Records, Crypto & Misc Serial) Results"
+          json_thousands_separator: ","
+          junit_files: "**/test-clients/build/test-results/**/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload HAPI Test (Misc Records, Crypto & Misc Serial) Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: HAPI Test (Misc Records, Crypto & Misc Serial) Reports
+          path: "**/test-clients/build/test-results/**/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload HAPI Test (Misc Records, Crypto & Misc Serial) Network Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && inputs.enable-network-log-capture && steps.gradle-hapi-misc-records-crypto-and-serial.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Misc Records, Crypto & Misc Serial) Network Logs
+          path: |
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Upload HAPI Test (Misc Records, Crypto & Misc Serial) Failure Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && steps.gradle-hapi-misc-records-crypto-and-serial.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Misc Records, Crypto & Misc Serial) Failure Artifacts
+          path: |
+            hedera-node/test-clients/build/**/*.blk.gz
+            hedera-node/test-clients/build/**/*.rcd.gz
+            hedera-node/test-clients/build/**/*.pb
+            hedera-node/test-clients/build/**/*.pces
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-hapi-misc-records-crypto-and-serial.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-hapi-misc-records-crypto-and-serial.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-hapi-misc-records-crypto-and-serial.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/838-call-execute-hapi-token-time-consuming.yaml
+++ b/.github/workflows/838-call-execute-hapi-token-time-consuming.yaml
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "838: [CALL] Exec HAPI Token/Time"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.hapi-tests-token-and-time-consuming.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  hapi-tests-token-and-time-consuming:
+    name: "HAPI Tests (Token & Time Consuming)"
+    runs-on: hl-cn-hapi-lin-lg
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: HAPI Testing (Token & Time Consuming)
+        id: gradle-hapi-token-and-time-consuming
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: |
+          status=0
+          run_subtask() {
+            local t=$1
+            echo "::group::$t"
+            if ${GRADLE_EXEC} "$t" --no-daemon; then
+              echo "::endgroup::"
+              return 0
+            fi
+            echo "::endgroup::"
+            status=1
+            echo "::error::$t failed"
+            echo "❌ $t FAILED — expand group above for details"
+          }
+          run_subtask hapiTestToken
+          run_subtask hapiTestTokenSerial
+          run_subtask hapiTestTimeConsuming
+          run_subtask hapiTestTimeConsumingSerial
+          exit $status
+
+      - name: Publish HAPI Test (Token & Time Consuming) Reports
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        with:
+          check_name: "Node: HAPI Test (Token & Time Consuming) Results"
+          json_thousands_separator: ","
+          junit_files: "**/test-clients/build/test-results/**/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload HAPI Test (Token & Time Consuming) Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: HAPI Test (Token & Time Consuming) Reports
+          path: "**/test-clients/build/test-results/**/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload HAPI Test (Token & Time Consuming) Network Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && inputs.enable-network-log-capture && steps.gradle-hapi-token-and-time-consuming.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Token & Time Consuming) Network Logs
+          path: |
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Upload HAPI Test (Token & Time Consuming) Failure Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && steps.gradle-hapi-token-and-time-consuming.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Token & Time Consuming) Failure Artifacts
+          path: |
+            hedera-node/test-clients/build/**/*.blk.gz
+            hedera-node/test-clients/build/**/*.rcd.gz
+            hedera-node/test-clients/build/**/*.pb
+            hedera-node/test-clients/build/**/*.pces
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-hapi-token-and-time-consuming.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-hapi-token-and-time-consuming.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-hapi-token-and-time-consuming.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/838-call-execute-hapi-token-time-consuming.yaml
+++ b/.github/workflows/838-call-execute-hapi-token-time-consuming.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "838: [CALL] Exec HAPI Token/Time"
+name: "838: [CALL] Exec HAPI Token Time"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/839-call-execute-hapi-simple-fees-nd-reconnect.yaml
+++ b/.github/workflows/839-call-execute-hapi-simple-fees-nd-reconnect.yaml
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "839: [CALL] Exec HAPI Fees/NDRec"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.hapi-tests-simple-fees-and-nd-reconnect.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  hapi-tests-simple-fees-and-nd-reconnect:
+    name: "HAPI Tests (Simple Fees & ND Reconnect)"
+    runs-on: hl-cn-hapi-lin-lg
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: HAPI Testing (Simple Fees & ND Reconnect)
+        id: gradle-hapi-simple-fees-and-nd-reconnect
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: |
+          status=0
+          run_subtask() {
+            local t=$1
+            echo "::group::$t"
+            if ${GRADLE_EXEC} "$t" --no-daemon; then
+              echo "::endgroup::"
+              return 0
+            fi
+            echo "::endgroup::"
+            status=1
+            echo "::error::$t failed"
+            echo "❌ $t FAILED — expand group above for details"
+          }
+          run_subtask hapiTestSimpleFees
+          run_subtask hapiTestSimpleFeesEmbedded
+          run_subtask hapiTestSimpleFeesSerial
+          run_subtask hapiTestNDReconnect
+          exit $status
+
+      - name: Publish HAPI Test (Simple Fees & ND Reconnect) Reports
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        with:
+          check_name: "Node: HAPI Test (Simple Fees & ND Reconnect) Results"
+          json_thousands_separator: ","
+          junit_files: "**/test-clients/build/test-results/**/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload HAPI Test (Simple Fees & ND Reconnect) Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: HAPI Test (Simple Fees & ND Reconnect) Reports
+          path: "**/test-clients/build/test-results/**/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload HAPI Test (Simple Fees & ND Reconnect) Network Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && inputs.enable-network-log-capture && steps.gradle-hapi-simple-fees-and-nd-reconnect.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Simple Fees & ND Reconnect) Network Logs
+          path: |
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Upload HAPI Test (Simple Fees & ND Reconnect) Failure Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && steps.gradle-hapi-simple-fees-and-nd-reconnect.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Simple Fees & ND Reconnect) Failure Artifacts
+          path: |
+            hedera-node/test-clients/build/**/*.blk.gz
+            hedera-node/test-clients/build/**/*.rcd.gz
+            hedera-node/test-clients/build/**/*.pb
+            hedera-node/test-clients/build/**/*.pces
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-hapi-simple-fees-and-nd-reconnect.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-hapi-simple-fees-and-nd-reconnect.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-hapi-simple-fees-and-nd-reconnect.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/839-call-execute-hapi-simple-fees-nd-reconnect.yaml
+++ b/.github/workflows/839-call-execute-hapi-simple-fees-nd-reconnect.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "839: [CALL] Exec HAPI Fees/NDRec"
+name: "839: [CALL] Exec HAPI Fees NDRec"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/840-call-execute-hapi-smart-contract-iss.yaml
+++ b/.github/workflows/840-call-execute-hapi-smart-contract-iss.yaml
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "840: [CALL] Exec HAPI SC/ISS"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.hapi-tests-smart-contracts-and-iss.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  hapi-tests-smart-contracts-and-iss:
+    name: "HAPI Tests (Smart Contracts & ISS)"
+    runs-on: hl-cn-hapi-lin-lg
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: HAPI Testing (Smart Contracts & ISS)
+        id: gradle-hapi-smart-contract-and-iss
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: |
+          status=0
+          run_subtask() {
+            local t=$1
+            echo "::group::$t"
+            if ${GRADLE_EXEC} "$t" --no-daemon; then
+              echo "::endgroup::"
+              return 0
+            fi
+            echo "::endgroup::"
+            status=1
+            echo "::error::$t failed"
+            echo "❌ $t FAILED — expand group above for details"
+          }
+          run_subtask hapiTestSmartContract
+          run_subtask hapiTestSmartContractSerial
+          run_subtask hapiTestIss
+          exit $status
+
+      - name: Publish HAPI Test (Smart Contracts & ISS) Reports
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        with:
+          check_name: "Node: HAPI Test (Smart Contracts & ISS) Results"
+          json_thousands_separator: ","
+          junit_files: "**/test-clients/build/test-results/**/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload HAPI Test (Smart Contracts & ISS) Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: HAPI Test (Smart Contracts & ISS) Reports
+          path: "**/test-clients/build/test-results/**/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload HAPI Test (Smart Contracts & ISS) Network Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && inputs.enable-network-log-capture && steps.gradle-hapi-smart-contract-and-iss.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Smart Contracts & ISS) Network Logs
+          path: |
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Upload HAPI Test (Smart Contracts & ISS) Failure Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && steps.gradle-hapi-smart-contract-and-iss.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Smart Contracts & ISS) Failure Artifacts
+          path: |
+            hedera-node/test-clients/build/**/*.blk.gz
+            hedera-node/test-clients/build/**/*.rcd.gz
+            hedera-node/test-clients/build/**/*.pb
+            hedera-node/test-clients/build/**/*.pces
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-hapi-smart-contract-and-iss.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-hapi-smart-contract-and-iss.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-hapi-smart-contract-and-iss.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/840-call-execute-hapi-smart-contract-iss.yaml
+++ b/.github/workflows/840-call-execute-hapi-smart-contract-iss.yaml
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-name: "840: [CALL] Exec HAPI SC/ISS"
+name: "840: [CALL] Exec HAPI SC ISS"
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/841-call-execute-hapi-restart.yaml
+++ b/.github/workflows/841-call-execute-hapi-restart.yaml
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "841: [CALL] Exec HAPI Restart"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.hapi-tests-restart.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  hapi-tests-restart:
+    name: "HAPI Tests (Restart)"
+    runs-on: hl-cn-hapi-lin-lg
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: HAPI Testing (Restart)
+        id: gradle-hapi-restart
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: ${GRADLE_EXEC} hapiTestRestart
+
+      - name: Publish HAPI Test (Restart) Reports
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        with:
+          check_name: "Node: HAPI Test (Restart) Results"
+          json_thousands_separator: ","
+          junit_files: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload HAPI Test (Restart) Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: HAPI Test (Restart) Reports
+          path: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload HAPI Test (Restart) Network Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && inputs.enable-network-log-capture && steps.gradle-hapi-restart.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Restart) Network Logs
+          path: |
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Upload HAPI Test (Restart) Failure Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && steps.gradle-hapi-restart.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Restart) Failure Artifacts
+          path: |
+            hedera-node/test-clients/build/**/*.blk.gz
+            hedera-node/test-clients/build/**/*.rcd.gz
+            hedera-node/test-clients/build/**/*.pb
+            hedera-node/test-clients/build/**/*.pces
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-hapi-restart.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-hapi-restart.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-hapi-restart.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/842-call-execute-hapi-atomic-batch.yaml
+++ b/.github/workflows/842-call-execute-hapi-atomic-batch.yaml
@@ -1,0 +1,162 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "842: [CALL] Exec HAPI Atomic Batch"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.hapi-tests-atomic-batch.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  hapi-tests-atomic-batch:
+    name: "HAPI Tests (Atomic Batch)"
+    runs-on: hl-cn-hapi-lin-xl
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: HAPI Testing (Atomic Batch)
+        id: gradle-hapi-atomic-batch
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: |
+          status=0
+          run_subtask() {
+            local t=$1
+            echo "::group::$t"
+            if ${GRADLE_EXEC} "$t" --no-daemon; then
+              echo "::endgroup::"
+              return 0
+            fi
+            echo "::endgroup::"
+            status=1
+            echo "::error::$t failed"
+            echo "❌ $t FAILED — expand group above for details"
+          }
+          run_subtask hapiTestAtomicBatch
+          run_subtask hapiTestAtomicBatchSerial
+          run_subtask hapiTestAtomicBatchEmbedded
+          exit $status
+
+      - name: Publish HAPI Test (Atomic Batch) Reports
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        with:
+          check_name: "Node: HAPI Test (Atomic Batch) Results"
+          json_thousands_separator: ","
+          junit_files: "**/test-clients/build/test-results/**/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload HAPI Test (Atomic Batch) Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: HAPI Test (Atomic Batch) Reports
+          path: "**/test-clients/build/test-results/**/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload HAPI Test (Atomic Batch) Network Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && inputs.enable-network-log-capture && steps.gradle-hapi-atomic-batch.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Atomic Batch) Network Logs
+          path: |
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Upload HAPI Test (Atomic Batch) Failure Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && steps.gradle-hapi-atomic-batch.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (Atomic Batch) Failure Artifacts
+          path: |
+            hedera-node/test-clients/build/**/*.blk.gz
+            hedera-node/test-clients/build/**/*.rcd.gz
+            hedera-node/test-clients/build/**/*.pb
+            hedera-node/test-clients/build/**/*.pces
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-hapi-atomic-batch.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-hapi-atomic-batch.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-hapi-atomic-batch.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi

--- a/.github/workflows/843-call-execute-hapi-state-throttling.yaml
+++ b/.github/workflows/843-call-execute-hapi-state-throttling.yaml
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "843: [CALL] Exec HAPI State Throttle"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The branch, tag or SHA to checkout."
+        required: false
+        type: string
+        default: ""
+      java-distribution:
+        description: "Java JDK Distribution:"
+        required: false
+        type: string
+        default: "temurin"
+      java-version:
+        description: "Java JDK Version:"
+        required: false
+        type: string
+      node-version:
+        description: "NodeJS Version:"
+        required: false
+        type: string
+        default: "20"
+      enable-network-log-capture:
+        description: "Network Log Capture Enabled"
+        required: false
+        type: string
+        default: "false"
+    secrets:
+      access-token:
+        description: "The GitHub access token used to checkout the repository, submodules, and make GitHub API calls."
+        required: true
+      gradle-cache-username:
+        description: "The username used to authenticate with the Gradle Build Cache Node."
+        required: true
+      gradle-cache-password:
+        description: "The password used to authenticate with the Gradle Build Cache Node."
+        required: true
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the job, if any."
+        value: ${{ jobs.hapi-tests-state-throttling.outputs.failure-mode }}
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  id-token: write
+  actions: read
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+env:
+  GRADLE_CACHE_USERNAME: ${{ secrets.gradle-cache-username }}
+  GRADLE_CACHE_PASSWORD: ${{ secrets.gradle-cache-password }}
+  GRADLE_EXEC: ionice -c 2 -n 2 nice -n 19 ./gradlew
+  CG_EXEC: ionice -c 2 -n 2 nice -n 19
+
+jobs:
+  hapi-tests-state-throttling:
+    name: "HAPI Tests (State Throttling)"
+    runs-on: hl-cn-hapi-lin-lg
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+          setup-java: "true"
+          java-version: "${{ inputs.java-version }}"
+          java-distribution: "${{ inputs.java-distribution }}"
+          setup-gradle: "true"
+          setup-testlens: "true"
+          gradle-cache-read-only: "false"
+          setup-node: "true"
+          node-version: "${{ inputs.node-version }}"
+
+      - name: HAPI Testing (State Throttling)
+        id: gradle-hapi-state-throttling
+        env:
+          LC_ALL: en.UTF-8
+          LANG: en_US.UTF-8
+        run: ${GRADLE_EXEC} hapiTestStateThrottling
+
+      - name: Publish HAPI Test (State Throttling) Reports
+        uses: step-security/publish-unit-test-result-action@681100d67b09305624c089873f12c545ee7cbc24 # v2.23.0
+        with:
+          check_name: "Node: HAPI Test (State Throttling) Results"
+          json_thousands_separator: ","
+          junit_files: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
+          comment_mode: errors # only comment if we could not find or parse the JUnit XML files
+
+      - name: Upload HAPI Test (State Throttling) Report Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: HAPI Test (State Throttling) Reports
+          path: "**/test-clients/build/test-results/testSubprocess/TEST-*.xml"
+          retention-days: 7
+
+      - name: Upload HAPI Test (State Throttling) Network Logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && inputs.enable-network-log-capture && steps.gradle-hapi-state-throttling.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (State Throttling) Network Logs
+          path: |
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Upload HAPI Test (State Throttling) Failure Artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        if: ${{ !cancelled() && steps.gradle-hapi-state-throttling.conclusion == 'failure' }}
+        with:
+          name: HAPI Test (State Throttling) Failure Artifacts
+          path: |
+            hedera-node/test-clients/build/**/*.blk.gz
+            hedera-node/test-clients/build/**/*.rcd.gz
+            hedera-node/test-clients/build/**/*.pb
+            hedera-node/test-clients/build/**/*.pces
+            hedera-node/test-clients/build/*-test/**/output/**
+            hedera-node/test-clients/build/*-test/**/*.log
+            hedera-node/test-clients/output/**
+          retention-days: 7
+
+      - name: Set Failure Mode Output
+        id: set-failure-mode
+        if: ${{ always() }}
+        run: |
+          if [[ "${{ steps.gradle-hapi-state-throttling.outcome || 'skipped' }}" == "success" \
+             || "${{ steps.gradle-hapi-state-throttling.outcome || 'skipped' }}" == "skipped" ]]; then
+            echo "failure-mode=none" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ steps.gradle-hapi-state-throttling.outcome || 'skipped' }}" == "failure" ]]; then
+            echo "failure-mode=test" >> "${GITHUB_OUTPUT}"
+          else
+            echo "failure-mode=workflow" >> "${GITHUB_OUTPUT}"
+          fi


### PR DESCRIPTION
Extract the eight MATS-consumed jobs from 805-call-execute-hapi-tests.yaml:

  836 hapi-misc                    hapiTestMisc, ...Embedded, ...Repeatable, :yahcli:testSubprocess
  837 hapi-misc-records-crypto     hapiTestMiscRecords, ...Serial, hapiTestCrypto, ...Embedded, ...Serial, hapiTestMiscSerial
  838 hapi-token-time-consuming    hapiTestToken, ...Serial, hapiTestTimeConsuming, ...Serial
  839 hapi-simple-fees-nd-reconnect hapiTestSimpleFees, ...Embedded, ...Serial, hapiTestNDReconnect
  840 hapi-smart-contract-iss      hapiTestSmartContract, ...Serial, hapiTestIss
  841 hapi-restart                 hapiTestRestart
  842 hapi-atomic-batch            hapiTestAtomicBatch, ...Serial, ...Embedded
  843 hapi-state-throttling        hapiTestStateThrottling

Steps are copied verbatim, including the run_subtask helper and the exact
ordered task lists. 842 keeps its hl-cn-hapi-lin-xl runner; the rest stay on
hl-cn-hapi-lin-lg. The only delta is the removed job-level enable toggle.

Each leaf exposes its own failure-mode output; the workflow-level
set-failure-mode aggregation stays behind in 805 and moves to the driver.

These are additive: nothing references them yet.

Refs: #26978

Signed-off-by: Roger Barker <roger.barker@swirldslabs.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
