### PR TITLE
fix(ci): drop stale cutover-solo-version pass-through that invalidates 900

### DIFF
--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -342,7 +342,6 @@ jobs:
       ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}
       branch-name: ${{ needs.fetch-xts-candidate.outputs.xts-commit-branch }}
       solo-version: ${{ needs.parameters.outputs.solo-version }}
-      cutover-solo-version: ${{ needs.extract-citr-vars.outputs.cutover-solo-version }}
       solo-ge-0440: ${{ needs.parameters.outputs.solo-ge-0440 }}
       helm-release-name: ${{ needs.parameters.outputs.helm-release-name }}
       custom-job-label: "XTS (main):"


### PR DESCRIPTION
Fixes #27007

## Problem

`main` currently has an **invalid** `900-cron-extended-test-suite.yaml`, so GitHub is not creating scheduled XTS runs at all:

```
Invalid workflow file: .github/workflows/900-cron-extended-test-suite.yaml#L345
(Line: 345, Col: 29): Invalid input, cutover-solo-version is not defined in the referenced workflow.
```

`900`'s `xts-execution` job passes `cutover-solo-version` to `815`, but #26989 removed that input from `815` when the Solo 0.78→0.79 cutover panel moved out to `824`. Passing an input the callee does not declare is a hard error.

This is a regression from the #26978 stack — the input-surface sequencing rule was applied to `800`'s callers (`600`/`300`/`000`) but missed for `815`'s caller `900`.

## Fix

Remove the stale pass-through. `815` has no use for it: the cutover panel lives in `824` now, and `106` re-derives its own variables via `855`.

`900`'s `verify-citr-vars` guard on `cutover-solo-version` is deliberately kept — it validates the CITR vars file, which the optional path still depends on.

## Verification

Audited **every** `uses: ./.github/workflows/*.yaml` call site in the repo against its callee's declared inputs. Before: 1 violation (this one). After: 0.

## Impact

XTS has not run since the stack merged; the 18:00 UTC slot produced no run. Today's earlier 06:00 and 12:00 UTC misses are unrelated and predate the merge — GitHub was dropping scheduled slots repo-wide (903, an hourly cron untouched by that work, ran with 2–4 hour gaps all day).

There is an unconsumed `xts-candidate` tag waiting; GitHub does not backfill dropped cron slots, so 900 will need a manual dispatch once this merges.

## Follow-up

This class of break is mechanically detectable. `857-call-workflow-unit-tests.yaml` would be the natural home for a check that validates reusable-workflow call sites against callee inputs — worth adding so it fails in CI rather than on the default branch.
