### PR TITLE
fix(scheduling): Add workflow priming job for scheduled runs in HCN

### DIFF
--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -37,6 +37,19 @@ env:
   BUILD_GREP_PATTERN: "build-*"
 
 jobs:
+  prime-workflow:
+    name: Prime workflow
+    runs-on: hl-cn-default-lin-ss
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Schedule Run
+        run: |
+          echo "Picking up scheduled run at $(date -u +'%Y-%m-%d %H:%M:%S') UTC"
+
   extract-citr-vars:
     name: Extract CITR Vars
     uses: ./.github/workflows/855-call-extract-citr-vars.yaml

--- a/.github/workflows/901-cron-promote-build-candidate.yaml
+++ b/.github/workflows/901-cron-promote-build-candidate.yaml
@@ -22,6 +22,19 @@ env:
   PROMOTED_GREP_PATTERN: "build-.{5}"
 
 jobs:
+  prime-workflow:
+    name: Prime workflow
+    runs-on: hl-cn-default-lin-ss
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Schedule Run
+        run: |
+          echo "Picking up scheduled run at $(date -u +'%Y-%m-%d %H:%M:%S') UTC"
+
   determine-build-candidate:
     name: Fetch Latest Build Candidate
     runs-on: hl-cn-default-lin-sm

--- a/.github/workflows/902-cron-auto-namespace-delete.yaml
+++ b/.github/workflows/902-cron-auto-namespace-delete.yaml
@@ -95,6 +95,19 @@ on:
         description: "*solo-sd*t-n14 (AdHoc Tests)"
 
 jobs:
+  prime-workflow:
+    name: Prime workflow
+    runs-on: hl-cn-default-lin-ss
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Schedule Run
+        run: |
+          echo "Picking up scheduled run at $(date -u +'%Y-%m-%d %H:%M:%S') UTC"
+
   delete-selected-namespaces:
     runs-on: hl-cn-default-lin-sm
     env:

--- a/.github/workflows/903-cron-clean.yaml
+++ b/.github/workflows/903-cron-clean.yaml
@@ -10,6 +10,19 @@ on:
   workflow_dispatch:
 
 jobs:
+  prime-workflow:
+    name: Prime workflow
+    runs-on: hl-cn-default-lin-ss
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Schedule Run
+        run: |
+          echo "Picking up scheduled run at $(date -u +'%Y-%m-%d %H:%M:%S') UTC"
+
   performance-tests-start:
     runs-on: hl-cn-default-lin-sm
 

--- a/.github/workflows/904-cron-release-branching.yaml
+++ b/.github/workflows/904-cron-release-branching.yaml
@@ -19,6 +19,19 @@ env:
   RELEASE_BRANCH_CHECK_SCRIPT: ".github/workflows/support/scripts/release-branch-check.sh"
 
 jobs:
+  prime-workflow:
+    name: Prime workflow
+    runs-on: hl-cn-default-lin-ss
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+
+      - name: Schedule Run
+        run: |
+          echo "Picking up scheduled run at $(date -u +'%Y-%m-%d %H:%M:%S') UTC"
+
   check-trigger:
     name: Check Trigger Conditions
     runs-on: hl-cn-default-lin-sm


### PR DESCRIPTION
## Description

This pull request introduces a new `prime-workflow` job to several scheduled GitHub Actions workflows. The main goal is to improve runner security and provide clear scheduling logs before the main workflow jobs execute. The changes are consistent across multiple workflow files.

The most important changes include:

**Security and Workflow Priming:**

* Added a `prime-workflow` job at the start of each workflow (`900-cron-extended-test-suite.yaml`, `901-cron-promote-build-candidate.yaml`, `902-cron-auto-namespace-delete.yaml`, `903-cron-clean.yaml`, `904-cron-release-branching.yaml`) that runs on `hl-cn-default-lin-ss` and executes two steps: [[1]](diffhunk://#diff-866e104331e826b6cd78ccd5a768be8eb64e8a8c1b8590d987ad572cb4adba29R40-R52) [[2]](diffhunk://#diff-5cadc65374e5157dfc08ee485145730e1a66e136cf8398a34857f63dc853bf2cR25-R37) [[3]](diffhunk://#diff-979a95b1867caac6fe5178dc294bef087cf16776268c51704d4de966cbf1d30bR98-R110) [[4]](diffhunk://#diff-c8c2f8f07286f200f31a3b9c3745d3b1cf60180f52e0736f8422c8826185530dR13-R25) [[5]](diffhunk://#diff-ed1a50e8073670784c0e33d166815d1f918c9a6c0957bd3c0fd4d920e6e3bb84R22-R34)
  - **Runner hardening:** Uses `step-security/harden-runner@v2.19.4` with `egress-policy: audit` to increase security.
  - **Scheduling log:** Adds a step that echoes the UTC time when the scheduled run is picked up, improving traceability and observability of workflow executions.

## Related issue(s)

Fixes #27003
