### PR TITLE
fix: ContractValidationRule order fix

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/ProcessorModule.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/processors/ProcessorModule.java
@@ -18,8 +18,8 @@ import com.hedera.node.app.service.contract.impl.exec.systemcontracts.HtsSystemC
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.PrngSystemContract;
 import dagger.Module;
 import dagger.Provides;
-import dagger.multibindings.IntoSet;
 import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
 import java.util.Map;
 import javax.inject.Singleton;
 import org.hyperledger.besu.datatypes.Address;
@@ -36,18 +36,22 @@ public interface ProcessorModule {
     boolean REQUIRE_CODE_DEPOSIT_TO_SUCCEED = true;
     int NUM_SYSTEM_ACCOUNTS = 750;
 
+    /**
+     * WARNING: The order of these rules is important and must not change without careful
+     * review. {@code ContractCreationProcessor} reports only the FIRST rule that fails as the
+     * deployment's {@code errorMessage}. If a deploy violates multiple rules, every node must
+     * pick the same one, or their committed records (and state roots) diverge, causing an ISS.
+     * Do not replace this {@link List} with a {@link java.util.Set}, and do not reorder without
+     * confirming all consensus nodes will observe the change simultaneously
+     *
+     * @param evmConfiguration the EVM configuration
+     * @return the ordered list of contract validation rules
+     */
     @Provides
     @Singleton
-    @IntoSet
-    static ContractValidationRule provideMaxCodeSizeRule(@NonNull final EvmConfiguration evmConfiguration) {
-        return MaxCodeSizeRule.from(EvmSpecVersion.defaultVersion(), evmConfiguration);
-    }
-
-    @Provides
-    @Singleton
-    @IntoSet
-    static ContractValidationRule providePrefixCodeRule() {
-        return PrefixCodeRule.of();
+    static List<ContractValidationRule> provideContractValidationRules(
+            @NonNull final EvmConfiguration evmConfiguration) {
+        return List.of(MaxCodeSizeRule.from(EvmSpecVersion.defaultVersion(), evmConfiguration), PrefixCodeRule.of());
     }
 
     /**

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/V030Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v030/V030Module.java
@@ -93,9 +93,9 @@ public interface V030Module {
     @Singleton
     @ServicesV030
     static ContractCreationProcessor provideContractCreationProcessor(
-            @ServicesV030 @NonNull final HEVM evm, @NonNull final Set<ContractValidationRule> validationRules) {
+            @ServicesV030 @NonNull final HEVM evm, @NonNull final List<ContractValidationRule> validationRules) {
         return new CustomContractCreationProcessor(
-                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, List.copyOf(validationRules), INITIAL_CONTRACT_NONCE);
+                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, validationRules, INITIAL_CONTRACT_NONCE);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/V034Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v034/V034Module.java
@@ -95,9 +95,9 @@ public interface V034Module {
     @Singleton
     @ServicesV034
     static ContractCreationProcessor provideContractCreationProcessor(
-            @ServicesV034 @NonNull final HEVM evm, @NonNull final Set<ContractValidationRule> validationRules) {
+            @ServicesV034 @NonNull final HEVM evm, @NonNull final List<ContractValidationRule> validationRules) {
         return new CustomContractCreationProcessor(
-                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, List.copyOf(validationRules), INITIAL_CONTRACT_NONCE);
+                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, validationRules, INITIAL_CONTRACT_NONCE);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/V038Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v038/V038Module.java
@@ -95,9 +95,9 @@ public interface V038Module {
     @Singleton
     @ServicesV038
     static ContractCreationProcessor provideContractCreationProcessor(
-            @ServicesV038 @NonNull final HEVM evm, @NonNull final Set<ContractValidationRule> validationRules) {
+            @ServicesV038 @NonNull final HEVM evm, @NonNull final List<ContractValidationRule> validationRules) {
         return new CustomContractCreationProcessor(
-                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, List.copyOf(validationRules), INITIAL_CONTRACT_NONCE);
+                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, validationRules, INITIAL_CONTRACT_NONCE);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v046/V046Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v046/V046Module.java
@@ -95,9 +95,9 @@ public interface V046Module {
     @Singleton
     @ServicesV046
     static ContractCreationProcessor provideContractCreationProcessor(
-            @ServicesV046 @NonNull final HEVM evm, @NonNull final Set<ContractValidationRule> validationRules) {
+            @ServicesV046 @NonNull final HEVM evm, @NonNull final List<ContractValidationRule> validationRules) {
         return new CustomContractCreationProcessor(
-                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, List.copyOf(validationRules), INITIAL_CONTRACT_NONCE);
+                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, validationRules, INITIAL_CONTRACT_NONCE);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v050/V050Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v050/V050Module.java
@@ -105,9 +105,9 @@ public interface V050Module {
     @Singleton
     @ServicesV050
     static ContractCreationProcessor provideContractCreationProcessor(
-            @ServicesV050 @NonNull final HEVM evm, @NonNull final Set<ContractValidationRule> validationRules) {
+            @ServicesV050 @NonNull final HEVM evm, @NonNull final List<ContractValidationRule> validationRules) {
         return new CustomContractCreationProcessor(
-                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, List.copyOf(validationRules), INITIAL_CONTRACT_NONCE);
+                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, validationRules, INITIAL_CONTRACT_NONCE);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v051/V051Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v051/V051Module.java
@@ -105,9 +105,9 @@ public interface V051Module {
     @Singleton
     @ServicesV051
     static ContractCreationProcessor provideContractCreationProcessor(
-            @ServicesV051 @NonNull final HEVM evm, @NonNull final Set<ContractValidationRule> validationRules) {
+            @ServicesV051 @NonNull final HEVM evm, @NonNull final List<ContractValidationRule> validationRules) {
         return new CustomContractCreationProcessor(
-                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, List.copyOf(validationRules), INITIAL_CONTRACT_NONCE);
+                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, validationRules, INITIAL_CONTRACT_NONCE);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v065/V065Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v065/V065Module.java
@@ -104,9 +104,9 @@ public interface V065Module {
     @Singleton
     @ServicesV065
     static ContractCreationProcessor provideContractCreationProcessor(
-            @ServicesV065 @NonNull final HEVM evm, @NonNull final Set<ContractValidationRule> validationRules) {
+            @ServicesV065 @NonNull final HEVM evm, @NonNull final List<ContractValidationRule> validationRules) {
         return new CustomContractCreationProcessor(
-                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, List.copyOf(validationRules), INITIAL_CONTRACT_NONCE);
+                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, validationRules, INITIAL_CONTRACT_NONCE);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v066/V066Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v066/V066Module.java
@@ -104,9 +104,9 @@ public interface V066Module {
     @Singleton
     @ServicesV066
     static ContractCreationProcessor provideContractCreationProcessor(
-            @ServicesV066 @NonNull final HEVM evm, @NonNull final Set<ContractValidationRule> validationRules) {
+            @ServicesV066 @NonNull final HEVM evm, @NonNull final List<ContractValidationRule> validationRules) {
         return new CustomContractCreationProcessor(
-                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, List.copyOf(validationRules), INITIAL_CONTRACT_NONCE);
+                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, validationRules, INITIAL_CONTRACT_NONCE);
     }
 
     @Provides

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v067/V067Module.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/v067/V067Module.java
@@ -93,9 +93,9 @@ public interface V067Module {
     @Singleton
     @ServicesV067
     static ContractCreationProcessor provideContractCreationProcessor(
-            @ServicesV067 @NonNull final HEVM evm, @NonNull final Set<ContractValidationRule> validationRules) {
+            @ServicesV067 @NonNull final HEVM evm, @NonNull final List<ContractValidationRule> validationRules) {
         return new CustomContractCreationProcessor(
-                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, List.copyOf(validationRules), INITIAL_CONTRACT_NONCE);
+                evm, REQUIRE_CODE_DEPOSIT_TO_SUCCEED, validationRules, INITIAL_CONTRACT_NONCE);
     }
 
     @Provides

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/BaseTranslator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/translators/BaseTranslator.java
@@ -735,12 +735,15 @@ public class BaseTranslator {
                     now = asTimestamp(asInstant(now).plusNanos(1));
                 }
                 if (!executedInitcode.hasContractId()) {
-                    sidecars.add(TransactionSidecarRecord.newBuilder()
-                            .consensusTimestamp(now)
-                            .bytecode(ContractBytecode.newBuilder()
-                                    .initcode(executedInitcode.explicitInitcodeOrThrow())
-                                    .build())
-                            .build());
+                    // in case of executedInitcode.initcode.kind == UNSET
+                    if (executedInitcode.hasExplicitInitcode()) {
+                        sidecars.add(TransactionSidecarRecord.newBuilder()
+                                .consensusTimestamp(now)
+                                .bytecode(ContractBytecode.newBuilder()
+                                        .initcode(executedInitcode.explicitInitcodeOrThrow())
+                                        .build())
+                                .build());
+                    }
                 } else {
                     final var contractId = executedInitcode.contractIdOrThrow();
                     final var bytecodeBuilder = ContractBytecode.newBuilder().contractId(contractId);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateIssTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/hapi/ContractCreateIssTest.java
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.contract.hapi;
+
+import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.RELAYER;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SHAPE;
+import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.CONTRACT_EXECUTION_EXCEPTION;
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.spec.TargetNetworkType;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+@Tag(SMART_CONTRACT)
+public class ContractCreateIssTest {
+
+    private static final ByteString INIT_CODE = ByteString.fromHex("60ef6000536160016000f3"); // size and prefix
+
+    @HapiTest
+    Stream<DynamicTest> contractCreateIssTest() {
+        final var cycles = 10;
+        return hapiTest(
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                cryptoCreate(RELAYER).balance(ONE_HUNDRED_HBARS),
+                withOpContext((spec, opLog) -> {
+                    Assertions.assertEquals(
+                            TargetNetworkType.SUBPROCESS_NETWORK,
+                            spec.targetNetworkType(),
+                            "This ISS test requires a subprocess (multi-node) network");
+                    final var nodes = spec.targetNetworkOrThrow().nodes();
+                    Assertions.assertTrue(nodes.size() > 1); // check we are on a multi-node env
+                    opLog.info("Running with {} nodes", nodes.size());
+                    // run cycles to each node
+                    for (int i = 0; i < cycles; i++) {
+                        final var txnName = "issTestContract-" + i;
+                        final var create = contractCreate("IssTestContract")
+                                .gas(15_000_000)
+                                .entityMemo("IssTestContract")
+                                .inlineInitCode(INIT_CODE)
+                                .hasKnownStatus(CONTRACT_EXECUTION_EXCEPTION)
+                                .via(txnName)
+                                .refusingEthConversion();
+                        allRunFor(spec, create);
+                        // error message is new for each cycle to confirm ISS is happening on specific cycle but not
+                        // between them
+                        final AtomicReference<String> error = new AtomicReference<>();
+                        for (var node : nodes) {
+                            allRunFor(
+                                    spec,
+                                    getTxnRecord(txnName)
+                                            .setNode(Long.toString(
+                                                    node.getAccountId().accountNum()))
+                                            .exposingTo(record -> {
+                                                final var currentErrorMessage = record.getContractCreateResult()
+                                                        .getErrorMessage();
+                                                if (error.get() == null) {
+                                                    error.set(currentErrorMessage);
+                                                } else {
+                                                    Assertions.assertEquals(error.get(), currentErrorMessage);
+                                                }
+                                            }));
+                        }
+                    }
+                }));
+    }
+}


### PR DESCRIPTION
> Migrated from the private `hashgraph/private-hedera-services` repository.

> Original source commit: `92e578d201baf8602f6ba0f30106436bf50bc700`

> This commit preserves the original author and author timestamp.



