### PR TITLE
docs: Update documentation

### DIFF
--- a/platform-sdk/CLAUDE.md
+++ b/platform-sdk/CLAUDE.md
@@ -12,6 +12,7 @@ new modules, or deciding where a new dependency belongs.
 4. Test fixtures must not expose impl classes transitively to other modules.
 5. Classes in `internal` packages must not be used outside their defining module.
 6. Functional-api modules must not depend on each other.
+7. Structural-transitional modules may depend on one another; otherwise rule 3 applies to them.
 
 ### base-* Modules
 
@@ -24,9 +25,9 @@ their own, so they are described here.
 
 ### base-* vs consensus-* Primitives
 
-Some `base-*` modules have a `consensus-*` counterpart that occupies the same niche one layer
-up: `base-concurrent`/`consensus-concurrent`, `base-utility`/`consensus-utility`. Both hold
-primitives, but the dividing line is knowledge of the consensus layer:
+One `base-*` module has a `consensus-*` counterpart that occupies the same niche one layer
+up: `base-utility`/`consensus-utility`. Both hold primitives, but the dividing line is
+knowledge of the consensus layer:
 
 - A `base-*` module holds **layer-agnostic** primitives — no dependency on `consensus-model`
   or any other consensus type. They could be used by any project, consensus or not.
@@ -59,40 +60,39 @@ principles as `consensus-*` modules.
 **Usage rules:**
 
 - **Allowed in all modules:** `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`
-- **Allowed in functional-api, functional-impl, self-contained functional, and fake modules only (not supporting modules):** `consensus-wiring-framework`
-- **Allowed in `consensus-platformstate`, `consensus-roster`, and `consensus-iss-detection` only:** `swirlds-state-api`, `swirlds-state-impl`
-- **Allowed in `consensus-state`, `consensus-state-management`, `consensus-transaction-handling`, and `consensus-fakes` only:** `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
-- **Transitional — currently present in `consensus-gossip`, `consensus-gossip-impl`, and `consensus-reconnect-impl` but not permitted in the final architecture:** `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
+- **Allowed in functional-api, functional-impl, self-contained functional, structural-transitional, and fake modules only (not supporting modules):** `consensus-wiring-framework`
 - **Prohibited everywhere — legacy modules being eliminated:** `swirlds-common`, `swirlds-platform-core`
 - **Prohibited everywhere — implementation modules; depend on the API instead:** `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`
 
 ### consensus-* Module Categories
 
-**Supporting modules** — shared data model, helpers, metrics, and concurrency primitives
-consumed across the layer. They form a strict DAG; no circular dependencies are permitted. See
+**Supporting modules** — shared data model, helpers, and metrics consumed across the layer. They form a strict DAG; no circular dependencies are permitted. See
 each module's `README.md` for its description and dependency rules.
 
 - `consensus-model` — **foundation**: holds the consensus data structures all other modules build on. Must not depend on any other supporting module or any other consensus module.
-- Remaining supporting modules: `consensus-concurrent`, `consensus-metrics`, `consensus-roster`, `consensus-platformstate`, `consensus-utility`.
+- Remaining supporting modules: `consensus-metrics`, `consensus-utility`.
 
 **Functional-api modules** — the public-facing API of each business-logic topic:
-- `consensus-event-creator`, `consensus-event-intake`, `consensus-gossip`, `consensus-hashgraph`, `consensus-pces`, `consensus-reconnect`
+- `consensus-event-creator`, `consensus-event-intake`, `consensus-gossip`, `consensus-hashgraph`, `consensus-pces`
 
 **Functional-impl modules** — implementations of the functional APIs. May depend on their
 paired API and any supporting module. Must not depend on other impl modules:
-- `consensus-event-creator-impl`, `consensus-event-intake-impl`, `consensus-event-intake-concurrent`, `consensus-gossip-impl`, `consensus-hashgraph-impl`, `consensus-pces-impl`, `consensus-pces-noop-impl`, `consensus-reconnect-impl`
+- `consensus-event-creator-impl`, `consensus-event-intake-impl`, `consensus-event-intake-concurrent`, `consensus-gossip-impl`, `consensus-hashgraph-impl`, `consensus-pces-impl`, `consensus-pces-noop-impl`
 
 **Self-contained functional modules** — permanent modules that bundle their public API and
 implementation in one module rather than a split api/impl pair. Unlike structural-transitional
 modules, other modules are expected to depend on them; the implementation stays unexported:
 - `consensus-status-monitor`
 
-**Structural-transitional modules** — treated like impl modules (rule 3 applies); temporary, awaiting either a move to the execution layer or removal:
-- `consensus-state` — will move to the execution layer.
-- `consensus-state-management` — will move to the execution layer alongside the signed-state machinery it drives.
+**Structural-transitional modules** — treated like impl modules (rules 3 and 7 apply); temporary, awaiting either a move to the execution layer or removal:
+- `consensus-state` — will move to the execution layer alongside the signed-state machinery it drives.
+- `consensus-platformstate` — passive data module; will move to the execution layer alongside the platform state it wraps.
+- `consensus-roster` — passive data module; will move to the execution layer alongside the roster data it holds.
 - `consensus-transaction-handling` — will move to the execution layer.
 - `consensus-event-stream` — will be deleted once the consensus event stream is superseded by the block stream.
 - `consensus-iss-detection` — will move to the execution layer alongside the state machinery it validates.
+- `consensus-reconnect` — reconnect API; the entire reconnect function will move to the execution layer and eventually be replaced with block node reconnect.
+- `consensus-reconnect-impl` — reconnect implementation; moves with `consensus-reconnect`.
 
 **Tooling modules** — not part of the runtime module graph; have relaxed dependency rules:
 - `consensus-gui`, `consensus-network-simulation`, `consensus-otter-docker-app`, `consensus-otter-tests`, `consensus-sloth`

--- a/platform-sdk/consensus-event-creator-impl/README.md
+++ b/platform-sdk/consensus-event-creator-impl/README.md
@@ -23,4 +23,7 @@ Must not depend on:
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
 `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-No known violations.
+Known violation — `requires org.hiero.consensus.roster`: `consensus-roster` is a
+structural-transitional module that nothing outside that category should depend on (rules 3 and
+7). This does not resolve on its own — the dependency has to be removed before `consensus-roster`
+can move to the execution layer.

--- a/platform-sdk/consensus-event-intake-concurrent/README.md
+++ b/platform-sdk/consensus-event-intake-concurrent/README.md
@@ -21,4 +21,7 @@ Must not depend on:
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
 `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-No known violations.
+Known violation — `requires transitive org.hiero.consensus.roster`: `consensus-roster` is a
+structural-transitional module that nothing outside that category should depend on (rules 3 and
+7). This does not resolve on its own — the dependency has to be removed before `consensus-roster`
+can move to the execution layer.

--- a/platform-sdk/consensus-event-intake-impl/README.md
+++ b/platform-sdk/consensus-event-intake-impl/README.md
@@ -21,4 +21,7 @@ Must not depend on:
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
 `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-No known violations.
+Known violation — `requires transitive org.hiero.consensus.roster`: `consensus-roster` is a
+structural-transitional module that nothing outside that category should depend on (rules 3 and
+7). This does not resolve on its own — the dependency has to be removed before `consensus-roster`
+can move to the execution layer.

--- a/platform-sdk/consensus-event-intake/README.md
+++ b/platform-sdk/consensus-event-intake/README.md
@@ -11,7 +11,7 @@ The API half of the event-intake module pair. For how intake works, see the
 ## Dependency Rules
 
 May depend on:
-- `consensus-model`, `consensus-metrics`, `consensus-roster`, `consensus-utility`
+- `consensus-model`, `consensus-metrics`, `consensus-utility`
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`,
 `consensus-wiring-framework`
 
@@ -22,4 +22,7 @@ Must not depend on:
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
 `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-No known violations.
+Known violation — `requires transitive org.hiero.consensus.roster`: `consensus-roster` is a
+structural-transitional module that nothing outside that category should depend on (rules 3 and
+7). This does not resolve on its own — the dependency has to be removed before `consensus-roster`
+can move to the execution layer.

--- a/platform-sdk/consensus-event-stream/README.md
+++ b/platform-sdk/consensus-event-stream/README.md
@@ -13,14 +13,14 @@ layer.
 ## Dependency Rules
 
 May depend on:
-- `consensus-model`, `consensus-concurrent`, `consensus-metrics`, `consensus-utility`
-- `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`
+- `consensus-model`, `consensus-metrics`, `consensus-utility`
+- `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`,
+`consensus-wiring-framework`
 
 Must not depend on:
 - Any functional-api or impl module
 - `swirlds-common`, `swirlds-platform-core` — legacy, being eliminated
-- `consensus-wiring-framework`, `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
-`swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
+- `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`, `swirlds-state-api`,
+`swirlds-state-impl`, `swirlds-virtualmap`
 
-Known violation — `requires transitive com.swirlds.component.framework`: as a supporting
-module this should not depend on `consensus-wiring-framework`; needs investigation.
+No known violations.

--- a/platform-sdk/consensus-gossip-impl/README.md
+++ b/platform-sdk/consensus-gossip-impl/README.md
@@ -11,7 +11,7 @@ the API, not this module directly. For how gossip is implemented, see the
 ## Dependency Rules
 
 May depend on:
-- `consensus-gossip` (its API), `consensus-state`, any supporting module
+- `consensus-gossip` (its API), any supporting module
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`,
 `consensus-wiring-framework`
 
@@ -21,6 +21,10 @@ Must not depend on:
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
 `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-Known violations — `requires transitive com.swirlds.state.api`, `com.swirlds.state.impl`,
-`com.swirlds.virtualmap`: transitional; acceptable during modularization but not permitted
-in the final architecture.
+Known violations:
+- `requires transitive com.swirlds.state.api`, `com.swirlds.state.impl`, `com.swirlds.virtualmap` —
+transitional; acceptable during modularization but not permitted in the final architecture.
+- `requires org.hiero.consensus.state`, `org.hiero.consensus.roster` — structural-transitional
+modules that nothing outside that category should depend on (rules 3 and 7). Neither resolves on
+its own — both dependencies have to be removed before those modules can move to the execution
+layer.

--- a/platform-sdk/consensus-gossip/README.md
+++ b/platform-sdk/consensus-gossip/README.md
@@ -12,7 +12,7 @@ network. For how gossip works, see the
 ## Dependency Rules
 
 May depend on:
-- `consensus-model`, `consensus-state`, `consensus-utility`
+- `consensus-model`, `consensus-utility`
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`,
 `consensus-wiring-framework`
 
@@ -23,6 +23,9 @@ Must not depend on:
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
 `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-Known violations — `requires transitive com.swirlds.state.api`, `com.swirlds.state.impl`,
-`com.swirlds.virtualmap`: transitional; acceptable during modularization but not permitted
-in the final architecture.
+Known violations:
+- `requires transitive com.swirlds.state.api`, `com.swirlds.state.impl`, `com.swirlds.virtualmap` —
+transitional; acceptable during modularization but not permitted in the final architecture.
+- `requires org.hiero.consensus.state` — `consensus-state` is a structural-transitional module that
+nothing outside that category should depend on (rules 3 and 7). This does not resolve on its own —
+the dependency has to be removed before `consensus-state` can move to the execution layer.

--- a/platform-sdk/consensus-hashgraph-impl/README.md
+++ b/platform-sdk/consensus-hashgraph-impl/README.md
@@ -21,4 +21,7 @@ Must not depend on:
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
 `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-No known violations.
+Known violation — `requires org.hiero.consensus.roster`: `consensus-roster` is a
+structural-transitional module that nothing outside that category should depend on (rules 3 and
+7). This does not resolve on its own — the dependency has to be removed before `consensus-roster`
+can move to the execution layer.

--- a/platform-sdk/consensus-iss-detection/README.md
+++ b/platform-sdk/consensus-iss-detection/README.md
@@ -15,22 +15,20 @@ machinery it validates. For how detection and ISS handling work, see the
 ## Dependency Rules
 
 May depend on:
-- Supporting modules: `consensus-model`, `consensus-concurrent`, `consensus-roster`,
-`consensus-utility`
+- Supporting modules: `consensus-model`, `consensus-utility`
 - Functional-api modules: `consensus-hashgraph`, `consensus-pces`
-- Structural-transitional module: `consensus-state`
+- Structural-transitional modules: `consensus-roster`, `consensus-state`
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`,
-`consensus-wiring-framework`
+`consensus-wiring-framework`, `swirlds-state-api`, `swirlds-state-impl`
 
 Must not depend on:
 - Any `consensus-*-impl` module — it depends on the functional APIs, not their implementations
 - `swirlds-common`, `swirlds-platform-core` — legacy, being eliminated
-- `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`, `swirlds-state-api`,
-`swirlds-virtualmap`
+- `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`, `swirlds-virtualmap`
 
-Accepted exceptions:
-- `requires com.swirlds.state.impl` — `swirlds-state-impl` is otherwise permitted only in
-`consensus-platformstate`, `consensus-roster`, and `consensus-state`. It is pulled in here
-because `consensus-state`'s signed-state types (`SignedState`, `ReservedSignedState`) expose
-`swirlds-state-impl` types in their signatures. This is an accepted exception, not a violation;
-it resolves when the module moves to the execution layer.
+No known violations.
+
+`swirlds-state-impl` is pulled in because `consensus-state`'s signed-state types
+([`SignedState.java`](../consensus-state/src/main/java/org/hiero/consensus/state/signed/SignedState.java),
+[`ReservedSignedState.java`](../consensus-state/src/main/java/org/hiero/consensus/state/signed/ReservedSignedState.java))
+expose `swirlds-state-impl` types such as `VirtualMapState` in their signatures.

--- a/platform-sdk/consensus-metrics/README.md
+++ b/platform-sdk/consensus-metrics/README.md
@@ -5,13 +5,13 @@ and the Prometheus exposition endpoint.
 
 ## Architecture
 
-Sits above `consensus-model` and `consensus-concurrent` in the supporting module DAG. Provides
-metrics infrastructure consumed across the layer.
+Sits above `consensus-model` in the supporting module DAG. Provides metrics infrastructure
+consumed across the layer.
 
 ## Dependency Rules
 
 May depend on:
-- `consensus-model`, `consensus-concurrent`
+- `consensus-model`
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`
 
 Must not depend on:

--- a/platform-sdk/consensus-platformstate/README.md
+++ b/platform-sdk/consensus-platformstate/README.md
@@ -6,8 +6,10 @@ execution layer.
 
 ## Architecture
 
-A passive data module — holds and exposes a well-defined slice of the Merkle tree state without
-orchestrating anything, analogous to `consensus-model` but scoped to platform state.
+A structural-transitional module, and a passive data module within that category — it holds and
+exposes a well-defined slice of the Merkle tree state without orchestrating anything, analogous to
+`consensus-model` but scoped to platform state. It will move to the execution layer alongside the platform
+state it wraps.
 
 ## Dependency Rules
 
@@ -16,7 +18,7 @@ May depend on:
 - `swirlds-base`, `swirlds-config-api`, `swirlds-state-api`, `swirlds-state-impl`
 
 Must not depend on:
-- Any `consensus-*-impl` module or structural-transitional module
+- Any `consensus-*-impl` module or other structural-transitional module
 - Any functional-api or self-contained functional module
 - `swirlds-common`, `swirlds-platform-core` — legacy, being eliminated
 - `consensus-wiring-framework`, `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,

--- a/platform-sdk/consensus-reconnect-impl/README.md
+++ b/platform-sdk/consensus-reconnect-impl/README.md
@@ -5,8 +5,11 @@ node that has fallen behind.
 
 ## Architecture
 
-Implements the [`consensus-reconnect`](../consensus-reconnect) API. Also wires directly into
-the gossip networking layer — hence the known dependency on `consensus-gossip-impl`. For how
+A structural-transitional module — treated like an impl module: nothing outside that category
+should depend on it except platform wiring, tooling, and test code. Implements the
+[`consensus-reconnect`](../consensus-reconnect) API and wires directly into the gossip networking
+layer — hence the known dependency on `consensus-gossip-impl`. The entire reconnect function will
+move to the execution layer. For how
 reconnect works, see the [reconnect topic](../docs/consensus-layer/architecture/topics/reconnect.md).
 
 ## Dependency Rules
@@ -15,7 +18,8 @@ May depend on:
 - `consensus-reconnect` (its API), any supporting module
 - Functional-api modules: `consensus-gossip`, `consensus-event-creator`, `consensus-event-intake`,
 `consensus-hashgraph`, `consensus-pces`
-- Structural-transitional module: `consensus-state`; supporting module: `consensus-platformstate`
+- Structural-transitional modules: `consensus-iss-detection`, `consensus-platformstate`,
+`consensus-roster`, `consensus-state`, `consensus-transaction-handling`
 - Self-contained functional module: `consensus-status-monitor`
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`,
 `consensus-wiring-framework`
@@ -35,9 +39,10 @@ to the execution layer; this dependency is expected during the transition.
 - `requires transitive com.swirlds.state.api`, `com.swirlds.state.impl`,
 `com.swirlds.virtualmap` — transitional; acceptable during modularization but not permitted
 in the final architecture.
-- `requires org.hiero.consensus.iss.detection`, `org.hiero.consensus.transaction.handling` —
-structural-transitional modules that nothing should depend on (rule 3). Neither is named
-anywhere in this module's sources; both are required because `DefaultReconnectModule` receives
-`ConsensusLayerBuildingBlocks`, whose record components are typed `IssDetectionModule` and
-`TransactionHandlingModule`. A consequence of the `com.swirlds.platform.core` dependency above,
-and it resolves with the same move to the execution layer.
+
+`org.hiero.consensus.iss.detection` and `org.hiero.consensus.transaction.handling` are permitted
+under rule 7, but neither is named anywhere in this module's sources: both are required because
+`DefaultReconnectModule` receives `ConsensusLayerBuildingBlocks`, whose record components are typed
+`IssDetectionModule` and `TransactionHandlingModule`. A consequence of the
+`com.swirlds.platform.core` dependency above, and it resolves with the same move to the execution
+layer.

--- a/platform-sdk/consensus-reconnect/README.md
+++ b/platform-sdk/consensus-reconnect/README.md
@@ -5,8 +5,10 @@ for gossip to catch it up.
 
 ## Architecture
 
-The API half of the reconnect module pair. Intentionally thin — the orchestration entry point
-lives in `swirlds-platform-core` today. For reconnect mechanics, see the
+A structural-transitional module, and the API half of the reconnect module pair — treated like an
+impl module: nothing outside that category should depend on it except platform wiring, tooling, and
+test code. Intentionally thin — the orchestration entry point lives in `swirlds-platform-core`
+today. The entire reconnect function will move to the execution layer. For reconnect mechanics, see the
 [reconnect topic](../docs/consensus-layer/architecture/topics/reconnect.md).
 
 ## Dependency Rules
@@ -15,8 +17,7 @@ May depend on:
 - `swirlds-config-api`; no consensus-layer modules currently needed
 
 Must not depend on:
-- Other functional-api modules
-- Any `*-impl` module
+- Any `consensus-*-impl` module, its own `consensus-reconnect-impl` included
 - `swirlds-common`, `swirlds-platform-core` — legacy, being eliminated
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`
 

--- a/platform-sdk/consensus-roster/README.md
+++ b/platform-sdk/consensus-roster/README.md
@@ -4,19 +4,19 @@ Roster data and lookup for the consensus layer. Will eventually move to the exec
 
 ## Architecture
 
-A passive data module — holds and exposes the current and future roster structures without
-orchestrating anything, analogous to `consensus-model` but scoped to roster data. Rosters are
-carried as round metadata so every module agrees on which roster applies to which round.
+A structural-transitional module, and a passive data module within that category — it holds and
+exposes the current and future roster structures without orchestrating anything, analogous to
+`consensus-model` but scoped to roster data. Rosters are carried as round metadata so every module
+agrees on which roster applies to which round.
 
 ## Dependency Rules
 
 May depend on:
-- `consensus-model`
+- `consensus-model`, `consensus-metrics`
 - `swirlds-base`, `swirlds-config-api`, `swirlds-state-api`, `swirlds-state-impl`
 
 Must not depend on:
-- Other supporting modules (`consensus-concurrent`, `consensus-metrics`, `consensus-utility`,
-`consensus-platformstate`)
+- Supporting module `consensus-utility`; structural-transitional module `consensus-platformstate`
 - Any functional-api, functional-impl, or self-contained functional module
 - `swirlds-common`, `swirlds-platform-core` — legacy, being eliminated
 - `consensus-wiring-framework`, `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,

--- a/platform-sdk/consensus-state/README.md
+++ b/platform-sdk/consensus-state/README.md
@@ -12,13 +12,14 @@ layer. Production code should not depend on it directly. For its role, see
 ## Dependency Rules
 
 May depend on:
-- `consensus-model`, `consensus-metrics`, `consensus-platformstate`, `consensus-roster`
+- Supporting modules: `consensus-model`, `consensus-metrics`
+- Structural-transitional modules: `consensus-platformstate`, `consensus-roster`
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`,
-`swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
+`swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`, `consensus-wiring-framework`
 
 Must not depend on:
 - Any `consensus-*-impl` module or functional-api module
 - `swirlds-common`, `swirlds-platform-core` — legacy, being eliminated
-- `consensus-wiring-framework`, `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`
+- `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`
 
 No known violations.

--- a/platform-sdk/consensus-status-monitor/README.md
+++ b/platform-sdk/consensus-status-monitor/README.md
@@ -22,7 +22,7 @@ quiescing node holds `ACTIVE`, see
 ## Dependency Rules
 
 May depend on:
-- Supporting modules: `consensus-model`, `consensus-metrics`, `consensus-roster`
+- Supporting modules: `consensus-model`, `consensus-metrics`
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`,
 `consensus-wiring-framework`
 
@@ -32,4 +32,7 @@ Must not depend on:
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`, `swirlds-state-api`,
 `swirlds-state-impl`, `swirlds-virtualmap`
 
-No known violations.
+Known violation — `requires org.hiero.consensus.roster`: `consensus-roster` is a
+structural-transitional module that nothing outside that category should depend on (rules 3 and
+7). This does not resolve on its own — the dependency has to be removed before `consensus-roster`
+can move to the execution layer.

--- a/platform-sdk/consensus-transaction-handling/README.md
+++ b/platform-sdk/consensus-transaction-handling/README.md
@@ -20,27 +20,27 @@ for the state pipeline it feeds, see
 ## Dependency Rules
 
 May depend on:
-- Supporting modules: `consensus-model`, `consensus-metrics`, `consensus-platformstate`,
-`consensus-utility`
+- Supporting modules: `consensus-model`, `consensus-metrics`, `consensus-utility`
 - Functional-api module: `consensus-hashgraph`
 - Self-contained functional module: `consensus-status-monitor`
-- Structural-transitional module: `consensus-state`
+- Structural-transitional modules: `consensus-event-stream`, `consensus-platformstate`,
+`consensus-state`
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`,
-`consensus-wiring-framework`
+`consensus-wiring-framework`, `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
 Must not depend on:
 - Any `consensus-*-impl` module
 - `swirlds-common`, `swirlds-platform-core` — legacy, being eliminated
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`
 
-Accepted exceptions:
-- `requires transitive com.swirlds.state.api`, `com.swirlds.state.impl`, `com.swirlds.virtualmap` —
-otherwise permitted only in `consensus-state` and `consensus-state-management`. The handler applies
-transactions directly to the state's merkle tree and virtual map, so these types appear in this
-module's signatures. Accepted during modularization; resolves when the module moves to the execution
-layer.
-- `requires org.hiero.consensus.event.stream` — `consensus-event-stream` is itself treated like an
-impl module (nothing should depend on it). `DefaultTransactionHandler` reads `EventStreamWiringConfig`
-to drive the legacy running event hash for the soon-to-be-retired consensus event stream
+`swirlds-state-api`, `swirlds-state-impl`, and `swirlds-virtualmap` are needed because the handler
+applies transactions directly to the state's merkle tree and virtual map, so these types appear in
+this module's signatures.
+
+`consensus-event-stream` is reached because `DefaultTransactionHandler` reads
+`EventStreamWiringConfig` to drive the legacy running event hash for the soon-to-be-retired
+consensus event stream
 ([`DefaultTransactionHandler.java`](src/main/java/org/hiero/consensus/transaction/handling/internal/DefaultTransactionHandler.java));
 the coupling disappears when the event stream is deleted.
+
+No known violations.

--- a/platform-sdk/consensus-utility/README.md
+++ b/platform-sdk/consensus-utility/README.md
@@ -5,12 +5,12 @@ handling, orphan tracking, and monitoring utilities.
 
 ## Architecture
 
-The top of the supporting module DAG — sits above model, concurrent, metrics, and roster.
+The top of the supporting module DAG — sits above `consensus-model` and `consensus-metrics`.
 
 ## Dependency Rules
 
 May depend on:
-- `consensus-model`, `consensus-concurrent`, `consensus-metrics`, `consensus-roster`
+- `consensus-model`, `consensus-metrics`
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`
 
 Must not depend on:
@@ -19,4 +19,7 @@ Must not depend on:
 - `consensus-wiring-framework`, `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
 `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-No known violations.
+Known violation — `requires org.hiero.consensus.roster`: `consensus-roster` is a
+structural-transitional module that nothing outside that category should depend on (rules 3 and
+7). This does not resolve on its own — the dependency has to be removed before `consensus-roster`
+can move to the execution layer.

--- a/platform-sdk/docs/consensus-layer/architecture/overview.md
+++ b/platform-sdk/docs/consensus-layer/architecture/overview.md
@@ -59,22 +59,11 @@ about what lives inside each module belongs in the per-topic files.
 - [`consensus-hashgraph`](../../../consensus-hashgraph) — run the
   hashgraph consensus algorithm; emit consensus rounds with timestamps
   and round metadata. See [`topics/hashgraph.md`](topics/hashgraph.md).
-- [`consensus-roster`](../../../consensus-roster) — roster representation
-  and lookup; rosters are carried as round metadata so every module agrees
-  on which roster applies to which round. See
-  [`topics/hashgraph.md`](topics/hashgraph.md) (round metadata) and
-  [`interfaces/consensus-execution-boundary.md`](interfaces/consensus-execution-boundary.md)
-  (where rosters cross the boundary).
 - [`consensus-reconnect`](../../../consensus-reconnect) — recover a node
   that has fallen behind to the point where gossip alone cannot catch it
   up; the orchestration entry point lives in
   [`swirlds-platform-core`](../../../swirlds-platform-core). See
   [`topics/reconnect.md`](topics/reconnect.md).
-- [`consensus-state`](../../../consensus-state) — Consensus-side state
-  structures shared at the boundary with Execution. See
-  [`topics/signed-state-management.md`](topics/signed-state-management.md)
-  and
-  [`interfaces/consensus-execution-boundary.md`](interfaces/consensus-execution-boundary.md).
 - [`swirlds-platform-core`](../../../swirlds-platform-core) — the wiring
   root: where Consensus modules are composed into a running platform and
   where the Consensus / Execution boundary is drawn today
@@ -85,13 +74,16 @@ about what lives inside each module belongs in the per-topic files.
 
 Supporting modules — [`consensus-model`](../../../consensus-model),
 [`consensus-utility`](../../../consensus-utility),
-[`consensus-metrics`](../../../consensus-metrics),
+[`consensus-metrics`](../../../consensus-metrics) — provide the shared
+data model, helpers, and metrics consumed by the modules above.
+
+Structural-transitional modules —
 [`consensus-event-stream`](../../../consensus-event-stream),
 [`consensus-platformstate`](../../../consensus-platformstate),
-[`consensus-concurrent`](../../../consensus-concurrent) — provide the
-shared data model, helpers, metrics, event streaming, platform-state
-structures, and concurrency primitives consumed by the modules above. The
-topic files cite them where relevant.
+[`consensus-roster`](../../../consensus-roster),
+[`consensus-state`](../../../consensus-state) — carry event streaming
+and state-adjacent structures on the Consensus side until they move to
+Execution or are retired. The topic files cite them where relevant.
 
 GUI, otter, and sloth modules (`consensus-gui`,
 `consensus-otter-docker-app`, `consensus-otter-tests`, `consensus-sloth`)


### PR DESCRIPTION
**Description**:

This PR updates the documentation of our modules and their dependencies:

- Removed references to `consensus-state-management` and `consensus-crypto`.
- Reclassified `consensus-roster`, `consensus-platformstate`, and `consensus-reconnect` as structural-transitional modules.
- Added a rule that structural-transitional modules may depend on each other, which avoids a number of specific rules.
- A few minor fixes.

**Related issue(s)**:

I have created #27074 to fix the uncovered violations regarding `consensus-roster`.

Fixes #27081 