### PR TITLE
ci(citr): add 824 XTS optional-panel callee

### DIFF
--- a/.github/workflows/824-call-xts-optional-tests.yaml
+++ b/.github/workflows/824-call-xts-optional-tests.yaml
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "824: [CALL] Exec XTS Optional Tests"
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: "The commit sha, tag, or branch to check out"
+        type: string
+      branch-name:
+        type: string
+        description: "The branch name, for JRS Panel output"
+      enable-migration-testing-panel:
+        type: string
+        description: "Run Migration Testing Panel"
+        default: "true"
+      enable-078-to-079-cutover-panel:
+        type: string
+        description: "Run Solo 0.78 to 0.79 Block Stream Cutover Panel"
+        default: "false"
+      solo-version:
+        type: string
+        description: "The solo version to use for the regression panels"
+        default: "latest"
+      cutover-solo-version:
+        type: string
+        description: "The Solo version to use for the 0.78 to 0.79 cutover panel"
+        required: true
+      solo-ge-0440:
+        type: string
+        description: "Is solo version greater than or equal to 0.44.0"
+        default: "false"
+      custom-job-label:
+        description: "Custom Job Label"
+        type: string
+        required: false
+      java-version:
+        description: "Java version for the XTS tests"
+        type: string
+        required: false
+    secrets:
+      access-token:
+        description: "Github Access Token"
+        required: false
+      regression-access-token:
+        description: "Regression Panel Access Token"
+        required: false
+      slack-citr-details-token:
+        description: "Slack CITR Detailed Reports Token"
+        required: false
+    outputs:
+      failure-mode:
+        description: "Indicates the failure mode of the workflow"
+        value: ${{ jobs.set-failure-mode.outputs.failure-mode }}
+
+permissions:
+  id-token: write
+  actions: write
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+# NOTE: There is deliberately no `build` (802 compile + spotless) job in this
+# workflow. Both optional panels (825 Migration Testing, 826 Solo 0.78 -> 0.79
+# Cutover) build their own local hedera-node artifacts on their own runners, so
+# the 802 compile was a redundant second compile per cron cycle. The panel `if:`
+# conditions below are the 815 conditions with only the
+# `needs.build.result == 'success'` clause removed.
+jobs:
+  commit-info:
+    name: Get Commit Info
+    runs-on: hl-cn-default-lin-sm
+    outputs:
+      sha: ${{ steps.commit-info.outputs.sha }}
+      migration-baseline-available: ${{ steps.migration-baseline.outputs.available }}
+    steps:
+      - name: Prepare Runner
+        id: prepare-runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.access-token }}"
+
+      - name: Get Commit Info
+        id: commit-info
+        run: |
+          COMMIT_SHA=$(git rev-parse HEAD)
+          echo "sha=${COMMIT_SHA}" | tee "${GITHUB_OUTPUT}"
+
+      # Migration Testing (825) deploys the previous minor (version.txt's
+      # minor - 1) as its baseline: a published v<prev>.* release if one exists,
+      # otherwise a source build of the release/<prev> branch (see
+      # solo-migration-test.sh). If NEITHER a tag nor that branch exists yet —
+      # the brief window right after a version roll — there is no baseline to
+      # migrate from, so the panel is skipped instead of failed (see
+      # migration-testing-baseline-skipped-notice). Coverage resumes
+      # automatically once either the tag or the branch appears. An inconclusive
+      # lookup (network/auth) defaults to available=true so the panel still runs
+      # and the script stays the authority.
+      - name: Resolve migration baseline availability
+        id: migration-baseline
+        run: |
+          raw="$(cat version.txt)"
+          major_minor="$(printf '%s' "${raw}" | cut -d. -f1,2)"
+          major="${major_minor%.*}"; minor="${major_minor#*.}"
+          prev_series="${major}.$((minor - 1))"
+          available=true
+          if tag_refs="$(git ls-remote --tags origin "v${prev_series}.*")" \
+             && branch_refs="$(git ls-remote --heads origin "release/${prev_series}")"; then
+            if [[ -z "${tag_refs}" && -z "${branch_refs}" ]]; then
+              available=false
+            fi
+          else
+            echo "::warning::Could not conclusively query origin for the v${prev_series}.* tag / release/${prev_series} branch; running Migration Testing and letting the script decide."
+          fi
+          echo "available=${available}" | tee "${GITHUB_OUTPUT}"
+          if [[ "${available}" == "false" ]]; then
+            echo "::notice::No v${prev_series}.* tag and no release/${prev_series} branch; Migration Testing will be skipped."
+          fi
+
+  migration-testing-panel:
+    name: Migration Testing Panel
+    needs:
+      - commit-info
+    if: ${{ inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 == 'true' && needs.commit-info.outputs.migration-baseline-available == 'true' }}
+    uses: ./.github/workflows/825-call-migration-testing.yaml
+    with:
+      ref: ${{ needs.commit-info.outputs.sha }}
+      custom-job-name: "${{ inputs.custom-job-label }} Migration Testing"
+      solo-version: ${{ inputs.solo-version }}
+      java-version: "${{ inputs.java-version }}"
+    secrets:
+      access-token: ${{ secrets.regression-access-token }}
+      slack-detailed-report-webhook: ${{ secrets.slack-citr-details-token }}
+
+  migration-testing-skipped-notice:
+    name: Migration Testing Panel (Skipped — solo < 0.44.0)
+    if: ${{ inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 != 'true' }}
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+
+      - name: Announce Skip
+        run: |
+          echo "::warning::Migration Testing Panel was requested (enable-migration-testing-panel=true) but skipped because solo-ge-0440='${{ inputs.solo-ge-0440 }}' (solo-version='${{ inputs.solo-version }}'). The panel requires Solo >= 0.44.0."
+          {
+            echo "## Migration Testing Panel — SKIPPED"
+            echo ""
+            echo "Requested via \`enable-migration-testing-panel=true\` but the \`solo-ge-0440\` gate is \`${{ inputs.solo-ge-0440 }}\`."
+            echo ""
+            echo "- Requested Solo version: \`${{ inputs.solo-version }}\`"
+            echo "- Required: \`>= 0.44.0\`"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  migration-testing-baseline-skipped-notice:
+    name: Migration Testing Panel (Skipped — no previous-minor baseline)
+    needs:
+      - commit-info
+    if: ${{ inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 == 'true' && needs.commit-info.outputs.migration-baseline-available != 'true' }}
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Prepare Runner
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+
+      - name: Announce Skip
+        run: |
+          echo "::warning::Migration Testing Panel skipped: no previous-minor baseline exists yet — neither a v<minor-1>.* tag nor a release/<minor-1> branch for the current version.txt. It runs automatically once either appears."
+          {
+            echo "## Migration Testing Panel — SKIPPED"
+            echo ""
+            echo "No previous-minor baseline exists yet: neither a \`v<minor-1>.*\` release tag nor a \`release/<minor-1>\` branch was found for the current \`version.txt\`."
+            echo ""
+            echo "Coverage resumes automatically once the previous minor is tagged or its release branch is cut."
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  solo-078-to-079-cutover-panel:
+    name: Solo 0.78 to 0.79 Cutover Panel
+    needs:
+      - commit-info
+    if: ${{ inputs.enable-078-to-079-cutover-panel == 'true' }}
+    uses: ./.github/workflows/826-call-solo-078-to-079-cutover.yaml
+    with:
+      ref: ${{ needs.commit-info.outputs.sha }}
+      custom-job-name: "${{ inputs.custom-job-label }} Solo 0.78 -> 0.79 Cutover"
+      solo-version: "${{ inputs.cutover-solo-version }}"
+      java-version: "${{ inputs.java-version }}"
+
+  set-failure-mode:
+    name: Set Failure Mode
+    runs-on: hl-cn-default-lin-sm
+    outputs:
+      failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
+    needs:
+      - commit-info
+      - migration-testing-panel
+      - solo-078-to-079-cutover-panel
+    if: ${{ !cancelled() && always() }} # always run unless cancelled
+    steps:
+      - name: Initialize GitHub Job
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Set Failure Mode
+        id: set-failure-mode
+        env:
+          INPUT_JOB_STATUSES: >-
+            ${{ needs.commit-info.result }}
+            ${{ needs.migration-testing-panel.result }}
+            ${{ needs.solo-078-to-079-cutover-panel.result }}
+          INPUT_JOB_FAILURE_MODES: >-
+            none
+            ${{ needs.migration-testing-panel.outputs.failure-mode || 'none' }}
+            ${{ needs.solo-078-to-079-cutover-panel.outputs.failure-mode || 'none' }}
+          INPUT_JOB_NAMES: >-
+            commit-info
+            migration-testing-panel
+            solo-078-to-079-cutover-panel
+        run: bash .github/workflows/support/scripts/set-failure-mode.sh


### PR DESCRIPTION
Adds 824-call-xts-optional-tests.yaml, a reusable callee holding the optional
XTS panels: migration-testing-panel, solo-078-to-079-cutover-panel and the
three *-skipped-notice jobs, plus its own commit-info and set-failure-mode.
Job bodies are copied from 815 verbatim.

824 has NO build job. In 815 the panels gate on `needs.build.result ==
'success'`, but 825 and 826 build their own local hedera-node artifacts, so
the 802 compile was an ordering dependency, not a data dependency - and since
both xts-execution and xts-optional-execution call 815, it meant XTS compiled
twice per cron cycle. Only the `needs.build.result == 'success'` clause was
stripped from each `if:`; every other clause is byte-identical.

This is a reusable workflow_call callee rather than panels living directly in
the dispatch controller, because a dispatch-only workflow cannot be reached by
`uses:` and 001 needs to call these panels inline for its dry run.

Additive: 815 still owns the live copies of these jobs until the end of the
stack, so optional XTS keeps running unchanged until 900 is switched over.

Refs: #26978

Signed-off-by: Roger Barker <roger.barker@swirldslabs.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
