### PR TITLE
ci(citr): point MATS at the 810/811 suite drivers

### DIFF
--- a/.github/workflows/800-call-mats-tests.yaml
+++ b/.github/workflows/800-call-mats-tests.yaml
@@ -219,7 +219,7 @@ jobs:
   mats-hapi-tests:
     name: HAPI Tests
     if: ${{ inputs.enable-hapi-tests == 'true' }}
-    uses: ./.github/workflows/805-call-execute-hapi-tests.yaml
+    uses: ./.github/workflows/810-call-execute-mats-hapi.yaml
     needs:
       - commit-info
       - compile-and-spotless
@@ -227,14 +227,6 @@ jobs:
       ref: ${{ needs.commit-info.outputs.sha || '' }}
       java-version: "${{ inputs.java-version }}"
       java-distribution: "${{ inputs.java-distribution }}"
-      enable-hapi-tests-misc: "${{ inputs.enable-hapi-tests == 'true' }}"
-      enable-hapi-tests-misc-records-crypto-and-serial: "${{ inputs.enable-hapi-tests == 'true' || inputs.enable-hapi-tests-misc-records-crypto-and-serial == 'true' }}"
-      enable-hapi-tests-token-and-time-consuming: "${{ inputs.enable-hapi-tests == 'true' || inputs.enable-hapi-tests-token-and-time-consuming == 'true' }}"
-      enable-hapi-tests-simple-fees-and-nd-reconnect: "${{ inputs.enable-hapi-tests == 'true' || inputs.enable-hapi-tests-simple-fees-and-nd-reconnect == 'true' }}"
-      enable-hapi-tests-atomic-batch: "${{ inputs.enable-hapi-tests == 'true' || inputs.enable-hapi-tests-atomic-batch == 'true' }}"
-      enable-hapi-tests-smart-contract-and-iss: "${{ inputs.enable-hapi-tests == 'true' || inputs.enable-hapi-tests-smart-contract-and-iss == 'true' }}"
-      enable-hapi-tests-restart: "${{ inputs.enable-hapi-tests == 'true' }}"
-      enable-hapi-tests-state-throttling: "${{ inputs.enable-hapi-tests-state-throttling == 'true' }}"
       enable-network-log-capture: "true"
     secrets:
       access-token: ${{ secrets.access-token }}
@@ -247,12 +239,11 @@ jobs:
     needs:
       - commit-info
       - compile-and-spotless
-    uses: ./.github/workflows/808-call-execute-otter-tests.yaml
+    uses: ./.github/workflows/811-call-execute-mats-otter.yaml
     with:
       ref: ${{ needs.commit-info.outputs.sha || '' }}
       java-version: "${{ inputs.java-version }}"
       java-distribution: "${{ inputs.java-distribution }}"
-      enable-fast-otter-tests: ${{ inputs.enable-otter-tests == 'true' }}
       enable-network-log-capture: true
     secrets:
       access-token: ${{ secrets.access-token }}


### PR DESCRIPTION
800's mats-hapi-tests now calls 810-call-execute-mats-hapi.yaml and
mats-otter-tests calls 811-call-execute-mats-otter.yaml, replacing the direct
805/808 calls and the eight enable-hapi-tests-* expressions that derived
per-suite toggles from a single input.

Behaviour is unchanged: the job-level `if:` gates on enable-hapi-tests /
enable-otter-tests exactly as before, and the drivers run the same eight HAPI
suites and the same fast-otter suite.

800 continues to DECLARE its granular enable-hapi-tests-* inputs even though it
no longer uses them, so 600, 300 and 000 keep working untouched. Passing an
input a called workflow does not declare is a hard error, so those inputs and
their three callers have to be removed in one commit - that happens at the end
of the stack.

Side effect: this removes 8 of the 10 pre-existing actionlint "bool value
cannot be assigned" findings in this file. The 2 that remain (the 804 call and
the 810 call) and the "failure-mode is not defined in object type {sha: string}"
finding on the set-failure-mode job are all pre-existing on main.

Refs: #26978

Signed-off-by: Roger Barker <roger.barker@swirldslabs.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
