### PR TITLE
ci(citr): cut the optional panels over from 815 to 824

### DIFF
--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -217,7 +217,6 @@ jobs:
       ref: ${{ inputs.ref }}
       branch-name: ${{ inputs.branch-name }}
       solo-version: ${{ needs.parameters.outputs.solo-version }}
-      cutover-solo-version: ${{ needs.extract-citr-vars.outputs.cutover-solo-version }}
       helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
       mirror-node-version: ${{ needs.extract-citr-vars.outputs.citr-mirror-node-version }}
       solo-ge-0440: ${{ needs.parameters.outputs.solo-ge-0440 }}
@@ -231,8 +230,6 @@ jobs:
       enable-mirror-node-regression-panel: ${{ inputs.enable-mirror-node-regression-panel }}
       enable-rpc-relay-regression-panel: ${{ inputs.enable-rpc-relay-regression-panel }}
       enable-block-node-regression-panel: ${{ inputs.enable-block-node-regression-panel }}
-      enable-migration-testing-panel: ${{ inputs.enable-migration-testing-panel }}
-      enable-078-to-079-cutover-panel: ${{ inputs.enable-078-to-079-cutover-panel }}
       java-version: ${{ needs.extract-jdk-version.outputs.jdk-version }}
       tck-version: "${{ inputs.tck-version || needs.extract-citr-vars.outputs.tck-version }}"
       js-sdk-version: "${{ inputs.js-sdk-version || needs.extract-citr-vars.outputs.js-sdk-version }}"
@@ -253,3 +250,28 @@ jobs:
       slack-api-token: ${{ secrets.PLATFORM_SLACK_API_TOKEN }}
       slack-citr-details-token: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}
       slack-tck-report-webhook: ${{ secrets.SLACK_TCK_MONITOR_WEBHOOK }}
+
+  # The optional panels moved out of 815 into 824. The dry run calls 824 directly rather than
+  # dispatching 106, so results land inline in this run instead of a separate fire-and-forget one.
+  xts-optional-execution:
+    name: XTS Optional Panels
+    needs:
+      - extract-citr-vars
+      - compute-solo-ge-0440
+      - parameters
+      - extract-jdk-version
+    uses: ./.github/workflows/824-call-xts-optional-tests.yaml
+    with:
+      ref: ${{ inputs.ref }}
+      branch-name: ${{ inputs.branch-name }}
+      solo-version: ${{ needs.parameters.outputs.solo-version }}
+      cutover-solo-version: ${{ needs.extract-citr-vars.outputs.cutover-solo-version }}
+      solo-ge-0440: ${{ needs.parameters.outputs.solo-ge-0440 }}
+      java-version: ${{ needs.extract-jdk-version.outputs.jdk-version }}
+      custom-job-label: "XTS (Dry Run):"
+      enable-migration-testing-panel: ${{ inputs.enable-migration-testing-panel }}
+      enable-078-to-079-cutover-panel: ${{ inputs.enable-078-to-079-cutover-panel }}
+    secrets:
+      access-token: ${{ secrets.GITHUB_TOKEN }}
+      regression-access-token: ${{ secrets.GH_ACCESS_TOKEN }}
+      slack-citr-details-token: ${{ secrets.SLACK_CITR_DETAILED_REPORTS_WEBHOOK }}

--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -49,22 +49,10 @@ on:
         type: string
         description: "Run Block Node Regression Panel"
         default: "false"
-      enable-migration-testing-panel:
-        type: string
-        description: "Run Migration Testing Panel"
-        default: "true"
-      enable-078-to-079-cutover-panel:
-        type: string
-        description: "Run Solo 0.78 to 0.79 Block Stream Cutover Panel"
-        default: "false"
       solo-version:
         type: string
         description: "The solo version to use for the regression panels"
         default: "latest"
-      cutover-solo-version:
-        type: string
-        description: "The Solo version to use for the 0.78 to 0.79 cutover panel"
-        required: true
       mirror-node-version:
         type: string
         description: "The mirror node version to deploy for the mirror node regression panel (if not specified, '0.145.2' will be used)"
@@ -173,7 +161,6 @@ jobs:
     runs-on: hl-cn-default-lin-sm
     outputs:
       sha: ${{ steps.commit-info.outputs.sha }}
-      migration-baseline-available: ${{ steps.migration-baseline.outputs.available }}
     steps:
       - name: Prepare Runner
         id: prepare-runner
@@ -189,37 +176,6 @@ jobs:
         run: |
           COMMIT_SHA=$(git rev-parse HEAD)
           echo "sha=${COMMIT_SHA}" | tee "${GITHUB_OUTPUT}"
-
-      # Migration Testing (825) deploys the previous minor (version.txt's
-      # minor - 1) as its baseline: a published v<prev>.* release if one exists,
-      # otherwise a source build of the release/<prev> branch (see
-      # solo-migration-test.sh). If NEITHER a tag nor that branch exists yet —
-      # the brief window right after a version roll — there is no baseline to
-      # migrate from, so the panel is skipped instead of failed (see
-      # migration-testing-baseline-skipped-notice). Coverage resumes
-      # automatically once either the tag or the branch appears. An inconclusive
-      # lookup (network/auth) defaults to available=true so the panel still runs
-      # and the script stays the authority.
-      - name: Resolve migration baseline availability
-        id: migration-baseline
-        run: |
-          raw="$(cat version.txt)"
-          major_minor="$(printf '%s' "${raw}" | cut -d. -f1,2)"
-          major="${major_minor%.*}"; minor="${major_minor#*.}"
-          prev_series="${major}.$((minor - 1))"
-          available=true
-          if tag_refs="$(git ls-remote --tags origin "v${prev_series}.*")" \
-             && branch_refs="$(git ls-remote --heads origin "release/${prev_series}")"; then
-            if [[ -z "${tag_refs}" && -z "${branch_refs}" ]]; then
-              available=false
-            fi
-          else
-            echo "::warning::Could not conclusively query origin for the v${prev_series}.* tag / release/${prev_series} branch; running Migration Testing and letting the script decide."
-          fi
-          echo "available=${available}" | tee "${GITHUB_OUTPUT}"
-          if [[ "${available}" == "false" ]]; then
-            echo "::notice::No v${prev_series}.* tag and no release/${prev_series} branch; Migration Testing will be skipped."
-          fi
 
   build:
     name: Compile and Spotless Check
@@ -420,79 +376,6 @@ jobs:
             echo "- Required: \`>= 0.44.0\`"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-  migration-testing-panel:
-    name: Migration Testing Panel
-    needs:
-      - commit-info
-      - build
-    if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 == 'true' && needs.commit-info.outputs.migration-baseline-available == 'true' }}
-    uses: ./.github/workflows/825-call-migration-testing.yaml
-    with:
-      ref: ${{ needs.commit-info.outputs.sha }}
-      custom-job-name: "${{ inputs.custom-job-label }} Migration Testing"
-      solo-version: ${{ inputs.solo-version }}
-      java-version: "${{ inputs.java-version }}"
-    secrets:
-      access-token: ${{ secrets.regression-access-token }}
-      slack-detailed-report-webhook: ${{ secrets.slack-citr-details-token }}
-
-  migration-testing-skipped-notice:
-    name: Migration Testing Panel (Skipped — solo < 0.44.0)
-    needs:
-      - build
-    if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 != 'true' }}
-    runs-on: hl-cn-default-lin-sm
-    steps:
-      - name: Prepare Runner
-        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
-
-      - name: Announce Skip
-        run: |
-          echo "::warning::Migration Testing Panel was requested (enable-migration-testing-panel=true) but skipped because solo-ge-0440='${{ inputs.solo-ge-0440 }}' (solo-version='${{ inputs.solo-version }}'). The panel requires Solo >= 0.44.0."
-          {
-            echo "## Migration Testing Panel — SKIPPED"
-            echo ""
-            echo "Requested via \`enable-migration-testing-panel=true\` but the \`solo-ge-0440\` gate is \`${{ inputs.solo-ge-0440 }}\`."
-            echo ""
-            echo "- Requested Solo version: \`${{ inputs.solo-version }}\`"
-            echo "- Required: \`>= 0.44.0\`"
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-  migration-testing-baseline-skipped-notice:
-    name: Migration Testing Panel (Skipped — no previous-minor baseline)
-    needs:
-      - commit-info
-      - build
-    if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 == 'true' && needs.commit-info.outputs.migration-baseline-available != 'true' }}
-    runs-on: hl-cn-default-lin-sm
-    steps:
-      - name: Prepare Runner
-        uses: pandaswhocode/initialize-github-job@5dbfbc4329ceab48a57d983325dadbd3ec8123e9 # v1.2.2
-
-      - name: Announce Skip
-        run: |
-          echo "::warning::Migration Testing Panel skipped: no previous-minor baseline exists yet — neither a v<minor-1>.* tag nor a release/<minor-1> branch for the current version.txt. It runs automatically once either appears."
-          {
-            echo "## Migration Testing Panel — SKIPPED"
-            echo ""
-            echo "No previous-minor baseline exists yet: neither a \`v<minor-1>.*\` release tag nor a \`release/<minor-1>\` branch was found for the current \`version.txt\`."
-            echo ""
-            echo "Coverage resumes automatically once the previous minor is tagged or its release branch is cut."
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-  solo-078-to-079-cutover-panel:
-    name: Solo 0.78 to 0.79 Cutover Panel
-    needs:
-      - commit-info
-      - build
-    if: ${{ needs.build.result == 'success' && inputs.enable-078-to-079-cutover-panel == 'true' }}
-    uses: ./.github/workflows/826-call-solo-078-to-079-cutover.yaml
-    with:
-      ref: ${{ needs.commit-info.outputs.sha }}
-      custom-job-name: "${{ inputs.custom-job-label }} Solo 0.78 -> 0.79 Cutover"
-      solo-version: "${{ inputs.cutover-solo-version }}"
-      java-version: "${{ inputs.java-version }}"
-
   set-failure-mode:
     name: Set Failure Mode
     runs-on: hl-cn-default-lin-sm
@@ -511,8 +394,6 @@ jobs:
       - mirror-node-regression-panel
       - json-rpc-relay-regression-panel
       - block-node-regression-panel
-      - migration-testing-panel
-      - solo-078-to-079-cutover-panel
     if: ${{ !cancelled() && always() }} # always run unless cancelled
     steps:
       - name: Initialize GitHub Job
@@ -536,8 +417,6 @@ jobs:
             ${{ needs.mirror-node-regression-panel.result }}
             ${{ needs.json-rpc-relay-regression-panel.result }}
             ${{ needs.block-node-regression-panel.result }}
-            ${{ needs.migration-testing-panel.result }}
-            ${{ needs.solo-078-to-079-cutover-panel.result }}
           INPUT_JOB_FAILURE_MODES: >-
             ${{ needs.commit-info.outputs.failure-mode || 'none' }}
             ${{ needs.build.outputs.failure-mode || 'none' }}
@@ -550,8 +429,6 @@ jobs:
             ${{ needs.mirror-node-regression-panel.outputs.failure-mode || 'none' }}
             ${{ needs.json-rpc-relay-regression-panel.outputs.failure-mode || 'none' }}
             ${{ needs.block-node-regression-panel.outputs.failure-mode || 'none' }}
-            ${{ needs.migration-testing-panel.outputs.failure-mode || 'none' }}
-            ${{ needs.solo-078-to-079-cutover-panel.outputs.failure-mode || 'none' }}
           INPUT_JOB_NAMES: >-
             commit-info
             build
@@ -564,6 +441,4 @@ jobs:
             mirror-node-regression-panel
             json-rpc-relay-regression-panel
             block-node-regression-panel
-            migration-testing-panel
-            solo-078-to-079-cutover-panel
         run: bash .github/workflows/support/scripts/set-failure-mode.sh


### PR DESCRIPTION
815 becomes mandatory-XTS only. Removes migration-testing-panel,
solo-078-to-079-cutover-panel and the three *-skipped-notice jobs, their
enable-migration-testing-panel / enable-078-to-079-cutover-panel /
cutover-solo-version inputs, and their entries in set-failure-mode.

Also removes the "Resolve migration baseline availability" step and the
migration-baseline-available output from 815's commit-info: the moved panels
were its only consumers, and 824 carries its own copy.

001 stops passing the optional toggles through to 815 and instead calls 824
directly in a new xts-optional-execution job, so one dry run still covers both
mandatory and optional XTS with results inline. Dispatching 106 from the dry
run was rejected - it would make the dry run fire-and-forget too, which is
poor ergonomics for a dry run.

This lands after the 900 cutover on purpose: 900 already dispatches 106, so
optional XTS is served by the new path before the old one is removed and there
is no window where it stops running.

Refs: #26978

Signed-off-by: Roger Barker <roger.barker@swirldslabs.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
