### PR TITLE
fix: require a node-controlled payer for NODE-category transactions

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/WorkflowsInjectionModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/WorkflowsInjectionModule.java
@@ -7,6 +7,8 @@ import com.hedera.node.app.throttle.ThrottleAccumulator;
 import com.hedera.node.app.throttle.ThrottleMetrics;
 import com.hedera.node.app.throttle.annotations.BackendThrottle;
 import com.hedera.node.app.workflows.handle.HandleWorkflowModule;
+import com.hedera.node.app.workflows.handle.dispatch.LiveNodeControlledPayerGuard;
+import com.hedera.node.app.workflows.handle.dispatch.NodeControlledPayerGuard;
 import com.hedera.node.app.workflows.ingest.IngestWorkflowInjectionModule;
 import com.hedera.node.app.workflows.prehandle.PreHandleWorkflowInjectionModule;
 import com.hedera.node.app.workflows.query.QueryWorkflowInjectionModule;
@@ -36,6 +38,16 @@ public interface WorkflowsInjectionModule {
     @Singleton
     static AtomicBoolean provideMaybeSystemEntitiesCreatedFlag(@NonNull final InitTrigger initTrigger) {
         return initTrigger == InitTrigger.GENESIS ? new AtomicBoolean(false) : null;
+    }
+
+    /**
+     * A real consensus node enforces the NODE-category foreign-payer guard; only the in-process standalone transaction
+     * executor (see {@code StandaloneModule}) binds a no-op.
+     */
+    @Provides
+    @Singleton
+    static NodeControlledPayerGuard provideNodeControlledPayerGuard() {
+        return new LiveNodeControlledPayerGuard();
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidator.java
@@ -2,6 +2,7 @@
 package com.hedera.node.app.workflows.handle.dispatch;
 
 import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_PAYER_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_PAYER_SIGNATURE;
 import static com.hedera.hapi.util.HapiUtils.isHollow;
 import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.BATCH_INNER;
@@ -45,6 +46,13 @@ public class DispatchValidator {
     private final TransactionChecker transactionChecker;
     private final AppFeeCharging feeCharging;
 
+    /**
+     * Decides whether a NODE-category dispatch with a non-node-controlled payer must be rejected. A live consensus node
+     * enforces this; the in-process standalone transaction executor binds a no-op. Encapsulated behind a policy object
+     * so this validator does not need to know why the standalone executor is exempt, only whether to reject.
+     */
+    private final NodeControlledPayerGuard nodeControlledPayerGuard;
+
     @Nullable
     private final AtomicBoolean systemEntitiesCreatedFlag;
 
@@ -53,17 +61,22 @@ public class DispatchValidator {
      *
      * @param recordCache the record cache
      * @param transactionChecker the transaction checker
+     * @param feeCharging the fee-charging strategy
+     * @param systemEntitiesCreatedFlag the genesis system-entities-created flag (present only on a genesis boot)
+     * @param nodeControlledPayerGuard the NODE-category foreign-payer guard for this component
      */
     @Inject
     public DispatchValidator(
             @NonNull final HederaRecordCache recordCache,
             @NonNull final TransactionChecker transactionChecker,
             @NonNull final AppFeeCharging feeCharging,
-            @Nullable final AtomicBoolean systemEntitiesCreatedFlag) {
+            @Nullable final AtomicBoolean systemEntitiesCreatedFlag,
+            @NonNull final NodeControlledPayerGuard nodeControlledPayerGuard) {
         this.recordCache = requireNonNull(recordCache);
         this.transactionChecker = requireNonNull(transactionChecker);
         this.feeCharging = requireNonNull(feeCharging);
         this.systemEntitiesCreatedFlag = systemEntitiesCreatedFlag;
+        this.nodeControlledPayerGuard = requireNonNull(nodeControlledPayerGuard);
     }
 
     /**
@@ -77,6 +90,14 @@ public class DispatchValidator {
     public FeeCharging.Validation validateFeeChargingScenario(@NonNull final Dispatch dispatch) {
         if (systemEntitiesCreatedFlag != null && !systemEntitiesCreatedFlag.get()) {
             return newGenesisWaiver(dispatch.creatorInfo().accountId());
+        }
+        // A NODE-category dispatch skips payer-signature verification below, so its payer MUST be node-controlled.
+        // Any other payer means a node is charging a foreign account it never authorized; treat it as a node
+        // due-diligence failure so the creator node is charged instead of the named payer. Genesis is already waived
+        // above. The guard enforces this on a live consensus node and is a no-op in the standalone executor, which
+        // legitimately dispatches NODE transactions with a caller-chosen payer.
+        if (nodeControlledPayerGuard.rejectsForeignNodePayer(dispatch)) {
+            return newCreatorError(dispatch.creatorInfo().accountId(), INVALID_PAYER_ACCOUNT_ID);
         }
         final var creatorError = creatorErrorIfKnown(dispatch);
         if (creatorError != null) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/LiveNodeControlledPayerGuard.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/LiveNodeControlledPayerGuard.java
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.workflows.handle.dispatch;
+
+import static com.hedera.node.app.spi.workflows.HandleContext.TransactionCategory.NODE;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.node.app.workflows.handle.Dispatch;
+import com.hedera.node.config.data.AccountsConfig;
+import com.hedera.node.config.data.HederaConfig;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * The live consensus node {@link NodeControlledPayerGuard}: a NODE-category dispatch is rejected unless its payer is
+ * node-controlled. Only two payers are node-controlled and therefore legitimate: the configured system admin account
+ * (used by synthetically dispatched system transactions such as node fee payments) and the creator node's own account
+ * (used by gossiped node-submitted votes the node pays for itself).
+ */
+@Singleton
+public class LiveNodeControlledPayerGuard implements NodeControlledPayerGuard {
+    @Inject
+    public LiveNodeControlledPayerGuard() {
+        // Dagger
+    }
+
+    @Override
+    public boolean rejectsForeignNodePayer(@NonNull final Dispatch dispatch) {
+        return dispatch.txnCategory() == NODE && !payerIsNodeControlled(dispatch);
+    }
+
+    private boolean payerIsNodeControlled(@NonNull final Dispatch dispatch) {
+        final var payerId = dispatch.payerId();
+        if (payerId.equals(dispatch.creatorInfo().accountId())) {
+            return true;
+        }
+        final var config = dispatch.config();
+        final var hederaConfig = config.getConfigData(HederaConfig.class);
+        final var accountsConfig = config.getConfigData(AccountsConfig.class);
+        final var systemAdminId = AccountID.newBuilder()
+                .shardNum(hederaConfig.shard())
+                .realmNum(hederaConfig.realm())
+                .accountNum(accountsConfig.systemAdmin())
+                .build();
+        return payerId.equals(systemAdminId);
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/NoOpNodeControlledPayerGuard.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/NoOpNodeControlledPayerGuard.java
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.workflows.handle.dispatch;
+
+import com.hedera.node.app.workflows.handle.Dispatch;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * The no-op {@link NodeControlledPayerGuard} bound by the in-process standalone transaction executor, which
+ * legitimately dispatches NODE-category transactions (empty signature map) with a caller-chosen payer. It never
+ * rejects, regardless of the dispatch — this is a deliberate, unconditional exemption, not an unfinished stub.
+ */
+@Singleton
+public class NoOpNodeControlledPayerGuard implements NodeControlledPayerGuard {
+    @Inject
+    public NoOpNodeControlledPayerGuard() {
+        // Dagger
+    }
+
+    @Override
+    public boolean rejectsForeignNodePayer(@NonNull final Dispatch dispatch) {
+        return false;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/NodeControlledPayerGuard.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/dispatch/NodeControlledPayerGuard.java
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.workflows.handle.dispatch;
+
+import com.hedera.node.app.workflows.handle.Dispatch;
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+/**
+ * Decides whether a NODE-category dispatch must be rejected because its payer is not node-controlled.
+ *
+ * <p>A NODE-category transaction (empty signature map) skips payer-signature verification, so its payer must be a
+ * node-controlled account. On a live consensus node this is enforced; the in-process standalone transaction executor
+ * legitimately dispatches NODE-category transactions with a caller-chosen payer and therefore binds a no-op that never
+ * rejects. A consumer only needs to know <em>whether</em> to reject, not <em>why</em> it is (or is not) exempt.
+ */
+public interface NodeControlledPayerGuard {
+    /**
+     * Returns whether the given dispatch must be rejected as a node due-diligence failure because it is a
+     * NODE-category dispatch whose payer is not node-controlled.
+     *
+     * @param dispatch the dispatch
+     * @return true if the dispatch must be rejected
+     */
+    boolean rejectsForeignNodePayer(@NonNull Dispatch dispatch);
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneModule.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/standalone/impl/StandaloneModule.java
@@ -12,6 +12,8 @@ import com.hedera.node.app.spi.metrics.StoreMetricsService;
 import com.hedera.node.app.throttle.ThrottleAccumulator;
 import com.hedera.node.app.throttle.ThrottleMetrics;
 import com.hedera.node.app.throttle.annotations.BackendThrottle;
+import com.hedera.node.app.workflows.handle.dispatch.NoOpNodeControlledPayerGuard;
+import com.hedera.node.app.workflows.handle.dispatch.NodeControlledPayerGuard;
 import com.hedera.node.config.ConfigProvider;
 import com.swirlds.metrics.api.Metrics;
 import dagger.Binds;
@@ -33,6 +35,17 @@ public interface StandaloneModule {
     @Singleton
     static AtomicBoolean provideMaybeSystemEntitiesCreatedFlag() {
         return null;
+    }
+
+    /**
+     * The standalone transaction executor legitimately dispatches NODE-category transactions (empty signature map)
+     * with a caller-chosen payer, so the NODE-payer due-diligence guard in {@code DispatchValidator} must not apply
+     * here; it binds a no-op that never rejects.
+     */
+    @Provides
+    @Singleton
+    static NodeControlledPayerGuard provideNodeControlledPayerGuard() {
+        return new NoOpNodeControlledPayerGuard();
     }
 
     @Provides

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/WorkflowsInjectionModuleTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/WorkflowsInjectionModuleTest.java
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.workflows;
+
+import static com.swirlds.platform.system.InitTrigger.GENESIS;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import com.hedera.node.app.workflows.handle.dispatch.LiveNodeControlledPayerGuard;
+import com.swirlds.platform.system.InitTrigger;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class WorkflowsInjectionModuleTest {
+    @Test
+    void genesisBootYieldsUnsetSystemEntitiesFlag() {
+        final var flag = WorkflowsInjectionModule.provideMaybeSystemEntitiesCreatedFlag(GENESIS);
+        assertNotNull(flag, "a genesis boot must have a system-entities flag so the genesis waiver can run");
+        assertFalse(flag.get(), "the flag starts unset until system entities are created");
+    }
+
+    /**
+     * Contract that keeps {@code DispatchValidator}'s genesis waiver ({@code systemEntitiesCreatedFlag != null &&
+     * !flag.get()}) from firing on a live node that did not boot at genesis. If a non-genesis boot ever returned a
+     * non-null flag, that flag would stay unset (system entities are not recreated on restart/reconnect), the waiver
+     * would fire, and the NODE foreign-payer guard would be skipped — silently letting a foreign-payer NODE dispatch
+     * through again. The guard itself is boot-independent (it is bound per component), but this waiver still reads the
+     * flag, so the "non-genesis ⇒ null" contract is load-bearing.
+     */
+    @ParameterizedTest
+    @EnumSource(
+            value = InitTrigger.class,
+            mode = EnumSource.Mode.EXCLUDE,
+            names = {"GENESIS"})
+    void nonGenesisBootYieldsNullSystemEntitiesFlag(final InitTrigger trigger) {
+        assertNull(WorkflowsInjectionModule.provideMaybeSystemEntitiesCreatedFlag(trigger));
+    }
+
+    @Test
+    void realNodeBindsTheLiveNodeControlledPayerGuard() {
+        // The real node must bind the live guard so DispatchValidator's NODE-payer guard fires; only the standalone
+        // executor (StandaloneModule) binds a no-op. Pins the signal against a future regression that would silently
+        // disable the guard network-wide.
+        assertInstanceOf(
+                LiveNodeControlledPayerGuard.class, WorkflowsInjectionModule.provideNodeControlledPayerGuard());
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/DispatchValidatorTest.java
@@ -5,6 +5,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.DUPLICATE_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_PAYER_ACCOUNT_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_PAYER_SIGNATURE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_DURATION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
@@ -57,10 +58,12 @@ import com.hedera.node.app.workflows.TransactionChecker;
 import com.hedera.node.app.workflows.TransactionInfo;
 import com.hedera.node.app.workflows.handle.Dispatch;
 import com.hedera.node.app.workflows.prehandle.PreHandleResult;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.time.Instant;
 import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.hiero.consensus.model.node.NodeId;
 import org.junit.jupiter.api.BeforeEach;
@@ -106,7 +109,15 @@ class DispatchValidatorTest {
 
     @BeforeEach
     void setUp() {
-        subject = new DispatchValidator(recordCache, transactionChecker, new AppFeeCharging(solvencyPreCheck), null);
+        // A live consensus node that booted from a restart/reconnect: system-entities flag is null (only a genesis
+        // boot has it), and the live guard is bound (a no-op only in the standalone executor). This is the boot state
+        // where the NODE-payer guard must apply.
+        subject = new DispatchValidator(
+                recordCache,
+                transactionChecker,
+                new AppFeeCharging(solvencyPreCheck),
+                null,
+                new LiveNodeControlledPayerGuard());
     }
 
     @Test
@@ -197,6 +208,86 @@ class DispatchValidatorTest {
                         NOT_INGEST,
                         CHECK_OFFERED_FEE);
         assertEquals(newSuccess(dispatch.creatorInfo().accountId(), payerAccount), report);
+    }
+
+    @Test
+    void nodeCategoryForeignPayerAllowedInStandaloneExecutor() throws PreCheckException {
+        // The in-process standalone transaction executor legitimately dispatches NODE-category transactions
+        // (empty signature map) with a caller-chosen, non-node payer. It binds a no-op guard (never rejects), so the
+        // dispatch proceeds to a normal success.
+        final var standaloneSubject = new DispatchValidator(
+                recordCache,
+                transactionChecker,
+                new AppFeeCharging(solvencyPreCheck),
+                null,
+                new NoOpNodeControlledPayerGuard());
+        givenCreatorInfo();
+        givenNodeDispatch();
+        givenNonDuplicate();
+        givenSolvencyCheckSetup();
+        given(dispatch.preHandleResult()).willReturn(SUCCESSFUL_PREHANDLE);
+        final var payerAccount = givenPayer(payer -> payer.tinybarBalance(1L));
+        doCallRealMethod().when(dispatch).feeChargingOrElse(any());
+
+        final var report = standaloneSubject.validateFeeChargingScenario(dispatch);
+
+        assertEquals(newSuccess(dispatch.creatorInfo().accountId(), payerAccount), report);
+    }
+
+    @Test
+    void nodeCategoryForeignPayerRejectedOnRestartedNode() {
+        // Regression guard: a restarted/reconnected live node has a null system-entities flag but still binds the live
+        // guard. The NODE-payer guard must still fire (it is bound per component, not gated on the genesis flag), so a
+        // foreign payer is a node due-diligence failure. Under the old flag-based gate this dispatch was wrongly
+        // allowed. The default subject is exactly this boot state (flag=null, live guard bound).
+        givenCreatorInfo();
+        givenNodeDispatch();
+        given(dispatch.payerId()).willReturn(PAYER_ACCOUNT_ID);
+        given(dispatch.config()).willReturn(HederaTestConfigBuilder.createConfig());
+
+        final var report = subject.validateFeeChargingScenario(dispatch);
+
+        assertEquals(newCreatorError(CREATOR_ACCOUNT_ID, INVALID_PAYER_ACCOUNT_ID), report);
+    }
+
+    @Test
+    void nodeCategoryForeignPayerRejectedOnGenesisBootedNode() {
+        // Companion to nodeCategoryForeignPayerRejectedOnRestartedNode. A node that booted at genesis and finished
+        // creating system entities holds a present, set flag (new AtomicBoolean(true)) — a real production state. The
+        // live guard fires independently of the flag, so a foreign NODE payer is rejected just as on a restarted node.
+        // Together the two tests show the guard fires identically regardless of boot type.
+        final var genesisBootedNode = new DispatchValidator(
+                recordCache,
+                transactionChecker,
+                new AppFeeCharging(solvencyPreCheck),
+                new AtomicBoolean(true),
+                new LiveNodeControlledPayerGuard());
+        givenCreatorInfo();
+        givenNodeDispatch();
+        given(dispatch.payerId()).willReturn(PAYER_ACCOUNT_ID);
+        given(dispatch.config()).willReturn(HederaTestConfigBuilder.createConfig());
+
+        final var report = genesisBootedNode.validateFeeChargingScenario(dispatch);
+
+        assertEquals(newCreatorError(CREATOR_ACCOUNT_ID, INVALID_PAYER_ACCOUNT_ID), report);
+    }
+
+    @Test
+    void nodeCategoryCreatorPayerAllowedOnLiveNode() throws PreCheckException {
+        // The creator node's own account is a legitimate NODE-category payer (gossiped node-submitted votes), so the
+        // guard permits it on a live node. Uses the default subject (a live node with the live guard bound), which is
+        // all the guard depends on; the genesis flag is irrelevant to this decision.
+        givenCreatorInfo();
+        givenNodeDispatch();
+        givenNonDuplicate();
+        givenSolvencyCheckSetup();
+        given(dispatch.preHandleResult()).willReturn(SUCCESSFUL_PREHANDLE);
+        final var payerAccount = givenPayer(CREATOR_ACCOUNT_ID, payer -> payer.tinybarBalance(1L));
+        doCallRealMethod().when(dispatch).feeChargingOrElse(any());
+
+        final var report = subject.validateFeeChargingScenario(dispatch);
+
+        assertEquals(newSuccess(CREATOR_ACCOUNT_ID, payerAccount), report);
     }
 
     @Test
@@ -467,19 +558,27 @@ class DispatchValidatorTest {
         given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.SCHEDULED);
     }
 
+    private void givenNodeDispatch() {
+        given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.NODE);
+    }
+
     private void givenCreatorInfo() {
         given(dispatch.creatorInfo()).willReturn(creatorInfo);
         given(creatorInfo.accountId()).willReturn(CREATOR_ACCOUNT_ID);
     }
 
     private Account givenPayer(@NonNull final Consumer<Account.Builder> spec) {
-        given(dispatch.payerId()).willReturn(PAYER_ACCOUNT_ID);
+        return givenPayer(PAYER_ACCOUNT_ID, spec);
+    }
+
+    private Account givenPayer(@NonNull final AccountID payerId, @NonNull final Consumer<Account.Builder> spec) {
+        given(dispatch.payerId()).willReturn(payerId);
         given(dispatch.readableStoreFactory()).willReturn(storeFactory);
         given(storeFactory.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
-        final var payer = Account.newBuilder().accountId(PAYER_ACCOUNT_ID).key(Key.DEFAULT);
+        final var payer = Account.newBuilder().accountId(payerId).key(Key.DEFAULT);
         spec.accept(payer);
         final var payerAccount = payer.build();
-        given(readableAccountStore.getAccountById(PAYER_ACCOUNT_ID)).willReturn(payerAccount);
+        given(readableAccountStore.getAccountById(payerId)).willReturn(payerAccount);
         return payerAccount;
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/LiveNodeControlledPayerGuardTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/dispatch/LiveNodeControlledPayerGuardTest.java
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.workflows.handle.dispatch;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.node.app.spi.info.NodeInfo;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.workflows.handle.Dispatch;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class LiveNodeControlledPayerGuardTest {
+    private static final AccountID CREATOR_ACCOUNT_ID =
+            AccountID.newBuilder().accountNum(3).build();
+    private static final AccountID FOREIGN_PAYER_ID =
+            AccountID.newBuilder().accountNum(1_234).build();
+    // 0.0.50 is the default systemAdmin account (see AccountsConfig)
+    private static final AccountID SYSTEM_ADMIN_ID =
+            AccountID.newBuilder().accountNum(50).build();
+
+    @Mock
+    private Dispatch dispatch;
+
+    @Mock
+    private NodeInfo creatorInfo;
+
+    private final LiveNodeControlledPayerGuard subject = new LiveNodeControlledPayerGuard();
+
+    @Test
+    void rejectsNodeCategoryForeignPayer() {
+        given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.NODE);
+        given(dispatch.payerId()).willReturn(FOREIGN_PAYER_ID);
+        givenCreatorInfo();
+        given(dispatch.config()).willReturn(HederaTestConfigBuilder.createConfig());
+
+        assertTrue(subject.rejectsForeignNodePayer(dispatch));
+    }
+
+    @Test
+    void allowsNodeCategoryCreatorPayer() {
+        given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.NODE);
+        given(dispatch.payerId()).willReturn(CREATOR_ACCOUNT_ID);
+        givenCreatorInfo();
+
+        assertFalse(subject.rejectsForeignNodePayer(dispatch));
+    }
+
+    @Test
+    void allowsNodeCategorySystemAdminPayer() {
+        given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.NODE);
+        given(dispatch.payerId()).willReturn(SYSTEM_ADMIN_ID);
+        givenCreatorInfo();
+        given(dispatch.config()).willReturn(HederaTestConfigBuilder.createConfig());
+
+        assertFalse(subject.rejectsForeignNodePayer(dispatch));
+    }
+
+    @Test
+    void doesNotApplyToNonNodeCategory() {
+        // The guard only concerns NODE-category dispatches (which skip payer-sig verification); a foreign payer on
+        // any other category is not this guard's business, so it never rejects.
+        given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.USER);
+
+        assertFalse(subject.rejectsForeignNodePayer(dispatch));
+    }
+
+    private void givenCreatorInfo() {
+        given(dispatch.creatorInfo()).willReturn(creatorInfo);
+        given(creatorInfo.accountId()).willReturn(CREATOR_ACCOUNT_ID);
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/impl/StandaloneModuleTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/standalone/impl/StandaloneModuleTest.java
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.workflows.standalone.impl;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.mockito.Mockito.mock;
+
+import com.hedera.node.app.workflows.handle.Dispatch;
+import com.hedera.node.app.workflows.handle.dispatch.NoOpNodeControlledPayerGuard;
+import org.junit.jupiter.api.Test;
+
+class StandaloneModuleTest {
+    @Test
+    void standaloneExecutorBindsANoOpNodeControlledPayerGuard() {
+        // The standalone transaction executor must bind the no-op guard so DispatchValidator's NODE-payer guard stays
+        // exempt for its sig-map-less, caller-payer dispatches (e.g. Mirror Node gas estimation / eth_call). A
+        // regression to the live guard here would reject those and break the Mirror Node executor.
+        final var guard = StandaloneModule.provideNodeControlledPayerGuard();
+        assertInstanceOf(NoOpNodeControlledPayerGuard.class, guard);
+        assertFalse(guard.rejectsForeignNodePayer(mock(Dispatch.class)));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NodeCategoryForeignPayerTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/NodeCategoryForeignPayerTest.java
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.crypto;
+
+import static com.hedera.services.bdd.junit.ContextRequirement.SYSTEM_ACCOUNT_BALANCES;
+import static com.hedera.services.bdd.junit.EmbeddedReason.MUST_SKIP_INGEST;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.reducedFromSnapshot;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.unchangedFromSnapshot;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.balanceSnapshot;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_PAYER_ACCOUNT_ID;
+
+import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+
+/**
+ * Verifies that a NODE-category transaction (one with an empty signature map) cannot debit a foreign
+ * account named as its payer.
+ *
+ * <p>A transaction with an empty signature map is categorized as a {@code NODE} transaction (see
+ * {@code ParentTxnFactory#getTxnCategory}), and NODE transactions skip payer-signature verification.
+ * Such a transaction can reach consensus without ingest checks when it is submitted directly to a
+ * non-default node. If it names a foreign account as its payer (which is also the sole sender, so the
+ * payer key is the very key NODE category skips), then without a guard the transfer would debit that
+ * account with no signature at all.
+ *
+ * <p>{@code DispatchValidator} treats a NODE-category dispatch whose payer is neither the system admin
+ * account nor the creator node's own account as a node due-diligence failure: the transaction fails with
+ * {@code INVALID_PAYER_ACCOUNT_ID}, the named payer is left untouched, and the submitting node is charged
+ * the network fee. This mirrors the existing {@code DuplicateManagementTest} behavior for an authorized
+ * (USER) transaction submitted without a valid payer signature.
+ */
+public class NodeCategoryForeignPayerTest {
+    private static final String FOREIGN_PAYER = "foreignPayer";
+    // 0.0.4 is a non-default node; submitting to it skips ingest in embedded mode
+    private static final String SUBMITTING_NODE_ACCOUNT_ID = "4";
+
+    @LeakyEmbeddedHapiTest(reason = MUST_SKIP_INGEST, requirement = SYSTEM_ACCOUNT_BALANCES)
+    @DisplayName("a node cannot debit a foreign payer with an unsigned NODE-category transaction")
+    final Stream<DynamicTest> nodeCannotDebitForeignPayerWithUnsignedNodeTransaction() {
+        return hapiTest(
+                cryptoCreate(FOREIGN_PAYER).balance(ONE_HUNDRED_HBARS),
+                // Fund the submitting node so we can observe it being charged the network fee
+                cryptoTransfer(tinyBarsFromTo(GENESIS, SUBMITTING_NODE_ACCOUNT_ID, ONE_HBAR)),
+                balanceSnapshot("foreignPayerPre", FOREIGN_PAYER),
+                balanceSnapshot("nodePre", SUBMITTING_NODE_ACCOUNT_ID),
+                // Submit an unsigned transfer directly to a non-default node (skipping ingest) that names
+                // the foreign account as payer; the empty signature map makes it a NODE transaction, which
+                // skips payer-sig checks
+                cryptoTransfer(tinyBarsFromTo(FOREIGN_PAYER, SUBMITTING_NODE_ACCOUNT_ID, ONE_HBAR))
+                        .payingWithNoSig(FOREIGN_PAYER)
+                        .signedBy()
+                        .fee(ONE_HBAR)
+                        .setNode(SUBMITTING_NODE_ACCOUNT_ID)
+                        .hasKnownStatus(INVALID_PAYER_ACCOUNT_ID),
+                // The foreign payer keeps every tinybar...
+                getAccountBalance(FOREIGN_PAYER).hasTinyBars(unchangedFromSnapshot("foreignPayerPre")),
+                // ...and the submitting node is charged the network fee for its due-diligence failure
+                getAccountBalance(SUBMITTING_NODE_ACCOUNT_ID).hasTinyBars(reducedFromSnapshot("nodePre")));
+    }
+}


### PR DESCRIPTION
Stacked release/0.76 migration PR 5 of 17.

Depends on sync/release-0.76/004-pr-523.
Original source PR number: 506
Original source commit: 3bc492ec2a9d2d3d2d693d63362d470c5db46d09

After the base PR merges, retarget this PR to release/0.76. Merge with Create a merge commit; do not squash or rebase merge.