### PR TITLE
fix: bound GNU long-name size and cap tar metadata headers before allocating

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/TarGzExtractor.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/history/TarGzExtractor.java
@@ -67,6 +67,7 @@ public final class TarGzExtractor {
         try (var fis = new FileInputStream(tarGzPath.toFile());
                 var gis = new GZIPInputStream(fis)) {
             int entryCount = 0;
+            int metadataHeaderCount = 0;
             long totalExtractedBytes = 0L;
             String longName = null;
 
@@ -81,12 +82,21 @@ public final class TarGzExtractor {
 
                 // Handle GNU long name extension: data is the real name, next header is the entry
                 if (typeFlag == TYPEFLAG_GNU_LONGNAME) {
+                    // Metadata headers are counted separately so they cannot be repeated without bound
+                    metadataHeaderCount++;
+                    if (metadataHeaderCount > MAX_ENTRIES) {
+                        throw new IOException("Tar archive contains too many metadata headers (>" + MAX_ENTRIES + ")");
+                    }
                     longName = readLongName(gis, entrySize);
                     continue;
                 }
 
                 // Skip PAX extended headers
                 if (typeFlag == 'x' || typeFlag == 'g' || typeFlag == 'X') {
+                    metadataHeaderCount++;
+                    if (metadataHeaderCount > MAX_ENTRIES) {
+                        throw new IOException("Tar archive contains too many metadata headers (>" + MAX_ENTRIES + ")");
+                    }
                     skipDataBlocks(gis, entrySize);
                     continue;
                 }
@@ -242,6 +252,11 @@ public final class TarGzExtractor {
     }
 
     private static String readLongName(@NonNull final InputStream is, final long size) throws IOException {
+        // The size field is attacker-controlled, so bound it before allocating (+1 for the trailing NUL)
+        if (size <= 0 || size > MAX_NAME_LENGTH + 1) {
+            throw new IOException(
+                    "Tar GNU long name entry has an invalid size (" + size + ", max=" + (MAX_NAME_LENGTH + 1) + ")");
+        }
         final byte[] nameBytes = is.readNBytes((int) size);
         if (nameBytes.length < size) {
             throw new IOException("Unexpected end of tar archive while reading long name");

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/TarGzExtractorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/TarGzExtractorTest.java
@@ -262,6 +262,65 @@ class TarGzExtractorTest {
     }
 
     @Test
+    void rejectsOversizedGnuLongNameBeforeAllocating() throws IOException {
+        // Type 'L' header declaring a 1 GiB name; must be rejected on the size field, not by allocating
+        final byte[] lHeader = buildRawHeader("././@LongLink", 1024L * 1024L * 1024L, (byte) 'L');
+        final var archive = writeTarGz(gzipRaw(lHeader));
+        final var e = assertThrows(IOException.class, () -> TarGzExtractor.extract(archive, tempDir));
+        assertTrue(e.getMessage().contains("invalid size"), e.getMessage());
+    }
+
+    @Test
+    void rejectsGnuLongNameSizeThatOverflowsInt() throws IOException {
+        // 2^31 casts to a negative int, which readNBytes would reject with IllegalArgumentException
+        final byte[] lHeader = buildRawHeader("././@LongLink", 2147483648L, (byte) 'L');
+        final var archive = writeTarGz(gzipRaw(lHeader));
+        final var e = assertThrows(IOException.class, () -> TarGzExtractor.extract(archive, tempDir));
+        assertTrue(e.getMessage().contains("invalid size"), e.getMessage());
+    }
+
+    @Test
+    void rejectsZeroSizedGnuLongName() throws IOException {
+        final byte[] lHeader = buildRawHeader("././@LongLink", 0, (byte) 'L');
+        final var archive = writeTarGz(gzipRaw(lHeader));
+        final var e = assertThrows(IOException.class, () -> TarGzExtractor.extract(archive, tempDir));
+        assertTrue(e.getMessage().contains("invalid size"), e.getMessage());
+    }
+
+    @Test
+    void rejectsTooManyGnuLongNameHeaders() throws IOException {
+        final byte[] name = "a\0".getBytes(StandardCharsets.US_ASCII);
+        final byte[][] entries = new byte[10_001][];
+        for (int i = 0; i < entries.length; i++) {
+            entries[i] = longNameHeader(name.length, name);
+        }
+        final var archive = writeTarGz(createTarGz(entries));
+        final var e = assertThrows(IOException.class, () -> TarGzExtractor.extract(archive, tempDir));
+        assertTrue(e.getMessage().contains("metadata headers"), e.getMessage());
+    }
+
+    @Test
+    void rejectsTooManyPaxHeaders() throws IOException {
+        final byte[][] entries = new byte[10_001][];
+        for (int i = 0; i < entries.length; i++) {
+            entries[i] = paxEntry((byte) 'x', new byte[0]);
+        }
+        final var archive = writeTarGz(createTarGz(entries));
+        final var e = assertThrows(IOException.class, () -> TarGzExtractor.extract(archive, tempDir));
+        assertTrue(e.getMessage().contains("metadata headers"), e.getMessage());
+    }
+
+    @Test
+    void acceptsGnuLongNameSizeAtMaxLength() throws IOException {
+        // A 4096-char name occupies 4097 payload bytes with its trailing NUL, so that size must pass
+        // the pre-allocation check - here the archive is truncated, which is a different failure
+        final byte[] lHeader = buildRawHeader("././@LongLink", 4097, (byte) 'L');
+        final var archive = writeTarGz(gzipRaw(lHeader));
+        final var e = assertThrows(IOException.class, () -> TarGzExtractor.extract(archive, tempDir));
+        assertFalse(e.getMessage().contains("invalid size"), e.getMessage());
+    }
+
+    @Test
     void skipsPaxHeaders() throws IOException {
         final byte[] content = "real".getBytes(StandardCharsets.UTF_8);
         final byte[] paxData = "20 path=extended.txt\n".getBytes(StandardCharsets.US_ASCII);
@@ -479,6 +538,16 @@ class TarGzExtractorTest {
         final byte[] result = new byte[lEntry.length + fileEntry.length];
         System.arraycopy(lEntry, 0, result, 0, lEntry.length);
         System.arraycopy(fileEntry, 0, result, lEntry.length, fileEntry.length);
+        return result;
+    }
+
+    /** Creates a type 'L' header declaring {@code declaredSize}, followed by {@code data} in whole blocks. */
+    private static byte[] longNameHeader(final long declaredSize, final byte[] data) {
+        final byte[] header = buildRawHeader("././@LongLink", declaredSize, (byte) 'L');
+        final int dataBlocks = (data.length + BLOCK_SIZE - 1) / BLOCK_SIZE;
+        final byte[] result = new byte[BLOCK_SIZE + dataBlocks * BLOCK_SIZE];
+        System.arraycopy(header, 0, result, 0, BLOCK_SIZE);
+        System.arraycopy(data, 0, result, BLOCK_SIZE, data.length);
         return result;
     }
 


### PR DESCRIPTION
## Description

`TarGzExtractor.readLongName()` sized its byte array straight from the tar header's size field, with no check before the allocation. A crafted GNU long-name (`'L'`) header could declare a name of ~2 GiB and force that allocation; the 4096-char limit was only applied afterwards, in `validateEntryName()`. A declared size in `[2^31, 2^32)` also cast to a negative `int`, so `readNBytes` threw an unchecked `IllegalArgumentException` rather than the declared `IOException`. Separately, `'L'` and PAX headers `continue`d before the entry counter, so an archive could repeat them without limit.

This PR:

- validates the declared long-name size before allocating (must be > 0 and <= `MAX_NAME_LENGTH` + 1, the +1 covering the trailing NUL)
- counts `'L'` and PAX headers against their own cap — kept separate from `MAX_ENTRIES` so a legitimate 10k-file archive where every file has a long name still extracts

Defense in depth: the only caller, `WrapsProvingKeyVerification`, extracts only after the archive's SHA-384 matches the operator-configured `tss.wrapsProvingKeyHash`, so there is no remote path to this today.
