### PR TITLE
ci(citr): add 106 XTS optional dispatch controller

### DIFF
--- a/.github/workflows/106-disp-xts-optional-tests.yaml
+++ b/.github/workflows/106-disp-xts-optional-tests.yaml
@@ -1,0 +1,383 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "106: [DISP] XTS Optional Tests"
+# The candidate SHA is carried in the run name so a dispatched optional run can be
+# correlated back to the mandatory XTS run (900 -> 815) for the same candidate.
+run-name: "106: [DISP] XTS Optional Tests — ${{ inputs.ref }}"
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        required: true
+        description: "XTS candidate commit SHA (already resolved by 900):"
+        type: string
+      branch-name:
+        required: false
+        description: "The branch the candidate commit lives on:"
+        type: string
+        default: "main"
+
+permissions:
+  id-token: write
+  actions: write
+  pull-requests: write
+  statuses: write
+  checks: write
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  extract-citr-vars:
+    name: Extract CITR Vars
+    uses: ./.github/workflows/855-call-extract-citr-vars.yaml
+    with:
+      ref: ${{ inputs.ref }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  verify-citr-vars:
+    name: Verify CITR vars
+    needs:
+      - extract-citr-vars
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        id: harden-runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      # Only the variables consumed by the optional panels are required here:
+      # citr-solo-version (Migration Testing) and cutover-solo-version (826).
+      - name: Check outputs
+        id: check-outputs
+        run: |
+          if [[ "${{ needs.extract-citr-vars.outputs.citr-solo-version }}" == "" || \
+            "${{ needs.extract-citr-vars.outputs.cutover-solo-version }}" == "" ]]; then
+            echo "::error::One or more required CITR variables are missing. Failing the job."
+            exit 1
+          else
+            echo "All required CITR variables are present."
+          fi
+
+  compute-solo-ge-0440:
+    name: Compute solo-ge-0440
+    needs:
+      - extract-citr-vars
+      - verify-citr-vars
+    uses: ./.github/workflows/856-call-solo-ge044.yaml
+    with:
+      solo-version: ${{ needs.extract-citr-vars.outputs.citr-solo-version }}
+
+  parameters:
+    name: Determine Configurable Parameters
+    runs-on: hl-cn-default-lin-sm
+    needs:
+      - extract-citr-vars
+      - verify-citr-vars
+      - compute-solo-ge-0440
+    outputs:
+      solo-ge-0440: ${{ needs.compute-solo-ge-0440.outputs.solo-ge-0440 }}
+      solo-version: ${{ steps.set-parameters.outputs.solo-version }}
+    steps:
+      - name: Initialize GitHub Job
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+
+      - name: Set Parameters
+        id: set-parameters
+        run: |
+          SOLO_VERSION="${{ needs.extract-citr-vars.outputs.citr-solo-version }}"
+          SOLO_GE_0440="${{ needs.compute-solo-ge-0440.outputs.solo-ge-0440 }}"
+
+          echo "::debug::SOLO_GE_0440=${SOLO_GE_0440}"
+          echo "::notice::SOLO_VERSION=${SOLO_VERSION} SOLO_GE_0440=${SOLO_GE_0440} (gates the Migration Testing panel)"
+          echo "solo-ge-0440=${SOLO_GE_0440}" >> "${GITHUB_OUTPUT}"
+          echo "solo-version=${SOLO_VERSION}" >> "${GITHUB_OUTPUT}"
+
+  extract-jdk-version:
+    name: Extract Java Version
+    uses: ./.github/workflows/854-call-extract-jdk-version.yaml
+    with:
+      ref: ${{ inputs.ref }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  candidate-info:
+    name: Resolve Candidate Commit Info
+    runs-on: hl-cn-default-lin-sm
+    outputs:
+      xts-tag-commit: ${{ steps.candidate-info.outputs.xts-tag-commit }}
+      xts-tag-short-commit: ${{ steps.candidate-info.outputs.xts-tag-short-commit }}
+      xts-tag-commit-author: ${{ steps.candidate-info.outputs.xts-tag-commit-author }}
+      xts-tag-commit-email: ${{ steps.candidate-info.outputs.xts-tag-commit-email }}
+      xts-info: ${{ steps.candidate-info.outputs.xts-info }}
+      commit-list: ${{ steps.candidate-info.outputs.commit-list }}
+    steps:
+      - name: Initialize GitHub Job
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: "${{ inputs.ref }}"
+          checkout-fetch-depth: "1"
+          checkout-token: "${{ secrets.GH_ACCESS_TOKEN }}"
+
+      # 900 has already resolved and validated the candidate; this job only
+      # collects the commit metadata needed for this run's own Slack reports.
+      - name: Collect Candidate Commit Info
+        id: candidate-info
+        env:
+          BRANCH_NAME: ${{ inputs.branch-name || 'main' }}
+        run: |
+          XTS_COMMIT="$(git rev-parse HEAD)"
+          XTS_SHORT_COMMIT="$(git rev-parse --short HEAD)"
+          AUTHOR_NAME="$(git log -1 --format='%an' "${XTS_COMMIT}")"
+          AUTHOR_EMAIL="$(git log -1 --format='%ae' "${XTS_COMMIT}")"
+          COMMIT_LIST="$(git log -n 1 --pretty=format:"- [%h: %s](https://github.com/${{ github.repository }}/commit/%H)" "${XTS_COMMIT}")"
+
+          PARSED_COMMIT_LIST="${COMMIT_LIST//\`/}"
+          ESCAPED_COMMIT_LIST="$(jq -Rs . <<< "${PARSED_COMMIT_LIST}")"
+          COMMIT_LIST_STR="${ESCAPED_COMMIT_LIST:1:-1}"
+
+          {
+            echo "xts-tag-commit=${XTS_COMMIT}"
+            echo "xts-tag-short-commit=${XTS_SHORT_COMMIT}"
+            echo "xts-tag-commit-author=${AUTHOR_NAME} <${AUTHOR_EMAIL}>"
+            echo "xts-tag-commit-email=${AUTHOR_EMAIL}"
+            echo "xts-info=Optional: ${BRANCH_NAME} - ${XTS_SHORT_COMMIT}"
+            echo "commit-list=${COMMIT_LIST_STR}"
+          } >> "${GITHUB_OUTPUT}"
+
+          {
+            echo "### XTS Optional Candidate"
+            echo "- Commit: \`${XTS_COMMIT}\`"
+            echo "- Author: ${AUTHOR_NAME} <${AUTHOR_EMAIL}>"
+            echo -e "${COMMIT_LIST}"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+  # NOTE: 816 (Build & Publish State Validator Uber JAR) is deliberately NOT
+  # called here. In 900 the optional job carried `needs: state-validator-uberjar`
+  # purely as an ordering dependency — 816's `gcs-uri` output is consumed by
+  # nothing in the repo, so building it for the optional panels was redundant.
+  xts-optional-execution:
+    name: Execute Optional XTS Tests
+    needs:
+      - candidate-info
+      - parameters
+      - extract-jdk-version
+      - extract-citr-vars
+      - verify-citr-vars
+    uses: ./.github/workflows/824-call-xts-optional-tests.yaml
+    with:
+      ref: ${{ needs.candidate-info.outputs.xts-tag-commit }}
+      branch-name: ${{ inputs.branch-name || 'main' }}
+      solo-version: ${{ needs.parameters.outputs.solo-version }}
+      cutover-solo-version: ${{ needs.extract-citr-vars.outputs.cutover-solo-version }}
+      solo-ge-0440: ${{ needs.parameters.outputs.solo-ge-0440 }}
+      custom-job-label: "XTS (Optional):"
+      enable-migration-testing-panel: "true"
+      # (FUTURE) Move to 815/xts-execution once the panel proves stable, so failures block build-candidate promotion.
+      enable-078-to-079-cutover-panel: "true"
+      java-version: "${{ needs.extract-jdk-version.outputs.jdk-version }}"
+    secrets:
+      access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      slack-citr-details-token: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
+
+  report-success:
+    name: Report XTS optional execution success
+    runs-on: hl-cn-default-lin-sm
+    needs:
+      - candidate-info
+      - xts-optional-execution
+    if: ${{ (needs.candidate-info.result == 'success' &&
+      needs.xts-optional-execution.result == 'success') &&
+      !cancelled() }}
+    steps:
+      - name: Initialize GitHub Job
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: main
+          checkout-fetch-depth: "1"
+          checkout-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          setup-gomplate: "true"
+
+      - name: Build Success Slack Payload
+        env:
+          XTS_INFO: ${{ needs.candidate-info.outputs.xts-info }}
+          FETCH_XTS_CANDIDATE_RESULT: ${{ needs.candidate-info.result }}
+          XTS_EXECUTION_RESULT: ${{ needs.xts-optional-execution.result }}
+          TAG_FOR_PROMOTION_RESULT: "n/a — optional panels do not gate promotion"
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.candidate-info.outputs.xts-tag-commit }}
+          COMMIT_AUTHOR: ${{ needs.candidate-info.outputs.xts-tag-commit-author }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_LIST: ${{ needs.candidate-info.outputs.commit-list }}
+        run: gomplate -f .github/workflows/templates/slack-xts-success-detailed.json.tpl -o slack_payload.json
+
+      - name: Report Success (slack)
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json
+
+  report-failure:
+    name: Report XTS optional execution failure
+    runs-on: hl-cn-default-lin-sm
+    needs:
+      - candidate-info
+      - xts-optional-execution
+    if: ${{ !( needs.candidate-info.result == 'success' &&
+      needs.xts-optional-execution.result == 'success') && always() }}
+
+    steps:
+      - name: Initialize GitHub Job
+        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
+        with:
+          checkout: "true"
+          checkout-ref: main
+          checkout-fetch-depth: "0"
+          checkout-token: ${{ secrets.GH_ACCESS_TOKEN }}
+          setup-gomplate: "true"
+
+      - name: Determine Report Category
+        id: report-category
+        run: |
+          if [[ "${{ needs.xts-optional-execution.result }}" == "cancelled" ]] \
+            || [[ "${{ needs.candidate-info.result }}" == "cancelled" ]]; then
+            echo "category=cancelled" >> "${GITHUB_OUTPUT}"
+          elif [[ "${{ needs.candidate-info.result }}" =~ ^(skipped|failure)$ ]] \
+            || [[ "${{ needs.xts-optional-execution.outputs.failure-mode }}" == "workflow" ]]; then
+            echo "category=environment" >> "${GITHUB_OUTPUT}"
+          else
+            echo "category=test" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Collect run logs in a log file
+        if: ${{ steps.report-category.outputs.category != 'cancelled' }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        continue-on-error: true
+        run: |
+          # NOTE: unlike 900's copy of this loop, the job ids are read into an
+          # array so every job is fetched (900 quotes the command substitution,
+          # so its loop only ever runs once - shellcheck SC2066).
+          mapfile -t job_ids < <(gh run view "${{ github.run_id }}" --json jobs --jq '.jobs | map(.databaseId) | .[0:-1] | .[]')
+          for job_id in "${job_ids[@]}"; do
+            echo "Fetching logs for job ${job_id}..."
+
+            current_job_name="$(gh run view "${{ github.run_id }}" --json jobs | jq --argjson job_id "${job_id}" -r '.jobs[] | select(.databaseId == $job_id) | .name')"
+
+            echo "Logs for job ${current_job_name} :" >> run.log
+
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "/repos/hiero-ledger/hiero-consensus-node/actions/jobs/${job_id}/logs" >> run.log
+          done
+
+      - name: Upload log as artifact
+        if: ${{ steps.report-category.outputs.category != 'cancelled' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        continue-on-error: true
+        with:
+          path: run.log
+
+      - name: Find Commit Author in Slack
+        id: find-commit-author-slack
+        if: ${{ steps.report-category.outputs.category == 'test' }}
+        continue-on-error: true
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_CITR_BOT_TOKEN }}
+          EMAIL: ${{ needs.candidate-info.outputs.xts-tag-commit-email }}
+        run: |
+          bash "${{ github.workspace }}/.github/workflows/support/scripts/find-commit-author-slack.sh"
+          echo "slack-user-id=${SLACK_USER_ID}" >> "${GITHUB_OUTPUT}"
+
+      # NOTE: no Rootly alert is raised here. These panels are non-blocking by
+      # definition (they do not gate build-candidate promotion), so a failure
+      # should notify Slack but must not page an on-call service.
+      - name: Build Test Failure Slack Payload
+        if: ${{ steps.report-category.outputs.category == 'test' }}
+        env:
+          XTS_INFO: "${{ needs.candidate-info.outputs.xts-info || '' }}"
+          FETCH_XTS_CANDIDATE_RESULT: ${{ needs.candidate-info.result }}
+          XTS_EXECUTION_RESULT: ${{ needs.xts-optional-execution.result }}
+          TAG_FOR_PROMOTION_RESULT: "n/a — optional panels do not gate promotion"
+          FAILED_TESTS: "Optional XTS panel(s) — see the workflow run for the failing panel"
+          COMMIT_URL: ${{ github.server_url }}/${{ github.repository }}/commit/${{ needs.candidate-info.outputs.xts-tag-commit }}
+          COMMIT_AUTHOR: ${{ needs.candidate-info.outputs.xts-tag-commit-author }}
+          SLACK_USER_ID: ${{ steps.find-commit-author-slack.outputs.slack-user-id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_RUN_ID: ${{ github.run_id }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_LIST: ${{ needs.candidate-info.outputs.commit-list }}
+        run: gomplate -f .github/workflows/templates/slack-xts-test-failure-detailed.json.tpl -o slack_payload.json
+
+      - name: Build Environment Failure Slack Payload
+        if: ${{ steps.report-category.outputs.category == 'environment' }}
+        env:
+          XTS_INFO: "${{ needs.candidate-info.outputs.xts-info || format('Optional: {0}', inputs.ref) }}"
+          FETCH_XTS_CANDIDATE_RESULT: ${{ needs.candidate-info.result }}
+          XTS_EXECUTION_RESULT: ${{ needs.xts-optional-execution.result }}
+          TAG_FOR_PROMOTION_RESULT: "n/a — optional panels do not gate promotion"
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+          WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: gomplate -f .github/workflows/templates/slack-xts-env-failure-detailed.json.tpl -o slack_payload.json
+
+      - name: Build Environment Failure Summary Payload
+        if: ${{ steps.report-category.outputs.category == 'environment' }}
+        env:
+          SLACK_SUMMARY_TEXT: ":warning: XTS optional environment failure (${{ needs.candidate-info.outputs.xts-info || inputs.ref }}) — candidate `${{ inputs.ref }}` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+        run: gomplate -f .github/workflows/templates/slack-env-failure-summary.json.tpl -o slack_payload_summary.json
+
+      - name: Build Cancelled Summary Payload
+        if: ${{ steps.report-category.outputs.category == 'cancelled' }}
+        env:
+          SLACK_SUMMARY_TEXT: ":no_entry_sign: XTS optional run cancelled (${{ needs.candidate-info.outputs.xts-info || inputs.ref }}) — candidate `${{ inputs.ref }}` — <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Run>"
+          XTS_PROCEED: "true"
+        run: gomplate -f .github/workflows/templates/slack-cancelled-summary.json.tpl -o slack_payload_summary.json
+
+      # Notification routing (mirrors 900):
+      #   test failures       -> citr-operations (detailed)
+      #   environment         -> citr-operations (summary) + citr-failures (detailed)
+      #   canceled            -> citr-operations (summary)
+      - name: Notify test failure detailed (citr-operations)
+        if: ${{ steps.report-category.outputs.category == 'test' }}
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json
+
+      - name: Notify environment failure summary (citr-operations)
+        if: ${{ steps.report-category.outputs.category == 'environment' }}
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload_summary.json
+
+      - name: Notify environment failure detailed (citr-failures)
+        if: ${{ steps.report-category.outputs.category == 'environment' }}
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          webhook: ${{ secrets.SLACK_CITR_FAILURES_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload.json
+
+      - name: Notify cancelled summary (citr-operations)
+        if: ${{ steps.report-category.outputs.category == 'cancelled' }}
+        uses: slackapi/slack-github-action@0d95c9a7becc1e6e297d76df9bc735c44f4cbcbc # v3.0.5
+        with:
+          webhook: ${{ secrets.SLACK_CITR_OPERATIONS_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload-templated: true
+          payload-file-path: slack_payload_summary.json

--- a/.github/workflows/826-call-solo-078-to-079-cutover.yaml
+++ b/.github/workflows/826-call-solo-078-to-079-cutover.yaml
@@ -23,11 +23,6 @@ on:
         description: "Consensus-node release tag for the initial 0.78 network deploy. The 0.79 cutover always upgrades to the local build from the checked-out ref. Leave blank to default to v0.78.0-rc.5."
         required: false
         type: string
-      block-node-ref:
-        description: "hiero-block-node ref to checkout. Only used for the serverStatus/proto sources consumed by the grpcurl diagnostics; the deployed Block Node chart version is pinned inside the scenario script. Defaults to the tag matching that chart."
-        required: false
-        type: string
-        default: "v0.41.0"
     outputs:
       failure-mode:
         description: "Failure Mode"
@@ -78,7 +73,12 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           repository: hiero-ledger/hiero-block-node
-          ref: ${{ inputs.block-node-ref }}
+          # Pinned rather than caller-supplied: this checks out an external repository and the
+          # job holds a writable Gradle cache, so a caller-influenced ref is a cache-poisoning
+          # vector (CodeQL actions/cache-poisoning/poisonable-step, alert #135). The deployed
+          # Block Node chart version is pinned inside the scenario script, and these sources are
+          # only used for the grpcurl serverStatus/proto diagnostics, so this must track it.
+          ref: v0.41.0
           path: hiero-block-node
           fetch-depth: 0
           token: ${{ github.token }}


### PR DESCRIPTION
Adds 106-disp-xts-optional-tests.yaml, a workflow_dispatch controller that
takes an already-resolved XTS candidate SHA and runs the optional panels via
824.

Placed in OPERATIONAL (100-199), the range for operational entry points. This
is the first disp-class workflow in 1xx - 100 through 105 are all user-class -
so it establishes the convention that machine-dispatched operational
controllers live here rather than in CITR alongside 221/222/223/225.

It re-derives its own variables (855, 856, 854, and 900's parameters job)
rather than taking ~9 version inputs, so the dispatch payload from 900 is just
the two values 900 uniquely knows.

It does NOT call 816. In 900 the optional job needs state-validator-uberjar,
but 816's only output (gcs-uri) is consumed by nothing in the repo, so that
was a pure ordering dependency and omitting it drops a redundant
build-and-publish per cron cycle.

It carries its own Slack reporting, mirroring 900's success/failure
categorisation and routing, because a dispatched run is invisible to 900's
report-success / report-failure jobs. The candidate SHA appears in the
run-name and in both Slack payloads so an optional run can be correlated back
to the mandatory XTS run for the same candidate.

Additive: nothing dispatches it yet.

Refs: #26978

Signed-off-by: Roger Barker <roger.barker@swirldslabs.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
