### PR TITLE
chore: upgrade io.netty:netty-codec-http to 4.2.17.Final

### DIFF
--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 dependencies {
-    api(platform("io.netty:netty-bom:4.2.15.Final"))
+    api(platform("io.netty:netty-bom:4.2.17.Final"))
 
     // forward logging from modules using SLF4J (e.g. 'org.hyperledger.besu.evm') to Log4J
     runtime("org.apache.logging.log4j:log4j-slf4j2-impl") {
@@ -28,6 +28,7 @@ val tuweni = "2.4.2"
 val webcompare = "2.1.8"
 
 dependencies.constraints {
+    api("io.netty:netty-codec-http:4.2.17.Final") { because("io.netty.codec.http") }
     api("io.helidon.common:helidon-common:$helidon") { because("io.helidon.common") }
     api("io.helidon.webclient:helidon-webclient:$helidon") { because("io.helidon.webclient") }
     api("io.helidon.webclient:helidon-webclient-grpc:$helidon") {


### PR DESCRIPTION
> Migrated from the private `hashgraph/private-hedera-services` repository.

> Original source commit: `1844609b455009a0edee5ff44f7bdf106f3d028d`

> This commit preserves the original author and author timestamp.

## Summary
Replicates [hiero-ledger/hiero-consensus-node#26954](https://github.com/hiero-ledger/hiero-consensus-node/pull/26954) for `release/0.76`.

- Bump the Netty BOM from `4.2.15.Final` to `4.2.17.Final`
- Add explicit constraint pinning `io.netty:netty-codec-http:4.2.17.Final`

## Test plan
- [ ] `./gradlew qualityGate`