### PR TITLE
fix(chewie): Erroneously passing repository value

### DIFF
--- a/.github/workflows/859-call-create-chewie-request.yaml
+++ b/.github/workflows/859-call-create-chewie-request.yaml
@@ -159,7 +159,7 @@ jobs:
             -n ${{ github.run_number }} \
             -t ${{ github.run_attempt }} \
             -o "${{ github.repository_owner }}" \
-            -r "${{ github.repository }}" \
+            -r "${{ github.event.repository.name }}" \
             -j "${{ github.job }}" \
             -e ${REQUEST_TIMEOUT}
           )


### PR DESCRIPTION
## Description

This pull request makes a small update to the workflow file to ensure the correct repository name is used in job parameters. Specifically, it changes the source of the repository name from the full repository identifier to just the repository name.

- Workflow improvement:
  * [`.github/workflows/859-call-create-chewie-request.yaml`](diffhunk://#diff-17b9b91172b90a2927cde3fe927bd0961e0ca2d5c185dc677af6166c6c29faebL162-R162): Updated the `-r` parameter to use `${{ github.event.repository.name }}` instead of `${{ github.repository }}` for more accurate repository name handling.
