### PR TITLE
chore: Rename and move file

### DIFF
--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileConstants.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileConstants.java
@@ -1,10 +1,10 @@
 // SPDX-License-Identifier: Apache-2.0
-package org.hiero.consensus.state.persistence;
+package org.hiero.consensus.state;
 
 /**
  * Utility methods for dealing with signed states on disk.
  */
-public final class SignedStateFileUtils {
+public final class SignedStateFileConstants {
 
     public static final String SIGNATURE_SET_FILE_NAME = "signatureSet.pbj";
 
@@ -20,5 +20,5 @@ public final class SignedStateFileUtils {
      */
     public static final String CONSENSUS_SNAPSHOT_FILE_NAME = "consensusSnapshot.json";
 
-    private SignedStateFileUtils() {}
+    private SignedStateFileConstants() {}
 }

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileReader.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileReader.java
@@ -3,7 +3,7 @@ package org.hiero.consensus.state;
 
 import static java.nio.file.Files.exists;
 import static java.util.Objects.requireNonNull;
-import static org.hiero.consensus.state.persistence.SignedStateFileUtils.SIGNATURE_SET_FILE_NAME;
+import static org.hiero.consensus.state.SignedStateFileConstants.SIGNATURE_SET_FILE_NAME;
 
 import com.hedera.hapi.node.base.SemanticVersion;
 import com.hedera.pbj.runtime.ParseException;

--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/SignedStateFileWriter.java
@@ -7,9 +7,9 @@ import static java.util.Objects.requireNonNull;
 import static org.hiero.base.file.FileUtils.executeAndRename;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.ancientThresholdOf;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.getInfoString;
-import static org.hiero.consensus.state.persistence.SignedStateFileUtils.CURRENT_ROSTER_FILE_NAME;
-import static org.hiero.consensus.state.persistence.SignedStateFileUtils.HASH_INFO_FILE_NAME;
-import static org.hiero.consensus.state.persistence.SignedStateFileUtils.SIGNATURE_SET_FILE_NAME;
+import static org.hiero.consensus.state.SignedStateFileConstants.CURRENT_ROSTER_FILE_NAME;
+import static org.hiero.consensus.state.SignedStateFileConstants.HASH_INFO_FILE_NAME;
+import static org.hiero.consensus.state.SignedStateFileConstants.SIGNATURE_SET_FILE_NAME;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.platform.state.ConsensusSnapshot;
@@ -46,7 +46,6 @@ import org.hiero.consensus.pces.PcesModule;
 import org.hiero.consensus.pces.impl.DefaultPcesModule;
 import org.hiero.consensus.platformstate.PlatformStateUtils;
 import org.hiero.consensus.state.config.StateConfig;
-import org.hiero.consensus.state.persistence.SignedStateFileUtils;
 import org.hiero.consensus.state.saved.SavedStateMetadata;
 import org.hiero.consensus.state.signed.ReservedSignedState;
 import org.hiero.consensus.state.signed.SignedState;
@@ -320,7 +319,7 @@ public final class SignedStateFileWriter {
      */
     private static void writeConsensusSnapshotFile(
             @NonNull final Path directory, @NonNull final SignedState signedState) {
-        final Path consensusSnapshotFile = directory.resolve(SignedStateFileUtils.CONSENSUS_SNAPSHOT_FILE_NAME);
+        final Path consensusSnapshotFile = directory.resolve(SignedStateFileConstants.CONSENSUS_SNAPSHOT_FILE_NAME);
         final ConsensusSnapshot snapshot = PlatformStateUtils.consensusSnapshotOf(signedState.getState());
         if (snapshot == null) {
             logger.error(

--- a/platform-sdk/consensus-state/src/test/java/org/hiero/consensus/state/SignedStateFileReadWriteTest.java
+++ b/platform-sdk/consensus-state/src/test/java/org/hiero/consensus/state/SignedStateFileReadWriteTest.java
@@ -5,15 +5,15 @@ import static com.swirlds.merkledb.test.fixtures.MerkleDbTestUtils.randomUtf8Byt
 import static com.swirlds.state.test.fixtures.merkle.TestStateUtils.destroyStateLifecycleManager;
 import static java.nio.file.Files.exists;
 import static org.hiero.base.file.FileUtils.throwIfFileExists;
+import static org.hiero.consensus.state.SignedStateFileConstants.CONSENSUS_SNAPSHOT_FILE_NAME;
+import static org.hiero.consensus.state.SignedStateFileConstants.CURRENT_ROSTER_FILE_NAME;
+import static org.hiero.consensus.state.SignedStateFileConstants.HASH_INFO_FILE_NAME;
+import static org.hiero.consensus.state.SignedStateFileConstants.SIGNATURE_SET_FILE_NAME;
 import static org.hiero.consensus.state.SignedStateFileReader.readState;
 import static org.hiero.consensus.state.SignedStateFileWriter.writeHashInfoFile;
 import static org.hiero.consensus.state.SignedStateFileWriter.writeSignatureSetFile;
 import static org.hiero.consensus.state.SignedStateFileWriter.writeSignedStateToDisk;
 import static org.hiero.consensus.state.StateFileManagerTests.hashState;
-import static org.hiero.consensus.state.persistence.SignedStateFileUtils.CONSENSUS_SNAPSHOT_FILE_NAME;
-import static org.hiero.consensus.state.persistence.SignedStateFileUtils.CURRENT_ROSTER_FILE_NAME;
-import static org.hiero.consensus.state.persistence.SignedStateFileUtils.HASH_INFO_FILE_NAME;
-import static org.hiero.consensus.state.persistence.SignedStateFileUtils.SIGNATURE_SET_FILE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
@@ -45,7 +45,6 @@ import org.hiero.base.utility.test.fixtures.file.TestFileSystemManager;
 import org.hiero.consensus.constructable.ConstructableRegistration;
 import org.hiero.consensus.fakes.noop.NoOpMetrics;
 import org.hiero.consensus.model.node.NodeId;
-import org.hiero.consensus.state.persistence.SignedStateFileUtils;
 import org.hiero.consensus.state.saved.DeserializedSignedState;
 import org.hiero.consensus.state.signed.SigSet;
 import org.hiero.consensus.state.signed.SignedState;
@@ -104,7 +103,7 @@ class SignedStateFileReadWriteTest {
         final VirtualMapState state = signedState.getState();
         writeHashInfoFile(testDirectory, state);
 
-        final Path hashInfoFile = testDirectory.resolve(SignedStateFileUtils.HASH_INFO_FILE_NAME);
+        final Path hashInfoFile = testDirectory.resolve(SignedStateFileConstants.HASH_INFO_FILE_NAME);
         assertTrue(exists(hashInfoFile), "file should exist");
 
         final String mnemonicString = Mnemonics.generateMnemonic(state.getHash());

--- a/platform-sdk/consensus-state/src/test/java/org/hiero/consensus/state/StateFileManagerTests.java
+++ b/platform-sdk/consensus-state/src/test/java/org/hiero/consensus/state/StateFileManagerTests.java
@@ -46,7 +46,6 @@ import org.hiero.consensus.state.config.StateConfig_;
 import org.hiero.consensus.state.persistence.DefaultSavedStateController;
 import org.hiero.consensus.state.persistence.DefaultStateSnapshotManager;
 import org.hiero.consensus.state.persistence.SignedStateFilePath;
-import org.hiero.consensus.state.persistence.SignedStateFileUtils;
 import org.hiero.consensus.state.persistence.StateSnapshotManager;
 import org.hiero.consensus.state.saved.DeserializedSignedState;
 import org.hiero.consensus.state.saved.SavedStateInfo;
@@ -123,7 +122,7 @@ class StateFileManagerTests {
         assertEventuallyEquals(
                 -1, originalState::getReservationCount, Duration.ofSeconds(1), "invalid reservation count");
 
-        final Path hashInfoFile = stateDirectory.resolve(SignedStateFileUtils.HASH_INFO_FILE_NAME);
+        final Path hashInfoFile = stateDirectory.resolve(SignedStateFileConstants.HASH_INFO_FILE_NAME);
         final Path settingsUsedFile = stateDirectory.resolve("settingsUsed.txt");
 
         assertTrue(exists(hashInfoFile), "no hash info file found");


### PR DESCRIPTION
This ticket was outdated since the named class does not contain any methods anymore. However, it's name was misleading so I renamed it and moved it next to the only files that use it.

Fixes #10292