### PR TITLE
fix: guard exchange-rate fee conversion against non-positive centEquiv and overflow

### DIFF
--- a/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/calc/OverflowCheckingCalc.java
+++ b/hedera-node/hapi-fees/src/main/java/com/hedera/node/app/hapi/fees/calc/OverflowCheckingCalc.java
@@ -62,21 +62,32 @@ public final class OverflowCheckingCalc {
         final long unscaledNodeFee = tinycentsToTinybars(nodeFeeTinycents, rate);
         final long unscaledServiceFee = tinycentsToTinybars(serviceFeeTinycents, rate);
 
+        // Saturate each component instead of throwing: a degenerate rate makes an unscaled fee
+        // Long.MAX_VALUE, and an extreme congestion multiplier can overflow the product; either way the fee
+        // must clamp to the maximum (an unpayable fee) rather than halt fee calculation network-wide.
         final long maxUnscaled = Long.MAX_VALUE / multiplier;
-        if (unscaledNetworkFee > maxUnscaled || unscaledNodeFee > maxUnscaled || unscaledServiceFee > maxUnscaled) {
-            throw new IllegalArgumentException(OVERFLOW_ERROR);
-        }
+        final long scaledNodeFee = unscaledNodeFee > maxUnscaled ? Long.MAX_VALUE : unscaledNodeFee * multiplier;
+        final long scaledNetworkFee =
+                unscaledNetworkFee > maxUnscaled ? Long.MAX_VALUE : unscaledNetworkFee * multiplier;
+        final long scaledServiceFee =
+                unscaledServiceFee > maxUnscaled ? Long.MAX_VALUE : unscaledServiceFee * multiplier;
 
-        return new FeeObject(
-                unscaledNodeFee * multiplier, unscaledNetworkFee * multiplier, unscaledServiceFee * multiplier);
+        return new FeeObject(scaledNodeFee, scaledNetworkFee, scaledServiceFee);
     }
 
     public static long tinycentsToTinybars(final long amount, final ExchangeRate rate) {
         final var hbarEquiv = rate.getHbarEquiv();
+        final var centEquiv = rate.getCentEquiv();
+        // A non-positive centEquiv would divide by zero, and a non-positive hbarEquiv would make the fee
+        // free or negative; saturate to Long.MAX_VALUE so a degenerate rate yields an unpayable fee instead
+        // of throwing or under-charging identically on every node.
+        if (centEquiv <= 0 || hbarEquiv <= 0) {
+            return Long.MAX_VALUE;
+        }
         if (productWouldOverflow(amount, hbarEquiv)) {
             return FeeBuilder.getTinybarsFromTinyCents(rate, amount);
         }
-        return amount * hbarEquiv / rate.getCentEquiv();
+        return amount * hbarEquiv / centEquiv;
     }
 
     private long networkFeeInTinycents(final UsageAccumulator usage, final FeeComponents networkPrices) {

--- a/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/calc/OverflowCheckingCalcTest.java
+++ b/hedera-node/hapi-fees/src/test/java/com/hedera/node/app/hapi/fees/calc/OverflowCheckingCalcTest.java
@@ -24,11 +24,53 @@ class OverflowCheckingCalcTest {
     private static final OverflowCheckingCalc subject = new OverflowCheckingCalc();
 
     @Test
-    void throwsOnMultiplierOverflow() {
+    void saturatesOnMultiplierOverflow() {
         final var usage = new UsageAccumulator();
         copyData(mockUsage, usage);
 
-        assertThrows(IllegalArgumentException.class, () -> subject.fees(usage, mockPrices, mockRate, Long.MAX_VALUE));
+        // A multiplier that would overflow the per-component product now saturates to Long.MAX_VALUE
+        // instead of throwing, so extreme congestion pricing cannot halt fee calculation network-wide.
+        final var fees = subject.fees(usage, mockPrices, mockRate, Long.MAX_VALUE);
+
+        assertEquals(Long.MAX_VALUE, fees.nodeFee());
+        assertEquals(Long.MAX_VALUE, fees.networkFee());
+        assertEquals(Long.MAX_VALUE, fees.serviceFee());
+    }
+
+    @Test
+    void tinycentsToTinybarsSaturatesOnNonPositiveCentEquiv() {
+        // A zero centEquiv would divide by zero; saturate to Long.MAX_VALUE instead of throwing.
+        final var zeroCentRate =
+                ExchangeRate.newBuilder().setHbarEquiv(1).setCentEquiv(0).build();
+        assertEquals(Long.MAX_VALUE, OverflowCheckingCalc.tinycentsToTinybars(100L, zeroCentRate));
+    }
+
+    @Test
+    void tinycentsToTinybarsSaturatesOnNonPositiveHbarEquiv() {
+        // A non-positive hbarEquiv would make the fee free or negative; saturate instead.
+        final var zeroHbarRate =
+                ExchangeRate.newBuilder().setHbarEquiv(0).setCentEquiv(120).build();
+        assertEquals(Long.MAX_VALUE, OverflowCheckingCalc.tinycentsToTinybars(100L, zeroHbarRate));
+
+        final var negativeHbarRate =
+                ExchangeRate.newBuilder().setHbarEquiv(-3).setCentEquiv(120).build();
+        assertEquals(Long.MAX_VALUE, OverflowCheckingCalc.tinycentsToTinybars(100L, negativeHbarRate));
+    }
+
+    @Test
+    void feesSaturateOnDegenerateRate() {
+        final var usage = new UsageAccumulator();
+        copyData(mockUsage, usage);
+
+        // End-to-end: a degenerate rate (zero centEquiv) makes each per-component conversion saturate, so
+        // fees() must yield Long.MAX_VALUE per component rather than throwing an ArithmeticException.
+        final var degenerateRate =
+                ExchangeRate.newBuilder().setHbarEquiv(1).setCentEquiv(0).build();
+        final var fees = subject.fees(usage, mockPrices, degenerateRate, multiplier);
+
+        assertEquals(Long.MAX_VALUE, fees.nodeFee());
+        assertEquals(Long.MAX_VALUE, fees.networkFee());
+        assertEquals(Long.MAX_VALUE, fees.serviceFee());
     }
 
     @Test

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeBuilder.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/fee/FeeBuilder.java
@@ -21,6 +21,7 @@ import java.util.List;
  * calculate Fee for Crypto, File and Smart Contracts Transactions and Query
  */
 public class FeeBuilder {
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
     public static final long MAX_ENTITY_LIFETIME = 100L * 365L * 24L * 60L * 60L;
 
     public static final int LONG_SIZE = 8;
@@ -140,10 +141,13 @@ public class FeeBuilder {
         long networkFee = getComponentFeeInTinyCents(feeData.getNetworkdata(), feeMatrices.getNetworkdata());
         long nodeFee = getComponentFeeInTinyCents(feeData.getNodedata(), feeMatrices.getNodedata());
         long serviceFee = getComponentFeeInTinyCents(feeData.getServicedata(), feeMatrices.getServicedata());
-        // convert the Fee to tiny hbars
-        networkFee = FeeBuilder.getTinybarsFromTinyCents(exchangeRate, networkFee) * multiplier;
-        nodeFee = FeeBuilder.getTinybarsFromTinyCents(exchangeRate, nodeFee) * multiplier;
-        serviceFee = FeeBuilder.getTinybarsFromTinyCents(exchangeRate, serviceFee) * multiplier;
+        // convert the Fee to tiny hbars, clamping the congestion-multiplier scaling so a saturated conversion
+        // (from a degenerate rate) cannot wrap to a bogus, possibly negative, fee.
+        networkFee =
+                CommonUtils.clampedMultiply(FeeBuilder.getTinybarsFromTinyCents(exchangeRate, networkFee), multiplier);
+        nodeFee = CommonUtils.clampedMultiply(FeeBuilder.getTinybarsFromTinyCents(exchangeRate, nodeFee), multiplier);
+        serviceFee =
+                CommonUtils.clampedMultiply(FeeBuilder.getTinybarsFromTinyCents(exchangeRate, serviceFee), multiplier);
         return new FeeObject(nodeFee, networkFee, serviceFee);
     }
 
@@ -284,12 +288,16 @@ public class FeeBuilder {
     }
 
     private static long getAFromB(final long bAmount, final int aEquiv, final int bEquiv) {
-        final var aMultiplier = BigInteger.valueOf(aEquiv);
-        final var bDivisor = BigInteger.valueOf(bEquiv);
-        return BigInteger.valueOf(bAmount)
-                .multiply(aMultiplier)
-                .divide(bDivisor)
-                .longValueExact();
+        // A degenerate exchange rate would either divide by zero (non-positive divisor) or make the result
+        // free/negative (non-positive multiplier); saturate to Long.MAX_VALUE instead so a malformed rate
+        // yields an unpayable fee and cannot halt fee conversion network-wide.
+        if (aEquiv <= 0 || bEquiv <= 0) {
+            return Long.MAX_VALUE;
+        }
+        final var result =
+                BigInteger.valueOf(bAmount).multiply(BigInteger.valueOf(aEquiv)).divide(BigInteger.valueOf(bEquiv));
+        // longValueExact() throws when the result exceeds the long range; saturate to the maximum instead.
+        return result.compareTo(LONG_MAX) >= 0 ? Long.MAX_VALUE : result.longValue();
     }
 
     public static FeeData getFeeDataMatrices(

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/FeeBuilderTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/fee/FeeBuilderTest.java
@@ -114,6 +114,46 @@ class FeeBuilderTest {
     }
 
     @Test
+    void getTinybarsFromTinyCentsSaturatesInsteadOfThrowing() {
+        // A zero centEquiv would divide by zero -> saturate to Long.MAX_VALUE instead of throwing.
+        var zeroCentRate =
+                ExchangeRate.newBuilder().setHbarEquiv(1).setCentEquiv(0).build();
+        assertEquals(Long.MAX_VALUE, FeeBuilder.getTinybarsFromTinyCents(zeroCentRate, 100L));
+
+        // A result beyond the long range would overflow longValueExact() -> saturate instead of throwing.
+        var skewedRate = ExchangeRate.newBuilder()
+                .setHbarEquiv(Integer.MAX_VALUE)
+                .setCentEquiv(1)
+                .build();
+        assertEquals(Long.MAX_VALUE, FeeBuilder.getTinybarsFromTinyCents(skewedRate, Long.MAX_VALUE / 2));
+    }
+
+    @Test
+    void getTinybarsFromTinyCentsSaturatesOnNonPositiveHbarEquiv() {
+        // A non-positive hbarEquiv would make the conversion free (== 0) or negative; saturate to
+        // Long.MAX_VALUE so a degenerate rate yields an unpayable fee rather than a wrong one.
+        var zeroHbarRate =
+                ExchangeRate.newBuilder().setHbarEquiv(0).setCentEquiv(100).build();
+        assertEquals(Long.MAX_VALUE, FeeBuilder.getTinybarsFromTinyCents(zeroHbarRate, 100L));
+
+        var negativeHbarRate =
+                ExchangeRate.newBuilder().setHbarEquiv(-5).setCentEquiv(100).build();
+        assertEquals(Long.MAX_VALUE, FeeBuilder.getTinybarsFromTinyCents(negativeHbarRate, 100L));
+    }
+
+    @Test
+    void getFeeObjectSaturatesMultiplierOnDegenerateRate() {
+        // A degenerate rate makes the per-component conversion saturate to Long.MAX_VALUE; multiplying by the
+        // congestion multiplier must clamp to Long.MAX_VALUE rather than wrap to a bogus (possibly negative) fee.
+        var zeroCentRate =
+                ExchangeRate.newBuilder().setHbarEquiv(1).setCentEquiv(0).build();
+        var feeObject = FeeBuilder.getFeeObject(feeData, feeMatrices, zeroCentRate, 10L);
+        assertEquals(Long.MAX_VALUE, feeObject.nodeFee());
+        assertEquals(Long.MAX_VALUE, feeObject.networkFee());
+        assertEquals(Long.MAX_VALUE, feeObject.serviceFee());
+    }
+
+    @Test
     void assertGetContractFunctionSize() {
         assertEquals(52, FeeBuilder.getContractFunctionSize(contractFunctionResult));
     }

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/Fees.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/Fees.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.spi.fees;
 
+import static com.hedera.node.app.hapi.utils.CommonUtils.clampedAdd;
 import static java.util.Objects.requireNonNull;
 import static org.hiero.hapi.fees.HighVolumePricingCalculator.DEFAULT_HIGH_VOLUME_MULTIPLIER;
 
@@ -97,9 +98,10 @@ public record Fees(long nodeFee, long networkFee, long serviceFee, long highVolu
      * @return the total fee. Will be non-negative.
      */
     public long totalFee() {
-        // Safely add the three components together, such that an overflow is detected. In practice this should never
-        // happen, since the maximum number of tinybars is less than Long.MAX_VALUE.
-        return Math.addExact(totalWithoutServiceFee(), serviceFee);
+        // Saturate rather than throw on overflow. In practice a legitimate total is well under Long.MAX_VALUE,
+        // but a saturated component (from a degenerate exchange rate) must clamp the total to Long.MAX_VALUE so
+        // the operation reaches the insufficient-balance outcome instead of raising an ArithmeticException.
+        return clampedAdd(totalWithoutServiceFee(), serviceFee);
     }
 
     /**
@@ -108,7 +110,7 @@ public record Fees(long nodeFee, long networkFee, long serviceFee, long highVolu
      * @return the total without service fees. Will be non-negative.
      */
     public long totalWithoutServiceFee() {
-        return Math.addExact(nodeFee, networkFee);
+        return clampedAdd(nodeFee, networkFee);
     }
 
     /**
@@ -117,7 +119,7 @@ public record Fees(long nodeFee, long networkFee, long serviceFee, long highVolu
      * @return the total without node fees. Will be non-negative.
      */
     public long totalWithoutNodeFee() {
-        return Math.addExact(networkFee, serviceFee);
+        return clampedAdd(networkFee, serviceFee);
     }
 
     /**

--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/util/FeeUtils.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/fees/util/FeeUtils.java
@@ -36,9 +36,16 @@ public class FeeUtils {
 
     public static long tinycentsToTinybars(final long amount, final ExchangeRate rate) {
         final var hbarEquiv = rate.getHbarEquiv();
+        final var centEquiv = rate.getCentEquiv();
+        // A non-positive centEquiv would divide by zero, and a non-positive hbarEquiv would make the fee
+        // free or negative; saturate to Long.MAX_VALUE instead of throwing, so a degenerate rate yields an
+        // unpayable fee rather than halting fee conversion identically on every node.
+        if (centEquiv <= 0 || hbarEquiv <= 0) {
+            return Long.MAX_VALUE;
+        }
         if (productWouldOverflow(amount, hbarEquiv)) {
             return FeeBuilder.getTinybarsFromTinyCents(rate, amount);
         }
-        return amount * hbarEquiv / rate.getCentEquiv();
+        return amount * hbarEquiv / centEquiv;
     }
 }

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/fees/FeesTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/fees/FeesTest.java
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.spi.fees;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+class FeesTest {
+    @Test
+    void totalsAddNormally() {
+        final var fees = new Fees(1, 2, 3);
+        assertEquals(6, fees.totalFee());
+        assertEquals(3, fees.totalWithoutServiceFee());
+        assertEquals(5, fees.totalWithoutNodeFee());
+    }
+
+    @Test
+    void totalFeeSaturatesInsteadOfThrowing() {
+        // Previously Math.addExact threw on overflow; a saturated (degenerate-rate) component must instead
+        // clamp the total to Long.MAX_VALUE so the operation reaches the insufficient-balance outcome.
+        final var maxed = new Fees(Long.MAX_VALUE, Long.MAX_VALUE, Long.MAX_VALUE);
+        assertEquals(Long.MAX_VALUE, maxed.totalFee());
+        assertEquals(Long.MAX_VALUE, maxed.totalWithoutServiceFee());
+        assertEquals(Long.MAX_VALUE, maxed.totalWithoutNodeFee());
+    }
+
+    @Test
+    void totalFeeSaturatesWithSingleMaxComponent() {
+        // Even one saturated component plus another positive one must clamp rather than throw.
+        assertEquals(Long.MAX_VALUE, new Fees(Long.MAX_VALUE, 1, 0).totalFee());
+        assertEquals(Long.MAX_VALUE, new Fees(0, Long.MAX_VALUE, 1).totalFee());
+        assertEquals(Long.MAX_VALUE, new Fees(1, 0, Long.MAX_VALUE).totalFee());
+    }
+}

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/fees/util/FeeUtilsTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/fees/util/FeeUtilsTest.java
@@ -53,4 +53,45 @@ class FeeUtilsTest {
         long result = FeeUtils.tinycentsToTinybars(10, rate);
         assertEquals(25, result); // (10 * 5) / 2 = 25
     }
+
+    @Test
+    void tinycentsToTinybars_saturatesOnNonPositiveCentEquiv() {
+        ExchangeRate rate = mock(ExchangeRate.class);
+        when(rate.getHbarEquiv()).thenReturn(1);
+        when(rate.getCentEquiv()).thenReturn(0);
+
+        // A zero centEquiv would divide by zero; the conversion saturates instead of throwing.
+        assertEquals(Long.MAX_VALUE, FeeUtils.tinycentsToTinybars(100L, rate));
+    }
+
+    @Test
+    void tinycentsToTinybars_saturatesOnNonPositiveHbarEquiv() {
+        ExchangeRate zeroHbarRate = mock(ExchangeRate.class);
+        when(zeroHbarRate.getHbarEquiv()).thenReturn(0);
+        when(zeroHbarRate.getCentEquiv()).thenReturn(120);
+        // A zero hbarEquiv would make the fee free; saturate so a degenerate rate is unpayable, not free.
+        assertEquals(Long.MAX_VALUE, FeeUtils.tinycentsToTinybars(100L, zeroHbarRate));
+
+        ExchangeRate negativeHbarRate = mock(ExchangeRate.class);
+        when(negativeHbarRate.getHbarEquiv()).thenReturn(-1);
+        when(negativeHbarRate.getCentEquiv()).thenReturn(120);
+        assertEquals(Long.MAX_VALUE, FeeUtils.tinycentsToTinybars(100L, negativeHbarRate));
+    }
+
+    @Test
+    void feeResultToFeesTotalSaturatesOnDegenerateRate() {
+        ExchangeRate rate = mock(ExchangeRate.class);
+        when(rate.getHbarEquiv()).thenReturn(1);
+        when(rate.getCentEquiv()).thenReturn(0);
+
+        // End-to-end: each component conversion saturates on the degenerate rate, and the saturating total
+        // clamps to Long.MAX_VALUE instead of overflowing Math.addExact in Fees.totalFee().
+        FeeResult feeResult = new FeeResult(30, 10, 2);
+        Fees fees = FeeUtils.feeResultToFees(feeResult, rate);
+
+        assertEquals(Long.MAX_VALUE, fees.nodeFee());
+        assertEquals(Long.MAX_VALUE, fees.networkFee());
+        assertEquals(Long.MAX_VALUE, fees.serviceFee());
+        assertEquals(Long.MAX_VALUE, fees.totalFee());
+    }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/fees/ExchangeRateManager.java
@@ -53,6 +53,7 @@ public final class ExchangeRateManager {
     private static final Logger log = LogManager.getLogger(ExchangeRateManager.class);
 
     private static final BigInteger ONE_HUNDRED = BigInteger.valueOf(100);
+    private static final BigInteger LONG_MAX = BigInteger.valueOf(Long.MAX_VALUE);
 
     private final ConfigProvider configProvider;
 
@@ -110,6 +111,14 @@ public final class ExchangeRateManager {
         if (!(proposedRates.hasCurrentRate()
                 && proposedRates.currentRateOrThrow().hasExpirationTime()
                 && proposedRates.hasNextRate())) {
+            throw new HandleException(ResponseCodeEnum.INVALID_EXCHANGE_RATE_FILE);
+        }
+
+        // Reject degenerate rates: a non-positive hbarEquiv/centEquiv would make fee conversion divide by
+        // zero (see getAFromB) or yield a nonsensical price, so such a rate must never become the live rate.
+        final var current = proposedRates.currentRateOrThrow();
+        final var next = proposedRates.nextRateOrThrow();
+        if (current.hbarEquiv() <= 0 || current.centEquiv() <= 0 || next.hbarEquiv() <= 0 || next.centEquiv() <= 0) {
             throw new HandleException(ResponseCodeEnum.INVALID_EXCHANGE_RATE_FILE);
         }
 
@@ -266,11 +275,15 @@ public final class ExchangeRateManager {
     }
 
     private static long getAFromB(final long bAmount, final int aEquiv, final int bEquiv) {
-        final var aMultiplier = BigInteger.valueOf(aEquiv);
-        final var bDivisor = BigInteger.valueOf(bEquiv);
-        return BigInteger.valueOf(bAmount)
-                .multiply(aMultiplier)
-                .divide(bDivisor)
-                .longValueExact();
+        // A degenerate exchange rate would either divide by zero (non-positive divisor) or make the result
+        // free/negative (non-positive multiplier); saturate to Long.MAX_VALUE instead so a malformed rate
+        // yields an unpayable fee and cannot halt fee conversion network-wide.
+        if (aEquiv <= 0 || bEquiv <= 0) {
+            return Long.MAX_VALUE;
+        }
+        final var result =
+                BigInteger.valueOf(bAmount).multiply(BigInteger.valueOf(aEquiv)).divide(BigInteger.valueOf(bEquiv));
+        // longValueExact() throws when the result exceeds the long range; saturate to the maximum instead.
+        return result.compareTo(LONG_MAX) >= 0 ? Long.MAX_VALUE : result.longValue();
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/fees/ExchangeRateManagerTest.java
@@ -91,6 +91,40 @@ class ExchangeRateManagerTest {
                 .has(responseCode(ResponseCodeEnum.INVALID_EXCHANGE_RATE_FILE));
     }
 
+    @Test
+    void updateRejectsNonPositiveCentEquiv() {
+        // A super-user bypasses the intraday-change limit, but must still not be able to install a rate whose
+        // centEquiv is zero -- that would make fee conversion divide by zero on every node.
+        final var zeroCentRate =
+                ExchangeRate.newBuilder().hbarEquiv(1).centEquiv(0).expirationTime(expirationTime);
+        final var zeroRates = ExchangeRateSet.newBuilder()
+                .currentRate(zeroCentRate)
+                .nextRate(zeroCentRate)
+                .build();
+        final var zeroRateBytes = ExchangeRateSet.PROTOBUF.toBytes(zeroRates);
+        final var superUser = AccountID.newBuilder().accountNum(50L).build();
+
+        assertThatThrownBy(() -> subject.update(zeroRateBytes, superUser))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(ResponseCodeEnum.INVALID_EXCHANGE_RATE_FILE));
+    }
+
+    @Test
+    void getAFromBSaturatesOnNonPositiveRateComponents() throws Exception {
+        // internalUpdate() is the single writer of the active rate and rejects degenerate rates, so the
+        // private converter can never see one through the public API. This exercises the defense-in-depth
+        // guard directly: a non-positive multiplier (aEquiv) or divisor (bEquiv) must saturate to
+        // Long.MAX_VALUE rather than divide by zero or yield a free/negative fee.
+        final var getAFromB =
+                ExchangeRateManager.class.getDeclaredMethod("getAFromB", long.class, int.class, int.class);
+        getAFromB.setAccessible(true);
+
+        assertEquals(Long.MAX_VALUE, (long) getAFromB.invoke(null, 100L, 0, centEquiv)); // aEquiv == 0
+        assertEquals(Long.MAX_VALUE, (long) getAFromB.invoke(null, 100L, -1, centEquiv)); // aEquiv < 0
+        assertEquals(Long.MAX_VALUE, (long) getAFromB.invoke(null, 100L, hbarEquiv, 0)); // bEquiv == 0
+        assertEquals(200L, (long) getAFromB.invoke(null, 100L, 100, 50)); // normal: 100 * 100 / 50
+    }
+
     @ParameterizedTest
     @MethodSource("provideConsensusTimesForActiveRate")
     void activeRateWorksAsExpected(Instant consensusTime, ExchangeRate expectedExchangeRate) {


### PR DESCRIPTION
Stacked release/0.76 migration PR 6 of 17.

Depends on sync/release-0.76/005-pr-506.
Original source PR number: 504
Original source commit: 8c7391beba4ff9a520996c1af0ed780d3343b3ed

After the base PR merges, retarget this PR to release/0.76. Merge with Create a merge commit; do not squash or rebase merge.