### PR TITLE
ci: harden workflow token permissions and add gradle wrapper validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+  - package-ecosystem: "docker"
+    directories:
+      - "/hedera-node/test-clients/validation-scenarios"
+      - "/hedera-node/yahcli"
+      - "/platform-sdk/consensus-otter-docker-app/src/testFixtures/docker"
+      - "/platform-sdk/consensus-sloth/src/testFixtures/docker"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10

--- a/.github/workflows/000-user-dry-run-mats-suite.yaml
+++ b/.github/workflows/000-user-dry-run-mats-suite.yaml
@@ -54,12 +54,6 @@ on:
         default: "MATS Tests"
 
 permissions:
-  id-token: write
-  actions: read
-  issues: write
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 defaults:
@@ -69,6 +63,14 @@ defaults:
 jobs:
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ inputs.ref || github.ref }}
@@ -77,6 +79,14 @@ jobs:
 
   mats-tests:
     name: MATS Tests
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - extract-jdk-version
     uses: ./.github/workflows/800-call-mats-tests.yaml

--- a/.github/workflows/001-user-dry-run-extended-test-suite.yaml
+++ b/.github/workflows/001-user-dry-run-extended-test-suite.yaml
@@ -80,12 +80,6 @@ on:
         description: "Execute the State Validator Uber JAR build job"
 
 permissions:
-  id-token: write
-  actions: write
-  issues: write
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 defaults:
@@ -95,6 +89,14 @@ defaults:
 jobs:
   extract-citr-vars:
     name: Extract CITR Vars
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     uses: ./.github/workflows/855-call-extract-citr-vars.yaml
     with:
       ref: ${{ inputs.ref || github.ref }}
@@ -103,6 +105,14 @@ jobs:
 
   verify-citr-vars:
     name: Verify CITR vars
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - extract-citr-vars
     runs-on: hl-cn-default-lin-sm
@@ -132,6 +142,14 @@ jobs:
 
   compute-solo-ge-0440:
     name: Compute solo-ge-0440
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - extract-citr-vars
       - verify-citr-vars
@@ -141,6 +159,14 @@ jobs:
 
   parameters:
     name: Workflow Parameters
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - extract-citr-vars
@@ -191,6 +217,14 @@ jobs:
 
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ inputs.ref }}
@@ -199,6 +233,14 @@ jobs:
 
   state-validator-uberjar:
     name: Build & Publish Hedera State Validator Uber JAR
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.execute-state-validator-build == true }}
     uses: ./.github/workflows/816-call-build-publish-state-validator.yaml
     with:
@@ -207,6 +249,14 @@ jobs:
 
   xts-execution:
     name: Execute XTS
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - parameters
       - extract-jdk-version

--- a/.github/workflows/002-user-deploy-adhoc-artifact.yaml
+++ b/.github/workflows/002-user-deploy-adhoc-artifact.yaml
@@ -34,13 +34,15 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  contents: write
-  actions: read
+  contents: read
 
 jobs:
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ github.event.inputs.ref }}
@@ -49,6 +51,10 @@ jobs:
 
   release-adhoc:
     name: Release [Adhoc]
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     if: ${{ github.event_name == 'workflow_dispatch' }}
     needs:
       - extract-jdk-version

--- a/.github/workflows/006-user-update-gs-state-variable.yaml
+++ b/.github/workflows/006-user-update-gs-state-variable.yaml
@@ -12,11 +12,13 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   update-gs-state-variable:
     name: Update GS_STATE Variable
+    permissions:
+      contents: write
     runs-on: hl-cn-default-lin-sm
     steps:
       - name: Harden Runner

--- a/.github/workflows/101-user-trigger-release.yaml
+++ b/.github/workflows/101-user-trigger-release.yaml
@@ -23,13 +23,15 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  contents: write
-  actions: read
+  contents: read
 
 jobs:
   create-new-tag:
     name: Create New Tag
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-md
     outputs:
       version: ${{ steps.next-release.outputs.version }}
@@ -287,6 +289,10 @@ jobs:
 
   create-github-release:
     name: Create GitHub Release
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     if: ${{ inputs.alpha-release != true && inputs.dry-run-enabled != true && github.event.repository.private == false }}
     uses: ./.github/workflows/853-call-create-github-release.yaml
     needs:

--- a/.github/workflows/102-user-memory-profile-ctrl.yaml
+++ b/.github/workflows/102-user-memory-profile-ctrl.yaml
@@ -36,10 +36,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
-  id-token: write
-  actions: write
-  statuses: write
+  contents: read
 
 env:
   GS_ROOT_DIR: gs://performance-engineering-reports/ephemeral/test_runs
@@ -48,6 +45,11 @@ env:
 jobs:
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ github.ref }}
@@ -56,6 +58,11 @@ jobs:
 
   run-single-node-tests:
     name: Single node tests
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-mem-profiler-lin
     needs:
       - extract-jdk-version

--- a/.github/workflows/105-user-publish-wraps-key.yaml
+++ b/.github/workflows/105-user-publish-wraps-key.yaml
@@ -24,7 +24,6 @@ defaults:
 
 permissions:
   contents: read
-  packages: write
 
 env:
   IMAGE_NAME: ghcr.io/${{ github.repository }}/wraps-proving-key
@@ -33,6 +32,9 @@ env:
 jobs:
   publish-wraps-proving-key-image:
     name: "Publish WRAPS Proving Key Image"
+    permissions:
+      contents: read
+      packages: write
     runs-on: hl-cn-default-lin-lg
     timeout-minutes: 60
     steps:

--- a/.github/workflows/201-user-sdpt-controller-adhoc.yaml
+++ b/.github/workflows/201-user-sdpt-controller-adhoc.yaml
@@ -66,14 +66,16 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
-  id-token: write
-  actions: write
-  statuses: write
+  contents: read
 
 jobs:
   verify-tag:
     name: Verify Tag
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     continue-on-error: true
     outputs:
@@ -113,6 +115,11 @@ jobs:
 
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ inputs.ref || github.ref }}
@@ -121,6 +128,11 @@ jobs:
 
   extract-citr-vars:
     name: Extract CITR Vars
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/855-call-extract-citr-vars.yaml
     with:
       ref: ${{ inputs.ref || github.ref }}
@@ -129,6 +141,11 @@ jobs:
 
   extract-chewie-props:
     name: Extract Chewie Properties
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/862-call-get-chewie-properties.yaml
     with:
       ref: ${{ inputs.ref || github.ref }}
@@ -137,6 +154,11 @@ jobs:
 
   verify-citr-vars:
     name: Verify CITR vars
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     needs:
       - extract-citr-vars
       - extract-chewie-props
@@ -188,6 +210,11 @@ jobs:
 
   run-single-day-performance-test:
     name: Performance Test
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     needs:
       - verify-tag
       - extract-jdk-version
@@ -215,6 +242,11 @@ jobs:
 
   tag-sdpt-result:
     name: Tag SDPT Result
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     needs:
       - run-single-day-performance-test
@@ -271,6 +303,11 @@ jobs:
 
   get-commit-info:
     name: Get Commit Information
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     if: ${{ inputs.disable-notifications != true }}
     needs:
@@ -307,6 +344,11 @@ jobs:
 
   report-success:
     name: Report SDPT execution success
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     needs:
       - verify-tag
@@ -356,6 +398,11 @@ jobs:
 
   report-failure:
     name: Report SDPT execution failure
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     needs:
       - verify-tag

--- a/.github/workflows/202-user-sdlt-controller-adhoc.yaml
+++ b/.github/workflows/202-user-sdlt-controller-adhoc.yaml
@@ -68,14 +68,16 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
-  id-token: write
-  actions: write
-  statuses: write
+  contents: read
 
 jobs:
   verify-tag:
     name: Verify Tag
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     continue-on-error: true
     outputs:
@@ -115,6 +117,11 @@ jobs:
 
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ inputs.ref || github.ref }}
@@ -123,6 +130,11 @@ jobs:
 
   extract-citr-vars:
     name: Extract CITR Vars
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/855-call-extract-citr-vars.yaml
     with:
       ref: ${{ inputs.ref || github.ref }}
@@ -131,6 +143,11 @@ jobs:
 
   extract-chewie-props:
     name: Extract Chewie Properties
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/862-call-get-chewie-properties.yaml
     with:
       ref: ${{ inputs.ref || github.ref }}
@@ -139,6 +156,11 @@ jobs:
 
   verify-citr-vars:
     name: Verify CITR vars
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     needs:
       - extract-citr-vars
       - extract-chewie-props
@@ -190,6 +212,11 @@ jobs:
 
   run-single-day-longevity-test:
     name: Longevity Test
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     needs:
       - verify-tag
       - extract-jdk-version
@@ -216,6 +243,11 @@ jobs:
 
   tag-sdlt-result:
     name: Tag SDLT Result
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     needs:
       - run-single-day-longevity-test
@@ -272,6 +304,11 @@ jobs:
 
   get-commit-info:
     name: Get Commit Information
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     if: ${{ inputs.disable-notifications != true }}
     needs:
@@ -309,6 +346,11 @@ jobs:
 
   report-success:
     name: Report SDLT execution success
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     needs:
       - verify-tag
@@ -358,6 +400,11 @@ jobs:
 
   report-failure:
     name: Report SDLT execution failure
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     needs:
       - verify-tag

--- a/.github/workflows/221-disp-sdpt-controller.yaml
+++ b/.github/workflows/221-disp-sdpt-controller.yaml
@@ -8,14 +8,16 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
-  id-token: write
-  actions: write
-  statuses: write
+  contents: read
 
 jobs:
   verify-tag:
     name: Verify Tag
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     continue-on-error: true
     outputs:
@@ -55,6 +57,11 @@ jobs:
 
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ github.ref }}
@@ -63,6 +70,11 @@ jobs:
 
   extract-citr-vars:
     name: Extract CITR Vars
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/855-call-extract-citr-vars.yaml
     with:
       ref: ${{ github.ref }}
@@ -71,6 +83,11 @@ jobs:
 
   extract-chewie-props:
     name: Extract Chewie Properties
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/862-call-get-chewie-properties.yaml
     with:
       ref: ${{ github.ref }}
@@ -79,6 +96,11 @@ jobs:
 
   verify-citr-vars:
     name: Verify CITR vars
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     needs:
       - extract-citr-vars
       - extract-chewie-props
@@ -116,6 +138,11 @@ jobs:
 
   run-single-day-performance-test:
     name: Performance Test
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     needs:
       - verify-tag
       - extract-jdk-version
@@ -143,6 +170,11 @@ jobs:
 
   tag-sdpt-result:
     name: Tag SDPT Result
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     needs:
       - run-single-day-performance-test
@@ -191,6 +223,11 @@ jobs:
 
   get-commit-info:
     name: Get Commit Information
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     needs:
       - verify-tag
@@ -226,6 +263,11 @@ jobs:
 
   report-success:
     name: Report SDPT execution success
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     needs:
       - verify-tag
@@ -275,6 +317,11 @@ jobs:
 
   report-failure:
     name: Report SDPT execution failure
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdpt-lin-sm
     needs:
       - verify-tag

--- a/.github/workflows/222-disp-sdlt-controller.yaml
+++ b/.github/workflows/222-disp-sdlt-controller.yaml
@@ -8,14 +8,16 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
-  id-token: write
-  actions: write
-  statuses: write
+  contents: read
 
 jobs:
   verify-tag:
     name: Verify Tag
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     continue-on-error: true
     outputs:
@@ -55,6 +57,11 @@ jobs:
 
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ github.ref }}
@@ -63,6 +70,11 @@ jobs:
 
   extract-citr-vars:
     name: Extract CITR Vars
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/855-call-extract-citr-vars.yaml
     with:
       ref: ${{ github.ref }}
@@ -71,6 +83,11 @@ jobs:
 
   extract-chewie-props:
     name: Extract Chewie Properties
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     uses: ./.github/workflows/862-call-get-chewie-properties.yaml
     with:
       ref: ${{ github.ref }}
@@ -79,6 +96,11 @@ jobs:
 
   verify-citr-vars:
     name: Verify CITR vars
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     needs:
       - extract-citr-vars
       - extract-chewie-props
@@ -116,6 +138,11 @@ jobs:
 
   run-single-day-longevity-test:
     name: Longevity Test
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     needs:
       - verify-tag
       - extract-jdk-version
@@ -143,6 +170,11 @@ jobs:
 
   tag-sdlt-result:
     name: Tag SDLT Result
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     needs:
       - run-single-day-longevity-test
@@ -191,6 +223,11 @@ jobs:
 
   get-commit-info:
     name: Get Commit Information
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     needs:
       - verify-tag
@@ -228,6 +265,11 @@ jobs:
 
   report-success:
     name: Report SDLT execution success
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     needs:
       - verify-tag
@@ -277,6 +319,11 @@ jobs:
 
   report-failure:
     name: Report SDLT execution failure
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
+      statuses: write
     runs-on: hl-cn-sdlt-lin-sm
     needs:
       - verify-tag

--- a/.github/workflows/300-flow-build-application.yaml
+++ b/.github/workflows/300-flow-build-application.yaml
@@ -11,17 +11,19 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  issues: write
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 jobs:
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ github.ref }}
@@ -30,6 +32,14 @@ jobs:
 
   mats-tests:
     name: MATS Tests
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     uses: ./.github/workflows/800-call-mats-tests.yaml
     needs:
       - extract-jdk-version
@@ -62,6 +72,14 @@ jobs:
 
   deploy-ci-trigger:
     name: Trigger CI Flows
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - mats-tests
@@ -106,6 +124,14 @@ jobs:
   # so it can classify the result into a category and send the appropriate Slack notification.
   report-status:
     name: Report MATS execution status
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - mats-tests

--- a/.github/workflows/301-flow-deploy-release-artifact.yaml
+++ b/.github/workflows/301-flow-deploy-release-artifact.yaml
@@ -23,13 +23,15 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  contents: write
-  actions: read
+  contents: read
 
 jobs:
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ github.ref }}
@@ -38,6 +40,10 @@ jobs:
 
   prepare-tag-release:
     name: Prepare Release [Tag]
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-sm
     if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
     outputs:
@@ -65,6 +71,10 @@ jobs:
 
   release-tag:
     name: Release [Tag]
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     uses: ./.github/workflows/850-call-build-release-artifact.yaml
     needs:
       - extract-jdk-version
@@ -98,6 +108,10 @@ jobs:
 
   update-hedera-protobufs:
     name: Update Hedera Protobufs
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - prepare-tag-release
@@ -155,6 +169,10 @@ jobs:
 
   release-branch:
     name: Release [Branch]
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     uses: ./.github/workflows/850-call-build-release-artifact.yaml
     needs:
       - extract-jdk-version
@@ -188,6 +206,10 @@ jobs:
 
   deploy-xts-ci-trigger:
     name: Trigger XTS CI Flow
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - release-branch
@@ -227,6 +249,10 @@ jobs:
 
   deploy-integration-ci-trigger:
     name: Trigger Deploy Integration Flow
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - release-branch
@@ -268,6 +294,10 @@ jobs:
 
   report-failures:
     name: Report Production Release Failures
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - release-branch

--- a/.github/workflows/302-disp-prepare-extended-test-suite.yaml
+++ b/.github/workflows/302-disp-prepare-extended-test-suite.yaml
@@ -17,9 +17,7 @@ defaults:
     shell: bash
 
 permissions:
-  actions: write
-  contents: write
-  statuses: write
+  contents: read
 
 env:
   XTS_CANDIDATE_TAG: "xts-candidate"
@@ -29,6 +27,10 @@ env:
 jobs:
   validate-input-ref:
     name: Validate Input Reference
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
     runs-on: hl-cn-default-lin-sm
     outputs:
       commit-is-present: ${{ steps.validate-input.outputs.commit_on_dev }}
@@ -59,6 +61,10 @@ jobs:
 
   tag-for-xts:
     name: Tag for XTS promotion
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - validate-input-ref
@@ -135,6 +141,10 @@ jobs:
 
   report-failures:
     name: Report Failures
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - validate-input-ref

--- a/.github/workflows/305-flow-generate-release-notes.yaml
+++ b/.github/workflows/305-flow-generate-release-notes.yaml
@@ -25,13 +25,15 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  contents: write
-  actions: read
+  contents: read
 
 jobs:
   generate-release-notes-tag:
     name: Generate Release Notes (Tag)
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     uses: ./.github/workflows/853-call-create-github-release.yaml
     if: ${{ github.event_name == 'push' }}
     with:
@@ -44,6 +46,10 @@ jobs:
 
   generate-release-notes-dispatch:
     name: Generate Release Notes (Workflow Dispatch)
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     uses: ./.github/workflows/853-call-create-github-release.yaml
     if: ${{ github.event_name == 'workflow_dispatch' }}
     with:

--- a/.github/workflows/306-flow-snyk-monitor.yaml
+++ b/.github/workflows/306-flow-snyk-monitor.yaml
@@ -9,11 +9,13 @@ on:
 
 permissions:
   contents: read
-  security-events: write
 
 jobs:
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      contents: read
+      security-events: write
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ github.ref }}
@@ -22,6 +24,9 @@ jobs:
 
   snyk:
     name: Snyk Monitor
+    permissions:
+      contents: read
+      security-events: write
     needs:
       - extract-jdk-version
     runs-on: hl-cn-snyk-check-lin

--- a/.github/workflows/600-flow-pull-request-checks.yaml
+++ b/.github/workflows/600-flow-pull-request-checks.yaml
@@ -13,12 +13,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  issues: write
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 concurrency:
@@ -28,6 +22,14 @@ concurrency:
 jobs:
   detect-change-type:
     name: Detect Change Type
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     outputs:
       docs-only: ${{ steps.classify.outputs.docs-only }}
@@ -52,6 +54,14 @@ jobs:
 
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ github.event.pull_request.head.sha }}
@@ -60,6 +70,14 @@ jobs:
 
   mats-pr-checks:
     name: MATS
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - detect-change-type
       - extract-jdk-version
@@ -91,6 +109,14 @@ jobs:
 
   workflow-unit-tests:
     name: Workflow File Tests
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - detect-change-type
     if: ${{ needs.detect-change-type.outputs.workflow-files-changed == 'true' }}
@@ -98,6 +124,14 @@ jobs:
 
   ci-complete:
     name: CI Complete
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - detect-change-type
@@ -130,6 +164,14 @@ jobs:
 
   report-summary:
     name: Report PR Check Summary
+    permissions:
+      id-token: write
+      actions: read
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - detect-change-type

--- a/.github/workflows/601-flow-pull-request-formatting.yaml
+++ b/.github/workflows/601-flow-pull-request-formatting.yaml
@@ -23,13 +23,15 @@ defaults:
     shell: bash
 
 permissions:
-  statuses: write
   contents: read
-  pull-requests: read
 
 jobs:
   title-check:
     name: Title Check
+    permissions:
+      statuses: write
+      contents: read
+      pull-requests: read
     runs-on: hl-cn-default-lin-sm
     steps:
       - name: Harden Runner
@@ -44,6 +46,10 @@ jobs:
 
   assignee-check:
     name: Assignee Check
+    permissions:
+      statuses: write
+      contents: read
+      pull-requests: read
     runs-on: hl-cn-default-lin-sm
 
     steps:

--- a/.github/workflows/602-flow-gradle-wrapper-check.yaml
+++ b/.github/workflows/602-flow-gradle-wrapper-check.yaml
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+name: "602: [FLOW] Gradle Wrapper Check"
+on:
+  push:
+    branches:
+      - main
+      - "release/**"
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  validation:
+    name: Validate Gradle Wrapper
+    runs-on: hl-cn-default-lin-sm
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0

--- a/.github/workflows/800-call-mats-tests.yaml
+++ b/.github/workflows/800-call-mats-tests.yaml
@@ -119,11 +119,6 @@ on:
         value: ${{ jobs.set-failure-mode.outputs.failed-tests }}
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 defaults:
@@ -133,6 +128,13 @@ defaults:
 jobs:
   commit-info:
     name: Get Commit Info
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     outputs:
       sha: ${{ steps.commit-info.outputs.sha }}
@@ -154,6 +156,13 @@ jobs:
 
   compile-and-spotless:
     name: "${{ inputs.custom-job-label }} Compile and Spotless"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     uses: ./.github/workflows/802-call-compile-and-spotless-check.yaml
     needs:
       - commit-info
@@ -168,6 +177,13 @@ jobs:
 
   dependency-check:
     name: "${{ inputs.custom-job-label }} Dependency (Module Info)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-dependency-check == 'true' }}
     uses: ./.github/workflows/809-call-dependency-module-check.yaml
     needs:
@@ -183,6 +199,13 @@ jobs:
 
   mats-unit-tests:
     name: Unit Tests
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-unit-tests == 'true' }}
     uses: ./.github/workflows/803-call-execute-unit-tests.yaml
     needs:
@@ -201,6 +224,13 @@ jobs:
 
   mats-integration-tests:
     name: Integration Tests
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-integration-tests == 'true' }}
     uses: ./.github/workflows/804-call-execute-integration-tests.yaml
     needs:
@@ -218,6 +248,13 @@ jobs:
 
   mats-hapi-tests:
     name: HAPI Tests
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests == 'true' }}
     uses: ./.github/workflows/805-call-execute-hapi-tests.yaml
     needs:
@@ -243,6 +280,13 @@ jobs:
 
   mats-otter-tests:
     name: Otter Tests
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-otter-tests == 'true' }}
     needs:
       - commit-info
@@ -261,6 +305,13 @@ jobs:
 
   mats-snyk-scan:
     name: Snyk Scan
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-snyk-scan == 'true' && !github.event.repository.fork }}
     needs:
       - commit-info
@@ -278,6 +329,13 @@ jobs:
 
   mats-gradle-determinism:
     name: Gradle Determinism
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-gradle-determinism == 'true' && !github.event.repository.fork }}
     needs:
       - commit-info
@@ -294,6 +352,13 @@ jobs:
 
   mats-docker-determinism:
     name: Docker Determinism
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-docker-determinism == 'true' && !github.event.repository.fork }}
     needs:
       - commit-info
@@ -310,6 +375,13 @@ jobs:
 
   set-failure-mode:
     name: Set Failure Mode
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/801-call-snyk-scan.yaml
+++ b/.github/workflows/801-call-snyk-scan.yaml
@@ -45,11 +45,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -61,6 +56,13 @@ env:
 jobs:
   snyk-checks:
     name: "Snyk Checks"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-snyk-check-lin
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/802-call-compile-and-spotless-check.yaml
+++ b/.github/workflows/802-call-compile-and-spotless-check.yaml
@@ -42,11 +42,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -58,6 +53,13 @@ env:
 jobs:
   compile-and-spotless-check:
     name: "Compile and Spotless Check"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-compile-app-lin
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/803-call-execute-unit-tests.yaml
+++ b/.github/workflows/803-call-execute-unit-tests.yaml
@@ -48,11 +48,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -64,6 +59,13 @@ env:
 jobs:
   execute-unit-tests:
     name: "Unit Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-unit-test-lin
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/804-call-execute-integration-tests.yaml
+++ b/.github/workflows/804-call-execute-integration-tests.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   execute-integration-tests:
     name: "Integration Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-integration-lin
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/805-call-execute-hapi-tests.yaml
+++ b/.github/workflows/805-call-execute-hapi-tests.yaml
@@ -97,11 +97,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -113,6 +108,13 @@ env:
 jobs:
   hapi-tests-misc:
     name: "HAPI Tests (Misc)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-misc == 'true' }}
     runs-on: hl-cn-hapi-lin-lg
     outputs:
@@ -235,6 +237,13 @@ jobs:
 
   hapi-tests-misc-records-crypto-and-serial:
     name: "HAPI Tests (Misc Records, Crypto & Misc Serial)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-misc-records-crypto-and-serial == 'true' }}
     runs-on: hl-cn-hapi-lin-lg
     outputs:
@@ -339,6 +348,13 @@ jobs:
 
   hapi-tests-token-and-time-consuming:
     name: "HAPI Tests (Token & Time Consuming)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-token-and-time-consuming == 'true' }}
     runs-on: hl-cn-hapi-lin-lg
     outputs:
@@ -441,6 +457,13 @@ jobs:
 
   hapi-tests-simple-fees-and-nd-reconnect:
     name: "HAPI Tests (Simple Fees & ND Reconnect)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-simple-fees-and-nd-reconnect == 'true' }}
     runs-on: hl-cn-hapi-lin-lg
     outputs:
@@ -543,6 +566,13 @@ jobs:
 
   hapi-tests-smart-contracts-and-iss:
     name: "HAPI Tests (Smart Contracts & ISS)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-smart-contract-and-iss == 'true' }}
     runs-on: hl-cn-hapi-lin-lg
     outputs:
@@ -644,6 +674,13 @@ jobs:
 
   hapi-tests-restart:
     name: "HAPI Tests (Restart)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-restart == 'true' }}
     runs-on: hl-cn-hapi-lin-lg
     outputs:
@@ -728,6 +765,13 @@ jobs:
 
   hapi-tests-bn-comms:
     name: "HAPI Tests (BN Comms)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-bn-communication == 'true' }}
     runs-on: hl-cn-hapi-bn-lin-xl
     outputs:
@@ -810,6 +854,13 @@ jobs:
 
   hapi-tests-atomic-batch:
     name: "HAPI Tests (Atomic Batch)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-atomic-batch == 'true' }}
     runs-on: hl-cn-hapi-lin-xl
     outputs:
@@ -911,6 +962,13 @@ jobs:
 
   hapi-tests-state-throttling:
     name: "HAPI Tests (State Throttling)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-state-throttling == 'true' }}
     runs-on: hl-cn-hapi-lin-lg
     outputs:
@@ -995,6 +1053,13 @@ jobs:
 
   hapi-tests-wraps:
     name: "HAPI Tests (Wraps)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-wraps == 'true' }}
     # Dedicated runner pool with the WRAPS proving-key artifacts mounted at
     # /opt/wraps-v1.0.0 (see hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key)
@@ -1089,6 +1154,13 @@ jobs:
 
   hapi-tests-cutover:
     name: "HAPI Tests (Cutover & Wraps Download)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     if: ${{ inputs.enable-hapi-tests-wraps == 'true' }}
     # Dedicated runner pool with the WRAPS proving-key artifacts mounted at
     # /opt/wraps-v1.0.0 (see hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key)
@@ -1198,6 +1270,13 @@ jobs:
 
   set-failure-mode:
     name: "Set Failure Mode"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - hapi-tests-misc

--- a/.github/workflows/806-call-execute-timing-sensitive-tests.yaml
+++ b/.github/workflows/806-call-execute-timing-sensitive-tests.yaml
@@ -42,11 +42,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -58,6 +53,13 @@ env:
 jobs:
   execute-timing-sensitive-tests:
     name: "Timing Sensitive Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-timing-sensitive-lin
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/807-call-execute-hammer-tests.yaml
+++ b/.github/workflows/807-call-execute-hammer-tests.yaml
@@ -42,11 +42,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -58,6 +53,13 @@ env:
 jobs:
   execute-hammer-tests:
     name: "Hammer Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hammer-lin
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/808-call-execute-otter-tests.yaml
+++ b/.github/workflows/808-call-execute-otter-tests.yaml
@@ -61,11 +61,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -77,6 +72,13 @@ env:
 jobs:
   full-otter:
     name: "Full Otter Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-otter-full-lin
     if: ${{ inputs.enable-full-otter-tests }}
     outputs:
@@ -146,6 +148,13 @@ jobs:
 
   fast-otter:
     name: "Fast Otter Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-otter-fast-lin
     if: ${{ inputs.enable-fast-otter-tests }}
     outputs:
@@ -223,6 +232,13 @@ jobs:
 
   chaos-otter:
     name: "Chaos Otter Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-otter-chaos-lin
     if: ${{ inputs.enable-chaos-otter-tests }}
     outputs:
@@ -300,6 +316,13 @@ jobs:
 
   set-failure-mode:
     name: "Set Failure Mode"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - full-otter

--- a/.github/workflows/809-call-dependency-module-check.yaml
+++ b/.github/workflows/809-call-dependency-module-check.yaml
@@ -41,11 +41,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -57,6 +52,13 @@ env:
 jobs:
   dependency-module-check:
     name: "Dependency Module Check"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-md
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/815-call-xts-tests.yaml
+++ b/.github/workflows/815-call-xts-tests.yaml
@@ -156,11 +156,6 @@ on:
         value: ${{ jobs.set-failure-mode.outputs.failed-tests }}
 
 permissions:
-  id-token: write
-  actions: write
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 defaults:
@@ -170,6 +165,13 @@ defaults:
 jobs:
   commit-info:
     name: Get Commit Info
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     outputs:
       sha: ${{ steps.commit-info.outputs.sha }}
@@ -223,6 +225,13 @@ jobs:
 
   build:
     name: Compile and Spotless Check
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     uses: ./.github/workflows/802-call-compile-and-spotless-check.yaml
     needs:
       - commit-info
@@ -237,6 +246,13 @@ jobs:
 
   xts-timing-sensitive-tests:
     name: XTS Timing Sensitive Tests
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -252,6 +268,13 @@ jobs:
 
   xts-hammer-tests:
     name: XTS Hammer Tests
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -267,6 +290,13 @@ jobs:
 
   xts-hapi-tests:
     name: XTS HAPI Tests
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -292,6 +322,13 @@ jobs:
 
   xts-otter-tests:
     name: XTS Otter Tests
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -310,6 +347,13 @@ jobs:
 
   xts-chaos-otter-tests:
     name: XTS Chaos Otter Tests
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -328,6 +372,13 @@ jobs:
 
   hedera-node-jrs-panel:
     name: Hedera Node JRS Panel
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -353,6 +404,13 @@ jobs:
 
   sdk-tck-regression-panel:
     name: SDK TCK Regression Panel
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -372,6 +430,13 @@ jobs:
 
   mirror-node-regression-panel:
     name: Mirror Node Regression Panel
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -390,6 +455,13 @@ jobs:
 
   json-rpc-relay-regression-panel:
     name: JSON-RPC Relay Regression Panel
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -408,6 +480,13 @@ jobs:
 
   block-node-regression-panel:
     name: Block Node Regression Panel
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -428,6 +507,13 @@ jobs:
 
   block-node-regression-skipped-notice:
     name: Block Node Regression Panel (Skipped — solo < 0.44.0)
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - build
     if: ${{ needs.build.result == 'success' && inputs.enable-block-node-regression-panel == 'true' && inputs.solo-ge-0440 != 'true' }}
@@ -447,6 +533,13 @@ jobs:
 
   migration-testing-panel:
     name: Migration Testing Panel
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -463,6 +556,13 @@ jobs:
 
   migration-testing-skipped-notice:
     name: Migration Testing Panel (Skipped — solo < 0.44.0)
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - build
     if: ${{ needs.build.result == 'success' && inputs.enable-migration-testing-panel == 'true' && inputs.solo-ge-0440 != 'true' }}
@@ -485,6 +585,13 @@ jobs:
 
   migration-testing-baseline-skipped-notice:
     name: Migration Testing Panel (Skipped — no previous-minor baseline)
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -507,6 +614,13 @@ jobs:
 
   solo-078-to-079-cutover-panel:
     name: Solo 0.78 to 0.79 Cutover Panel
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - commit-info
       - build
@@ -520,6 +634,13 @@ jobs:
 
   set-failure-mode:
     name: Set Failure Mode
+    permissions:
+      id-token: write
+      actions: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/817-call-jrs-regression.yaml
+++ b/.github/workflows/817-call-jrs-regression.yaml
@@ -155,13 +155,15 @@ defaults:
     working-directory: platform-sdk
 
 permissions:
-  id-token: write
-  checks: write
   contents: read
 
 jobs:
   jrs-regression:
     name: ${{ inputs.custom-job-name || 'Standard' }}
+    permissions:
+      id-token: write
+      checks: write
+      contents: read
     runs-on: hl-cn-jrs-regression-lin-lg
     if: ${{ !github.event.repository.fork }}
     outputs:

--- a/.github/workflows/818-call-json-rpc-relay-regression.yaml
+++ b/.github/workflows/818-call-json-rpc-relay-regression.yaml
@@ -49,11 +49,7 @@ defaults:
     shell: bash
 
 permissions:
-  checks: write
   contents: read
-  actions: write
-  statuses: write
-  id-token: write
 
 env:
   SOLO_CLUSTER_NAME: "solo-rpc-relay-e2e"
@@ -67,6 +63,12 @@ jobs:
   # Execute JSON-RPC Relay Regression Tests using specified version of hiero-consensus-node
   json-rpc-relay-regression:
     name: ${{ inputs.custom-job-name || 'Standard' }}
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-rpc-relay-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
@@ -271,6 +273,12 @@ jobs:
 
   build-slack-payload:
     name: ${{ inputs.custom-job-name || 'Standard' }} Build Slack Payload
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-rpc-relay-lin-sm
     needs:
       - json-rpc-relay-regression
@@ -303,6 +311,12 @@ jobs:
 
   report-json-rpc-relay-regression-status:
     name: ${{ inputs.custom-job-name || 'Standard' }} Slack Report
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-rpc-relay-lin-sm
     needs:
       - build-slack-payload

--- a/.github/workflows/819-call-tck-regression.yaml
+++ b/.github/workflows/819-call-tck-regression.yaml
@@ -53,11 +53,7 @@ defaults:
     shell: bash
 
 permissions:
-  checks: write
   contents: read
-  actions: write
-  statuses: write
-  id-token: write
 
 env:
   SOLO_CLUSTER_NAME: "solo-tck-e2e"
@@ -72,6 +68,12 @@ jobs:
   # Execute TCK Regression Tests using specified version of hiero-consensus-node
   tck-regression:
     name: ${{ inputs.custom-job-name || 'Standard' }}
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-sdk-tck-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}
@@ -381,6 +383,12 @@ jobs:
 
   build-slack-payload:
     name: ${{ inputs.custom-job-name || 'Standard' }} Build Slack Payload
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-sdk-tck-lin-sm
     needs:
       - tck-regression
@@ -414,6 +422,12 @@ jobs:
 
   report-tck-regression-status:
     name: ${{ inputs.custom-job-name || 'Standard' }} Slack Report
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-sdk-tck-lin-sm
     needs:
       - build-slack-payload

--- a/.github/workflows/821-call-block-node-regression.yaml
+++ b/.github/workflows/821-call-block-node-regression.yaml
@@ -59,11 +59,7 @@ defaults:
     shell: bash
 
 permissions:
-  checks: write
   contents: read
-  actions: write
-  statuses: write
-  id-token: write
 
 env:
   SOLO_CLUSTER_NAME: "solo-block-node-e2e"
@@ -75,6 +71,12 @@ env:
 jobs:
   # Execute Block Node Regression Tests using specified version of hiero-consensus-node
   block-node-regression:
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     timeout-minutes: 60
     name: ${{ inputs.custom-job-name || 'Standard' }}
     runs-on: hl-cn-bn-regression-lin-lg
@@ -562,6 +564,12 @@ jobs:
 
   build-slack-payload:
     name: ${{ inputs.custom-job-name || 'Standard' }} Build Slack Payload
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-bn-regression-lin-sm
     needs:
       - block-node-regression
@@ -594,6 +602,12 @@ jobs:
 
   report-block-node-regression-status:
     name: ${{ inputs.custom-job-name || 'Standard' }} Slack Report
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-bn-regression-lin-sm
     needs:
       - build-slack-payload

--- a/.github/workflows/825-call-migration-testing.yaml
+++ b/.github/workflows/825-call-migration-testing.yaml
@@ -36,14 +36,16 @@ defaults:
     shell: bash
 
 permissions:
-  checks: write
   contents: read
-  actions: write
-  statuses: write
-  id-token: write
 
 jobs:
   migration-testing:
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     timeout-minutes: 90
     name: ${{ inputs.custom-job-name || 'Standard' }}
     runs-on: hl-cn-migration-lin-lg
@@ -188,6 +190,12 @@ jobs:
 
   report-migration-testing-status:
     name: ${{ inputs.custom-job-name || 'Standard' }} Slack Report
+    permissions:
+      checks: write
+      contents: read
+      actions: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-migration-lin-sm
     needs: migration-testing
     if: ${{ always() }}

--- a/.github/workflows/831-call-single-day-performance-test.yaml
+++ b/.github/workflows/831-call-single-day-performance-test.yaml
@@ -75,9 +75,7 @@ on:
         value: ${{ jobs.single-day-performance-test-result.outputs.result }}
 
 permissions:
-  contents: write
-  id-token: write
-  actions: write
+  contents: read
 
 env:
   TIMEOUT_6H_LIMIT: 340
@@ -105,12 +103,20 @@ env:
 
 jobs:
   get-chewie-jwt:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     uses: ./.github/workflows/858-call-get-chewie-jwt.yaml
     secrets:
       chewie-key: ${{ secrets.chewie-id-key }}
       chewie-host: ${{ secrets.chewie-host }}
 
   get-sdpt-config:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     uses: ./.github/workflows/861-call-get-test-config.yaml
     with:
       test-type: "sdpt"
@@ -119,6 +125,10 @@ jobs:
       checkout-token: ${{ secrets.github-token }}
 
   validate-chewie-jwt:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     needs: get-chewie-jwt
     uses: ./.github/workflows/860-call-validate-chewie-jwt.yaml
     with:
@@ -129,6 +139,10 @@ jobs:
       checkout-token: ${{ secrets.github-token }}
 
   acquire-kubernetes-resources:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     needs:
       - validate-chewie-jwt
       - get-chewie-jwt
@@ -149,6 +163,10 @@ jobs:
       chewie-host: ${{ secrets.chewie-host }}
 
   print-allocation-details:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - acquire-kubernetes-resources
@@ -175,6 +193,10 @@ jobs:
 
   performance-tests-start:
     name: Start
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdpt-lin-lg
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     needs:
@@ -768,6 +790,10 @@ jobs:
 
   performance-NftTransferLoadTest-watch1:
     name: NFT Transfer Load Test
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdpt-lin-lg
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     needs:
@@ -946,6 +972,10 @@ jobs:
 
   performance-NftTransferLoadTest-report:
     name: NFT Transfer Load Test Report
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdpt-lin-lg
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     needs:
@@ -1213,6 +1243,10 @@ jobs:
           #sh "${{ github.workspace }}"/.github/workflows/support/citr/resetCNlogs.sh "${{ needs.acquire-kubernetes-resources.outputs.namespace }}"
 
   performance-HCSLoadTest:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     needs:
       - acquire-kubernetes-resources
@@ -1232,6 +1266,10 @@ jobs:
       java-version: "${{ inputs.java-version }}"
 
   performance-CryptoTransferLoadTest:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     needs:
       - acquire-kubernetes-resources
@@ -1251,6 +1289,10 @@ jobs:
       java-version: "${{ inputs.java-version }}"
 
   performance-SmartContractLoadTest:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     needs:
       - acquire-kubernetes-resources
@@ -1270,6 +1312,10 @@ jobs:
       java-version: "${{ inputs.java-version }}"
 
   performance-HeliSwapLoadTest:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     needs:
       - acquire-kubernetes-resources
@@ -1290,6 +1336,10 @@ jobs:
 
   performance-post-test-validation:
     name: Consensus Node State Validator
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     runs-on: hl-cn-sdpt-lin-lg
     needs:
@@ -1404,6 +1454,10 @@ jobs:
   # Send this output back to the caller workflow
   single-day-performance-test-result:
     name: Calculate Result
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdpt-lin-lg
     if: ${{ !cancelled() }}
     needs:
@@ -1491,6 +1545,10 @@ jobs:
 
   performance-report-to-rootly:
     name: Report Failures to Rootly
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdpt-lin-sm
     needs:
       - acquire-kubernetes-resources
@@ -1555,6 +1613,10 @@ jobs:
           echo "${{ steps.summary.outputs.summary }}" >> "${GITHUB_STEP_SUMMARY}"
 
   performance-report-to-slack:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdpt-lin-sm
     needs:
       - performance-NftTransferLoadTest-report

--- a/.github/workflows/832-call-execute-performance-test.yaml
+++ b/.github/workflows/832-call-execute-performance-test.yaml
@@ -74,12 +74,14 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
   performance-test:
     name: ${{ inputs.custom-job-name || 'Run CITR Performance Test' }}
+    permissions:
+      contents: write
+      id-token: write
     runs-on: hl-cn-sdpt-lin-lg
 
     outputs:

--- a/.github/workflows/833-call-single-day-longevity-test.yaml
+++ b/.github/workflows/833-call-single-day-longevity-test.yaml
@@ -70,9 +70,7 @@ on:
         value: ${{ jobs.single-day-longevity-test-result.outputs.result }}
 
 permissions:
-  contents: write
-  id-token: write
-  actions: write
+  contents: read
 
 env:
   TIMEOUT_6H_LIMIT: 340
@@ -86,12 +84,20 @@ env:
 
 jobs:
   get-chewie-jwt:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     uses: ./.github/workflows/858-call-get-chewie-jwt.yaml
     secrets:
       chewie-key: ${{ secrets.chewie-id-key }}
       chewie-host: ${{ secrets.chewie-host }}
 
   get-sdlt-config:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     uses: ./.github/workflows/861-call-get-test-config.yaml
     with:
       test-type: "sdlt"
@@ -100,6 +106,10 @@ jobs:
       checkout-token: ${{ secrets.github-token }}
 
   validate-chewie-jwt:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     needs:
       - get-chewie-jwt
     uses: ./.github/workflows/860-call-validate-chewie-jwt.yaml
@@ -111,6 +121,10 @@ jobs:
       checkout-token: ${{ secrets.github-token }}
 
   acquire-kubernetes-resources:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     needs:
       - validate-chewie-jwt
       - get-chewie-jwt
@@ -131,6 +145,10 @@ jobs:
       chewie-host: ${{ secrets.chewie-host }}
 
   print-allocation-details:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - acquire-kubernetes-resources
@@ -157,6 +175,10 @@ jobs:
 
   longevity-tests-start:
     name: Start
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdlt-lin-lg
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     outputs:
@@ -536,6 +558,10 @@ jobs:
 
   longevity-tests-wait:
     name: Wait for Longevity test
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdlt-lin-lg
     if: ${{ !cancelled() && needs.acquire-kubernetes-resources.result == 'success' }}
     needs:
@@ -682,6 +708,10 @@ jobs:
 
   longevity-tests-finish:
     name: Read results of Longevity test
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdlt-lin-lg
     if: ${{ !cancelled() }}
     needs:
@@ -848,6 +878,10 @@ jobs:
   # Send this output back to the caller workflow
   longevity-test-reconnect:
     name: Reconnect test
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdlt-lin-lg
     if: ${{ !cancelled() }}
     needs:
@@ -1014,6 +1048,10 @@ jobs:
   # Send this output back to the caller workflow
   single-day-longevity-test-result:
     name: Calculate Result
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdlt-lin-lg
     if: ${{ !cancelled() }}
     needs:
@@ -1062,6 +1100,10 @@ jobs:
 
   longevity-report-failures:
     name: Report Failures
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdlt-lin-sm
     needs:
       - longevity-tests-start
@@ -1109,6 +1151,10 @@ jobs:
           echo "${{ steps.summary.outputs.summary }}" | tee -a "${GITHUB_STEP_SUMMARY}"
 
   longevity-report-to-slack:
+    permissions:
+      contents: write
+      id-token: write
+      actions: write
     runs-on: hl-cn-sdlt-lin-sm
     needs:
       - longevity-tests-finish

--- a/.github/workflows/836-call-execute-hapi-misc.yaml
+++ b/.github/workflows/836-call-execute-hapi-misc.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-misc:
     name: "HAPI Tests (Misc)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hapi-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/837-call-execute-hapi-misc-records-crypto.yaml
+++ b/.github/workflows/837-call-execute-hapi-misc-records-crypto.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-misc-records-crypto-and-serial:
     name: "HAPI Tests (Misc Records, Crypto & Misc Serial)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hapi-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/838-call-execute-hapi-token-time-consuming.yaml
+++ b/.github/workflows/838-call-execute-hapi-token-time-consuming.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-token-and-time-consuming:
     name: "HAPI Tests (Token & Time Consuming)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hapi-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/839-call-execute-hapi-simple-fees-nd-reconnect.yaml
+++ b/.github/workflows/839-call-execute-hapi-simple-fees-nd-reconnect.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-simple-fees-and-nd-reconnect:
     name: "HAPI Tests (Simple Fees & ND Reconnect)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hapi-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/840-call-execute-hapi-smart-contract-iss.yaml
+++ b/.github/workflows/840-call-execute-hapi-smart-contract-iss.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-smart-contracts-and-iss:
     name: "HAPI Tests (Smart Contracts & ISS)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hapi-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/841-call-execute-hapi-restart.yaml
+++ b/.github/workflows/841-call-execute-hapi-restart.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-restart:
     name: "HAPI Tests (Restart)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hapi-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/842-call-execute-hapi-atomic-batch.yaml
+++ b/.github/workflows/842-call-execute-hapi-atomic-batch.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-atomic-batch:
     name: "HAPI Tests (Atomic Batch)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hapi-lin-xl
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/843-call-execute-hapi-state-throttling.yaml
+++ b/.github/workflows/843-call-execute-hapi-state-throttling.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-state-throttling:
     name: "HAPI Tests (State Throttling)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hapi-lin-lg
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/844-call-execute-hapi-bn-communication.yaml
+++ b/.github/workflows/844-call-execute-hapi-bn-communication.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-bn-comms:
     name: "HAPI Tests (BN Comms)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-hapi-bn-lin-xl
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/845-call-execute-hapi-wraps.yaml
+++ b/.github/workflows/845-call-execute-hapi-wraps.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-wraps:
     name: "HAPI Tests (Wraps)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     # Dedicated runner pool with the WRAPS proving-key artifacts mounted at
     # /opt/wraps-v1.0.0 (see hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key)
     runs-on: hl-cn-hapi-wraps-lin-lg

--- a/.github/workflows/846-call-execute-hapi-cutover.yaml
+++ b/.github/workflows/846-call-execute-hapi-cutover.yaml
@@ -47,11 +47,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -63,6 +58,13 @@ env:
 jobs:
   hapi-tests-cutover:
     name: "HAPI Tests (Cutover & Wraps Download)"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     # Dedicated runner pool with the WRAPS proving-key artifacts mounted at
     # /opt/wraps-v1.0.0 (see hedera-node/infrastructure/docker/containers/production-next/wraps-proving-key)
     runs-on: hl-cn-hapi-wraps-lin-lg

--- a/.github/workflows/847-call-execute-otter-fast.yaml
+++ b/.github/workflows/847-call-execute-otter-fast.yaml
@@ -46,11 +46,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -62,6 +57,13 @@ env:
 jobs:
   fast-otter:
     name: "Fast Otter Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-otter-fast-lin
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/848-call-execute-otter-full.yaml
+++ b/.github/workflows/848-call-execute-otter-full.yaml
@@ -46,11 +46,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -62,6 +57,13 @@ env:
 jobs:
   full-otter:
     name: "Full Otter Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-otter-full-lin
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/849-call-execute-otter-chaos.yaml
+++ b/.github/workflows/849-call-execute-otter-chaos.yaml
@@ -46,11 +46,6 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  actions: read
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 env:
@@ -62,6 +57,13 @@ env:
 jobs:
   chaos-otter:
     name: "Chaos Otter Tests"
+    permissions:
+      id-token: write
+      actions: read
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-otter-chaos-lin
     outputs:
       failure-mode: ${{ steps.set-failure-mode.outputs.failure-mode }}

--- a/.github/workflows/850-call-build-release-artifact.yaml
+++ b/.github/workflows/850-call-build-release-artifact.yaml
@@ -105,13 +105,15 @@ env:
   SKOPEO_VERSION: v1.14.0
 
 permissions:
-  id-token: write
-  contents: write
-  actions: read
+  contents: read
 
 jobs:
   validate:
     name: Validate
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-md
     # Repository-pinning holds regardless of the caller's trigger (pull_request,
     # pull_request_target, workflow_run, push) and of a fork being renamed — unlike
@@ -241,6 +243,10 @@ jobs:
 
   build-artifact:
     name: Build Artifact
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-md
     needs:
       - validate
@@ -393,6 +399,10 @@ jobs:
 
   local-node-images:
     name: Publish Local Node Images
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-lg
     needs:
       - validate
@@ -536,6 +546,10 @@ jobs:
 
   gcp-production-image:
     name: Publish Production Image
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     uses: ./.github/workflows/852-call-publish-production-image.yaml
     needs:
       - validate
@@ -556,6 +570,10 @@ jobs:
 
   jfr-production-image:
     name: Publish Production Image
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     uses: ./.github/workflows/852-call-publish-production-image.yaml
     needs:
       - validate
@@ -576,6 +594,10 @@ jobs:
 
   validate-production-image:
     name: Validate Production Image
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-md
     needs:
       - gcp-production-image
@@ -692,6 +714,10 @@ jobs:
 
   publish:
     name: Publish to ${{ inputs.version-policy == 'specified' && 'Maven Central' || 'GCP Registry' }}
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-lg
     outputs:
       create-release: ${{ steps.set-gh-release-flag.outputs.create-release }}
@@ -904,6 +930,10 @@ jobs:
 
   create-github-release:
     name: Create GitHub Release
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     if: ${{ github.event.repository.private == false && needs.publish.outputs.create-release == 'true' }}
     uses: ./.github/workflows/853-call-create-github-release.yaml
     needs:
@@ -919,6 +949,10 @@ jobs:
 
   send-notifications:
     name: Send Release Notifications
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - validate

--- a/.github/workflows/853-call-create-github-release.yaml
+++ b/.github/workflows/853-call-create-github-release.yaml
@@ -36,13 +36,15 @@ defaults:
     shell: bash
 
 permissions:
-  id-token: write
-  contents: write
-  actions: read
+  contents: read
 
 jobs:
   validate-input-version:
     name: Validate Input Version
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     runs-on: hl-cn-default-lin-sm
     outputs:
       release-identifier: ${{ steps.validate.outputs.release-identifier }}
@@ -120,6 +122,10 @@ jobs:
 
   generate-release-notes:
     name: Generate Release Notes File
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     needs:
       - validate-input-version
     runs-on: hl-cn-default-lin-sm
@@ -166,6 +172,10 @@ jobs:
 
   full-commit-history:
     name: Full Commit History
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     needs:
       - validate-input-version
     runs-on: hl-cn-default-lin-sm
@@ -189,6 +199,10 @@ jobs:
 
   create-github-release:
     name: Create Github Release
+    permissions:
+      id-token: write
+      contents: write
+      actions: read
     needs: generate-release-notes
     runs-on: hl-cn-default-lin-sm
     steps:

--- a/.github/workflows/860-call-validate-chewie-jwt.yaml
+++ b/.github/workflows/860-call-validate-chewie-jwt.yaml
@@ -19,6 +19,9 @@ on:
         description: "Token for checking out the repo"
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   validate-jwt:
     runs-on: hl-cn-chewie-lin-sm

--- a/.github/workflows/861-call-get-test-config.yaml
+++ b/.github/workflows/861-call-get-test-config.yaml
@@ -35,6 +35,9 @@ on:
         description: "Memory request for Aux nodes in MB"
         value: ${{ jobs.get-test-config.outputs.aux-mem-request-mb }}
 
+permissions:
+  contents: read
+
 jobs:
   get-test-config:
     runs-on: hl-cn-chewie-lin-sm

--- a/.github/workflows/862-call-get-chewie-properties.yaml
+++ b/.github/workflows/862-call-get-chewie-properties.yaml
@@ -19,6 +19,9 @@ on:
         description: "Default timeout for chewie requests"
         value: ${{ jobs.get-chewie-props.outputs.request-timeout }}
 
+permissions:
+  contents: read
+
 jobs:
   get-chewie-props:
     runs-on: hl-cn-chewie-lin-sm

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -18,12 +18,6 @@ on:
     - cron: "0 */3 * * *"
 
 permissions:
-  id-token: write
-  actions: write
-  issues: write
-  pull-requests: write
-  statuses: write
-  checks: write
   contents: read
 
 defaults:
@@ -39,6 +33,14 @@ env:
 jobs:
   extract-citr-vars:
     name: Extract CITR Vars
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     uses: ./.github/workflows/855-call-extract-citr-vars.yaml
     with:
       ref: ${{ inputs.rc-tag || github.ref }}
@@ -47,6 +49,14 @@ jobs:
 
   verify-citr-vars:
     name: Verify CITR vars
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - extract-citr-vars
     runs-on: hl-cn-default-lin-sm
@@ -76,6 +86,14 @@ jobs:
 
   compute-solo-ge-0440:
     name: Compute solo-ge-0440
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - extract-citr-vars
       - verify-citr-vars
@@ -85,6 +103,14 @@ jobs:
 
   parameters:
     name: Determine Configurable Parameters
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - extract-citr-vars
@@ -117,6 +143,14 @@ jobs:
 
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs: fetch-xts-candidate
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
@@ -126,6 +160,14 @@ jobs:
 
   fetch-xts-candidate:
     name: Fetch XTS Candidate Tag
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     outputs:
       xts-proceed: ${{ steps.check-tags-exist.outputs.xts-proceed }}
@@ -320,6 +362,14 @@ jobs:
 
   state-validator-uberjar:
     name: Build & Publish Hedera State Validator Uber JAR
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - fetch-xts-candidate
     if: ${{ needs.fetch-xts-candidate.result == 'success' && needs.fetch-xts-candidate.outputs.xts-proceed == 'true' }}
@@ -329,6 +379,14 @@ jobs:
 
   xts-execution:
     name: Execute XTS
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - fetch-xts-candidate
       - parameters
@@ -379,6 +437,14 @@ jobs:
 
   xts-optional-execution:
     name: Execute Optional XTS Tests
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     needs:
       - fetch-xts-candidate
       - parameters
@@ -410,6 +476,14 @@ jobs:
 
   tag-for-promotion:
     name: Tag as XTS-Passing
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - fetch-xts-candidate
@@ -473,6 +547,14 @@ jobs:
 
   report-success:
     name: Report XTS execution success
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - fetch-xts-candidate
@@ -515,6 +597,14 @@ jobs:
 
   report-failure:
     name: Report XTS execution failure
+    permissions:
+      id-token: write
+      actions: write
+      issues: write
+      pull-requests: write
+      statuses: write
+      checks: write
+      contents: read
     runs-on: hl-cn-default-lin-sm
     needs:
       - fetch-xts-candidate

--- a/.github/workflows/901-cron-promote-build-candidate.yaml
+++ b/.github/workflows/901-cron-promote-build-candidate.yaml
@@ -8,10 +8,7 @@ on:
     - cron: "0 1 * * 2-6"
 
 permissions:
-  actions: write
-  contents: write
-  statuses: write
-  id-token: write
+  contents: read
 
 defaults:
   run:
@@ -24,6 +21,11 @@ env:
 jobs:
   determine-build-candidate:
     name: Fetch Latest Build Candidate
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-default-lin-sm
     outputs:
       build-candidate-exists: ${{ steps.find-build-candidates.outputs.build-candidate-exists }}
@@ -96,6 +98,11 @@ jobs:
 
   promote-build-candidate:
     name: Promote Build Candidate
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - determine-build-candidate
@@ -164,6 +171,11 @@ jobs:
 
   deploy-ci-trigger:
     name: Trigger CI Flows
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - promote-build-candidate
@@ -203,6 +215,11 @@ jobs:
 
   report-promotion:
     name: Report Build Promotion
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - determine-build-candidate
@@ -241,6 +258,11 @@ jobs:
 
   report-no-promotion:
     name: Report No Build Promotion
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - determine-build-candidate
@@ -283,6 +305,11 @@ jobs:
 
   report-failure:
     name: Report Build Promotion failure
+    permissions:
+      actions: write
+      contents: write
+      statuses: write
+      id-token: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - determine-build-candidate

--- a/.github/workflows/904-cron-release-branching.yaml
+++ b/.github/workflows/904-cron-release-branching.yaml
@@ -10,7 +10,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   GITHUB_CLI_VERSION: 2.21.2
@@ -21,6 +21,8 @@ env:
 jobs:
   check-trigger:
     name: Check Trigger Conditions
+    permissions:
+      contents: write
     runs-on: hl-cn-default-lin-sm
     if: ${{ !github.event.workflow_dispatch.repository.fork }}
     outputs:
@@ -65,6 +67,8 @@ jobs:
 
   check-branch:
     name: Check Branching Conditions
+    permissions:
+      contents: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - check-trigger
@@ -93,6 +97,8 @@ jobs:
 
   create-branch:
     name: Create Release Branch
+    permissions:
+      contents: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - check-branch
@@ -187,6 +193,8 @@ jobs:
 
   extract-jdk-version:
     name: Extract Java Version
+    permissions:
+      contents: write
     uses: ./.github/workflows/854-call-extract-jdk-version.yaml
     with:
       ref: ${{ github.ref }}
@@ -195,6 +203,8 @@ jobs:
 
   create-tag:
     name: Create Release Tag
+    permissions:
+      contents: write
     runs-on: hl-cn-default-lin-sm
     needs:
       - check-branch

--- a/.github/workflows/docs/workflow-manifest.md
+++ b/.github/workflows/docs/workflow-manifest.md
@@ -39,6 +39,7 @@
 | # TEST HELPERS (600-699)                     |                                        |                                                       |                                                                   |
 | 600-flow-pull-request-checks.yaml            | 600: [FLOW] PR Checks                  | node-flow-pull-request-checks.yaml                    | Node: PR Checks                                                   |
 | 601-flow-pull-request-formatting.yaml        | 601: [FLOW] PR Formatting              | flow-pull-request-formatting.yaml                     | PR Formatting                                                     |
+| 602-flow-gradle-wrapper-check.yaml           | 602: [FLOW] Gradle Wrapper Check       |                                                       |                                                                   |
 |                                              |                                        |                                                       |                                                                   |
 | # AI HELPERS (700-799)                       |                                        |                                                       |                                                                   |
 | 700-flow-copilot-setup-steps.yaml            | 700: [FLOW] Copilot Setup Steps        | 700-flow-copilot-setup-steps.yaml                     | 700: [FLOW] Copilot Setup Steps                                   |

--- a/hedera-node/test-clients/validation-scenarios/Dockerfile
+++ b/hedera-node/test-clients/validation-scenarios/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:22.04@sha256:2edbbc5dc405e9612ba3584ce95480277e3eb374407b5505fe26f17df77c7dbc
 # JDK
 ENV JAVA_HOME /opt/java/openjdk
 ENV PATH $JAVA_HOME/bin:$PATH

--- a/hedera-node/yahcli/Dockerfile
+++ b/hedera-node/yahcli/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25-jdk
+FROM eclipse-temurin:25-jdk@sha256:e787e08ef76f4c16866108cd7f9fcd96a68eef3ac6cc76866897d4d02d5a2262
 
 RUN mkdir -p /launch /opt/bin
 

--- a/platform-sdk/consensus-otter-docker-app/src/testFixtures/docker/Dockerfile
+++ b/platform-sdk/consensus-otter-docker-app/src/testFixtures/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25.0.2_10-jdk
+FROM eclipse-temurin:25.0.2_10-jdk@sha256:1bda4d9e668f44f399abed30636c34e0befb727408fba27b1e6aaefcf9df346b
 
 # Create non-root user and group
 RUN groupadd -r appuser && useradd -r -g appuser appuser

--- a/platform-sdk/consensus-sloth/src/testFixtures/docker/Dockerfile
+++ b/platform-sdk/consensus-sloth/src/testFixtures/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:25
+FROM eclipse-temurin:25@sha256:e787e08ef76f4c16866108cd7f9fcd96a68eef3ac6cc76866897d4d02d5a2262
 
 # Create non-root user and group
 RUN groupadd -r appuser && useradd -r -g appuser appuser


### PR DESCRIPTION
**Description**:

Raise the repository's OpenSSF Scorecard score (currently 6.8; Token-Permissions 0) without changing the effective permissions of any existing job.

* Declare a read-only top-level `permissions` block (`contents: read`) in every workflow and move the previous top-level scopes verbatim to `jobs.<id>.permissions` for every job in that workflow, so each job keeps exactly the token it has today
* Add a top-level `contents: read` block to the three reusable workflows that had none (`860`, `861`, `862`); their jobs only check out the repository (with the caller-supplied PAT) and read config files
* Add `602: [FLOW] Gradle Wrapper Check` using `gradle/actions/wrapper-validation` on PRs and pushes to `main`/`release/**`
* Pin the four static `FROM` base images (`ubuntu:22.04`, `eclipse-temurin:25-jdk`, `eclipse-temurin:25.0.2_10-jdk`, `eclipse-temurin:25`) by digest and add a Dependabot `docker` entry for those directories so the digests keep getting bumped
* List the new workflow in `.github/workflows/docs/workflow-manifest.md`

**Changes by Scorecard check**

*Token-Permissions* (0 → 10): Scorecard scores any top-level `contents`/`actions`/`packages: write` as 0 for the whole repository and deducts for top-level `checks`/`statuses`/`security-events: write` and for workflows with no top-level block. Job-level write scopes are not penalised. 59 workflow files were changed. The transformation is purely mechanical: the top-level block becomes `contents: read`, and the block that was at the top level is copied unchanged (same scopes, same order) into every job of that workflow. Because a job-level `permissions` block replaces the inherited one, this preserves the current effective token for every job, including jobs that call reusable workflows (the called workflow still receives the same ceiling it receives today). Narrowing individual jobs to the scopes they actually use is a possible follow-up but is intentionally not part of this change.

*Binary-Artifacts* (9 → 10): Scorecard exempts `gradle/wrapper/gradle-wrapper.jar` only when a `gradle/actions/wrapper-validation` workflow has a successful run on the latest `main` commit. The `setup-gradle` action's implicit validation does not count for this exemption. The new workflow reuses the `gradle/actions@v5.0.0` and `step-security/harden-runner@v2.19.4` pins already used in this repository.

*Pinned-Dependencies* (8 via the API; 9 → 9 locally): four static base images pinned by digest (digests verified with `docker buildx imagetools inspect`); container images go from 2/20 to 6/20 pinned.

*SAST*: no CodeQL workflow is added. CodeQL default setup is already enabled on this repository and posts a successful `CodeQL` check-run on every pull request, which is what the Scorecard SAST check counts (`scorecard --repo github.com/hiero-ledger/hiero-consensus-node --checks SAST` currently reports 10). GitHub does not process results from an advanced-setup workflow while default setup is enabled, so adding one would only introduce failing checks.

| Check | Before | After (local `scorecard --local`) |
|---|---|---|
| Token-Permissions | 0 | 10 |
| Dangerous-Workflow | 10 | 10 |
| Pinned-Dependencies | 9 | 9 (container images 2/20 → 6/20) |
| Binary-Artifacts | 9 | 9 locally; 10 once `602` has a successful run on `main` |

**Intentionally not changed**

* `FROM ubuntu:${UBUNTU_TAG}`, `FROM ubuntu@${UBUNTU_SHA}`, `FROM debian:${UBUNTU_TAG}` and `FROM ${IMAGE_PREFIX}network-node-base:${IMAGE_TAG}` in the `hedera-node/infrastructure/docker` images: Scorecard cannot resolve build-arg references, and the production images are already digest-pinned via `UBUNTU_SHA`; restructuring them is out of scope
* `npm install -g @hashgraph/solo@...` / `npm install` global tool installs in workflows and Solo scripts: Scorecard only accepts `npm ci` with a lockfile, which does not apply to global CLI installs
* `pip install requests` in `853` and the Codacy `bash <(curl ...)` reporter in `803`: left as is
* Workflows whose top-level block is already read-only plus non-penalised scopes (`id-token`, `pull-requests`, `issues`) were not touched
* No CodeQL workflow (see the SAST note above) and no property-based/fuzz testing (Java is not detected by the Fuzzing check without a Jazzer integration)

**Related issue(s)**:

N/A

**Notes for reviewer**:

Every workflow diff can be verified with the same rule: `permissions:` at the top level now reads `contents: read`, and each job under `jobs:` gained a `permissions:` block equal to what the top level contained before. Verification performed locally:

* `actionlint` on all 60 touched/added workflow files: no new messages compared with `main` (the only messages on the new file are the usual unknown self-hosted runner label notices that every workflow in this repository produces)
* `scorecard --local . --checks Token-Permissions,Pinned-Dependencies,Binary-Artifacts,Dangerous-Workflow` before and after (table above)
* A YAML round-trip check that, apart from `permissions`, no workflow content changed, and that every job's effective permissions are identical before and after

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
