### PR TITLE
chore: `streamMode=BOTH` block size circuit breaker

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/BlockStreamManager.java
@@ -13,6 +13,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -187,6 +188,22 @@ public interface BlockStreamManager extends BlockRecordInfo, StateHashedListener
      * @throws IllegalStateException if the stream is closed
      */
     void writeItem(@NonNull Function<Timestamp, BlockItem> itemSpec);
+
+    /**
+     * Atomically writes all block items produced by a savepoint stack, unless the block-size circuit breaker has opened.
+     * Regardless of whether the items are written, advances the logical last-used consensus time to the supplied value.
+     *
+     * @param items the block items produced by a savepoint stack
+     * @param lastUsedConsensusTime the last consensus time assigned to the stack's output
+     */
+    void writeSavepointItems(@NonNull List<BlockItem> items, @NonNull Instant lastUsedConsensusTime);
+
+    /**
+     * Returns whether savepoint-stack block output is suppressed for the current block.
+     *
+     * @return whether savepoint-stack block output is suppressed
+     */
+    boolean isSavepointOutputSuppressed();
 
     /**
      * Notifies the block stream manager that a fatal event has occurred, e.g. an ISS. This event should

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImpl.java
@@ -21,11 +21,13 @@ import static com.hedera.node.app.quiescence.TctProbe.blockStreamInfoFrom;
 import static com.hedera.node.app.records.BlockRecordService.EPOCH;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCKS_STATE_ID;
 import static com.hedera.node.app.workflows.handle.HandleWorkflow.ALERT_MESSAGE;
+import static com.hedera.node.config.types.StreamMode.BOTH;
 import static java.util.Objects.requireNonNull;
 import static org.hiero.consensus.model.quiescence.QuiescenceCommand.QUIESCE;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.creationSemanticVersionOf;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.hedera.hapi.block.stream.Block;
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.BlockProof;
 import com.hedera.hapi.block.stream.MerkleSiblingHash;
@@ -119,6 +121,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
 
     private final int roundsPerBlock;
     private final Duration blockPeriod;
+    private final boolean blockSizeCircuitBreakerApplicable;
     private final BlockHashSigner blockHashSigner;
     private final SemanticVersion version;
     private final SemanticVersion hapiVersion;
@@ -161,6 +164,13 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
     private Instant consensusTimeCurrentRound;
     private Timestamp lastUsedTime;
     private BlockItemWriter writer;
+    // The circuit-breaker size configuration snapshot for the current block.
+    private boolean blockSizeCircuitBreakerEnabled;
+    private long maxBlockSizeBytes;
+    // The canonical serialized size of all items accepted into the current block, excluding its asynchronous proof.
+    private long currentBlockSizeBytes;
+    // Once open, no more output from savepoint stacks is accepted until the next block starts.
+    private boolean savepointOutputSuppressed;
 
     // Block merkle subtrees and leaves
     private IncrementalStreamingHasher previousBlockHashes;
@@ -229,6 +239,8 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
      */
     private final Counter indirectProofCounter;
 
+    private final Counter blockSizeCircuitBreakerTripsCounter;
+
     @Inject
     public BlockStreamManagerImpl(
             @NonNull final BlockHashSigner blockHashSigner,
@@ -260,6 +272,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         final var blockStreamConfig = config.getConfigData(BlockStreamConfig.class);
         this.roundsPerBlock = blockStreamConfig.roundsPerBlock();
         this.blockPeriod = blockStreamConfig.blockPeriod();
+        this.blockSizeCircuitBreakerApplicable = blockStreamConfig.streamMode() == BOTH;
         final var networkAdminConfig = config.getConfigData(NetworkAdminConfig.class);
         this.diskNetworkExport = networkAdminConfig.diskNetworkExport();
         this.diskNetworkExportFile = networkAdminConfig.diskNetworkExportFile();
@@ -272,6 +285,9 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
         indirectProofCounter = requireNonNull(metrics)
                 .getOrCreate(new Counter.Config("block", "numIndirectProofs")
                         .withDescription("Number of blocks closed with indirect proofs"));
+        blockSizeCircuitBreakerTripsCounter = metrics.getOrCreate(new Counter.Config(
+                        "block", "numBlockSizeCircuitBreakerTrips")
+                .withDescription("Number of preview blocks whose savepoint output was suppressed by the size limit"));
         if (!quiescenceEnabled) {
             log.info("Quiescence is disabled");
             quiescedHeartbeat.shutdown();
@@ -439,6 +455,12 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
 
         // Writer will be null when beginning a new block
         if (writer == null) {
+            final var blockStreamConfig = configProvider.getConfiguration().getConfigData(BlockStreamConfig.class);
+            maxBlockSizeBytes = blockStreamConfig.maxBlockSizeBytes();
+            blockSizeCircuitBreakerEnabled = blockSizeCircuitBreakerApplicable && maxBlockSizeBytes > 0;
+            currentBlockSizeBytes = 0;
+            savepointOutputSuppressed = false;
+
             writer = writerSupplier.get();
             blockTimestamp = asTimestamp(firstConsensusTimestampOf(round));
 
@@ -478,7 +500,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
                     .softwareVersion(creationSemanticVersionOf(state))
                     .blockTimestamp(blockTimestamp)
                     .hapiProtoVersion(hapiVersion);
-            worker.addItem(BlockItem.newBuilder().blockHeader(header).build());
+            writeItem(BlockItem.newBuilder().blockHeader(header).build());
         }
         consensusTimeCurrentRound = round.getConsensusTimestamp();
     }
@@ -643,7 +665,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             quiescenceController.finishHandlingInProgressBlock();
             state.commitSingletons();
             // Flush all boundary state changes besides the BlockStreamInfo
-            worker.addItem(flushChangesFromListener(boundaryStateChangeListener));
+            writeItem(flushChangesFromListener(boundaryStateChangeListener));
             worker.sync();
 
             // This block's starting state hash is the end state hash of the last non-empty round
@@ -698,7 +720,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             ((CommittableWritableStates) writableState).commit();
 
             // Produce one more state change item (i.e. putting the block stream info just constructed into state)
-            worker.addItem(flushChangesFromListener(boundaryStateChangeListener));
+            writeItem(flushChangesFromListener(boundaryStateChangeListener));
             worker.sync();
 
             final var stateChangesHash = Bytes.wrap(stateChangesHasher.computeRootHash());
@@ -730,7 +752,7 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
             // Write BlockFooter to block stream (last item before BlockProof)
             final var footerItem =
                     BlockItem.newBuilder().blockFooter(blockFooter).build();
-            worker.addItem(footerItem);
+            writeItem(footerItem);
             worker.sync();
 
             // Create a pending block, waiting to be signed
@@ -873,11 +895,9 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
 
     @Override
     public void writeItem(@NonNull final BlockItem item) {
-        lastUsedTime = switch (item.item().kind()) {
-            case STATE_CHANGES -> item.stateChangesOrThrow().consensusTimestampOrThrow();
-            case TRANSACTION_RESULT -> item.transactionResultOrThrow().consensusTimestampOrThrow();
-            default -> lastUsedTime;
-        };
+        requireNonNull(item);
+        accountForWrittenItems(List.of(item));
+        updateLastUsedTimeFrom(item);
         worker.addItem(item);
     }
 
@@ -885,6 +905,87 @@ public class BlockStreamManagerImpl implements BlockStreamManager {
     public void writeItem(@NonNull final Function<Timestamp, BlockItem> itemSpec) {
         requireNonNull(itemSpec);
         writeItem(itemSpec.apply(lastUsedTime));
+    }
+
+    @Override
+    public void writeSavepointItems(
+            @NonNull final List<BlockItem> items, @NonNull final Instant lastUsedConsensusTime) {
+        requireNonNull(items);
+        requireNonNull(lastUsedConsensusTime);
+
+        if (blockSizeCircuitBreakerEnabled) {
+            if (savepointOutputSuppressed) {
+                advanceLastUsedTimeTo(lastUsedConsensusTime);
+                return;
+            }
+            final long candidateSize = serializedBlockSize(items);
+            final long projectedSize = saturatedAdd(currentBlockSizeBytes, candidateSize);
+            if (projectedSize > maxBlockSizeBytes) {
+                tripBlockSizeCircuitBreaker(projectedSize, candidateSize);
+                advanceLastUsedTimeTo(lastUsedConsensusTime);
+                return;
+            }
+            currentBlockSizeBytes = projectedSize;
+            items.forEach(item -> {
+                updateLastUsedTimeFrom(item);
+                worker.addItem(item);
+            });
+        } else {
+            items.forEach(this::writeItem);
+        }
+        advanceLastUsedTimeTo(lastUsedConsensusTime);
+    }
+
+    @Override
+    public boolean isSavepointOutputSuppressed() {
+        return savepointOutputSuppressed;
+    }
+
+    private void accountForWrittenItems(@NonNull final List<BlockItem> items) {
+        if (!blockSizeCircuitBreakerEnabled) {
+            return;
+        }
+        final long addedSize = serializedBlockSize(items);
+        currentBlockSizeBytes = saturatedAdd(currentBlockSizeBytes, addedSize);
+        if (!savepointOutputSuppressed && currentBlockSizeBytes > maxBlockSizeBytes) {
+            tripBlockSizeCircuitBreaker(currentBlockSizeBytes, addedSize);
+        }
+    }
+
+    private void tripBlockSizeCircuitBreaker(final long projectedSize, final long addedSize) {
+        savepointOutputSuppressed = true;
+        blockSizeCircuitBreakerTripsCounter.increment();
+        log.error(
+                "Preview block #{} reached a projected serialized size of {} bytes after adding {} bytes, "
+                        + "exceeding the {}-byte limit; suppressing savepoint output for the rest of the block",
+                blockNumber,
+                projectedSize,
+                addedSize,
+                maxBlockSizeBytes);
+    }
+
+    private static long serializedBlockSize(@NonNull final List<BlockItem> items) {
+        // A Block is only a repeated BlockItem field, so measuring a Block containing this batch gives its exact
+        // contribution to the canonical, uncompressed protobuf representation.
+        return Block.PROTOBUF.measureRecord(new Block(items));
+    }
+
+    private static long saturatedAdd(final long a, final long b) {
+        return a > Long.MAX_VALUE - b ? Long.MAX_VALUE : a + b;
+    }
+
+    private void updateLastUsedTimeFrom(@NonNull final BlockItem item) {
+        lastUsedTime = switch (item.item().kind()) {
+            case STATE_CHANGES -> item.stateChangesOrThrow().consensusTimestampOrThrow();
+            case TRANSACTION_RESULT -> item.transactionResultOrThrow().consensusTimestampOrThrow();
+            default -> lastUsedTime;
+        };
+    }
+
+    private void advanceLastUsedTimeTo(@NonNull final Instant consensusTime) {
+        if (lastUsedTime == null || consensusTime.isAfter(asInstant(lastUsedTime))) {
+            lastUsedTime = asTimestamp(consensusTime);
+        }
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/BlockRecordSource.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/state/recordcache/BlockRecordSource.java
@@ -89,6 +89,26 @@ public class BlockRecordSource implements RecordSource {
         outputs.forEach(output -> output.forEachItem(action));
     }
 
+    /**
+     * Returns all block items in this source in externalization order.
+     *
+     * @return the block items in externalization order
+     */
+    public @NonNull List<BlockItem> blockItems() {
+        final var items = new ArrayList<BlockItem>();
+        outputs.forEach(output -> items.addAll(output.blockItems()));
+        return items;
+    }
+
+    /**
+     * Returns whether this source contains any block-stream outputs.
+     *
+     * @return whether this source contains any block-stream outputs
+     */
+    public boolean hasOutputs() {
+        return !outputs.isEmpty();
+    }
+
     @Override
     public List<IdentifiedReceipt> identifiedReceipts() {
         return computedReceipts();

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleOutput.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleOutput.java
@@ -67,7 +67,6 @@ public record HandleOutput(
         // The stack for the user txn should never be committed
         parentTxn.stack().rollbackFullStack();
 
-        RecordSource cacheableRecordSource = null;
         final RecordSource recordSource;
         if (streamMode != BLOCKS) {
             final var failInvalidBuilder = new RecordStreamBuilder(REVERSIBLE, NOOP_SIGNED_TX_CUSTOMIZER, USER);
@@ -75,7 +74,7 @@ public record HandleOutput(
                     .status(FAIL_INVALID)
                     .consensusTimestamp(parentTxn.consensusNow());
             final var failInvalidRecord = failInvalidBuilder.build();
-            cacheableRecordSource = recordSource = new LegacyListRecordSource(
+            recordSource = new LegacyListRecordSource(
                     List.of(failInvalidRecord),
                     List.of(new RecordSource.IdentifiedReceipt(
                             failInvalidRecord.transactionRecord().transactionIDOrThrow(),
@@ -91,17 +90,18 @@ public record HandleOutput(
                     .status(FAIL_INVALID)
                     .consensusTimestamp(parentTxn.consensusNow());
             outputs.add(failInvalidBuilder.build(true, null));
-            cacheableRecordSource = blockRecordSource = new BlockRecordSource(outputs);
+            blockRecordSource = new BlockRecordSource(outputs);
         } else {
             blockRecordSource = null;
         }
 
+        final var handleOutput = new HandleOutput(blockRecordSource, recordSource, parentTxn.consensusNow());
         recordCache.addRecordSource(
                 parentTxn.creatorInfo().nodeId(),
                 requireNonNull(parentTxn.txnInfo().transactionID()),
                 HederaRecordCache.DueDiligenceFailure.NO,
-                requireNonNull(cacheableRecordSource));
-        return new HandleOutput(blockRecordSource, recordSource, parentTxn.consensusNow());
+                handleOutput.preferredRecordSource());
+        return handleOutput;
     }
 
     public @NonNull RecordSource recordSourceOrThrow() {
@@ -112,8 +112,18 @@ public record HandleOutput(
         return requireNonNull(blockRecordSource);
     }
 
-    public @NonNull RecordSource preferringBlockRecordSource() {
-        return blockRecordSource != null ? blockRecordSource : requireNonNull(recordSource);
+    /**
+     * Returns the only available source. When both are available, returns the block-stream source if it has outputs,
+     * otherwise the record-stream source. This preserves normal block-derived query behavior while allowing
+     * record-derived queries after preview block output is suppressed.
+     *
+     * @return the source to use for receipt and record queries
+     */
+    public @NonNull RecordSource preferredRecordSource() {
+        if (blockRecordSource != null && (recordSource == null || blockRecordSource.hasOutputs())) {
+            return blockRecordSource;
+        }
+        return requireNonNull(recordSource);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -642,7 +642,8 @@ public class HandleWorkflow {
             blockRecordManager.endUserTransaction(records.stream(), state);
         }
         if (streamMode != RECORDS) {
-            handleOutput.blockRecordSourceOrThrow().forEachItem(blockStreamManager::writeItem);
+            blockStreamManager.writeSavepointItems(
+                    handleOutput.blockRecordSourceOrThrow().blockItems(), handleOutput.lastAssignedConsensusTime());
         } else if (handleOutput.lastAssignedConsensusTime().isAfter(consensusNow)) {
             blockRecordManager.setLastUsedConsensusTime(handleOutput.lastAssignedConsensusTime(), state);
         }
@@ -778,7 +779,9 @@ public class HandleWorkflow {
                     final var handleOutput = executeScheduled(state, nextTime, creatorInfo, executableTxn);
                     transactionsDispatched = true;
                     if (streamMode != RECORDS) {
-                        handleOutput.blockRecordSourceOrThrow().forEachItem(blockStreamManager::writeItem);
+                        blockStreamManager.writeSavepointItems(
+                                handleOutput.blockRecordSourceOrThrow().blockItems(),
+                                handleOutput.lastAssignedConsensusTime());
                     } else if (handleOutput.lastAssignedConsensusTime().isAfter(consensusNow)) {
                         blockRecordManager.setLastUsedConsensusTime(handleOutput.lastAssignedConsensusTime(), state);
                     }
@@ -888,7 +891,7 @@ public class HandleWorkflow {
                     parentTxn.creatorInfo().nodeId(),
                     parentTxn.txnInfo().transactionID(),
                     parentTxn.preHandleResult().dueDiligenceFailure(),
-                    handleOutput.preferringBlockRecordSource());
+                    handleOutput.preferredRecordSource());
             return handleOutput;
         } catch (Exception e) {
             logger.error("{} - exception thrown while handling user transaction", ALERT_MESSAGE, e);
@@ -934,7 +937,7 @@ public class HandleWorkflow {
                     scheduledTxn.creatorInfo().nodeId(),
                     scheduledTxn.txnInfo().transactionID(),
                     DueDiligenceFailure.NO,
-                    handleOutput.preferringBlockRecordSource());
+                    handleOutput.preferredRecordSource());
             return handleOutput;
         } catch (final Exception e) {
             logger.error("{} - exception thrown while handling scheduled transaction", ALERT_MESSAGE, e);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/SystemTransactions.java
@@ -873,7 +873,7 @@ public class SystemTransactions {
                 spec.accept(builder);
                 final var body = builder.build();
                 final var output = dispatch(body, 0, triggerStakePeriodSideEffects);
-                final var statuses = output.preferringBlockRecordSource().identifiedReceipts().stream()
+                final var statuses = output.preferredRecordSource().identifiedReceipts().stream()
                         .map(RecordSource.IdentifiedReceipt::receipt)
                         .map(TransactionReceipt::status)
                         .toList();
@@ -949,7 +949,9 @@ public class SystemTransactions {
                     blockRecordManager.endUserTransaction(records.stream(), state);
                 }
                 if (streamMode != RECORDS) {
-                    handleOutput.blockRecordSourceOrThrow().forEachItem(blockStreamManager::writeItem);
+                    blockStreamManager.writeSavepointItems(
+                            handleOutput.blockRecordSourceOrThrow().blockItems(),
+                            handleOutput.lastAssignedConsensusTime());
                 }
                 return handleOutput;
             }
@@ -1026,7 +1028,7 @@ public class SystemTransactions {
                     creatorInfo.nodeId(),
                     parentTxn.txnInfo().transactionID(),
                     HederaRecordCache.DueDiligenceFailure.NO,
-                    handleOutput.preferringBlockRecordSource());
+                    handleOutput.preferredRecordSource());
             return handleOutput;
         } catch (final Exception e) {
             log.error("{} - exception thrown while handling system transaction", ALERT_MESSAGE, e);

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImpl.java
@@ -18,6 +18,7 @@ import static com.hedera.node.app.spi.workflows.record.StreamBuilder.ReversingBe
 import static com.hedera.node.app.spi.workflows.record.StreamBuilder.SignedTxCustomizer.NOOP_SIGNED_TX_CUSTOMIZER;
 import static com.hedera.node.app.workflows.handle.stack.savepoints.AbstractSavepoint.SUCCESSES;
 import static com.hedera.node.config.types.StreamMode.BLOCKS;
+import static com.hedera.node.config.types.StreamMode.BOTH;
 import static com.hedera.node.config.types.StreamMode.RECORDS;
 import static java.util.Objects.requireNonNull;
 
@@ -58,6 +59,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import org.hiero.base.crypto.Hash;
 
@@ -87,6 +89,7 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
 
     private final StreamMode streamMode;
 
+    private final BooleanSupplier blockStreamOutputSuppressed;
     // Per-dispatch trace-data cap; inherited by child stacks so batched/scheduled calls enforce the same limit
     private final int maxSerializedTraceDataBytes;
 
@@ -114,6 +117,39 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
             @NonNull final ImmediateStateChangeListener immediateStateChangeListener,
             @NonNull final StreamMode streamMode,
             final int maxSerializedTraceDataBytes) {
+        return newRootStack(
+                state,
+                maxBuildersBeforeUser,
+                maxBuildersAfterUser,
+                boundaryStateChangeListener,
+                immediateStateChangeListener,
+                streamMode,
+                maxSerializedTraceDataBytes,
+                () -> false);
+    }
+
+    /**
+     * Constructs the root stack with a supplier indicating whether preview block output is suppressed.
+     *
+     * @param state the state
+     * @param maxBuildersBeforeUser the maximum number of preceding builders with available consensus times
+     * @param maxBuildersAfterUser the maximum number of following builders with available consensus times
+     * @param boundaryStateChangeListener the listener for the round state changes
+     * @param immediateStateChangeListener the listener for the key/value state changes
+     * @param streamMode the stream mode
+     * @param maxSerializedTraceDataBytes the maximum estimated serialized contract trace data size in bytes
+     * @param blockStreamOutputSuppressed supplies whether block output is suppressed for the current block
+     * @return the root {@link SavepointStackImpl}
+     */
+    public static SavepointStackImpl newRootStack(
+            @NonNull final State state,
+            final int maxBuildersBeforeUser,
+            final int maxBuildersAfterUser,
+            @NonNull final BoundaryStateChangeListener boundaryStateChangeListener,
+            @NonNull final ImmediateStateChangeListener immediateStateChangeListener,
+            @NonNull final StreamMode streamMode,
+            final int maxSerializedTraceDataBytes,
+            @NonNull final BooleanSupplier blockStreamOutputSuppressed) {
         return new SavepointStackImpl(
                 state,
                 maxBuildersBeforeUser,
@@ -121,7 +157,8 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
                 boundaryStateChangeListener,
                 immediateStateChangeListener,
                 streamMode,
-                maxSerializedTraceDataBytes);
+                maxSerializedTraceDataBytes,
+                blockStreamOutputSuppressed);
     }
 
     /**
@@ -161,11 +198,13 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
             @NonNull final BoundaryStateChangeListener boundaryStateChangeListener,
             @NonNull final ImmediateStateChangeListener immediateStateChangeListener,
             @NonNull final StreamMode streamMode,
-            final int maxSerializedTraceDataBytes) {
+            final int maxSerializedTraceDataBytes,
+            @NonNull final BooleanSupplier blockStreamOutputSuppressed) {
         this.state = requireNonNull(state);
         this.immediateStateChangeListener = requireNonNull(immediateStateChangeListener);
         this.boundaryStateChangeListener = requireNonNull(boundaryStateChangeListener);
         this.streamMode = requireNonNull(streamMode);
+        this.blockStreamOutputSuppressed = requireNonNull(blockStreamOutputSuppressed);
         this.maxSerializedTraceDataBytes = maxSerializedTraceDataBytes;
         builderSink = new BuilderSinkImpl(maxBuildersBeforeUser, maxBuildersAfterUser + 1);
         presetIdsAllowed = true;
@@ -194,6 +233,7 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
         requireNonNull(customizer);
         requireNonNull(category);
         this.streamMode = requireNonNull(streamMode);
+        this.blockStreamOutputSuppressed = parent.blockStreamOutputSuppressed;
         this.state = requireNonNull(parent);
         this.maxSerializedTraceDataBytes = parent.maxSerializedTraceDataBytes;
         this.builderSink = null;
@@ -533,6 +573,7 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
         final List<BlockStreamBuilder.Output> outputs = streamMode != RECORDS ? new LinkedList<>() : null;
         final List<SingleTransactionRecord> records = streamMode != BLOCKS ? new ArrayList<>() : null;
         final List<RecordSource.IdentifiedReceipt> receipts = streamMode != BLOCKS ? new ArrayList<>() : null;
+        final boolean suppressBlockOutput = streamMode == BOTH && blockStreamOutputSuppressed.getAsBoolean();
 
         var lastAssignedConsenusTime = consensusTime;
         final var builders = requireNonNull(builderSink).allBuilders();
@@ -626,10 +667,18 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
                 }
                 case BOTH -> {
                     final var pairedBuilder = (PairedStreamBuilder) builder;
-                    records.add(pairedBuilder.recordStreamBuilder().build());
-                    final var groupStateChanges = grouped ? baseBuilder.getStateChanges() : null;
-                    requireNonNull(outputs)
-                            .add(pairedBuilder.blockStreamBuilder().build(builder == baseBuilder, groupStateChanges));
+                    final var nextRecord = pairedBuilder.recordStreamBuilder().build();
+                    records.add(nextRecord);
+                    receipts.add(new RecordSource.IdentifiedReceipt(
+                            nextRecord.transactionRecord().transactionIDOrThrow(),
+                            nextRecord.transactionRecord().receiptOrThrow()));
+                    if (!suppressBlockOutput) {
+                        final var groupStateChanges = grouped ? baseBuilder.getStateChanges() : null;
+                        requireNonNull(outputs)
+                                .add(pairedBuilder
+                                        .blockStreamBuilder()
+                                        .build(builder == baseBuilder, groupStateChanges));
+                    }
                 }
             }
         }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/ParentTxnFactory.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/steps/ParentTxnFactory.java
@@ -459,7 +459,8 @@ public class ParentTxnFactory {
                 boundaryStateChangeListener,
                 immediateStateChangeListener,
                 blockStreamConfig.streamMode(),
-                contractsConfig.maxSerializedTraceDataBytes());
+                contractsConfig.maxSerializedTraceDataBytes(),
+                blockStreamManager::isSavepointOutputSuppressed);
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/BlockStreamManagerImplTest.java
@@ -65,6 +65,7 @@ import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfigImpl;
 import com.hedera.node.config.data.BlockStreamConfig;
 import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.hedera.node.config.types.StreamMode;
 import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.metrics.api.Counter;
@@ -199,6 +200,9 @@ class BlockStreamManagerImplTest {
     private Counter indirectProofsCounter;
 
     @Mock
+    private Counter blockSizeCircuitBreakerTripsCounter;
+
+    @Mock
     private ReadableSingletonState<Object> platformStateReadableSingletonState;
 
     @Mock
@@ -219,7 +223,116 @@ class BlockStreamManagerImplTest {
     @BeforeEach
     void setUp() {
         writableStates = mock(WritableStates.class, withSettings().extraInterfaces(CommittableWritableStates.class));
-        lenient().when(metrics.getOrCreate(any(Counter.Config.class))).thenReturn(indirectProofsCounter);
+        lenient().when(metrics.getOrCreate(any(Counter.Config.class))).thenAnswer(invocation -> {
+            final Counter.Config counterConfig = invocation.getArgument(0);
+            return "numBlockSizeCircuitBreakerTrips".equals(counterConfig.getName())
+                    ? blockSizeCircuitBreakerTripsCounter
+                    : indirectProofsCounter;
+        });
+    }
+
+    @Test
+    void suppressesOversizedSavepointBatchesAtomicallyInBothMode() {
+        givenSubjectWith(
+                1,
+                0,
+                StreamMode.BOTH,
+                10_000,
+                blockStreamInfoWith(Bytes.EMPTY, CREATION_VERSION),
+                platformStateWithFreezeTime(null),
+                aWriter);
+        givenEndOfRoundSetup();
+        subject.init(state, FAKE_RESTART_BLOCK_HASH);
+        subject.startRound(round, state);
+
+        final var oversizedItem = BlockItem.newBuilder()
+                .signedTransaction(Bytes.wrap(new byte[20_000]))
+                .build();
+        final var pairedResult = transactionResultItemFrom(CONSENSUS_NOW.plusNanos(1));
+        final var lastAssignedTime = CONSENSUS_NOW.plusNanos(2);
+        subject.writeSavepointItems(List.of(oversizedItem, pairedResult), lastAssignedTime);
+        subject.writeSavepointItems(List.of(FAKE_SIGNED_TRANSACTION), lastAssignedTime.plusNanos(1));
+        subject.prngSeed();
+
+        assertTrue(subject.isSavepointOutputSuppressed());
+        assertEquals(lastAssignedTime.plusNanos(1), subject.lastUsedConsensusTime());
+        verify(aWriter, never()).writePbjItemAndBytes(eq(oversizedItem), any());
+        verify(aWriter, never()).writePbjItemAndBytes(eq(pairedResult), any());
+        verify(aWriter, never()).writePbjItemAndBytes(eq(FAKE_SIGNED_TRANSACTION), any());
+    }
+
+    @Test
+    void opensCircuitBreakerWhenARequiredItemCrossesLimit() {
+        givenSubjectWith(
+                1,
+                0,
+                StreamMode.BOTH,
+                1,
+                blockStreamInfoWith(Bytes.EMPTY, CREATION_VERSION),
+                platformStateWithFreezeTime(null),
+                aWriter);
+        givenEndOfRoundSetup();
+        subject.init(state, FAKE_RESTART_BLOCK_HASH);
+
+        subject.startRound(round, state);
+
+        assertTrue(subject.isSavepointOutputSuppressed());
+        verify(blockSizeCircuitBreakerTripsCounter).increment();
+    }
+
+    @Test
+    void configuredLimitIsInactiveInBlocksMode() {
+        givenSubjectWith(
+                1,
+                0,
+                StreamMode.BLOCKS,
+                1,
+                blockStreamInfoWith(Bytes.EMPTY, CREATION_VERSION),
+                platformStateWithFreezeTime(null),
+                aWriter);
+        givenEndOfRoundSetup();
+        subject.init(state, FAKE_RESTART_BLOCK_HASH);
+        subject.startRound(round, state);
+
+        final var lastAssignedTime = CONSENSUS_NOW.plusNanos(1);
+        subject.writeSavepointItems(List.of(FAKE_SIGNED_TRANSACTION), lastAssignedTime);
+        subject.prngSeed();
+
+        assertFalse(subject.isSavepointOutputSuppressed());
+        assertEquals(lastAssignedTime, subject.lastUsedConsensusTime());
+        verify(aWriter).writePbjItemAndBytes(eq(FAKE_SIGNED_TRANSACTION), any());
+    }
+
+    @Test
+    void refreshesCircuitBreakerConfigurationAtTheStartOfEveryBlock() {
+        givenSubjectWith(
+                1,
+                0,
+                StreamMode.BOTH,
+                0,
+                blockStreamInfoWith(Bytes.EMPTY, CREATION_VERSION),
+                platformStateWithFreezeTime(null),
+                aWriter,
+                bWriter);
+        givenEndOfRoundSetup();
+        given(blockHashSigner.isReady()).willReturn(true);
+        given(blockHashSigner.sign(any(), any()))
+                .willReturn(new BlockHashSigner.Attempt(null, null, mockSigningFuture));
+        given(mockSigningFuture.thenAcceptAsync(any())).willReturn(completedFuture(null));
+        subject.init(state, FAKE_RESTART_BLOCK_HASH);
+
+        // The constructor saw a disabled limit, but the first block sees the latest, enabled value.
+        given(configProvider.getConfiguration()).willReturn(versionedConfigWith(StreamMode.BOTH, 1, 2L));
+        subject.startRound(round, state);
+        assertTrue(subject.isSavepointOutputSuppressed());
+        subject.endRound(state, ROUND_NO);
+
+        // Disabling the limit is picked up when the next block starts.
+        given(configProvider.getConfiguration()).willReturn(versionedConfigWith(StreamMode.BOTH, 0, 3L));
+        given(round.getRoundNum()).willReturn(ROUND_NO + 1);
+        given(round.getConsensusTimestamp()).willReturn(CONSENSUS_NOW.plusSeconds(1));
+        subject.startRound(round, state);
+        assertFalse(subject.isSavepointOutputSuppressed());
     }
 
     @Test
@@ -1777,13 +1890,20 @@ class BlockStreamManagerImplTest {
             @NonNull final BlockStreamInfo blockStreamInfo,
             @NonNull final PlatformState platformState,
             @NonNull final BlockItemWriter... writers) {
+        givenSubjectWith(roundsPerBlock, blockPeriod, StreamMode.BOTH, 0, blockStreamInfo, platformState, writers);
+    }
+
+    private void givenSubjectWith(
+            final int roundsPerBlock,
+            final int blockPeriod,
+            @NonNull final StreamMode streamMode,
+            final long maxBlockSizeBytes,
+            @NonNull final BlockStreamInfo blockStreamInfo,
+            @NonNull final PlatformState platformState,
+            @NonNull final BlockItemWriter... writers) {
         final AtomicInteger nextWriter = new AtomicInteger(0);
-        final var config = HederaTestConfigBuilder.create()
-                .withConfigDataType(BlockStreamConfig.class)
-                .withValue("blockStream.roundsPerBlock", roundsPerBlock)
-                .withValue("blockStream.blockPeriod", Duration.of(blockPeriod, ChronoUnit.SECONDS))
-                .getOrCreateConfig();
-        given(configProvider.getConfiguration()).willReturn(new VersionedConfigImpl(config, 1L));
+        given(configProvider.getConfiguration())
+                .willReturn(versionedConfigWith(roundsPerBlock, blockPeriod, streamMode, maxBlockSizeBytes, 1L));
         subject = new BlockStreamManagerImpl(
                 blockHashSigner,
                 () -> writers[nextWriter.getAndIncrement()],
@@ -1804,6 +1924,27 @@ class BlockStreamManagerImplTest {
         stateRef.set(platformState);
         blockStreamInfoState = new FunctionWritableSingletonState<>(
                 BLOCK_STREAM_INFO_STATE_ID, BLOCK_STREAM_INFO_STATE_LABEL, infoRef::get, infoRef::set);
+    }
+
+    private VersionedConfigImpl versionedConfigWith(
+            @NonNull final StreamMode streamMode, final long maxBlockSizeBytes, final long version) {
+        return versionedConfigWith(1, 0, streamMode, maxBlockSizeBytes, version);
+    }
+
+    private VersionedConfigImpl versionedConfigWith(
+            final int roundsPerBlock,
+            final int blockPeriod,
+            @NonNull final StreamMode streamMode,
+            final long maxBlockSizeBytes,
+            final long version) {
+        final var config = HederaTestConfigBuilder.create()
+                .withConfigDataType(BlockStreamConfig.class)
+                .withValue("blockStream.roundsPerBlock", roundsPerBlock)
+                .withValue("blockStream.blockPeriod", Duration.of(blockPeriod, ChronoUnit.SECONDS))
+                .withValue("blockStream.streamMode", streamMode.name())
+                .withValue("blockStream.maxBlockSizeBytes", maxBlockSizeBytes)
+                .getOrCreateConfig();
+        return new VersionedConfigImpl(config, version);
     }
 
     private void givenEndOfRoundSetup() {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/BlockRecordSourceTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/state/recordcache/BlockRecordSourceTest.java
@@ -101,6 +101,26 @@ class BlockRecordSourceTest {
     }
 
     @Test
+    void returnsAllItemsInExternalizationOrder() {
+        subjectWith(List.of(
+                new BlockStreamBuilder.Output(
+                        List.of(TRANSACTION_RESULT, FIRST_OUTPUT), translationContext, BLOCK_NUMBER),
+                new BlockStreamBuilder.Output(List.of(TRANSACTION_RESULT), translationContext, BLOCK_NUMBER)));
+
+        assertThat(subject.blockItems()).containsExactly(TRANSACTION_RESULT, FIRST_OUTPUT, TRANSACTION_RESULT);
+    }
+
+    @Test
+    void reportsWhetherItHasOutputs() {
+        subjectWith(List.of());
+        assertThat(subject.hasOutputs()).isFalse();
+
+        subjectWith(
+                List.of(new BlockStreamBuilder.Output(List.of(TRANSACTION_RESULT), translationContext, BLOCK_NUMBER)));
+        assertThat(subject.hasOutputs()).isTrue();
+    }
+
+    @Test
     void hasDefaultBlockItemTranslator() {
         assertDoesNotThrow(() -> new BlockRecordSource(List.of()));
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleOutputTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleOutputTest.java
@@ -2,6 +2,7 @@
 package com.hedera.node.app.workflows.handle;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
 
 import com.hedera.node.app.spi.records.RecordSource;
 import com.hedera.node.app.state.recordcache.BlockRecordSource;
@@ -46,11 +47,21 @@ class HandleOutputTest {
     }
 
     @Test
-    void returnsBlockRecordSourceWhenPresentOtherwiseRecordSource() {
-        final var withBlockSource = new HandleOutput(blockRecordSource, recordSource, LAST_TIME);
-        assertEquals(blockRecordSource, withBlockSource.preferringBlockRecordSource());
+    void prefersBlockRecordSourceWhenItHasOutputs() {
+        given(blockRecordSource.hasOutputs()).willReturn(true);
+        final var withBothSources = new HandleOutput(blockRecordSource, recordSource, LAST_TIME);
+        assertEquals(blockRecordSource, withBothSources.preferredRecordSource());
+    }
 
-        final var withoutBlockSource = new HandleOutput(null, recordSource, LAST_TIME);
-        assertEquals(recordSource, withoutBlockSource.preferringBlockRecordSource());
+    @Test
+    void fallsBackToRecordSourceWhenBlockSourceHasNoOutputs() {
+        final var withSuppressedBlockOutput = new HandleOutput(blockRecordSource, recordSource, LAST_TIME);
+        assertEquals(recordSource, withSuppressedBlockOutput.preferredRecordSource());
+    }
+
+    @Test
+    void prefersTheOnlyAvailableSource() {
+        assertEquals(blockRecordSource, new HandleOutput(blockRecordSource, null, LAST_TIME).preferredRecordSource());
+        assertEquals(recordSource, new HandleOutput(null, recordSource, LAST_TIME).preferredRecordSource());
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImplTest.java
@@ -349,6 +349,41 @@ class SavepointStackImplTest extends StateTestBase {
                 .isNull());
     }
 
+    @Test
+    void suppressesOnlyBlockOutputInBothMode() {
+        final var txnId = TransactionID.newBuilder()
+                .accountID(PAYER_ID)
+                .transactionValidStart(VALID_START)
+                .build();
+        final var stack = SavepointStackImpl.newRootStack(
+                baseState,
+                3,
+                50,
+                roundStateChangeListener,
+                immediateStateChangeListener,
+                StreamMode.BOTH,
+                TraceDataSizeLimiter.NO_LIMIT,
+                () -> true);
+        stack.getBaseBuilder(StreamBuilder.class)
+                .transactionID(txnId)
+                .signedTx(SignedTransaction.DEFAULT)
+                .status(SUCCESS)
+                .exchangeRate(ExchangeRateSet.DEFAULT);
+        stack.commitFullStack();
+
+        final var handleOutput = stack.buildHandleOutput(
+                Instant.ofEpochSecond(VALID_START.seconds(), VALID_START.nanos()),
+                ExchangeRateSet.DEFAULT,
+                BLOCK_NUMBER);
+
+        assertThat(handleOutput.blockRecordSourceOrThrow().blockItems()).isEmpty();
+        assertThat(handleOutput.recordSourceOrThrow().identifiedReceipts())
+                .singleElement()
+                .extracting(receipt -> receipt.txnId())
+                .isEqualTo(txnId);
+        assertThat(handleOutput.preferredRecordSource()).isSameAs(handleOutput.recordSourceOrThrow());
+    }
+
     @Nested
     @DisplayName("Tests for adding new savepoints to the stack")
     class SavepointTests {

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/BlockStreamConfig.java
@@ -17,6 +17,8 @@ import java.time.Duration;
  * @param blockFileDir directory to store block files
  * @param roundsPerBlock the number of rounds per block
  * @param blockPeriod the block period
+ * @param maxBlockSizeBytes the maximum serialized preview block size in bytes before savepoint output is suppressed;
+ *                          zero disables the circuit breaker
  * @param receiptEntriesBatchSize the maximum number of receipts to accumulate in a {@link com.hedera.hapi.node.state.recordcache.TransactionReceiptEntries} wrapper before writing a queue state changes item to the block stream
  * @param maxReadDepth the max allowed depth of nested protobuf messages
  * @param maxReadBytesSize the max size in bytes of protobuf messages to read
@@ -39,6 +41,9 @@ public record BlockStreamConfig(
 
         @ConfigProperty(defaultValue = "2s") @Min(0) @NetworkProperty
         Duration blockPeriod,
+
+        @ConfigProperty(defaultValue = "20971520") @Min(0) @NetworkProperty
+        long maxBlockSizeBytes,
 
         @ConfigProperty(defaultValue = "8192") @Min(1) @NetworkProperty
         int receiptEntriesBatchSize,

--- a/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/BlockStreamConfigTest.java
+++ b/hedera-node/hedera-config/src/test/java/com/hedera/node/config/data/BlockStreamConfigTest.java
@@ -41,6 +41,7 @@ class BlockStreamConfigTest {
                 "/opt/hgcapp/blockStreams",
                 1,
                 Duration.ofSeconds(2),
+                0,
                 8192,
                 Duration.ofMillis(10),
                 100,


### PR DESCRIPTION
> Migrated from the private `hashgraph/private-hedera-services` repository.

> Original source commit: `11172d37802c6f6ac2d3ab93fdc67353dd69bb6a`

> This commit preserves the original author and author timestamp.

## Description

Adds a `streamMode=BOTH`-specific circuit breaker that bounds the amount of preview block-stream output admitted during a block while leaving the authoritative record stream available.

The implemented policy is: **In `streamMode=BOTH`, if admitting a transaction's block items would push the preview block past its configured size limit, atomically drop that batch and suppress further transaction block items for the rest of the block, while keeping the authoritative record stream and required block structure intact and resetting the circuit breaker for the next block.**

### Behavior

- Adds the network property `blockStream.maxBlockSizeBytes`; `0` (the default) disables the circuit breaker.
- Enables the limit only in `streamMode=BOTH`; `RECORDS` and `BLOCKS` behavior is unchanged.
- Measures the exact contribution of each admitted batch to the canonical, uncompressed protobuf `Block` representation.
- Treats every savepoint stack's output as one atomic batch: it is either admitted in full or discarded in full.
- Once the projected size exceeds the limit, drops the triggering batch and suppresses later savepoint-stack output until the next block begins.
- Continues writing required structural items so the current block can close normally, including its footer and asynchronous proof. Therefore the configured value is a circuit-breaker threshold, not a strict maximum file size; required items can take the final block over the threshold, and the proof is not included in the measured size.
- Continues advancing the block manager's logical last-used consensus time for discarded batches, preserving scheduled-execution timestamp continuity.
- Avoids constructing block-stream output in later savepoint stacks after the breaker has opened.
- Continues building record-stream records and receipts in `BOTH`, and prefers the record-stream source for record-cache/query data so incomplete preview block output is never authoritative.

### Observability

- Logs an error when the breaker opens, including the block number, projected size, triggering batch size, and configured limit.
- Increments `block.numBlockSizeCircuitBreakerTrips` once per affected block.

### Validation

- Added coverage for atomic oversized-batch rejection, suppression of later batches, required-item trips, logical timestamp continuity, reset-at-next-block behavior, and inactivity in `BLOCKS` mode.
- Added coverage that `BOTH` still produces record receipts while suppressing block output and prefers the record-stream source for queries/cache updates.
- Added coverage for flattening block items into transaction/savepoint batches in externalization order.
- Passed the full `:app:test` and `:config:test` suites (10,512 application tests passed; 7 skipped) and the relevant Spotless checks.
