### PR TITLE
chore: Remove consensus-roster from EventCreator module

### DIFF
--- a/platform-sdk/CLAUDE.md
+++ b/platform-sdk/CLAUDE.md
@@ -99,7 +99,7 @@ modules, other modules are expected to depend on them; the implementation stays 
 
 **Fake modules** — implementations for tools and tests only, never for production code: no-op
 implementations, deliberately insecure cryptographic entities, and the like. May depend on any
-consensus-layer module whose API they fake, plus `consensus-wiring-framework`. Must not depend
-on an impl module.
+supporting, functional-api, functional-impl, or self-contained functional module whose API they fake, plus
+`consensus-wiring-framework`. Must not depend on a structural-transitional module.
 - `consensus-fakes` — Transitional: also reached from production paths in
 `swirlds-platform-core` (`PlatformContext.create`, `DefaultSwirldMain`, `ConsensusNoOpModules`).

--- a/platform-sdk/consensus-event-creator-impl/README.md
+++ b/platform-sdk/consensus-event-creator-impl/README.md
@@ -23,7 +23,4 @@ Must not depend on:
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender`,
 `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-Known violation — `requires org.hiero.consensus.roster`: `consensus-roster` is a
-structural-transitional module that nothing outside that category should depend on (rules 3 and
-7). This does not resolve on its own — the dependency has to be removed before `consensus-roster`
-can move to the execution layer.
+No known violations.

--- a/platform-sdk/consensus-event-creator-impl/build.gradle.kts
+++ b/platform-sdk/consensus-event-creator-impl/build.gradle.kts
@@ -18,6 +18,7 @@ jmhModuleInfo {
 description = "Default Consensus Event Creator Implementation"
 
 testModuleInfo {
+    requires("com.hedera.node.hapi")
     requires("com.swirlds.base.test.fixtures")
     requires("com.swirlds.config.extensions.test.fixtures")
     requires("org.hiero.base.crypto.test.fixtures")

--- a/platform-sdk/consensus-event-creator-impl/build.gradle.kts
+++ b/platform-sdk/consensus-event-creator-impl/build.gradle.kts
@@ -6,12 +6,11 @@ plugins {
 }
 
 jmhModuleInfo {
-    requires("com.hedera.node.hapi")
     requires("com.swirlds.config.extensions.test.fixtures")
     requires("org.hiero.consensus.event.creator")
     requires("org.hiero.consensus.event.creator.impl")
     requires("org.hiero.consensus.fakes")
-    requires("org.hiero.consensus.roster.test.fixtures")
+    requires("org.hiero.consensus.model.test.fixtures")
     requires("jmh.core")
 }
 

--- a/platform-sdk/consensus-event-creator-impl/src/jmh/java/org/hiero/consensus/event/creator/impl/jmh/EventCreatorNetworkBenchmark.java
+++ b/platform-sdk/consensus-event-creator-impl/src/jmh/java/org/hiero/consensus/event/creator/impl/jmh/EventCreatorNetworkBenchmark.java
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.creator.impl.jmh;
 
-import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
@@ -27,6 +25,8 @@ import org.hiero.consensus.fakes.noop.NoOpMetrics;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterEntryWrapper;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.orphan.DefaultOrphanBuffer;
 import org.hiero.consensus.orphan.OrphanBuffer;
@@ -74,7 +74,7 @@ public class EventCreatorNetworkBenchmark {
     private List<DefaultEventCreationManager> eventCreators;
 
     /** The roster defining the network. */
-    private Roster roster;
+    private RosterWrapper roster;
 
     /** Total number of events created in the current iteration. */
     private int eventsCreatedInIteration;
@@ -91,8 +91,9 @@ public class EventCreatorNetworkBenchmark {
     @Setup(Level.Trial)
     public void setupTrial() {
         // Build a roster with real keys
-        roster = RosterFactory.randomRosterWithKeys(Randotron.create(seed), numNodes, WeightGenerators.BALANCED)
-                .getRoster();
+        roster = RosterWrapper.of(
+                RosterFactory.randomRosterWithKeys(Randotron.create(seed), numNodes, WeightGenerators.BALANCED)
+                        .getRoster());
         eventWindowUpdateInterval = Math.round(numNodes * Math.log(numNodes));
     }
 
@@ -108,8 +109,8 @@ public class EventCreatorNetworkBenchmark {
         final Time time = Time.getCurrent();
 
         // Create an event creator for each node
-        for (final RosterEntry entry : roster.rosterEntries()) {
-            final NodeId nodeId = NodeId.of(entry.nodeId());
+        for (final RosterEntryWrapper entry : roster.rosterEntries()) {
+            final NodeId nodeId = entry.nodeId();
             final SecureRandom nodeRandom = new SecureRandom();
             nodeRandom.setSeed(nodeId.id());
             final KeyPair keyPair = SigningFactory.generateKeyPair(signingType.getSigningSchema(), nodeRandom);

--- a/platform-sdk/consensus-event-creator-impl/src/jmh/java/org/hiero/consensus/event/creator/impl/jmh/EventCreatorNetworkBenchmark.java
+++ b/platform-sdk/consensus-event-creator-impl/src/jmh/java/org/hiero/consensus/event/creator/impl/jmh/EventCreatorNetworkBenchmark.java
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.creator.impl.jmh;
 
+import static org.hiero.consensus.model.test.fixtures.roster.RosterWrapperFactory.randomRosterWithKeys;
+
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
@@ -30,7 +32,6 @@ import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.orphan.DefaultOrphanBuffer;
 import org.hiero.consensus.orphan.OrphanBuffer;
-import org.hiero.consensus.roster.test.fixtures.RosterFactory;
 import org.hiero.consensus.test.fixtures.Randotron;
 import org.hiero.consensus.test.fixtures.WeightGenerators;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -91,9 +92,7 @@ public class EventCreatorNetworkBenchmark {
     @Setup(Level.Trial)
     public void setupTrial() {
         // Build a roster with real keys
-        roster = RosterWrapper.of(
-                RosterFactory.randomRosterWithKeys(Randotron.create(seed), numNodes, WeightGenerators.BALANCED)
-                        .getRoster());
+        roster = randomRosterWithKeys(Randotron.create(seed), numNodes, WeightGenerators.BALANCED);
         eventWindowUpdateInterval = Math.round(numNodes * Math.log(numNodes));
     }
 

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/module-info.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/module-info.java
@@ -7,7 +7,6 @@ module org.hiero.consensus.event.creator.impl {
     exports org.hiero.consensus.event.creator.impl.tipset;
     exports org.hiero.consensus.event.creator.impl;
 
-    requires transitive com.hedera.node.hapi;
     requires transitive com.swirlds.base;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;
@@ -20,7 +19,6 @@ module org.hiero.consensus.event.creator.impl {
     requires com.swirlds.logging;
     requires org.hiero.base.concurrent;
     requires org.hiero.base.utility;
-    requires org.hiero.consensus.roster;
     requires org.hiero.consensus.utility;
     requires org.apache.logging.log4j;
     requires static transitive com.github.spotbugs.annotations;

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/DefaultEventCreationManager.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/DefaultEventCreationManager.java
@@ -5,7 +5,6 @@ import static org.hiero.consensus.event.creator.impl.EventCreationStatus.ATTEMPT
 import static org.hiero.consensus.event.creator.impl.EventCreationStatus.IDLE;
 import static org.hiero.consensus.event.creator.impl.EventCreationStatus.NO_ELIGIBLE_PARENTS;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.DoubleGauge;
@@ -35,6 +34,7 @@ import org.hiero.consensus.model.gossip.SyncProgress;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.quiescence.QuiescenceCommand;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.model.transaction.SignatureTransactionCheck;
 
@@ -97,7 +97,7 @@ public class DefaultEventCreationManager implements EventCreationManager {
             @NonNull final Time time,
             @NonNull final SignatureTransactionCheck signatureTransactionCheck,
             @NonNull final EventCreator eventCreator,
-            @NonNull final Roster roster,
+            @NonNull final RosterWrapper roster,
             @NonNull final NodeId selfId) {
         this.creator = Objects.requireNonNull(eventCreator);
         this.syncLagCalculator = new SyncLagCalculator(selfId, roster);

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/DefaultEventCreatorModule.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/DefaultEventCreatorModule.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import static org.hiero.consensus.wiring.framework.wires.SolderType.INJECT;
 import static org.hiero.consensus.wiring.framework.wires.SolderType.OFFER;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
@@ -26,6 +25,7 @@ import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.quiescence.QuiescenceCommand;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.model.transaction.EventTransactionSupplier;
 import org.hiero.consensus.model.transaction.SignatureTransactionCheck;
@@ -57,7 +57,7 @@ public class DefaultEventCreatorModule implements EventCreatorModule {
             @NonNull final Time time,
             @NonNull final SecureRandom random,
             @NonNull final KeysAndCerts keysAndCerts,
-            @NonNull final Roster roster,
+            @NonNull final RosterWrapper roster,
             @NonNull final NodeId selfId,
             @NonNull final EventTransactionSupplier transactionSupplier,
             @NonNull final SignatureTransactionCheck signatureTransactionCheck) {

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculator.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculator.java
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.creator.impl.rules;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.Map;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterWrapper;
 
 // utility class to hold weight and lag in a map value
 record WeightAndLag(long weight, long lag) {}
@@ -43,17 +43,17 @@ public class SyncLagCalculator {
      * @param selfId current node id
      * @param roster roster of all the nodes in network
      */
-    public SyncLagCalculator(final NodeId selfId, final Roster roster) {
+    public SyncLagCalculator(final NodeId selfId, final RosterWrapper roster) {
         this.selfId = selfId;
         otherNodesTotalWeight = roster.rosterEntries().stream()
-                .peek(entry -> weightMap.put(NodeId.of(entry.nodeId()), entry.weight()))
+                .peek(entry -> weightMap.put(entry.nodeId(), entry.weight()))
                 .peek(entry -> {
-                    if (selfId.id() != entry.nodeId()) {
-                        consensusLag.put(NodeId.of(entry.nodeId()), new WeightAndLag(entry.weight(), 0));
+                    if (!selfId.equals(entry.nodeId())) {
+                        consensusLag.put(entry.nodeId(), new WeightAndLag(entry.weight(), 0));
                     }
                 })
                 .mapToLong(entry -> {
-                    if (selfId.id() == entry.nodeId()) {
+                    if (selfId.equals(entry.nodeId())) {
                         return 0;
                     } else {
                         return entry.weight();

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/Tipset.java
@@ -1,22 +1,21 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.creator.impl.tipset;
 
-import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import org.hiero.consensus.model.event.EventConstants;
 import org.hiero.consensus.model.node.NodeId;
-import org.hiero.consensus.roster.RosterUtils;
+import org.hiero.consensus.model.roster.RosterEntryWrapper;
+import org.hiero.consensus.model.roster.RosterWrapper;
 
 /**
  * Represents a slice of the hashgraph, containing one "tip" from each event creator.
  */
 public class Tipset {
 
-    private final Roster roster;
+    private final RosterWrapper roster;
 
     /**
      * The tip generations, indexed by node index.
@@ -28,7 +27,7 @@ public class Tipset {
      *
      * @param roster the current address book
      */
-    public Tipset(@NonNull final Roster roster) {
+    public Tipset(@NonNull final RosterWrapper roster) {
         this.roster = Objects.requireNonNull(roster);
         tips = new long[roster.rosterEntries().size()];
 
@@ -86,7 +85,7 @@ public class Tipset {
      * @return the tip generation for the node
      */
     public long getTipSequenceNumberForNode(@NonNull final NodeId nodeId) {
-        final int index = RosterUtils.getIndex(roster, nodeId.id());
+        final int index = roster.getIndex(nodeId);
         if (index == -1) {
             return EventConstants.SEQUENCE_NUMBER_UNDEFINED;
         }
@@ -110,7 +109,7 @@ public class Tipset {
      * @return this object
      */
     public @NonNull Tipset advance(@NonNull final NodeId creator, final long generation) {
-        final int index = RosterUtils.getIndex(roster, creator.id());
+        final int index = roster.getIndex(creator);
         tips[index] = Math.max(tips[index], generation);
         return this;
     }
@@ -140,7 +139,7 @@ public class Tipset {
         long nonZeroWeight = 0;
         long zeroWeightCount = 0;
 
-        final int selfIndex = RosterUtils.getIndex(roster, selfId.id());
+        final int selfIndex = roster.getIndex(selfId);
         for (int index = 0; index < tips.length; index++) {
             if (index == selfIndex) {
                 // We don't consider self advancement here, since self advancement does nothing to help consensus.
@@ -148,7 +147,7 @@ public class Tipset {
             }
 
             if (this.tips[index] < that.tips[index]) {
-                final RosterEntry address = roster.rosterEntries().get(index);
+                final RosterEntryWrapper address = roster.rosterEntries().get(index);
 
                 if (address.weight() == 0) {
                     zeroWeightCount += 1;

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreator.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreator.java
@@ -2,8 +2,8 @@
 package org.hiero.consensus.event.creator.impl.tipset;
 
 import static com.swirlds.logging.legacy.LogMarker.INVALID_EVENT_ERROR;
+import static java.util.Objects.requireNonNull;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.time.Time;
 import com.swirlds.base.utility.Pair;
 import com.swirlds.config.api.Configuration;
@@ -37,9 +37,9 @@ import org.hiero.consensus.model.event.UnsignedEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.quiescence.QuiescenceCommand;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.transaction.EventTransactionSupplier;
 import org.hiero.consensus.model.transaction.TimestampedTransaction;
-import org.hiero.consensus.roster.RosterUtils;
 
 /**
  * Responsible for creating new events using the tipset algorithm.
@@ -64,7 +64,7 @@ public class TipsetEventCreator implements EventCreator {
     /**
      * The address book for the current network.
      */
-    private final Roster roster;
+    private final RosterWrapper roster;
 
     /**
      * The size of the current address book.
@@ -124,16 +124,16 @@ public class TipsetEventCreator implements EventCreator {
             @NonNull final Time time,
             @NonNull final SecureRandom random,
             @NonNull final BytesSigner signer,
-            @NonNull final Roster roster,
+            @NonNull final RosterWrapper roster,
             @NonNull final NodeId selfId,
             @NonNull final EventTransactionSupplier transactionSupplier) {
 
-        this.time = Objects.requireNonNull(time);
-        this.random = Objects.requireNonNull(random);
-        this.signer = Objects.requireNonNull(signer);
-        this.selfId = Objects.requireNonNull(selfId);
-        this.transactionSupplier = Objects.requireNonNull(transactionSupplier);
-        this.roster = Objects.requireNonNull(roster);
+        this.time = requireNonNull(time);
+        this.random = requireNonNull(random);
+        this.signer = requireNonNull(signer);
+        this.selfId = requireNonNull(selfId);
+        this.transactionSupplier = requireNonNull(transactionSupplier);
+        this.roster = requireNonNull(roster);
 
         final EventCreationConfig eventCreationConfig = configuration.getConfigData(EventCreationConfig.class);
 
@@ -143,7 +143,7 @@ public class TipsetEventCreator implements EventCreator {
         childlessOtherEventTracker = new ChildlessEventTracker();
         tipsetWeightCalculator = new TipsetWeightCalculator(
                 configuration, time, roster, selfId, tipsetTracker, childlessOtherEventTracker);
-        networkSize = roster.rosterEntries().size();
+        networkSize = roster.size();
 
         zeroAdvancementWeightLogger = new RateLimitedLogger(logger, time, Duration.ofMinutes(1));
         noParentFoundLogger = new RateLimitedLogger(logger, time, Duration.ofMinutes(1));
@@ -168,7 +168,7 @@ public class TipsetEventCreator implements EventCreator {
         }
 
         final NodeId eventCreator = event.getCreatorId();
-        if (RosterUtils.getIndex(roster, eventCreator.id()) == -1) {
+        if (!roster.contains(eventCreator)) {
             return;
         }
         final boolean selfEvent = eventCreator.equals(selfId);
@@ -205,7 +205,7 @@ public class TipsetEventCreator implements EventCreator {
      */
     @Override
     public void setEventWindow(@NonNull final EventWindow eventWindow) {
-        this.eventWindow = Objects.requireNonNull(eventWindow);
+        this.eventWindow = requireNonNull(eventWindow);
         this.lastReceivedEventWindow = time.now();
         tipsetTracker.setEventWindow(eventWindow);
         childlessOtherEventTracker.pruneOldEvents(eventWindow);
@@ -213,7 +213,7 @@ public class TipsetEventCreator implements EventCreator {
 
     @Override
     public void quiescenceCommand(@NonNull final QuiescenceCommand quiescenceCommand) {
-        this.quiescenceCommand = Objects.requireNonNull(quiescenceCommand);
+        this.quiescenceCommand = requireNonNull(quiescenceCommand);
     }
 
     /**

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetMetrics.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetMetrics.java
@@ -3,8 +3,6 @@ package org.hiero.consensus.event.creator.impl.tipset;
 
 import static com.swirlds.metrics.api.FloatFormats.FORMAT_4_2;
 
-import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.HashMap;
@@ -13,6 +11,8 @@ import org.hiero.consensus.metrics.RunningAverageMetric;
 import org.hiero.consensus.metrics.SpeedometerMetric;
 import org.hiero.consensus.metrics.statistics.AverageStat;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterEntryWrapper;
+import org.hiero.consensus.model.roster.RosterWrapper;
 
 /**
  * Encapsulates metrics for the tipset event creator.
@@ -43,7 +43,7 @@ public class TipsetMetrics {
      * @param metrics the metrics instance to use
      * @param roster  the roster of nodes in the network
      */
-    public TipsetMetrics(@NonNull final Metrics metrics, @NonNull final Roster roster) {
+    public TipsetMetrics(@NonNull final Metrics metrics, @NonNull final RosterWrapper roster) {
 
         tipsetAdvancementMetric = metrics.getOrCreate(TIPSET_ADVANCEMENT_CONFIG);
         selfishnessMetric = metrics.getOrCreate(SELFISHNESS_CONFIG);
@@ -55,8 +55,8 @@ public class TipsetMetrics {
                 FORMAT_4_2,
                 AverageStat.WEIGHT_VOLATILE);
 
-        for (final RosterEntry address : roster.rosterEntries()) {
-            final NodeId nodeId = NodeId.of(address.nodeId());
+        for (final RosterEntryWrapper address : roster.rosterEntries()) {
+            final NodeId nodeId = address.nodeId();
 
             final SpeedometerMetric.Config parentConfig = new SpeedometerMetric.Config(
                             "platform", "tipsetParent" + nodeId.id())

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTracker.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTracker.java
@@ -3,7 +3,6 @@ package org.hiero.consensus.event.creator.impl.tipset;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.time.Time;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -17,6 +16,7 @@ import org.hiero.consensus.model.event.EventDescriptorWrapper;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.sequence.map.SequenceMap;
 import org.hiero.consensus.model.sequence.map.StandardSequenceMap;
 
@@ -41,7 +41,7 @@ public class TipsetTracker {
      */
     private Tipset latestGenerations;
 
-    private final Roster roster;
+    private final RosterWrapper roster;
 
     private EventWindow eventWindow;
     private final NodeId selfId;
@@ -55,7 +55,7 @@ public class TipsetTracker {
      * @param selfId      the id of this node
      * @param roster      the current roster
      */
-    public TipsetTracker(@NonNull final Time time, @NonNull final NodeId selfId, @NonNull final Roster roster) {
+    public TipsetTracker(@NonNull final Time time, @NonNull final NodeId selfId, @NonNull final RosterWrapper roster) {
         this.roster = Objects.requireNonNull(roster);
         this.selfId = Objects.requireNonNull(selfId);
         this.latestGenerations = new Tipset(roster);
@@ -199,6 +199,8 @@ public class TipsetTracker {
 
     /**
      * Get number of tipsets being tracked.
+     *
+     * @return the number of tipsets being tracked
      */
     public int size() {
         return tipsets.getSize();

--- a/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculator.java
+++ b/platform-sdk/consensus-event-creator-impl/src/main/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculator.java
@@ -2,10 +2,10 @@
 package org.hiero.consensus.event.creator.impl.tipset;
 
 import static com.swirlds.logging.legacy.LogMarker.EXCEPTION;
+import static java.util.Objects.requireNonNull;
 import static org.hiero.base.utility.Threshold.SUPER_MAJORITY;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetAdvancementWeight.ZERO_ADVANCEMENT_WEIGHT;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -15,7 +15,6 @@ import java.util.Deque;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Objects;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.hiero.base.concurrent.throttle.RateLimitedLogger;
@@ -23,7 +22,7 @@ import org.hiero.consensus.event.creator.config.EventCreationConfig;
 import org.hiero.consensus.model.event.EventDescriptorWrapper;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.node.NodeId;
-import org.hiero.consensus.roster.RosterUtils;
+import org.hiero.consensus.model.roster.RosterWrapper;
 
 /**
  * Calculates tipset advancement weights for events created by a node.
@@ -89,7 +88,7 @@ public class TipsetWeightCalculator {
      */
     private Tipset latestSelfEventTipset;
 
-    private final Roster roster;
+    private final RosterWrapper roster;
 
     private final RateLimitedLogger ancientParentLogger;
     private final RateLimitedLogger allParentsAreAncientLogger;
@@ -107,18 +106,18 @@ public class TipsetWeightCalculator {
     public TipsetWeightCalculator(
             @NonNull final Configuration configuration,
             @NonNull final Time time,
-            @NonNull final Roster roster,
+            @NonNull final RosterWrapper roster,
             @NonNull final NodeId selfId,
             @NonNull final TipsetTracker tipsetTracker,
             @NonNull final ChildlessEventTracker childlessEventTracker) {
 
-        this.selfId = Objects.requireNonNull(selfId);
-        this.tipsetTracker = Objects.requireNonNull(tipsetTracker);
-        this.childlessEventTracker = Objects.requireNonNull(childlessEventTracker);
-        this.roster = Objects.requireNonNull(roster);
+        this.selfId = requireNonNull(selfId);
+        this.tipsetTracker = requireNonNull(tipsetTracker);
+        this.childlessEventTracker = requireNonNull(childlessEventTracker);
+        this.roster = requireNonNull(roster);
 
-        totalWeight = RosterUtils.computeTotalWeight(roster);
-        selfWeight = RosterUtils.getRosterEntry(roster, selfId.id()).weight();
+        totalWeight = roster.totalWeight();
+        selfWeight = roster.getRosterEntry(selfId).weight();
         maximumPossibleAdvancementWeight = totalWeight - selfWeight;
         maxSnapshotHistorySize =
                 configuration.getConfigData(EventCreationConfig.class).tipsetSnapshotHistorySize();
@@ -133,6 +132,8 @@ public class TipsetWeightCalculator {
 
     /**
      * Get the maximum possible tipset advancement weight that a new event can achieve.
+     *
+     * @return the maximum possible tipset advancement weight
      */
     public long getMaximumPossibleAdvancementWeight() {
         return maximumPossibleAdvancementWeight;
@@ -163,7 +164,7 @@ public class TipsetWeightCalculator {
      * previous event passed to this method
      */
     public TipsetAdvancementWeight addEventAndGetAdvancementWeight(@NonNull final EventDescriptorWrapper event) {
-        Objects.requireNonNull(event);
+        requireNonNull(event);
         if (!event.creator().equals(selfId)) {
             throw new IllegalArgumentException("event creator must be the same as self ID");
         }

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/EventCreatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/EventCreatorTests.java
@@ -27,6 +27,7 @@ import org.hiero.consensus.model.gossip.SyncProgress;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.quiescence.QuiescenceCommand;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.model.test.fixtures.hashgraph.EventWindowBuilder;
 import org.hiero.consensus.roster.test.fixtures.RandomRosterEntryBuilder;
@@ -62,7 +63,7 @@ class EventCreatorTests {
                     .build());
         }
 
-        final Roster roster = new Roster(rosterEntries);
+        final RosterWrapper roster = RosterWrapper.of(new Roster(rosterEntries));
 
         manager = new DefaultEventCreationManager(
                 configuration, metrics, time, () -> false, creator, roster, NodeId.of(1));

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/EventCreatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/EventCreatorTests.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.creator.impl;
 
+import static org.hiero.consensus.model.test.fixtures.roster.RosterWrapperFactory.createRosterWrapper;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -11,7 +12,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.base.test.fixtures.time.FakeTime;
 import com.swirlds.config.api.Configuration;
@@ -63,7 +63,7 @@ class EventCreatorTests {
                     .build());
         }
 
-        final RosterWrapper roster = RosterWrapper.of(new Roster(rosterEntries));
+        final RosterWrapper roster = createRosterWrapper(rosterEntries);
 
         manager = new DefaultEventCreationManager(
                 configuration, metrics, time, () -> false, creator, roster, NodeId.of(1));

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculatorTests.java
@@ -6,11 +6,11 @@ import static org.hiero.consensus.test.fixtures.WeightGenerators.GAUSSIAN;
 import static org.hiero.consensus.test.fixtures.WeightGenerators.SINGLE_NODE_HAS_ALL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import java.util.concurrent.atomic.AtomicLong;
 import org.hiero.base.utility.test.fixtures.RandomUtils;
 import org.hiero.base.utility.test.fixtures.ResettableRandom;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.roster.test.fixtures.RosterFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -29,11 +29,11 @@ public class SyncLagCalculatorTests {
     @Test
     public void randomWeightSameLag() {
         final long reportedLag = 123456L;
-        final Roster roster = RosterFactory.randomRoster(random, 10, GAUSSIAN);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 10, GAUSSIAN));
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         roster.rosterEntries().forEach(entry -> {
-            if (entry.nodeId() != NodeId.FIRST_NODE_ID.id()) {
-                slc.reportSyncLag(NodeId.of(entry.nodeId()), reportedLag);
+            if (!NodeId.FIRST_NODE_ID.equals(entry.nodeId())) {
+                slc.reportSyncLag(entry.nodeId(), reportedLag);
             }
         });
 
@@ -43,12 +43,12 @@ public class SyncLagCalculatorTests {
     @Test
     public void sameWeightComputeLag() {
 
-        final Roster roster = RosterFactory.randomRoster(random, 10, BALANCED_1000_PER_NODE);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 10, BALANCED_1000_PER_NODE));
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         final AtomicLong lag = new AtomicLong(10);
         roster.rosterEntries().forEach(entry -> {
-            if (entry.nodeId() != NodeId.FIRST_NODE_ID.id()) {
-                slc.reportSyncLag(NodeId.of(entry.nodeId()), lag.getAndAdd(10));
+            if (!NodeId.FIRST_NODE_ID.equals(entry.nodeId())) {
+                slc.reportSyncLag(entry.nodeId(), lag.getAndAdd(10));
             }
         });
 
@@ -58,12 +58,12 @@ public class SyncLagCalculatorTests {
     @Test
     public void sameWeightComputeLagEvenAmountOfPeers() {
 
-        final Roster roster = RosterFactory.randomRoster(random, 11, BALANCED_1000_PER_NODE);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 11, BALANCED_1000_PER_NODE));
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         final AtomicLong lag = new AtomicLong(10);
         roster.rosterEntries().forEach(entry -> {
-            if (entry.nodeId() != NodeId.FIRST_NODE_ID.id()) {
-                slc.reportSyncLag(NodeId.of(entry.nodeId()), lag.getAndAdd(10));
+            if (!NodeId.FIRST_NODE_ID.equals(entry.nodeId())) {
+                slc.reportSyncLag(entry.nodeId(), lag.getAndAdd(10));
             }
         });
 
@@ -73,15 +73,15 @@ public class SyncLagCalculatorTests {
     @Test
     public void randomWeightsALotOfZeroes() {
 
-        final Roster roster = RosterFactory.randomRoster(random, 10, GAUSSIAN);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 10, GAUSSIAN));
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         final AtomicLong counter = new AtomicLong(0);
         roster.rosterEntries().forEach(entry -> {
-            if (entry.nodeId() != NodeId.FIRST_NODE_ID.id()) {
+            if (!NodeId.FIRST_NODE_ID.equals(entry.nodeId())) {
                 if (counter.incrementAndGet() < 7) {
-                    slc.reportSyncLag(NodeId.of(entry.nodeId()), 0);
+                    slc.reportSyncLag(entry.nodeId(), 0);
                 } else {
-                    slc.reportSyncLag(NodeId.of(entry.nodeId()), 10000);
+                    slc.reportSyncLag(entry.nodeId(), 10000);
                 }
             }
         });
@@ -92,11 +92,11 @@ public class SyncLagCalculatorTests {
     @Test
     public void missingNodesAssumedToBeZero() {
 
-        final Roster roster = RosterFactory.randomRoster(random, 10, GAUSSIAN);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 10, GAUSSIAN));
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         roster.rosterEntries().subList(0, 3).forEach(entry -> {
-            if (entry.nodeId() != NodeId.FIRST_NODE_ID.id()) {
-                slc.reportSyncLag(NodeId.of(entry.nodeId()), 10000);
+            if (!NodeId.FIRST_NODE_ID.equals(entry.nodeId())) {
+                slc.reportSyncLag(entry.nodeId(), 10000);
             }
         });
 
@@ -107,7 +107,8 @@ public class SyncLagCalculatorTests {
     @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
     public void singleNodeNetworkRealNode(final int zeroWeightNodeCount) {
 
-        final Roster roster = RosterFactory.randomRoster(random, zeroWeightNodeCount + 1, SINGLE_NODE_HAS_ALL);
+        final RosterWrapper roster =
+                RosterWrapper.of(RosterFactory.randomRoster(random, zeroWeightNodeCount + 1, SINGLE_NODE_HAS_ALL));
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         assertEquals(0, slc.getSyncRoundLag());
     }
@@ -116,14 +117,15 @@ public class SyncLagCalculatorTests {
     @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9})
     public void singleNodeNetworkUselessNode(final int zeroWeightNodeCount) {
 
-        final Roster roster = RosterFactory.randomRoster(random, zeroWeightNodeCount + 1, SINGLE_NODE_HAS_ALL);
-        final NodeId selfNodeId = NodeId.of(roster.rosterEntries()
+        final RosterWrapper roster =
+                RosterWrapper.of(RosterFactory.randomRoster(random, zeroWeightNodeCount + 1, SINGLE_NODE_HAS_ALL));
+        final NodeId selfNodeId = roster.rosterEntries()
                 .get(1 + random.nextInt(zeroWeightNodeCount))
-                .nodeId());
+                .nodeId();
         final SyncLagCalculator slc = new SyncLagCalculator(selfNodeId, roster);
 
         for (int i = 0; i <= zeroWeightNodeCount; i++) {
-            final NodeId nodeId = NodeId.of(roster.rosterEntries().get(i).nodeId());
+            final NodeId nodeId = roster.rosterEntries().get(i).nodeId();
             if (!nodeId.equals(selfNodeId)) {
                 slc.reportSyncLag(nodeId, random.nextLong(10000000));
             }

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/rules/SyncLagCalculatorTests.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.creator.impl.rules;
 
+import static org.hiero.consensus.model.test.fixtures.roster.RosterWrapperFactory.randomRoster;
 import static org.hiero.consensus.test.fixtures.WeightGenerators.BALANCED_1000_PER_NODE;
 import static org.hiero.consensus.test.fixtures.WeightGenerators.GAUSSIAN;
 import static org.hiero.consensus.test.fixtures.WeightGenerators.SINGLE_NODE_HAS_ALL;
@@ -11,7 +12,6 @@ import org.hiero.base.utility.test.fixtures.RandomUtils;
 import org.hiero.base.utility.test.fixtures.ResettableRandom;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.roster.RosterWrapper;
-import org.hiero.consensus.roster.test.fixtures.RosterFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,7 +29,7 @@ public class SyncLagCalculatorTests {
     @Test
     public void randomWeightSameLag() {
         final long reportedLag = 123456L;
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 10, GAUSSIAN));
+        final RosterWrapper roster = randomRoster(random, 10, GAUSSIAN);
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         roster.rosterEntries().forEach(entry -> {
             if (!NodeId.FIRST_NODE_ID.equals(entry.nodeId())) {
@@ -43,7 +43,7 @@ public class SyncLagCalculatorTests {
     @Test
     public void sameWeightComputeLag() {
 
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 10, BALANCED_1000_PER_NODE));
+        final RosterWrapper roster = randomRoster(random, 10, BALANCED_1000_PER_NODE);
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         final AtomicLong lag = new AtomicLong(10);
         roster.rosterEntries().forEach(entry -> {
@@ -58,7 +58,7 @@ public class SyncLagCalculatorTests {
     @Test
     public void sameWeightComputeLagEvenAmountOfPeers() {
 
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 11, BALANCED_1000_PER_NODE));
+        final RosterWrapper roster = randomRoster(random, 11, BALANCED_1000_PER_NODE);
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         final AtomicLong lag = new AtomicLong(10);
         roster.rosterEntries().forEach(entry -> {
@@ -73,7 +73,7 @@ public class SyncLagCalculatorTests {
     @Test
     public void randomWeightsALotOfZeroes() {
 
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 10, GAUSSIAN));
+        final RosterWrapper roster = randomRoster(random, 10, GAUSSIAN);
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         final AtomicLong counter = new AtomicLong(0);
         roster.rosterEntries().forEach(entry -> {
@@ -92,7 +92,7 @@ public class SyncLagCalculatorTests {
     @Test
     public void missingNodesAssumedToBeZero() {
 
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, 10, GAUSSIAN));
+        final RosterWrapper roster = randomRoster(random, 10, GAUSSIAN);
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         roster.rosterEntries().subList(0, 3).forEach(entry -> {
             if (!NodeId.FIRST_NODE_ID.equals(entry.nodeId())) {
@@ -107,8 +107,7 @@ public class SyncLagCalculatorTests {
     @ValueSource(ints = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
     public void singleNodeNetworkRealNode(final int zeroWeightNodeCount) {
 
-        final RosterWrapper roster =
-                RosterWrapper.of(RosterFactory.randomRoster(random, zeroWeightNodeCount + 1, SINGLE_NODE_HAS_ALL));
+        final RosterWrapper roster = randomRoster(random, zeroWeightNodeCount + 1, SINGLE_NODE_HAS_ALL);
         final SyncLagCalculator slc = new SyncLagCalculator(NodeId.FIRST_NODE_ID, roster);
         assertEquals(0, slc.getSyncRoundLag());
     }
@@ -117,8 +116,7 @@ public class SyncLagCalculatorTests {
     @ValueSource(ints = {1, 2, 3, 4, 5, 6, 7, 8, 9})
     public void singleNodeNetworkUselessNode(final int zeroWeightNodeCount) {
 
-        final RosterWrapper roster =
-                RosterWrapper.of(RosterFactory.randomRoster(random, zeroWeightNodeCount + 1, SINGLE_NODE_HAS_ALL));
+        final RosterWrapper roster = randomRoster(random, zeroWeightNodeCount + 1, SINGLE_NODE_HAS_ALL);
         final NodeId selfNodeId = roster.rosterEntries()
                 .get(1 + random.nextInt(zeroWeightNodeCount))
                 .nodeId();

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTestUtils.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTestUtils.java
@@ -61,7 +61,7 @@ public class TipsetEventCreatorTestUtils {
     public static EventCreator buildEventCreator(
             @NonNull final Random random,
             @NonNull final Time time,
-            @NonNull final Roster roster,
+            @NonNull final Roster pbjRoster,
             @NonNull final NodeId nodeId,
             @NonNull final EventTransactionSupplier transactionSupplier,
             final int maxParents) {
@@ -93,7 +93,7 @@ public class TipsetEventCreatorTestUtils {
                 time,
                 secureRandom,
                 signer,
-                RosterWrapper.of(roster),
+                RosterWrapper.of(pbjRoster),
                 nodeId,
                 transactionSupplier);
     }
@@ -105,27 +105,28 @@ public class TipsetEventCreatorTestUtils {
     public static Map<NodeId, SimulatedNode> buildSimulatedNodes(
             @NonNull final Random random,
             @NonNull final Time time,
-            @NonNull final Roster roster,
+            @NonNull final Roster pbjRoster,
             @NonNull final EventTransactionSupplier transactionSupplier) {
 
-        final RosterWrapper rosterWrapper = RosterWrapper.of(roster);
+        final RosterWrapper roster = RosterWrapper.of(pbjRoster);
         final Map<NodeId, SimulatedNode> eventCreators = new HashMap<>();
         final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
         final Metrics metrics = new NoOpMetrics();
 
-        for (final RosterEntryWrapper address : rosterWrapper.rosterEntries()) {
+        for (final RosterEntryWrapper address : roster.rosterEntries()) {
 
             final NodeId selfId = address.nodeId();
-            final EventCreator eventCreator = buildEventCreator(random, time, roster, selfId, transactionSupplier, 1);
+            final EventCreator eventCreator =
+                    buildEventCreator(random, time, pbjRoster, selfId, transactionSupplier, 1);
 
             // Set a wide event window so that no events get stuck in the Future Event Buffer
             eventCreator.setEventWindow(EventWindow.getGenesisEventWindow());
 
-            final TipsetTracker tipsetTracker = new TipsetTracker(time, selfId, rosterWrapper);
+            final TipsetTracker tipsetTracker = new TipsetTracker(time, selfId, roster);
 
             final ChildlessEventTracker childlessEventTracker = new ChildlessEventTracker();
             final TipsetWeightCalculator tipsetWeightCalculator = new TipsetWeightCalculator(
-                    configuration, time, rosterWrapper, selfId, tipsetTracker, childlessEventTracker);
+                    configuration, time, roster, selfId, tipsetTracker, childlessEventTracker);
             final OrphanBuffer orphanBuffer = new DefaultOrphanBuffer(metrics, mock(IntakeEventCounter.class));
 
             eventCreators.put(

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTestUtils.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetEventCreatorTestUtils.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
@@ -42,6 +41,8 @@ import org.hiero.consensus.model.event.EventDescriptorWrapper;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterEntryWrapper;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.test.fixtures.event.TestingEventBuilder;
 import org.hiero.consensus.model.test.fixtures.transaction.TestingTransactions;
 import org.hiero.consensus.model.transaction.EventTransactionSupplier;
@@ -87,7 +88,14 @@ public class TipsetEventCreatorTestUtils {
         secureRandom.setSeed(random.nextLong());
 
         return new TipsetEventCreator(
-                configuration, metrics, time, secureRandom, signer, roster, nodeId, transactionSupplier);
+                configuration,
+                metrics,
+                time,
+                secureRandom,
+                signer,
+                RosterWrapper.of(roster),
+                nodeId,
+                transactionSupplier);
     }
 
     /**
@@ -100,33 +108,29 @@ public class TipsetEventCreatorTestUtils {
             @NonNull final Roster roster,
             @NonNull final EventTransactionSupplier transactionSupplier) {
 
+        final RosterWrapper rosterWrapper = RosterWrapper.of(roster);
         final Map<NodeId, SimulatedNode> eventCreators = new HashMap<>();
         final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
         final Metrics metrics = new NoOpMetrics();
 
-        for (final RosterEntry address : roster.rosterEntries()) {
+        for (final RosterEntryWrapper address : rosterWrapper.rosterEntries()) {
 
-            final NodeId selfId = NodeId.of(address.nodeId());
+            final NodeId selfId = address.nodeId();
             final EventCreator eventCreator = buildEventCreator(random, time, roster, selfId, transactionSupplier, 1);
 
             // Set a wide event window so that no events get stuck in the Future Event Buffer
             eventCreator.setEventWindow(EventWindow.getGenesisEventWindow());
 
-            final TipsetTracker tipsetTracker = new TipsetTracker(time, selfId, roster);
+            final TipsetTracker tipsetTracker = new TipsetTracker(time, selfId, rosterWrapper);
 
             final ChildlessEventTracker childlessEventTracker = new ChildlessEventTracker();
             final TipsetWeightCalculator tipsetWeightCalculator = new TipsetWeightCalculator(
-                    configuration, time, roster, NodeId.of(address.nodeId()), tipsetTracker, childlessEventTracker);
+                    configuration, time, rosterWrapper, selfId, tipsetTracker, childlessEventTracker);
             final OrphanBuffer orphanBuffer = new DefaultOrphanBuffer(metrics, mock(IntakeEventCounter.class));
 
             eventCreators.put(
                     selfId,
-                    new SimulatedNode(
-                            NodeId.of(address.nodeId()),
-                            orphanBuffer,
-                            tipsetTracker,
-                            eventCreator,
-                            tipsetWeightCalculator));
+                    new SimulatedNode(selfId, orphanBuffer, tipsetTracker, eventCreator, tipsetWeightCalculator));
         }
 
         return eventCreators;

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
@@ -4,6 +4,7 @@ package org.hiero.consensus.event.creator.impl.tipset;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
 import static org.hiero.consensus.event.creator.impl.util.CollectionsUtilities.permutations;
+import static org.hiero.consensus.model.test.fixtures.roster.RosterWrapperFactory.randomRoster;
 
 import java.util.HashMap;
 import java.util.List;
@@ -12,7 +13,6 @@ import java.util.Random;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.roster.RosterEntryWrapper;
 import org.hiero.consensus.model.roster.RosterWrapper;
-import org.hiero.consensus.roster.test.fixtures.RosterFactory;
 import org.hiero.consensus.test.fixtures.WeightGenerators;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -33,7 +33,7 @@ class TipsetTests {
 
         final int nodeCount = 100;
 
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
+        final RosterWrapper roster = randomRoster(random, nodeCount);
 
         final Tipset tipset = new Tipset(roster);
         assertThat(tipset.size()).isEqualTo(nodeCount);
@@ -59,7 +59,7 @@ class TipsetTests {
 
         final int nodeCount = 100;
 
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
+        final RosterWrapper roster = randomRoster(random, nodeCount);
 
         // Given:
         final Tipset emptyTipset = new Tipset(roster);
@@ -135,8 +135,7 @@ class TipsetTests {
 
         final int nodeCount = 100;
 
-        final RosterWrapper roster =
-                RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED));
+        final RosterWrapper roster = randomRoster(random, nodeCount, WeightGenerators.BALANCED);
 
         final NodeId selfId =
                 roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId();
@@ -188,7 +187,7 @@ class TipsetTests {
         final Random random = getRandomPrintSeed();
         final int nodeCount = 100;
 
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
+        final RosterWrapper roster = randomRoster(random, nodeCount);
 
         final Map<NodeId, Long> weights = new HashMap<>();
         for (final RosterEntryWrapper address : roster.rosterEntries()) {

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTests.java
@@ -5,13 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
 import static org.hiero.consensus.event.creator.impl.util.CollectionsUtilities.permutations;
 
-import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterEntryWrapper;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.roster.test.fixtures.RosterFactory;
 import org.hiero.consensus.test.fixtures.WeightGenerators;
 import org.junit.jupiter.api.DisplayName;
@@ -33,7 +33,7 @@ class TipsetTests {
 
         final int nodeCount = 100;
 
-        final Roster roster = RosterFactory.randomRoster(random, nodeCount);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
 
         final Tipset tipset = new Tipset(roster);
         assertThat(tipset.size()).isEqualTo(nodeCount);
@@ -42,8 +42,7 @@ class TipsetTests {
 
         for (int iteration = 0; iteration < 10; iteration++) {
             for (int creator = 0; creator < nodeCount; creator++) {
-                final NodeId creatorId =
-                        NodeId.of(roster.rosterEntries().get(creator).nodeId());
+                final NodeId creatorId = roster.rosterEntries().get(creator).nodeId();
                 final long generation = random.nextLong(1, 100);
 
                 tipset.advance(creatorId, generation);
@@ -60,7 +59,7 @@ class TipsetTests {
 
         final int nodeCount = 100;
 
-        final Roster roster = RosterFactory.randomRoster(random, nodeCount);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
 
         // Given:
         final Tipset emptyTipset = new Tipset(roster);
@@ -69,12 +68,12 @@ class TipsetTests {
         final Tipset biggerTipset = new Tipset(roster);
         final Tipset smallerTipset = new Tipset(roster);
 
-        for (final RosterEntry entry : roster.rosterEntries()) {
-            maxTipset.advance(NodeId.of(entry.nodeId()), Long.MAX_VALUE);
+        for (final RosterEntryWrapper entry : roster.rosterEntries()) {
+            maxTipset.advance(entry.nodeId(), Long.MAX_VALUE);
             final long generation = random.nextLong(1, Long.MAX_VALUE - 1);
-            biggerTipset.advance(NodeId.of(entry.nodeId()), generation + 1);
-            randomTipset.advance(NodeId.of(entry.nodeId()), generation);
-            smallerTipset.advance(NodeId.of(entry.nodeId()), generation - 1);
+            biggerTipset.advance(entry.nodeId(), generation + 1);
+            randomTipset.advance(entry.nodeId(), generation);
+            smallerTipset.advance(entry.nodeId(), generation - 1);
         }
 
         // verify that an empty tipset merged against any other the result is the other
@@ -136,15 +135,15 @@ class TipsetTests {
 
         final int nodeCount = 100;
 
-        final Roster roster = RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED);
+        final RosterWrapper roster =
+                RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED));
 
         final NodeId selfId =
-                NodeId.of(roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId());
+                roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId();
 
         final Tipset initialTipset = new Tipset(roster);
         for (long creator = 0; creator < nodeCount; creator++) {
-            final NodeId creatorId =
-                    NodeId.of(roster.rosterEntries().get((int) creator).nodeId());
+            final NodeId creatorId = roster.rosterEntries().get((int) creator).nodeId();
             final long generation = random.nextLong(1, 100);
             initialTipset.advance(creatorId, generation);
         }
@@ -153,8 +152,7 @@ class TipsetTests {
         final Tipset comparisonTipset = new Tipset(roster).merge(List.of(initialTipset));
         assertThat(comparisonTipset.size()).isEqualTo(initialTipset.size());
         for (int creator = 0; creator < 100; creator++) {
-            final NodeId creatorId =
-                    NodeId.of(roster.rosterEntries().get(creator).nodeId());
+            final NodeId creatorId = roster.rosterEntries().get(creator).nodeId();
             assertThat(comparisonTipset.getTipSequenceNumberForNode(creatorId))
                     .isEqualTo(initialTipset.getTipSequenceNumberForNode(creatorId));
         }
@@ -162,8 +160,7 @@ class TipsetTests {
         // Cause the comparison tipset to advance in a random way
         for (int entryIndex = 0; entryIndex < 100; entryIndex++) {
             final long creator = random.nextLong(100);
-            final NodeId creatorId =
-                    NodeId.of(roster.rosterEntries().get((int) creator).nodeId());
+            final NodeId creatorId = roster.rosterEntries().get((int) creator).nodeId();
             final long generation = random.nextLong(1, 100);
 
             comparisonTipset.advance(creatorId, generation);
@@ -171,7 +168,7 @@ class TipsetTests {
 
         long expectedAdvancementCount = 0;
         for (int i = 0; i < 100; i++) {
-            final NodeId nodeId = NodeId.of(roster.rosterEntries().get(i).nodeId());
+            final NodeId nodeId = roster.rosterEntries().get(i).nodeId();
             if (nodeId.equals(selfId)) {
                 // Self advancements are not counted
                 continue;
@@ -191,20 +188,19 @@ class TipsetTests {
         final Random random = getRandomPrintSeed();
         final int nodeCount = 100;
 
-        final Roster roster = RosterFactory.randomRoster(random, nodeCount);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
 
         final Map<NodeId, Long> weights = new HashMap<>();
-        for (final RosterEntry address : roster.rosterEntries()) {
-            weights.put(NodeId.of(address.nodeId()), address.weight());
+        for (final RosterEntryWrapper address : roster.rosterEntries()) {
+            weights.put(address.nodeId(), address.weight());
         }
 
         final NodeId selfId =
-                NodeId.of(roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId());
+                roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId();
 
         final Tipset initialTipset = new Tipset(roster);
         for (long creator = 0; creator < 100; creator++) {
-            final NodeId creatorId =
-                    NodeId.of(roster.rosterEntries().get((int) creator).nodeId());
+            final NodeId creatorId = roster.rosterEntries().get((int) creator).nodeId();
             final long generation = random.nextLong(1, 100);
             initialTipset.advance(creatorId, generation);
         }
@@ -213,21 +209,20 @@ class TipsetTests {
         final Tipset comparisonTipset = new Tipset(roster).merge(List.of(initialTipset));
         assertThat(comparisonTipset.size()).isEqualTo(initialTipset.size());
         for (int creator = 0; creator < 100; creator++) {
-            final NodeId creatorId =
-                    NodeId.of(roster.rosterEntries().get(creator).nodeId());
+            final NodeId creatorId = roster.rosterEntries().get(creator).nodeId();
             assertThat(comparisonTipset.getTipSequenceNumberForNode(creatorId))
                     .isEqualTo(initialTipset.getTipSequenceNumberForNode(creatorId));
         }
 
         // Cause the comparison tipset to advance in a random way
-        for (final RosterEntry address : roster.rosterEntries()) {
+        for (final RosterEntryWrapper address : roster.rosterEntries()) {
             final long generation = random.nextLong(1, 100);
-            comparisonTipset.advance(NodeId.of(address.nodeId()), generation);
+            comparisonTipset.advance(address.nodeId(), generation);
         }
 
         long expectedAdvancementCount = 0;
-        for (final RosterEntry address : roster.rosterEntries()) {
-            final NodeId nodeId = NodeId.of(address.nodeId());
+        for (final RosterEntryWrapper address : roster.rosterEntries()) {
+            final NodeId nodeId = address.nodeId();
             if (nodeId.equals(selfId)) {
                 // Self advancements are not counted
                 continue;

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
@@ -3,6 +3,7 @@ package org.hiero.consensus.event.creator.impl.tipset;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.base.utility.test.fixtures.RandomUtils.getRandomPrintSeed;
+import static org.hiero.consensus.model.test.fixtures.roster.RosterWrapperFactory.randomRoster;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
@@ -26,7 +27,6 @@ import org.hiero.consensus.model.roster.RosterEntryWrapper;
 import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.test.fixtures.event.TestingEventBuilder;
 import org.hiero.consensus.model.test.fixtures.hashgraph.EventWindowBuilder;
-import org.hiero.consensus.roster.test.fixtures.RosterFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -57,7 +57,7 @@ class TipsetTrackerTests {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
+        final RosterWrapper roster = randomRoster(random, nodeCount);
         final NodeId selfId = NodeId.of(random.nextLong(nodeCount));
 
         final Map<NodeId, PlatformEvent> latestEvents = new HashMap<>();

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetTrackerTests.java
@@ -7,8 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
-import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.base.time.Time;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.ArrayList;
@@ -24,6 +22,8 @@ import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusConstants;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterEntryWrapper;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.test.fixtures.event.TestingEventBuilder;
 import org.hiero.consensus.model.test.fixtures.hashgraph.EventWindowBuilder;
 import org.hiero.consensus.roster.test.fixtures.RosterFactory;
@@ -34,15 +34,15 @@ import org.junit.jupiter.api.Test;
 class TipsetTrackerTests {
 
     private static void assertTipsetEquality(
-            @NonNull final Roster roster, @NonNull final Tipset expected, @NonNull final Tipset actual) {
+            @NonNull final RosterWrapper roster, @NonNull final Tipset expected, @NonNull final Tipset actual) {
         assertThat(actual.size()).isEqualTo(expected.size());
 
-        for (final RosterEntry address : roster.rosterEntries()) {
-            assertThat(actual.getTipSequenceNumberForNode(NodeId.of(address.nodeId())))
+        for (final RosterEntryWrapper address : roster.rosterEntries()) {
+            assertThat(actual.getTipSequenceNumberForNode(address.nodeId()))
                     .withFailMessage(
                             "Expected tip generation for node %s to be %s but was %s",
                             address.nodeId(), expected, actual)
-                    .isEqualTo(expected.getTipSequenceNumberForNode(NodeId.of(address.nodeId())));
+                    .isEqualTo(expected.getTipSequenceNumberForNode(address.nodeId()));
         }
     }
 
@@ -57,7 +57,7 @@ class TipsetTrackerTests {
         final Random random = getRandomPrintSeed();
 
         final int nodeCount = random.nextInt(10, 20);
-        final Roster roster = RosterFactory.randomRoster(random, nodeCount);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
         final NodeId selfId = NodeId.of(random.nextLong(nodeCount));
 
         final Map<NodeId, PlatformEvent> latestEvents = new HashMap<>();
@@ -69,8 +69,8 @@ class TipsetTrackerTests {
 
         for (int eventIndex = 0; eventIndex < 1000; eventIndex++) {
 
-            final NodeId creator = NodeId.of(
-                    roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId());
+            final NodeId creator =
+                    roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId();
 
             birthRound += random.nextLong(0, 3) / 2;
 
@@ -78,8 +78,8 @@ class TipsetTrackerTests {
             final Set<NodeId> desiredParents = new HashSet<>();
             final int maxParentCount = random.nextInt(nodeCount);
             for (int parentIndex = 0; parentIndex < maxParentCount; parentIndex++) {
-                final NodeId parent = NodeId.of(
-                        roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId());
+                final NodeId parent =
+                        roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId();
 
                 // We are only trying to generate a random number of parents, the exact count is unimportant.
                 // So it doesn't matter if the actual number of parents is less than the number we requested.

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
@@ -13,7 +13,6 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 
 import com.hedera.hapi.node.state.roster.Roster;
-import com.hedera.hapi.node.state.roster.RosterEntry;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.api.ConfigurationBuilder;
@@ -30,6 +29,8 @@ import org.hiero.consensus.model.event.NonDeterministicGeneration;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterEntryWrapper;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.test.fixtures.event.TestingEventBuilder;
 import org.hiero.consensus.model.test.fixtures.hashgraph.EventWindowBuilder;
 import org.hiero.consensus.roster.test.fixtures.RosterFactory;
@@ -127,17 +128,17 @@ class TipsetWeightCalculatorTests {
 
         final Map<NodeId, PlatformEvent> latestEvents = new HashMap<>();
 
-        final Roster roster = RosterFactory.randomRoster(random, nodeCount);
+        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
 
         final Map<NodeId, Long> weightMap = new HashMap<>();
         long totalWeight = 0;
-        for (final RosterEntry address : roster.rosterEntries()) {
-            weightMap.put(NodeId.of(address.nodeId()), address.weight());
+        for (final RosterEntryWrapper address : roster.rosterEntries()) {
+            weightMap.put(address.nodeId(), address.weight());
             totalWeight += address.weight();
         }
 
         final NodeId selfId =
-                NodeId.of(roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId());
+                roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId();
 
         final Configuration configuration =
                 ConfigurationBuilder.create().autoDiscoverExtensions().build();
@@ -153,8 +154,8 @@ class TipsetWeightCalculatorTests {
         Tipset previousSnapshot = calculator.getSnapshot();
 
         for (int eventIndex = 0; eventIndex < 1000; eventIndex++) {
-            final NodeId creator = NodeId.of(
-                    roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId());
+            final NodeId creator =
+                    roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId();
             final long nGen;
             if (latestEvents.containsKey(creator)) {
                 nGen = latestEvents.get(creator).getNGen() + 1;
@@ -166,8 +167,8 @@ class TipsetWeightCalculatorTests {
             final Set<NodeId> desiredOtherParents = new HashSet<>();
             final int maxParentCount = random.nextInt(nodeCount);
             for (int parentIndex = 0; parentIndex < maxParentCount; parentIndex++) {
-                final NodeId parent = NodeId.of(
-                        roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId());
+                final NodeId parent =
+                        roster.rosterEntries().get(random.nextInt(nodeCount)).nodeId();
 
                 // We are only trying to generate a random number of parents, the exact count is unimportant.
                 // So it doesn't matter if the actual number of parents is less than the number we requested.
@@ -272,13 +273,14 @@ class TipsetWeightCalculatorTests {
     @DisplayName("Selfish Node Test")
     public void selfishNodeTest(@ParamName("random") final Random random) {
         final int nodeCount = 4;
-        final Roster roster = RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED);
+        final RosterWrapper roster =
+                RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED));
 
         // In this test, we simulate from the perspective of node A. All nodes have 1 weight.
-        final NodeId nodeA = NodeId.of(roster.rosterEntries().get(0).nodeId());
-        final NodeId nodeB = NodeId.of(roster.rosterEntries().get(1).nodeId());
-        final NodeId nodeC = NodeId.of(roster.rosterEntries().get(2).nodeId());
-        final NodeId nodeD = NodeId.of(roster.rosterEntries().get(3).nodeId());
+        final NodeId nodeA = roster.rosterEntries().get(0).nodeId();
+        final NodeId nodeB = roster.rosterEntries().get(1).nodeId();
+        final NodeId nodeC = roster.rosterEntries().get(2).nodeId();
+        final NodeId nodeD = roster.rosterEntries().get(3).nodeId();
 
         final Configuration configuration =
                 ConfigurationBuilder.create().autoDiscoverExtensions().build();
@@ -484,7 +486,7 @@ class TipsetWeightCalculatorTests {
     public void zeroWeightNodeTest(@ParamName("random") final Random random) {
         final int nodeCount = 4;
 
-        Roster roster = RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED);
+        final Roster roster = RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED);
         // In this test, we simulate from the perspective of node A.
         // All nodes have 1 weight except for D, which has 0 weight.
         final NodeId nodeA = NodeId.of(roster.rosterEntries().get(0).nodeId());
@@ -492,26 +494,24 @@ class TipsetWeightCalculatorTests {
         final NodeId nodeC = NodeId.of(roster.rosterEntries().get(2).nodeId());
         final NodeId nodeD = NodeId.of(roster.rosterEntries().get(3).nodeId());
 
-        roster = Roster.newBuilder()
-                .rosterEntries(roster.rosterEntries().stream()
-                        .map(entry -> {
-                            if (entry.nodeId() == nodeD.id()) {
-                                return entry.copyBuilder().weight(0).build();
-                            } else {
-                                return entry;
-                            }
-                        })
-                        .toList())
-                .build();
+        final RosterWrapper rosterWrapper = RosterWrapper.of(new Roster(roster.rosterEntries().stream()
+                .map(entry -> {
+                    if (entry.nodeId() == nodeD.id()) {
+                        return entry.copyBuilder().weight(0).build();
+                    } else {
+                        return entry;
+                    }
+                })
+                .toList()));
 
         final Configuration configuration =
                 ConfigurationBuilder.create().autoDiscoverExtensions().build();
         final Time time = Time.getCurrent();
 
-        final TipsetTracker builder = new TipsetTracker(Time.getCurrent(), nodeA, roster);
+        final TipsetTracker builder = new TipsetTracker(Time.getCurrent(), nodeA, rosterWrapper);
         final ChildlessEventTracker childlessEventTracker = new ChildlessEventTracker();
         final TipsetWeightCalculator calculator =
-                new TipsetWeightCalculator(configuration, time, roster, nodeA, builder, childlessEventTracker);
+                new TipsetWeightCalculator(configuration, time, rosterWrapper, nodeA, builder, childlessEventTracker);
 
         final Tipset snapshot1 = calculator.getSnapshot();
 
@@ -579,12 +579,13 @@ class TipsetWeightCalculatorTests {
     public void ancientParentTest(@ParamName("random") final Random random) {
         final int nodeCount = 4;
 
-        final Roster roster = RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED);
+        final RosterWrapper roster =
+                RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED));
 
-        final NodeId nodeA = NodeId.of(roster.rosterEntries().get(0).nodeId());
-        final NodeId nodeB = NodeId.of(roster.rosterEntries().get(1).nodeId());
-        final NodeId nodeC = NodeId.of(roster.rosterEntries().get(2).nodeId());
-        final NodeId nodeD = NodeId.of(roster.rosterEntries().get(3).nodeId());
+        final NodeId nodeA = roster.rosterEntries().get(0).nodeId();
+        final NodeId nodeB = roster.rosterEntries().get(1).nodeId();
+        final NodeId nodeC = roster.rosterEntries().get(2).nodeId();
+        final NodeId nodeD = roster.rosterEntries().get(3).nodeId();
 
         final Configuration configuration =
                 ConfigurationBuilder.create().autoDiscoverExtensions().build();

--- a/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
+++ b/platform-sdk/consensus-event-creator-impl/src/test/java/org/hiero/consensus/event/creator/impl/tipset/TipsetWeightCalculatorTests.java
@@ -5,6 +5,8 @@ import static org.hiero.base.utility.Threshold.SUPER_MAJORITY;
 import static org.hiero.consensus.event.creator.impl.tipset.TipsetAdvancementWeight.ZERO_ADVANCEMENT_WEIGHT;
 import static org.hiero.consensus.model.event.NonDeterministicGeneration.FIRST_GENERATION;
 import static org.hiero.consensus.model.hashgraph.ConsensusConstants.ROUND_FIRST;
+import static org.hiero.consensus.model.test.fixtures.roster.RosterWrapperFactory.createRosterWrapper;
+import static org.hiero.consensus.model.test.fixtures.roster.RosterWrapperFactory.randomRoster;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -128,7 +130,7 @@ class TipsetWeightCalculatorTests {
 
         final Map<NodeId, PlatformEvent> latestEvents = new HashMap<>();
 
-        final RosterWrapper roster = RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount));
+        final RosterWrapper roster = randomRoster(random, nodeCount);
 
         final Map<NodeId, Long> weightMap = new HashMap<>();
         long totalWeight = 0;
@@ -273,8 +275,7 @@ class TipsetWeightCalculatorTests {
     @DisplayName("Selfish Node Test")
     public void selfishNodeTest(@ParamName("random") final Random random) {
         final int nodeCount = 4;
-        final RosterWrapper roster =
-                RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED));
+        final RosterWrapper roster = randomRoster(random, nodeCount, WeightGenerators.BALANCED);
 
         // In this test, we simulate from the perspective of node A. All nodes have 1 weight.
         final NodeId nodeA = roster.rosterEntries().get(0).nodeId();
@@ -486,15 +487,15 @@ class TipsetWeightCalculatorTests {
     public void zeroWeightNodeTest(@ParamName("random") final Random random) {
         final int nodeCount = 4;
 
-        final Roster roster = RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED);
+        final Roster pbjRoster = RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED);
         // In this test, we simulate from the perspective of node A.
         // All nodes have 1 weight except for D, which has 0 weight.
-        final NodeId nodeA = NodeId.of(roster.rosterEntries().get(0).nodeId());
-        final NodeId nodeB = NodeId.of(roster.rosterEntries().get(1).nodeId());
-        final NodeId nodeC = NodeId.of(roster.rosterEntries().get(2).nodeId());
-        final NodeId nodeD = NodeId.of(roster.rosterEntries().get(3).nodeId());
+        final NodeId nodeA = NodeId.of(pbjRoster.rosterEntries().get(0).nodeId());
+        final NodeId nodeB = NodeId.of(pbjRoster.rosterEntries().get(1).nodeId());
+        final NodeId nodeC = NodeId.of(pbjRoster.rosterEntries().get(2).nodeId());
+        final NodeId nodeD = NodeId.of(pbjRoster.rosterEntries().get(3).nodeId());
 
-        final RosterWrapper rosterWrapper = RosterWrapper.of(new Roster(roster.rosterEntries().stream()
+        final RosterWrapper roster = createRosterWrapper(pbjRoster.rosterEntries().stream()
                 .map(entry -> {
                     if (entry.nodeId() == nodeD.id()) {
                         return entry.copyBuilder().weight(0).build();
@@ -502,16 +503,16 @@ class TipsetWeightCalculatorTests {
                         return entry;
                     }
                 })
-                .toList()));
+                .toList());
 
         final Configuration configuration =
                 ConfigurationBuilder.create().autoDiscoverExtensions().build();
         final Time time = Time.getCurrent();
 
-        final TipsetTracker builder = new TipsetTracker(Time.getCurrent(), nodeA, rosterWrapper);
+        final TipsetTracker builder = new TipsetTracker(Time.getCurrent(), nodeA, roster);
         final ChildlessEventTracker childlessEventTracker = new ChildlessEventTracker();
         final TipsetWeightCalculator calculator =
-                new TipsetWeightCalculator(configuration, time, rosterWrapper, nodeA, builder, childlessEventTracker);
+                new TipsetWeightCalculator(configuration, time, roster, nodeA, builder, childlessEventTracker);
 
         final Tipset snapshot1 = calculator.getSnapshot();
 
@@ -579,8 +580,7 @@ class TipsetWeightCalculatorTests {
     public void ancientParentTest(@ParamName("random") final Random random) {
         final int nodeCount = 4;
 
-        final RosterWrapper roster =
-                RosterWrapper.of(RosterFactory.randomRoster(random, nodeCount, WeightGenerators.BALANCED));
+        final RosterWrapper roster = randomRoster(random, nodeCount, WeightGenerators.BALANCED);
 
         final NodeId nodeA = roster.rosterEntries().get(0).nodeId();
         final NodeId nodeB = roster.rosterEntries().get(1).nodeId();

--- a/platform-sdk/consensus-event-creator/src/main/java/module-info.java
+++ b/platform-sdk/consensus-event-creator/src/main/java/module-info.java
@@ -6,7 +6,6 @@ module org.hiero.consensus.event.creator {
     exports org.hiero.consensus.event.creator.config;
     exports org.hiero.consensus.event.creator;
 
-    requires transitive com.hedera.node.hapi;
     requires transitive com.swirlds.base;
     requires transitive com.swirlds.config.api;
     requires transitive com.swirlds.metrics.api;

--- a/platform-sdk/consensus-event-creator/src/main/java/org/hiero/consensus/event/creator/EventCreatorModule.java
+++ b/platform-sdk/consensus-event-creator/src/main/java/org/hiero/consensus/event/creator/EventCreatorModule.java
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.event.creator;
 
-import com.hedera.hapi.node.state.roster.Roster;
 import com.swirlds.base.time.Time;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.metrics.api.Metrics;
@@ -15,6 +14,7 @@ import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.quiescence.QuiescenceCommand;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.model.transaction.EventTransactionSupplier;
 import org.hiero.consensus.model.transaction.SignatureTransactionCheck;
@@ -49,7 +49,7 @@ public interface EventCreatorModule {
             @NonNull Time time,
             @NonNull SecureRandom random,
             @NonNull KeysAndCerts keysAndCerts,
-            @NonNull Roster roster,
+            @NonNull RosterWrapper roster,
             @NonNull NodeId selfId,
             @NonNull EventTransactionSupplier transactionSupplier,
             @NonNull SignatureTransactionCheck signatureTransactionCheck);

--- a/platform-sdk/consensus-fakes/README.md
+++ b/platform-sdk/consensus-fakes/README.md
@@ -14,18 +14,18 @@ it without inheriting that module's test fixtures (modularization rule 4 in
 ## Dependency Rules
 
 May depend on:
-- Any consensus-layer module whose API it fakes — supporting, functional-api, and
-structural-transitional modules alike
+- Any supporting, functional-api, functional-impl, or self-contained functional module whose API it fakes
 - `consensus-wiring-framework` — a fake of a wired module has to expose the same components as
 the real one
 - `swirlds-base`, `swirlds-logging`, `swirlds-config-api`, `swirlds-metrics-api`
-- `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap` — otherwise permitted only in
-the state-adjacent modules, but a fake of one of those exposes their types in its signatures
 
 Must not depend on:
-- Any `consensus-*-impl` module — a fake stands in for an API and never builds on the real
-implementation
+- Any structural-transitional module — those are on their way out of the consensus layer, and a
+fake must not pin them in place
 - `swirlds-common`, `swirlds-platform-core` — legacy, being eliminated
 - `swirlds-metrics-impl`, `swirlds-logging-log4j-appender` — depend on the API instead
+- `swirlds-state-api`, `swirlds-state-impl`, `swirlds-virtualmap`
 
-No known violations.
+Known violation — `requires transitive org.hiero.consensus.roster`: `FakeRosterFactory` returns a
+`RosterHistory`, which lives in a structural-transitional module. This does not resolve on its own —
+that class has to move out of this module before `consensus-roster` can move to the execution layer.

--- a/platform-sdk/consensus-model/build.gradle.kts
+++ b/platform-sdk/consensus-model/build.gradle.kts
@@ -14,6 +14,7 @@ testModuleInfo {
     requires("org.hiero.consensus.model.test.fixtures")
     requires("org.hiero.consensus.utility")
     requires("org.hiero.consensus.utility.test.fixtures")
+    requires("org.assertj.core")
     requires("org.junit.jupiter.api")
     requires("org.mockito")
 }

--- a/platform-sdk/consensus-model/src/main/java/module-info.java
+++ b/platform-sdk/consensus-model/src/main/java/module-info.java
@@ -1,19 +1,20 @@
 // SPDX-License-Identifier: Apache-2.0
 module org.hiero.consensus.model {
-    exports org.hiero.consensus.model;
     exports org.hiero.consensus.model.event;
+    exports org.hiero.consensus.model.gossip;
     exports org.hiero.consensus.model.hashgraph;
     exports org.hiero.consensus.model.node;
     exports org.hiero.consensus.model.notification;
     exports org.hiero.consensus.model.quiescence;
-    exports org.hiero.consensus.model.sequence;
+    exports org.hiero.consensus.model.roster;
     exports org.hiero.consensus.model.sequence.map;
     exports org.hiero.consensus.model.sequence.set;
+    exports org.hiero.consensus.model.sequence;
     exports org.hiero.consensus.model.state;
     exports org.hiero.consensus.model.status;
     exports org.hiero.consensus.model.stream;
     exports org.hiero.consensus.model.transaction;
-    exports org.hiero.consensus.model.gossip;
+    exports org.hiero.consensus.model;
 
     requires transitive com.hedera.node.hapi;
     requires transitive com.hedera.pbj.runtime;

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/roster/RosterEntryWrapper.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/roster/RosterEntryWrapper.java
@@ -18,7 +18,10 @@ import org.hiero.consensus.model.node.NodeId;
  */
 public class RosterEntryWrapper {
 
+    @NonNull
     private final RosterEntry rosterEntry;
+
+    @NonNull
     private final NodeId nodeId;
 
     @Nullable

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/roster/RosterEntryWrapper.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/roster/RosterEntryWrapper.java
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.model.roster;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.ServiceEndpoint;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import org.hiero.base.crypto.CryptoUtils;
+import org.hiero.base.crypto.CryptographyException;
+import org.hiero.consensus.model.node.NodeId;
+
+/**
+ * A wrapper around a {@link RosterEntry} that provides additional functionality and convenience methods.
+ */
+public class RosterEntryWrapper {
+
+    private final RosterEntry rosterEntry;
+    private final NodeId nodeId;
+
+    @Nullable
+    private final X509Certificate gossipCaCertificate;
+
+    /**
+     * Constructs a new {@link RosterEntryWrapper} instance.
+     *
+     * @param rosterEntry the {@link RosterEntry} to wrap
+     */
+    public RosterEntryWrapper(@NonNull final RosterEntry rosterEntry) {
+        this.rosterEntry = requireNonNull(rosterEntry);
+        this.nodeId = NodeId.of(rosterEntry.nodeId());
+        X509Certificate certificate;
+        try {
+            certificate = CryptoUtils.decodeCertificate(
+                    rosterEntry.gossipCaCertificate().toByteArray());
+        } catch (final CryptographyException e) {
+            certificate = null;
+        }
+        this.gossipCaCertificate = certificate;
+    }
+
+    /**
+     * Returns the {@link NodeId} associated with this roster entry.
+     *
+     * @return the {@link NodeId} of this roster entry
+     */
+    @NonNull
+    public NodeId nodeId() {
+        return nodeId;
+    }
+
+    /**
+     * Returns the weight of this roster entry.
+     *
+     * @return the weight of this roster entry
+     */
+    public long weight() {
+        return rosterEntry.weight();
+    }
+
+    /**
+     * Returns the gossip CA certificate associated with this roster entry.
+     *
+     * @return the gossip CA certificate of this roster entry
+     */
+    @Nullable
+    public X509Certificate gossipCaCertificate() {
+        return gossipCaCertificate;
+    }
+
+    /**
+     * Returns the gossip endpoints associated with this roster entry.
+     *
+     * @return the gossip endpoints of this roster entry
+     */
+    @NonNull
+    public List<ServiceEndpoint> gossipEndpoint() {
+        return rosterEntry.gossipEndpoint();
+    }
+
+    /**
+     * Returns the underlying {@link RosterEntry} instance.
+     *
+     * @return the underlying {@link RosterEntry}
+     */
+    @NonNull
+    public RosterEntry toPbj() {
+        return rosterEntry;
+    }
+}

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/roster/RosterWrapper.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/roster/RosterWrapper.java
@@ -12,11 +12,18 @@ import org.hiero.consensus.model.node.NodeId;
  */
 public class RosterWrapper {
 
+    @NonNull
     private final Roster roster;
 
+    @NonNull
     private final List<RosterEntryWrapper> rosterEntries;
 
-    // We use a lookup table, because searching in a small array of primitives is usually faster than HashMap-lookups.
+    /*
+      This array is used to find the index of an entry based on its NodeId (stored as a long).
+      We use a lookup table, because searching in a small array of primitives
+      is usually faster than HashMap-lookups.
+    */
+    @NonNull
     private final long[] idLookupTable;
 
     private final long totalWeight;
@@ -52,6 +59,7 @@ public class RosterWrapper {
      *
      * @return the list of {@link RosterEntryWrapper} instances
      */
+    @NonNull
     public List<RosterEntryWrapper> rosterEntries() {
         return rosterEntries;
     }
@@ -97,6 +105,7 @@ public class RosterWrapper {
      * @return the corresponding {@link RosterEntryWrapper}
      * @throws IllegalArgumentException if the {@link NodeId} is not present in this roster
      */
+    @NonNull
     public RosterEntryWrapper getRosterEntry(@NonNull final NodeId nodeId) {
         final int index = getIndex(nodeId);
         if (index == -1) {
@@ -120,6 +129,7 @@ public class RosterWrapper {
      *
      * @return the underlying {@link Roster}
      */
+    @NonNull
     public Roster toPbj() {
         return roster;
     }

--- a/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/roster/RosterWrapper.java
+++ b/platform-sdk/consensus-model/src/main/java/org/hiero/consensus/model/roster/RosterWrapper.java
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.model.roster;
+
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import org.hiero.consensus.model.node.NodeId;
+
+/**
+ * A wrapper around a {@link Roster} that provides additional functionality and convenience methods.
+ */
+public class RosterWrapper {
+
+    private final Roster roster;
+
+    private final List<RosterEntryWrapper> rosterEntries;
+
+    // We use a lookup table, because searching in a small array of primitives is usually faster than HashMap-lookups.
+    private final long[] idLookupTable;
+
+    private final long totalWeight;
+
+    /**
+     * Constructs a new {@link RosterWrapper} instance.
+     *
+     * @param roster the {@link Roster} to wrap
+     */
+    private RosterWrapper(@NonNull final Roster roster) {
+        this.roster = roster;
+        rosterEntries =
+                roster.rosterEntries().stream().map(RosterEntryWrapper::new).toList();
+        idLookupTable =
+                roster.rosterEntries().stream().mapToLong(RosterEntry::nodeId).toArray();
+        totalWeight =
+                rosterEntries.stream().mapToLong(RosterEntryWrapper::weight).sum();
+    }
+
+    /**
+     * Creates a new {@link RosterWrapper} instance from the given {@link Roster}.
+     *
+     * @param roster the {@link Roster} to wrap
+     * @return a new {@link RosterWrapper} instance
+     */
+    @NonNull
+    public static RosterWrapper of(@NonNull final Roster roster) {
+        return new RosterWrapper(roster);
+    }
+
+    /**
+     * Returns the list of {@link RosterEntryWrapper} instances in this roster.
+     *
+     * @return the list of {@link RosterEntryWrapper} instances
+     */
+    public List<RosterEntryWrapper> rosterEntries() {
+        return rosterEntries;
+    }
+
+    /**
+     * Returns the number of entries in this roster.
+     *
+     * @return the number of entries
+     */
+    public int size() {
+        return rosterEntries().size();
+    }
+
+    /**
+     * Returns the index of the given {@link NodeId} in this roster, or -1 if the node is not present.
+     *
+     * @param nodeId the {@link NodeId} to look up
+     * @return the index of the given {@link NodeId}, or {@code -1} if not present
+     */
+    public int getIndex(@NonNull final NodeId nodeId) {
+        final long id = nodeId.id();
+        for (int i = 0, n = idLookupTable.length; i < n; i++) {
+            if (idLookupTable[i] == id) {
+                return i;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * Returns the total weight of all entries in this roster.
+     *
+     * @return the total weight
+     */
+    public long totalWeight() {
+        return totalWeight;
+    }
+
+    /**
+     * Returns the {@link RosterEntryWrapper} for the given {@link NodeId}.
+     *
+     * @param nodeId the {@link NodeId} to look up
+     * @return the corresponding {@link RosterEntryWrapper}
+     * @throws IllegalArgumentException if the {@link NodeId} is not present in this roster
+     */
+    public RosterEntryWrapper getRosterEntry(@NonNull final NodeId nodeId) {
+        final int index = getIndex(nodeId);
+        if (index == -1) {
+            throw new IllegalArgumentException("NodeId " + nodeId + " is not in the roster");
+        }
+        return rosterEntries.get(index);
+    }
+
+    /**
+     * Checks if the given {@link NodeId} is present in this roster.
+     *
+     * @param nodeId the {@link NodeId} to check
+     * @return {@code true} if the {@link NodeId} is present, {@code false} otherwise
+     */
+    public boolean contains(@NonNull final NodeId nodeId) {
+        return getIndex(nodeId) != -1;
+    }
+
+    /**
+     * Returns the underlying {@link Roster} instance.
+     *
+     * @return the underlying {@link Roster}
+     */
+    public Roster toPbj() {
+        return roster;
+    }
+}

--- a/platform-sdk/consensus-model/src/test/java/org/hiero/consensus/model/roster/RosterEntryWrapperTest.java
+++ b/platform-sdk/consensus-model/src/test/java/org/hiero/consensus/model/roster/RosterEntryWrapperTest.java
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.model.roster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.security.cert.CertificateEncodingException;
+import java.security.cert.X509Certificate;
+import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.test.fixtures.crypto.PreGeneratedX509Certs;
+import org.junit.jupiter.api.Test;
+
+class RosterEntryWrapperTest {
+
+    private static RosterEntryWrapper wrap(final Bytes gossipCaCertificate) {
+        return new RosterEntryWrapper(RosterEntry.newBuilder()
+                .nodeId(7)
+                .gossipCaCertificate(gossipCaCertificate)
+                .build());
+    }
+
+    @Test
+    void gossipCaCertificateIsDecoded() throws CertificateEncodingException {
+        final X509Certificate certificate = PreGeneratedX509Certs.getSigCert(7);
+
+        final RosterEntryWrapper wrapper = wrap(Bytes.wrap(certificate.getEncoded()));
+
+        assertEquals(NodeId.of(7), wrapper.nodeId());
+        assertEquals(certificate, wrapper.gossipCaCertificate());
+    }
+
+    /**
+     * A roster entry without a usable certificate must still be wrappable: some tests wrap rosters they never
+     * gossips with, and an unusable certificate is reported as {@code null} rather than thrown.
+     */
+    @Test
+    void unusableGossipCaCertificateIsReportedAsNull() {
+        final RosterEntryWrapper wrapper1 = wrap(Bytes.EMPTY);
+        final RosterEntryWrapper wrapper2 = wrap(Bytes.wrap(new byte[] {1, 2, 3}));
+
+        assertThat(wrapper1.gossipCaCertificate()).isNull();
+        assertThat(wrapper2.gossipCaCertificate()).isNull();
+    }
+}

--- a/platform-sdk/consensus-model/src/test/java/org/hiero/consensus/model/roster/RosterEntryWrapperTest.java
+++ b/platform-sdk/consensus-model/src/test/java/org/hiero/consensus/model/roster/RosterEntryWrapperTest.java
@@ -12,6 +12,9 @@ import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.test.fixtures.crypto.PreGeneratedX509Certs;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Unit tests for the {@link RosterEntryWrapper} class.
+ */
 class RosterEntryWrapperTest {
 
     private static RosterEntryWrapper wrap(final Bytes gossipCaCertificate) {
@@ -21,6 +24,11 @@ class RosterEntryWrapperTest {
                 .build());
     }
 
+    /**
+     * Test that a valid gossip CA certificate is correctly decoded and returned by the wrapper.
+     *
+     * @throws CertificateEncodingException if there is an error encoding the certificate
+     */
     @Test
     void gossipCaCertificateIsDecoded() throws CertificateEncodingException {
         final X509Certificate certificate = PreGeneratedX509Certs.getSigCert(7);

--- a/platform-sdk/consensus-model/src/test/java/org/hiero/consensus/model/roster/RosterWrapperTest.java
+++ b/platform-sdk/consensus-model/src/test/java/org/hiero/consensus/model/roster/RosterWrapperTest.java
@@ -11,6 +11,9 @@ import org.hiero.consensus.model.node.NodeId;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Unit tests for the {@link RosterWrapper} class.
+ */
 class RosterWrapperTest {
 
     private static final NodeId NODE_3 = NodeId.of(3);
@@ -20,6 +23,9 @@ class RosterWrapperTest {
 
     private RosterWrapper roster;
 
+    /**
+     * Sets up a test roster with three entries before each test.
+     */
     @BeforeEach
     void setUp() {
         final RosterEntry entry3 = entry(NODE_3, 10);
@@ -32,6 +38,9 @@ class RosterWrapperTest {
         return RosterEntry.newBuilder().nodeId(nodeId.id()).weight(weight).build();
     }
 
+    /**
+     * Test that the index of each node in the roster follows the order of the entries.
+     */
     @Test
     void indexFollowsRosterOrder() {
         assertThat(roster.getIndex(NODE_3)).isEqualTo(0);
@@ -43,6 +52,10 @@ class RosterWrapperTest {
         assertThat(roster.contains(ABSENT_NODE)).isFalse();
     }
 
+    /**
+     * Test that the roster entry for a given node ID can be looked up correctly,
+     * and that looking up an absent node throws an exception.
+     */
     @Test
     void rosterEntryIsLookedUpByNodeId() {
         assertThat(roster.getRosterEntry(NODE_7).nodeId()).isEqualTo(NODE_7);
@@ -51,6 +64,9 @@ class RosterWrapperTest {
         assertThatThrownBy(() -> roster.getRosterEntry(ABSENT_NODE)).isInstanceOf(IllegalArgumentException.class);
     }
 
+    /**
+     * Test that the total weight of the roster sums all entries correctly.
+     */
     @Test
     void totalWeightSumsAllEntries() {
         assertThat(roster.totalWeight()).isEqualTo(60L);

--- a/platform-sdk/consensus-model/src/test/java/org/hiero/consensus/model/roster/RosterWrapperTest.java
+++ b/platform-sdk/consensus-model/src/test/java/org/hiero/consensus/model/roster/RosterWrapperTest.java
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.model.roster;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import java.util.List;
+import org.hiero.consensus.model.node.NodeId;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class RosterWrapperTest {
+
+    private static final NodeId NODE_3 = NodeId.of(3);
+    private static final NodeId NODE_7 = NodeId.of(7);
+    private static final NodeId NODE_11 = NodeId.of(11);
+    private static final NodeId ABSENT_NODE = NodeId.of(5);
+
+    private RosterWrapper roster;
+
+    @BeforeEach
+    void setUp() {
+        final RosterEntry entry3 = entry(NODE_3, 10);
+        final RosterEntry entry7 = entry(NODE_7, 20);
+        final RosterEntry entry11 = entry(NODE_11, 30);
+        roster = RosterWrapper.of(new Roster(List.of(entry3, entry7, entry11)));
+    }
+
+    private static RosterEntry entry(final NodeId nodeId, final long weight) {
+        return RosterEntry.newBuilder().nodeId(nodeId.id()).weight(weight).build();
+    }
+
+    @Test
+    void indexFollowsRosterOrder() {
+        assertThat(roster.getIndex(NODE_3)).isEqualTo(0);
+        assertThat(roster.getIndex(NODE_7)).isEqualTo(1);
+        assertThat(roster.getIndex(NODE_11)).isEqualTo(2);
+
+        assertThat(roster.getIndex(ABSENT_NODE)).isEqualTo(-1);
+        assertThat(roster.contains(NODE_7)).isTrue();
+        assertThat(roster.contains(ABSENT_NODE)).isFalse();
+    }
+
+    @Test
+    void rosterEntryIsLookedUpByNodeId() {
+        assertThat(roster.getRosterEntry(NODE_7).nodeId()).isEqualTo(NODE_7);
+        assertThat(roster.getRosterEntry(NODE_7).weight()).isEqualTo(20L);
+
+        assertThatThrownBy(() -> roster.getRosterEntry(ABSENT_NODE)).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void totalWeightSumsAllEntries() {
+        assertThat(roster.totalWeight()).isEqualTo(60L);
+    }
+}

--- a/platform-sdk/consensus-model/src/testFixtures/java/module-info.java
+++ b/platform-sdk/consensus-model/src/testFixtures/java/module-info.java
@@ -2,11 +2,14 @@
 open module org.hiero.consensus.model.test.fixtures {
     exports org.hiero.consensus.model.test.fixtures.event;
     exports org.hiero.consensus.model.test.fixtures.hashgraph;
+    exports org.hiero.consensus.model.test.fixtures.roster;
     exports org.hiero.consensus.model.test.fixtures.transaction;
 
     requires transitive com.hedera.pbj.runtime;
     requires transitive org.hiero.consensus.model;
-    requires com.hedera.node.hapi;
+    requires transitive org.hiero.consensus.utility.test.fixtures;
+    requires transitive com.hedera.node.hapi;
+    requires org.hiero.consensus.roster.test.fixtures;
     requires org.hiero.base.crypto.test.fixtures;
     requires org.hiero.base.utility.test.fixtures;
     requires static transitive com.github.spotbugs.annotations;

--- a/platform-sdk/consensus-model/src/testFixtures/java/org/hiero/consensus/model/test/fixtures/roster/RosterWrapperFactory.java
+++ b/platform-sdk/consensus-model/src/testFixtures/java/org/hiero/consensus/model/test/fixtures/roster/RosterWrapperFactory.java
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.model.test.fixtures.roster;
+
+import com.hedera.hapi.node.state.roster.Roster;
+import com.hedera.hapi.node.state.roster.RosterEntry;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import java.util.Random;
+import org.hiero.consensus.model.roster.RosterWrapper;
+import org.hiero.consensus.roster.test.fixtures.RosterFactory;
+import org.hiero.consensus.test.fixtures.WeightGenerator;
+
+public class RosterWrapperFactory {
+
+    /**
+     * Create a random roster with the given size and weight generator with pre-generated keys for each node.
+     *
+     * @param random the source of randomness
+     * @param size the number of entries in the roster
+     * @param weightGenerator the weight generator to use
+     * @return a {@link RosterWrapper} instance
+     */
+    @NonNull
+    public static RosterWrapper randomRoster(
+            @NonNull final Random random, final int size, @NonNull final WeightGenerator weightGenerator) {
+        final Roster pbjRoster = RosterFactory.randomRoster(random, size, weightGenerator);
+        return RosterWrapper.of(pbjRoster);
+    }
+
+    /**
+     * Create a random roster with the given size and pre-generated keys for each node.
+     *
+     * @param random the source of randomness
+     * @param size the number of entries in the roster
+     * @return a {@link RosterWrapper} instance
+     */
+    @NonNull
+    public static RosterWrapper randomRoster(@NonNull final Random random, final int size) {
+        final Roster pbjRoster = RosterFactory.randomRoster(random, size);
+        return RosterWrapper.of(pbjRoster);
+    }
+
+    /**
+     * Create a random roster with the given size and weight generator, generating real keys for each node.
+     *
+     * @param random the source of randomness
+     * @param size the number of entries in the roster
+     * @param weightGenerator the weight generator to use
+     * @return a {@link RosterWrapper} instance
+     */
+    @NonNull
+    public static RosterWrapper randomRosterWithKeys(
+            @NonNull final Random random, final int size, @NonNull final WeightGenerator weightGenerator) {
+        final Roster pbjRoster = RosterFactory.randomRosterWithKeys(random, size, weightGenerator)
+                .getRoster();
+        return RosterWrapper.of(pbjRoster);
+    }
+
+    /**
+     * Create a RosterWrapper from a list of RosterEntry instances.
+     *
+     * @param rosterEntries the list of RosterEntry instances
+     * @return a {@link RosterWrapper} instance
+     */
+    @NonNull
+    public static RosterWrapper createRosterWrapper(@NonNull final List<RosterEntry> rosterEntries) {
+        return RosterWrapper.of(new Roster(rosterEntries));
+    }
+}

--- a/platform-sdk/consensus-network-simulation/src/test/java/org/hiero/consensus/network/simulation/NetworkSimulationTest.java
+++ b/platform-sdk/consensus-network-simulation/src/test/java/org/hiero/consensus/network/simulation/NetworkSimulationTest.java
@@ -341,8 +341,9 @@ public class NetworkSimulationTest {
                 creatorNetwork.getPlatformContext().getConfiguration(),
                 creatorNetwork.getPlatformContext().getMetrics(),
                 creatorNetwork.getPlatformContext().getTime(),
-                creatorNetwork.getRoster(),
-                NodeId.of(creatorNetwork.getRoster().rosterEntries().getFirst().nodeId()),
+                creatorNetwork.getPbjRoster(),
+                NodeId.of(
+                        creatorNetwork.getPbjRoster().rosterEntries().getFirst().nodeId()),
                 _ -> false,
                 0L);
 

--- a/platform-sdk/consensus-network-simulation/src/testFixtures/java/org/hiero/consensus/network/simulation/fixtures/EventCreatorNetwork.java
+++ b/platform-sdk/consensus-network-simulation/src/testFixtures/java/org/hiero/consensus/network/simulation/fixtures/EventCreatorNetwork.java
@@ -29,6 +29,7 @@ import org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreator;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterEntryWrapper;
 import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.model.transaction.TimestampedTransaction;
@@ -44,7 +45,7 @@ public class EventCreatorNetwork {
     final Map<NodeId, DefaultEventCreationManager> eventCreators;
     final DefaultOrphanBuffer orphanBuffer;
     final FakeTime time;
-    final Roster roster;
+    final Roster pbjRoster;
     final PlatformContext platformContext;
     final SimulatedBroadcast network;
 
@@ -59,9 +60,9 @@ public class EventCreatorNetwork {
     public EventCreatorNetwork(
             final long seed, final int numNodes, final Configuration configuration, final NetworkLatency latency) {
         // Build a roster with real keys
-        roster = RosterFactory.randomRosterWithKeys(Randotron.create(seed), numNodes, WeightGenerators.BALANCED)
+        pbjRoster = RosterFactory.randomRosterWithKeys(Randotron.create(seed), numNodes, WeightGenerators.BALANCED)
                 .getRoster();
-        final RosterWrapper rosterWrapper = RosterWrapper.of(roster);
+        final RosterWrapper roster = RosterWrapper.of(pbjRoster);
 
         eventCreators = new HashMap<>();
         time = new FakeTime(Instant.parse("2026-01-01T00:00:00Z"), Duration.ZERO);
@@ -73,7 +74,7 @@ public class EventCreatorNetwork {
         final Metrics metrics = platformContext.getMetrics();
 
         // Create an event creator for each node
-        for (final RosterEntry entry : roster.rosterEntries()) {
+        for (final RosterEntry entry : pbjRoster.rosterEntries()) {
             final NodeId nodeId = NodeId.of(entry.nodeId());
             final SecureRandom nodeRandom = DeterministicSecureRandom.getInstance(seed);
             final KeyPair keyPair = SigningFactory.generateKeyPair(SigningSchema.ED25519, nodeRandom);
@@ -85,12 +86,12 @@ public class EventCreatorNetwork {
                     time,
                     nodeRandom,
                     signer,
-                    rosterWrapper,
+                    roster,
                     nodeId,
                     () -> List.of(new TimestampedTransaction(Bytes.EMPTY, time.now())));
 
             final DefaultEventCreationManager eventCreationManager = new DefaultEventCreationManager(
-                    configuration, metrics, time, () -> false, eventCreator, rosterWrapper, nodeId);
+                    configuration, metrics, time, () -> false, eventCreator, roster, nodeId);
 
             // Set platform status to ACTIVE so events can be created
             eventCreationManager.updatePlatformStatus(PlatformStatus.ACTIVE);
@@ -98,9 +99,8 @@ public class EventCreatorNetwork {
             eventCreators.put(nodeId, eventCreationManager);
         }
         orphanBuffer = new DefaultOrphanBuffer(metrics, new NoOpIntakeEventCounter());
-        final List<NodeId> ids = roster.rosterEntries().stream()
-                .map(entry -> NodeId.of(entry.nodeId()))
-                .toList();
+        final List<NodeId> ids =
+                roster.rosterEntries().stream().map(RosterEntryWrapper::nodeId).toList();
         network = new SimulatedBroadcast(time.now(), ids);
         network.setLatency(latency);
     }
@@ -110,8 +110,8 @@ public class EventCreatorNetwork {
      *
      * @return the roster
      */
-    public Roster getRoster() {
-        return roster;
+    public Roster getPbjRoster() {
+        return pbjRoster;
     }
 
     /**

--- a/platform-sdk/consensus-network-simulation/src/testFixtures/java/org/hiero/consensus/network/simulation/fixtures/EventCreatorNetwork.java
+++ b/platform-sdk/consensus-network-simulation/src/testFixtures/java/org/hiero/consensus/network/simulation/fixtures/EventCreatorNetwork.java
@@ -29,6 +29,7 @@ import org.hiero.consensus.event.creator.impl.tipset.TipsetEventCreator;
 import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.model.transaction.TimestampedTransaction;
 import org.hiero.consensus.orphan.DefaultOrphanBuffer;
@@ -60,6 +61,7 @@ public class EventCreatorNetwork {
         // Build a roster with real keys
         roster = RosterFactory.randomRosterWithKeys(Randotron.create(seed), numNodes, WeightGenerators.BALANCED)
                 .getRoster();
+        final RosterWrapper rosterWrapper = RosterWrapper.of(roster);
 
         eventCreators = new HashMap<>();
         time = new FakeTime(Instant.parse("2026-01-01T00:00:00Z"), Duration.ZERO);
@@ -83,12 +85,12 @@ public class EventCreatorNetwork {
                     time,
                     nodeRandom,
                     signer,
-                    roster,
+                    rosterWrapper,
                     nodeId,
                     () -> List.of(new TimestampedTransaction(Bytes.EMPTY, time.now())));
 
             final DefaultEventCreationManager eventCreationManager = new DefaultEventCreationManager(
-                    configuration, metrics, time, () -> false, eventCreator, roster, nodeId);
+                    configuration, metrics, time, () -> false, eventCreator, rosterWrapper, nodeId);
 
             // Set platform status to ACTIVE so events can be created
             eventCreationManager.updatePlatformStatus(PlatformStatus.ACTIVE);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/falcon/FalconWiring.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/falcon/FalconWiring.java
@@ -34,6 +34,7 @@ import org.hiero.consensus.model.event.PlatformEvent;
 import org.hiero.consensus.model.hashgraph.ConsensusRound;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.model.transaction.EventTransactionSupplier;
 import org.hiero.consensus.model.transaction.SignatureTransactionCheck;
@@ -75,11 +76,13 @@ public class FalconWiring implements TimeTickReceiver {
             @NonNull final Roster roster,
             @NonNull final SecureRandom secureRandom) {
 
+        final RosterWrapper rosterWrapper = RosterWrapper.of(roster);
+
         final Metrics metrics = new NoOpMetrics();
 
         model = WiringModelBuilder.create(metrics, time)
                 .deterministic()
-                .withUncaughtExceptionHandler((t, e) -> fail("Unexpected exception in wiring framework", e))
+                .withUncaughtExceptionHandler((_, e) -> fail("Unexpected exception in wiring framework", e))
                 .build();
 
         final EventIntakeWiringConfig eventIntakeConfig = configuration.getConfigData(EventIntakeWiringConfig.class);
@@ -102,10 +105,10 @@ public class FalconWiring implements TimeTickReceiver {
         final BytesSigner byteSigner = _ -> DEFAULT_SIGNATURE;
         final EventTransactionSupplier transactionSupplier = List::of;
         final EventCreator eventCreator = new TipsetEventCreator(
-                configuration, metrics, time, secureRandom, byteSigner, roster, selfId, transactionSupplier);
+                configuration, metrics, time, secureRandom, byteSigner, rosterWrapper, selfId, transactionSupplier);
         final SignatureTransactionCheck signatureTransactionCheck = () -> false;
         final EventCreationManager eventCreationManager = new DefaultEventCreationManager(
-                configuration, metrics, time, signatureTransactionCheck, eventCreator, roster, selfId);
+                configuration, metrics, time, signatureTransactionCheck, eventCreator, rosterWrapper, selfId);
         eventCreationManagerWiring =
                 new ComponentWiring<>(model, EventCreationManager.class, eventCreationConfig.eventCreationManager());
         eventCreationManagerWiring.bind(eventCreationManager);

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/falcon/FalconWiring.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/falcon/FalconWiring.java
@@ -66,17 +66,17 @@ public class FalconWiring implements TimeTickReceiver {
      * @param configuration the configuration for the wiring
      * @param time the time source
      * @param selfId the ID of the current node
-     * @param roster the roster of nodes
+     * @param pbjRoster the roster of nodes
      * @param secureRandom the secure random number generator
      */
     public FalconWiring(
             @NonNull final Configuration configuration,
             @NonNull final Time time,
             @NonNull final NodeId selfId,
-            @NonNull final Roster roster,
+            @NonNull final Roster pbjRoster,
             @NonNull final SecureRandom secureRandom) {
 
-        final RosterWrapper rosterWrapper = RosterWrapper.of(roster);
+        final RosterWrapper roster = RosterWrapper.of(pbjRoster);
 
         final Metrics metrics = new NoOpMetrics();
 
@@ -96,7 +96,7 @@ public class FalconWiring implements TimeTickReceiver {
         final long transactionOffsetNanos = 0L;
         final HashgraphWiringConfig hashgraphConfig = configuration.getConfigData(HashgraphWiringConfig.class);
         final ConsensusEngine consensusEngine = new DefaultConsensusEngine(
-                configuration, metrics, time, roster, selfId, freezePeriodChecker, transactionOffsetNanos);
+                configuration, metrics, time, pbjRoster, selfId, freezePeriodChecker, transactionOffsetNanos);
         consensusEngineWiring = new ComponentWiring<>(model, ConsensusEngine.class, hashgraphConfig.consensusEngine());
         consensusEngineWiring.bind(consensusEngine);
 
@@ -105,10 +105,10 @@ public class FalconWiring implements TimeTickReceiver {
         final BytesSigner byteSigner = _ -> DEFAULT_SIGNATURE;
         final EventTransactionSupplier transactionSupplier = List::of;
         final EventCreator eventCreator = new TipsetEventCreator(
-                configuration, metrics, time, secureRandom, byteSigner, rosterWrapper, selfId, transactionSupplier);
+                configuration, metrics, time, secureRandom, byteSigner, roster, selfId, transactionSupplier);
         final SignatureTransactionCheck signatureTransactionCheck = () -> false;
         final EventCreationManager eventCreationManager = new DefaultEventCreationManager(
-                configuration, metrics, time, signatureTransactionCheck, eventCreator, rosterWrapper, selfId);
+                configuration, metrics, time, signatureTransactionCheck, eventCreator, roster, selfId);
         eventCreationManagerWiring =
                 new ComponentWiring<>(model, EventCreationManager.class, eventCreationConfig.eventCreationManager());
         eventCreationManagerWiring.bind(eventCreationManager);

--- a/platform-sdk/docs/consensus-layer/architecture/overview.md
+++ b/platform-sdk/docs/consensus-layer/architecture/overview.md
@@ -79,10 +79,15 @@ data model, helpers, and metrics consumed by the modules above.
 
 Structural-transitional modules —
 [`consensus-event-stream`](../../../consensus-event-stream),
+[`consensus-iss-detection`](../../../consensus-iss-detection),
 [`consensus-platformstate`](../../../consensus-platformstate),
+[`consensus-reconnect`](../../../consensus-reconnect),
+[`consensus-reconnect-impl`](../../../consensus-reconnect-impl),
 [`consensus-roster`](../../../consensus-roster),
-[`consensus-state`](../../../consensus-state) — carry event streaming
-and state-adjacent structures on the Consensus side until they move to
+[`consensus-state`](../../../consensus-state),
+[`consensus-transaction-handling`](../../../consensus-transaction-handling)
+— carry event streaming, state-adjacent structures, transaction
+handling, and reconnect on the Consensus side until they move to
 Execution or are retired. The topic files cite them where relevant.
 
 GUI, otter, and sloth modules (`consensus-gui`,

--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/ConsensusNoOpModules.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/ConsensusNoOpModules.java
@@ -42,6 +42,7 @@ import org.hiero.consensus.iss.detection.IssDetectionModule;
 import org.hiero.consensus.metrics.statistics.EventPipelineTracker;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.monitoring.FallenBehindMonitor;
 import org.hiero.consensus.pces.PcesModule;
 import org.hiero.consensus.roster.RosterHistory;
@@ -82,7 +83,7 @@ public class ConsensusNoOpModules {
             throw new RuntimeException("Exception thrown while creating dummy KeysAndCerts", e);
         }
         final RosterEntry rosterEntry = new RosterEntry(selfId.id(), 0L, Bytes.EMPTY, List.of());
-        final Roster roster = new Roster(List.of(rosterEntry));
+        final RosterWrapper roster = RosterWrapper.of(new Roster(List.of(rosterEntry)));
 
         final EventCreatorModule eventCreatorModule = createModule(EventCreatorModule.class, configuration);
         eventCreatorModule.initialize(

--- a/platform-sdk/swirlds-platform-core/src/main/java/org/hiero/consensus/ConsensusLayerFactory.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/org/hiero/consensus/ConsensusLayerFactory.java
@@ -63,6 +63,7 @@ import org.hiero.consensus.model.event.EventOrigin;
 import org.hiero.consensus.model.hashgraph.EventWindow;
 import org.hiero.consensus.model.node.KeysAndCerts;
 import org.hiero.consensus.model.node.NodeId;
+import org.hiero.consensus.model.roster.RosterWrapper;
 import org.hiero.consensus.monitoring.FallenBehindMonitor;
 import org.hiero.consensus.pces.PcesModule;
 import org.hiero.consensus.roster.RosterHistory;
@@ -108,6 +109,9 @@ public class ConsensusLayerFactory {
 
     @NonNull
     private final RosterHistory rosterHistory;
+
+    @NonNull
+    private final RosterWrapper currentRoster;
 
     @NonNull
     private final KeysAndCerts keysAndCerts;
@@ -170,6 +174,7 @@ public class ConsensusLayerFactory {
         metrics = inputs.metrics();
         time = inputs.time();
         rosterHistory = inputs.rosterHistory();
+        currentRoster = RosterWrapper.of(rosterHistory.getCurrentRoster());
         keysAndCerts = inputs.keysAndCerts();
         selfId = inputs.selfId();
         recycleBin = inputs.recycleBin();
@@ -507,7 +512,7 @@ public class ConsensusLayerFactory {
                 time,
                 secureRandom,
                 keysAndCerts,
-                rosterHistory.getCurrentRoster(),
+                currentRoster,
                 selfId,
                 executionLayer,
                 executionLayer);


### PR DESCRIPTION
**Description**:

This PR introduces `RosterWrapper` and `RosterEntryWrapper`. Both wrap PBJ classes and provide additional convenience functionality, thus avoiding helper methods in `consensus-roster`. In addition, it also ensures all expensive conversions are done only once.

The EventCreator module was migrated first. Other modules will follow.

**Related issue(s)**:

Fixes #27076
