### PR TITLE
fix(ci): dispatch optional XTS on the candidate branch, not the commit SHA

### DIFF
--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -391,18 +391,19 @@ jobs:
       # Dispatched fire-and-forget: the optional panels do not gate promotion, and this run is
       # deliberately not awaited.
       #
-      # Dispatch on the candidate COMMIT, not on a branch name. The dispatched run reads 106's
-      # definition from whatever ref it is given, so a branch name would run the branch tip's
-      # version of the workflow against an older candidate -- and once XTS runs on release
-      # branches, dispatching on `main` would run the wrong definition entirely. The commit is
-      # also always resolvable here, whereas the xts-candidate tag has already been deleted by
-      # fetch-xts-candidate.
+      # `ref` must be a BRANCH, not a commit SHA. The action's README claims a SHA is accepted,
+      # but the underlying workflow-dispatches API rejects one outright:
+      #   Error: No ref found for: 1e68d40ad1a113da0c832da1bb54af3486947e8b
+      # Use the branch the candidate actually lives on rather than a hardcoded `main`, so this
+      # keeps working once XTS runs on release branches. The exact candidate commit is still
+      # pinned -- it is handed to 106 as the `ref` input, which 106 checks out. The xts-candidate
+      # tag is not an option either; fetch-xts-candidate has already deleted it by this point.
       - name: "Trigger 106: [DISP] XTS Optional Tests"
         uses: step-security/workflow-dispatch@b4c1dc0afa074d0b4f0e653d3b80d4b2798599aa # v1.2.7
         with:
           workflow: .github/workflows/106-disp-xts-optional-tests.yaml
           repo: hiero-ledger/hiero-consensus-node # ensure we are executing in the hiero-ledger org
-          ref: ${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}
+          ref: ${{ needs.fetch-xts-candidate.outputs.xts-commit-branch }}
           token: ${{ secrets.GH_ACCESS_TOKEN }}
           inputs: '{
             "ref": "${{ needs.fetch-xts-candidate.outputs.xts-tag-commit }}",

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -255,6 +255,25 @@ jobs:
           fi
           set -e
 
+          # XTS_COMMIT_BRANCH is now load-bearing: deploy-xts-optional-trigger dispatches 106 on
+          # it, and the workflow-dispatch API only accepts a branch or tag. git name-rev can hand
+          # back something that is not a dispatchable branch (a commit reachable only from a tag,
+          # or from a branch that has since been deleted), so check it and warn rather than fail -
+          # mandatory XTS does not depend on this value, only the optional dispatch does.
+          set +e
+          git show-ref --verify --quiet "refs/remotes/origin/${XTS_COMMIT_BRANCH}"
+          BRANCH_IS_DISPATCHABLE="${?}"
+          set -e
+          if [[ "${BRANCH_IS_DISPATCHABLE}" -ne 0 ]]; then
+            echo "::warning title=XTS candidate branch not dispatchable::Resolved branch '${XTS_COMMIT_BRANCH}' for commit ${XTS_COMMIT} does not exist as refs/remotes/origin/${XTS_COMMIT_BRANCH}. Mandatory XTS is unaffected, but the optional XTS dispatch will likely fail with 'No ref found for: ${XTS_COMMIT_BRANCH}'."
+            {
+              echo "### Optional XTS dispatch may fail"
+              echo ""
+              echo "Resolved branch \`${XTS_COMMIT_BRANCH}\` for commit \`${XTS_COMMIT}\` is not a remote branch."
+              echo "Mandatory XTS is unaffected; only the 106 dispatch depends on this value."
+            } >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
           # Print branch debug info
           echo "::debug::XTS_COMMIT_BRANCH=${XTS_COMMIT_BRANCH}"
           echo "::debug::COMMIT_ON_DEFAULT_BRANCH=${COMMIT_ON_DEFAULT_BRANCH}"


### PR DESCRIPTION
## Problem

Every optional-XTS dispatch from `900` is failing:

```
Run step-security/workflow-dispatch@b4c1dc0...
  with:
    ref: 1e68d40ad1a113da0c832da1bb54af3486947e8b
🔎 Found workflow, id: 343942254, name: 106: [DISP] XTS Optional Tests
🚀 Calling GitHub API to dispatch workflow...
Error: No ref found for: 1e68d40ad1a113da0c832da1bb54af3486947e8b
```

`900` passes the candidate commit SHA as `ref`. The workflow-dispatches REST endpoint does not accept a SHA — it documents `ref` as *"The reference can be a branch or tag name."*

**The action's README is wrong.** It claims *"The reference can be a branch, tag, or a commit SHA."* It isn't; the action just forwards `ref` to the API, which rejects it. That README claim is what motivated the SHA in the first place.

## Fix

Dispatch on `fetch-xts-candidate.outputs.xts-commit-branch` — the branch the candidate actually lives on — rather than a hardcoded `main`. That satisfies the API constraint while still being correct once XTS runs on release branches.

**The candidate commit is not lost.** It is still passed to `106` as the `ref` *input*, and that is what `106` checks out. The only thing now taken from the branch tip is `106`'s own workflow definition — an unavoidable consequence of the API only accepting branches/tags.

The `xts-candidate` tag is not an option either: `fetch-xts-candidate` deletes it (`git push --delete origin`) before this job runs.

## Verification

- `actionlint`: no structural findings
- Reusable-workflow call-site contract audit across the repo: 0 violations

## Note (unrelated, seen in the same log)

The action pins to a Node 20 runtime and emits a `url.parse()` deprecation warning; GitHub is deprecating Node 20 on runners. Worth a follow-up to bump `step-security/workflow-dispatch` once a Node 24 release exists — not addressed here.