### PR TITLE
chore: upgrade io.netty:netty-codec-http to 4.2.17.Final

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 dependencies {
-    api(platform("io.netty:netty-bom:4.2.15.Final"))
+    api(platform("io.netty:netty-bom:4.2.17.Final"))
 
     // forward logging from modules using SLF4J (e.g. 'org.hyperledger.besu.evm') to Log4J
     runtime("org.apache.logging.log4j:log4j-slf4j2-impl") {
@@ -28,6 +28,7 @@ val tuweni = "2.4.2"
 val webcompare = "2.1.8"
 
 dependencies.constraints {
+    api("io.netty:netty-codec-http:4.2.17.Final") { because("io.netty.codec.http") }
     api("io.helidon.common:helidon-common:$helidon") { because("io.helidon.common") }
     api("io.helidon.webclient:helidon-webclient:$helidon") { because("io.helidon.webclient") }
     api("io.helidon.webclient:helidon-webclient-grpc:$helidon") {


### PR DESCRIPTION
Stacked release/0.76 migration PR 17 of 17.

Depends on sync/release-0.76/016-pr-526.
Original source PR number: 527
Original source commit: 1844609b455009a0edee5ff44f7bdf106f3d028d

After the base PR merges, retarget this PR to release/0.76. Merge with Create a merge commit; do not squash or rebase merge.