### PR TITLE
fix: require a prepared upgrade before scheduling a freeze upgrade

### DIFF
--- a/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeHandler.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/main/java/com/hedera/node/app/service/networkadmin/impl/handlers/FreezeHandler.java
@@ -224,7 +224,33 @@ public class FreezeHandler implements TransactionHandler {
                 && (updateFileID == null || upgradeStore.peek(updateFileID) == null)) {
             throw new IllegalStateException("Update file not found");
         }
+
+        if (freezeTxn.freezeType() == FREEZE_UPGRADE) {
+            validatePreparedUpgrade(freezeTxn, freezeStore);
+        }
     }
+
+    /**
+     * Verifies that a {@code FREEZE_UPGRADE} confirms an upgrade that was actually prepared: an earlier
+     * {@code PREPARE_UPGRADE} must have recorded an update file hash, and the hash named by this
+     * transaction must match the recorded one. A {@code FREEZE_ABORT} clears the recorded hash, so a
+     * freeze upgrade aborted in the meantime is treated as having no prepared upgrade.
+     *
+     * @param freezeTxn the freeze transaction body being handled
+     * @param freezeStore the store holding the prepared update file hash
+     * @throws HandleException if no upgrade has been prepared, or the prepared hash does not match
+     */
+    private static void validatePreparedUpgrade(
+            @NonNull final FreezeTransactionBody freezeTxn, @NonNull final ReadableFreezeStore freezeStore) {
+        final Bytes preparedFileHash = freezeStore.updateFileHash();
+        if (preparedFileHash == null || Bytes.EMPTY.equals(preparedFileHash)) {
+            throw new HandleException(ResponseCodeEnum.NO_UPGRADE_HAS_BEEN_PREPARED);
+        }
+        if (!preparedFileHash.equals(freezeTxn.fileHash())) {
+            throw new HandleException(ResponseCodeEnum.UPDATE_FILE_HASH_DOES_NOT_MATCH_PREPARED);
+        }
+    }
+
     /**
      * For freeze types FREEZE_ONLY, FREEZE_UPGRADE, and TELEMETRY_UPGRADE, the startTime field must be set to
      * a time in the future, where future is defined as a time after the current consensus time.

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeHandlerTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeHandlerTest.java
@@ -356,6 +356,8 @@ class FreezeHandlerTest {
         given(upgradeFileStore.peek(fileUpgradeFileId))
                 .willReturn(File.newBuilder().build());
         given(upgradeFileStore.getFull(fileUpgradeFileId)).willReturn(UPGRADE_FILE_CONTENTS);
+        // A FREEZE_UPGRADE must confirm an upgrade prepared earlier, so record a matching prepared hash
+        given(freezeStore.updateFileHash()).willReturn(UPGRADE_FILE_HASH);
 
         for (FreezeType freezeType : freezeTypes) {
             TransactionID txnId = TransactionID.newBuilder()

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeUpgradePreparedUpgradeTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeUpgradePreparedUpgradeTest.java
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.networkadmin.impl.test.handlers;
+
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NO_UPGRADE_HAS_BEEN_PREPARED;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.UPDATE_FILE_HASH_DOES_NOT_MATCH_PREPARED;
+import static com.hedera.hapi.node.freeze.FreezeType.FREEZE_UPGRADE;
+import static com.hedera.node.app.hapi.utils.CommonUtils.noThrowSha384HashOf;
+import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mock.Strictness.LENIENT;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.node.base.TransactionID;
+import com.hedera.hapi.node.freeze.FreezeTransactionBody;
+import com.hedera.hapi.node.state.file.File;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.service.entityid.EntityIdFactory;
+import com.hedera.node.app.service.file.ReadableUpgradeFileStore;
+import com.hedera.node.app.service.networkadmin.impl.WritableFreezeStore;
+import com.hedera.node.app.service.networkadmin.impl.handlers.FreezeHandler;
+import com.hedera.node.app.spi.store.StoreFactory;
+import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.HandleException;
+import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import com.swirlds.config.api.Configuration;
+import java.io.IOException;
+import java.util.concurrent.ForkJoinPool;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Covers how {@link FreezeHandler} treats the prepared upgrade hash held in the freeze store when a
+ * {@code FREEZE_UPGRADE} is handled. That hash is written by {@code PREPARE_UPGRADE} and cleared by
+ * {@code FREEZE_ABORT}, so it records whether an upgrade was prepared and which file it was prepared for.
+ *
+ * <p>A {@code FREEZE_UPGRADE} is expected to be honored only when it confirms a prepared upgrade: the
+ * network-admin service design requires it to be rejected with {@code NO_UPGRADE_HAS_BEEN_PREPARED} when
+ * no upgrade was prepared, and with {@code UPDATE_FILE_HASH_DOES_NOT_MATCH_PREPARED} when the prepared
+ * hash does not match the hash named by the transaction.
+ */
+@ExtendWith(MockitoExtension.class)
+class FreezeUpgradePreparedUpgradeTest {
+    private static final Bytes UPGRADE_FILE_CONTENTS = Bytes.wrap("Upgrade file bytes".getBytes());
+    private static final Bytes UPGRADE_FILE_HASH = Bytes.wrap(noThrowSha384HashOf(UPGRADE_FILE_CONTENTS.toByteArray()));
+    private static final Bytes UNRELATED_FILE_HASH = Bytes.wrap(noThrowSha384HashOf("a different file".getBytes()));
+
+    @Mock(strictness = LENIENT)
+    private ReadableUpgradeFileStore upgradeFileStore;
+
+    @Mock(strictness = LENIENT)
+    private WritableFreezeStore freezeStore;
+
+    @Mock(strictness = LENIENT)
+    private HandleContext handleContext;
+
+    @Mock(strictness = LENIENT)
+    private StoreFactory storeFactory;
+
+    @Mock
+    private EntityIdFactory entityIdFactory;
+
+    private final FileID fileUpgradeFileId = FileID.newBuilder().fileNum(150L).build();
+    private final AccountID nonAdminAccount =
+            AccountID.newBuilder().accountNum(9999L).build();
+
+    private FreezeHandler subject;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        subject = new FreezeHandler(
+                new ForkJoinPool(
+                        1,
+                        ForkJoinPool.defaultForkJoinWorkerThreadFactory,
+                        Thread.getDefaultUncaughtExceptionHandler(),
+                        true),
+                entityIdFactory);
+
+        final Configuration config = HederaTestConfigBuilder.createConfig();
+        given(handleContext.configuration()).willReturn(config);
+        given(handleContext.storeFactory()).willReturn(storeFactory);
+        given(storeFactory.readableStore(ReadableUpgradeFileStore.class)).willReturn(upgradeFileStore);
+        given(storeFactory.writableStore(WritableFreezeStore.class)).willReturn(freezeStore);
+
+        given(upgradeFileStore.peek(fileUpgradeFileId))
+                .willReturn(File.newBuilder().build());
+        given(upgradeFileStore.getFull(fileUpgradeFileId)).willReturn(UPGRADE_FILE_CONTENTS);
+
+        given(handleContext.body()).willReturn(freezeUpgradeTxn());
+    }
+
+    /** A well-formed FREEZE_UPGRADE naming update file 0.0.150 and that file's hash. */
+    private TransactionBody freezeUpgradeTxn() {
+        return TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder()
+                        .accountID(nonAdminAccount)
+                        .transactionValidStart(
+                                Timestamp.newBuilder().seconds(1000).build())
+                        .build())
+                .freeze(FreezeTransactionBody.newBuilder()
+                        .freezeType(FREEZE_UPGRADE)
+                        .startTime(Timestamp.newBuilder().seconds(2000).build())
+                        .updateFile(fileUpgradeFileId)
+                        .fileHash(UPGRADE_FILE_HASH)
+                        .build())
+                .build();
+    }
+
+    @Test
+    void rejectsFreezeUpgradeWhenNoUpgradeHasBeenPrepared() {
+        given(freezeStore.updateFileHash()).willReturn(null);
+
+        assertThatThrownBy(() -> subject.handle(handleContext))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(NO_UPGRADE_HAS_BEEN_PREPARED));
+    }
+
+    @Test
+    void rejectsFreezeUpgradeWhenPreparedHashDiffersFromTransactionHash() {
+        given(freezeStore.updateFileHash()).willReturn(UNRELATED_FILE_HASH);
+
+        assertThatThrownBy(() -> subject.handle(handleContext))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(UPDATE_FILE_HASH_DOES_NOT_MATCH_PREPARED));
+    }
+
+    @Test
+    void acceptsFreezeUpgradeWhenPreparedHashMatchesTransactionHash() {
+        given(freezeStore.updateFileHash()).willReturn(UPGRADE_FILE_HASH);
+
+        assertDoesNotThrow(() -> subject.handle(handleContext));
+    }
+}

--- a/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeUpgradePreparedUpgradeTest.java
+++ b/hedera-node/hedera-network-admin-service-impl/src/test/java/com/hedera/node/app/service/networkadmin/impl/test/handlers/FreezeUpgradePreparedUpgradeTest.java
@@ -122,6 +122,20 @@ class FreezeUpgradePreparedUpgradeTest {
                 .has(responseCode(NO_UPGRADE_HAS_BEEN_PREPARED));
     }
 
+    /**
+     * A {@code FREEZE_ABORT} clears the recorded hash by writing {@link Bytes#EMPTY}. The store normalizes
+     * that back to null, but the handler treats an empty hash as "nothing prepared" in its own right so the
+     * guarantee does not depend on that normalization.
+     */
+    @Test
+    void rejectsFreezeUpgradeWhenPreparedHashWasCleared() {
+        given(freezeStore.updateFileHash()).willReturn(Bytes.EMPTY);
+
+        assertThatThrownBy(() -> subject.handle(handleContext))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(NO_UPGRADE_HAS_BEEN_PREPARED));
+    }
+
     @Test
     void rejectsFreezeUpgradeWhenPreparedHashDiffersFromTransactionHash() {
         given(freezeStore.updateFileHash()).willReturn(UNRELATED_FILE_HASH);

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeUpgradePrerequisitesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeUpgradePrerequisitesTest.java
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.freeze;
+
+import static com.hedera.services.bdd.junit.TestTags.UPGRADE;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.transactions.TxnUtils.BYTES_4K;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.buildUpgradeZipFrom;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeUpgrade;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateSpecialFile;
+import static com.hedera.services.bdd.spec.utilops.upgrade.BuildUpgradeZipOp.FAKE_UPGRADE_ZIP_LOC;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.freeze.CommonUpgradeResources.DEFAULT_UPGRADE_FILE_ID;
+import static com.hedera.services.bdd.suites.freeze.CommonUpgradeResources.FAKE_ASSETS_LOC;
+import static com.hedera.services.bdd.suites.freeze.CommonUpgradeResources.upgradeFileAppendsPerBurst;
+import static com.hedera.services.bdd.suites.freeze.CommonUpgradeResources.upgradeFileHashAt;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.NO_UPGRADE_HAS_BEEN_PREPARED;
+
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.suites.regression.system.LifecycleTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Exercises the prerequisites of a {@code FREEZE_UPGRADE}. The upgrade file {@code 0.0.150} is staged so
+ * that the pre-handle file-hash check passes, but {@code PREPARE_UPGRADE} is deliberately skipped, so the
+ * freeze store holds no prepared upgrade hash.
+ *
+ * <p>A {@code FREEZE_UPGRADE} is expected to be honored only when it confirms a prepared upgrade, so the
+ * network-admin service design requires this transaction to be rejected with
+ * {@code NO_UPGRADE_HAS_BEEN_PREPARED}. Because it is rejected, no freeze is scheduled and no
+ * {@code FREEZE_ABORT} is needed.
+ */
+@Tag(UPGRADE)
+@HapiTestLifecycle
+public class FreezeUpgradePrerequisitesTest implements LifecycleTest {
+    @HapiTest
+    final Stream<DynamicTest> freezeUpgradeIsRejectedWithoutPreparedUpgrade() {
+        return hapiTest(
+                buildUpgradeZipFrom(FAKE_ASSETS_LOC),
+                // Stage 0.0.150 so the pre-handle file-hash check passes, without a PREPARE_UPGRADE.
+                sourcing(() -> updateSpecialFile(
+                        GENESIS,
+                        DEFAULT_UPGRADE_FILE_ID,
+                        FAKE_UPGRADE_ZIP_LOC,
+                        BYTES_4K,
+                        upgradeFileAppendsPerBurst())),
+                sourcing(() -> freezeUpgrade()
+                        .startingIn(60)
+                        .seconds()
+                        .withUpdateFile(DEFAULT_UPGRADE_FILE_ID)
+                        .havingHash(upgradeFileHashAt(FAKE_UPGRADE_ZIP_LOC))
+                        .payingWith(GENESIS)
+                        .hasKnownStatus(NO_UPGRADE_HAS_BEEN_PREPARED)));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeUpgradePrerequisitesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/freeze/FreezeUpgradePrerequisitesTest.java
@@ -5,6 +5,7 @@ import static com.hedera.services.bdd.junit.TestTags.UPGRADE;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnUtils.BYTES_4K;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.buildUpgradeZipFrom;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeAbort;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.freezeUpgrade;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.updateSpecialFile;
@@ -39,6 +40,9 @@ public class FreezeUpgradePrerequisitesTest implements LifecycleTest {
     @HapiTest
     final Stream<DynamicTest> freezeUpgradeIsRejectedWithoutPreparedUpgrade() {
         return hapiTest(
+                // Clear any upgrade prepared by an earlier spec sharing this network, so the condition
+                // under test - that no upgrade has been prepared - holds regardless of execution order.
+                freezeAbort().payingWith(GENESIS),
                 buildUpgradeZipFrom(FAKE_ASSETS_LOC),
                 // Stage 0.0.150 so the pre-handle file-hash check passes, without a PREPARE_UPGRADE.
                 sourcing(() -> updateSpecialFile(


### PR DESCRIPTION
`FreezeHandler.handle()` honored a `FREEZE_UPGRADE` without confirming that an earlier `PREPARE_UPGRADE` had recorded an update file hash, or that the hash named by the transaction matched it. The recorded hash is written by `PREPARE_UPGRADE` and cleared by `FREEZE_ABORT`, but no switch arm read it back, so a freeze could be scheduled with no upgrade to apply.

`validateSemantics` now rejects a `FREEZE_UPGRADE` with `NO_UPGRADE_HAS_BEEN_PREPARED` when no hash is recorded, and `UPDATE_FILE_HASH_DOES_NOT_MATCH_PREPARED` when it does not match. This matches the network-admin service design and the `FREEZE_UPGRADE` documentation in `freeze_type.proto`, which states that "A software upgrade file MUST be prepared prior to this transaction."

Tests:
- `FreezeUpgradePreparedUpgradeTest` (new) covers the three prepared-hash states: absent, mismatched, matching.
- `FreezeUpgradePrerequisitesTest` (new HAPI) exercises the rejection end-to-end on a subprocess network.
- `FreezeHandlerTest.happyPathFreezeUpgradeOrTelemetryUpgrade` now records a matching prepared hash, as it previously relied on the unchecked behavior.

Not included: the design document also requires `UPDATE_FILE_ID_DOES_NOT_MATCH_PREPARED`, which cannot be implemented as-is because the freeze store records only the prepared hash and the freeze time, not the prepared file id.