### PR TITLE
ci(fix): broken TCK & JS SDK XTS tests

### DIFF
--- a/.github/workflows/819-call-tck-regression.yaml
+++ b/.github/workflows/819-call-tck-regression.yaml
@@ -169,7 +169,7 @@ jobs:
           echo "Using proto version: ${PROTO_VERSION}"
 
           # Install with the extracted versions
-          pnpm add @hiero-ledger/sdk@^${SDK_VERSION} long@${LONG_VERSION} @hiero-ledger/proto@${PROTO_VERSION}
+          pnpm add @hiero-ledger/sdk@${SDK_VERSION} long@${LONG_VERSION} @hiero-ledger/proto@${PROTO_VERSION}
           pnpm install
           nohup pnpm start &
           server_pid=$!

--- a/.github/workflows/821-call-block-node-regression.yaml
+++ b/.github/workflows/821-call-block-node-regression.yaml
@@ -221,7 +221,7 @@ jobs:
           echo "Using proto version: ${PROTO_VERSION}"
 
           # Install with the extracted versions
-          pnpm add "@hiero-ledger/sdk@^${SDK_VERSION}" "long@${LONG_VERSION}" "@hiero-ledger/proto@${PROTO_VERSION}"
+          pnpm add "@hiero-ledger/sdk@${SDK_VERSION}" "long@${LONG_VERSION}" "@hiero-ledger/proto@${PROTO_VERSION}"
           pnpm install
           nohup pnpm start &
           server_pid=$!


### PR DESCRIPTION
> Migrated from the private `hashgraph/private-hedera-services` repository.

> Original source commit: `21c10b0556944d53301ede6f63e4f781894ad5ee`

> This commit preserves the original author and author timestamp.