### PR TITLE
fix: strip DAB nodeId suffix in toSpecProperties() 

### DIFF
--- a/hedera-node/yahcli/src/main/java/com/hedera/services/yahcli/config/domain/NetConfig.java
+++ b/hedera-node/yahcli/src/main/java/com/hedera/services/yahcli/config/domain/NetConfig.java
@@ -72,7 +72,15 @@ public class NetConfig {
 
     public Map<String, String> toSpecProperties() {
         Map<String, String> customProps = new HashMap<>();
-        customProps.put("nodes", nodes.stream().map(NodeConfig::toString).collect(Collectors.joining(",")));
+        // Strip the #id suffix so NodeConnectInfo can parse the account literal correctly;
+        // without this, the #id suffix prevents ID_LITERAL_PATTERN from matching and causes
+        // HapiSpecSetup.nodes() to assign sequential stub accounts instead of the real ones.
+        customProps.put(
+                "nodes",
+                nodes.stream()
+                        .map(NodeConfig::toString)
+                        .map(s -> s.contains("#") ? s.substring(0, s.indexOf('#')) : s)
+                        .collect(Collectors.joining(",")));
         if (shard != null) {
             customProps.put("hapi.spec.default.shard", String.valueOf(shard));
         }

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/config/NetConfigTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/config/NetConfigTest.java
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.yahcli.test.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.services.bdd.spec.props.NodeConnectInfo;
+import com.hedera.services.yahcli.config.domain.NetConfig;
+import com.hedera.services.yahcli.config.domain.NodeConfig;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class NetConfigTest {
+    /**
+     * Reproduces the mainnet topology where DAB nodeIds have gaps (retired nodes 2 and 3),
+     * so accounts are non-sequential: 0→3, 1→4, 4→7. Without stripping the #id suffix,
+     * NodeConnectInfo falls back to sequential stub accounts (3, 4, 5) causing account 7
+     * to be misrouted to the wrong gRPC endpoint.
+     */
+    @Test
+    void toSpecPropertiesStripsNodeIdSuffixForCorrectAccountParsing() {
+        final var netConfig = new NetConfig();
+        netConfig.setNodes(List.of(
+                nodeConfig(0, 3, "35.237.208.135"),
+                nodeConfig(1, 4, "35.236.222.232"),
+                nodeConfig(4, 7, "34.94.94.224")));
+
+        final var props = netConfig.toSpecProperties();
+        final var nodesValue = props.get("nodes");
+
+        assertThat(nodesValue).doesNotContain("#");
+
+        // Verify NodeConnectInfo can parse each entry with the correct account
+        final var entries = nodesValue.split(",");
+        assertThat(entries).hasSize(3);
+        assertThat(new NodeConnectInfo(entries[0]).getAccount().getAccountNum()).isEqualTo(3L);
+        assertThat(new NodeConnectInfo(entries[1]).getAccount().getAccountNum()).isEqualTo(4L);
+        assertThat(new NodeConnectInfo(entries[2]).getAccount().getAccountNum()).isEqualTo(7L);
+    }
+
+    @Test
+    void toSpecPropertiesFormsCorrectNodeString() {
+        final var netConfig = new NetConfig();
+        netConfig.setNodes(List.of(nodeConfig(4, 7, "34.94.94.224")));
+
+        final var nodesValue = netConfig.toSpecProperties().get("nodes");
+
+        assertThat(nodesValue).isEqualTo("34.94.94.224:0.0.7");
+    }
+
+    private static NodeConfig nodeConfig(int id, long account, String ip) {
+        final var n = new NodeConfig();
+        n.setId(id);
+        n.setAccount(account);
+        n.setIpv4Addr(ip);
+        return n;
+    }
+}

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
@@ -3,28 +3,31 @@ package com.hedera.services.yahcli.test.regression;
 
 import static com.hedera.services.bdd.junit.hedera.utils.WorkingDirUtils.guaranteedExtantDir;
 import static com.hedera.services.bdd.junit.hedera.utils.WorkingDirUtils.rm;
+import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
 import static com.hedera.services.yahcli.test.YahcliTestBase.REGRESSION;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.DEFAULT_WORKING_DIR;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.TEST_NETWORK;
-import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliIvy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.newAccountCapturer;
+import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliAccounts;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.spec.props.NodeConnectInfo;
 import com.hedera.services.yahcli.config.domain.GlobalConfig;
 import com.hedera.services.yahcli.config.domain.NetConfig;
-import com.hedera.services.yahcli.config.domain.NodeConfig;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
@@ -42,48 +45,73 @@ import org.yaml.snakeyaml.constructor.Constructor;
  * retired), so real accounts are non-sequential (3, 4, 7, 8, 9, …). Sequential fallback numbering
  * (3, 4, 5, 6, 7, …) diverges at the first gap, routing gRPC calls to the wrong node, which then
  * rejects transactions with {@code INVALID_NODE_ACCOUNT}.
+ *
+ * <p>Unit-level assertions for {@code toSpecProperties()} live in
+ * {@code com.hedera.services.yahcli.test.config.NetConfigTest}.
  */
 @Tag(REGRESSION)
 public class NodeRoutingRegressionTest {
 
     /**
-     * Verifies that a crypto transfer actually succeeds when the yahcli config uses nodes with
-     * non-sequential nodeIds (a gap topology). Uses nodes 0 and 3 from the embedded 4-node
-     * network (nodeIds 0 and 3, accounts 3 and 6, skipping nodeIds 1 and 2).
+     * Verifies that account-creation requests succeed when routed explicitly to both nodes in a
+     * gap topology. Uses nodes 0 and 3 from the embedded 4-node network (nodeIds 0 and 3,
+     * accounts 3 and 6, skipping nodeIds 1 and 2).
      *
      * <p>Without the fix, {@code toSpecProperties()} includes {@code #id} suffixes, causing
-     * {@link NodeConnectInfo} to fall back to sequential accounts 3 and 4. When {@code nodeAccounts}
-     * (built from {@code toNodeInfos()}, which correctly strips suffixes) cycles to account 6,
-     * {@code HapiClients.stubId()} finds no stub for account 6 and throws, causing yahcli to exit
-     * non-zero and the test to fail.
+     * {@link NodeConnectInfo} to assign sequential stub accounts 3 and 4. Routing to node account 6
+     * then finds no matching stub and throws, making yahcli exit non-zero.
      *
-     * <p>With the fix, stubs are keyed by accounts 3 and 6 correctly, so routing to account 6
-     * succeeds and the crypto transfer completes.
+     * <p>With the fix, stubs are keyed by accounts 3 and 6 correctly, so both account-creation
+     * requests succeed and the resulting accounts carry the expected 1-hbar balance.
      */
     @HapiTest
-    final Stream<DynamicTest> cryptoTransferSucceedsWhenNodeIdsHaveGaps() {
+    final Stream<DynamicTest> accountCreationSucceedsWhenRoutedToGapNodes() {
         final var gapConfigPath = new AtomicReference<String>();
         final var gapWorkDirPath = new AtomicReference<String>();
+        final var node0Account = new AtomicReference<String>();
+        final var node3Account = new AtomicReference<String>();
+        final var acctViaNode0 = new AtomicLong();
+        final var acctViaNode3 = new AtomicLong();
 
         return hapiTest(
                 doingContextual(spec -> {
                     try {
-                        setupGapWorkDir(gapConfigPath, gapWorkDirPath);
+                        setupGapWorkDir(gapConfigPath, gapWorkDirPath, node0Account, node3Account);
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }
                 }),
-                sourcingContextual(spec -> yahcliIvy("scenarios", "--crypto")
+                // Create an account routed explicitly to node 0 (account 3 in gap topology)
+                sourcingContextual(spec -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
                         .withConfigLoc(gapConfigPath.get())
-                        .withWorkingDir(gapWorkDirPath.get())));
+                        .withWorkingDir(gapWorkDirPath.get())
+                        .withNodeAccount(node0Account.get())
+                        .exposingOutputTo(newAccountCapturer(acctViaNode0::set))),
+                // Create an account routed explicitly to node 3 (account 6 in gap topology — the gap node)
+                sourcingContextual(spec -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
+                        .withConfigLoc(gapConfigPath.get())
+                        .withWorkingDir(gapWorkDirPath.get())
+                        .withNodeAccount(node3Account.get())
+                        .exposingOutputTo(newAccountCapturer(acctViaNode3::set))),
+                // Verify both accounts were created with the expected 1-hbar balance
+                sourcingContextual(spec -> getAccountInfo(
+                                asAccountString(spec.accountIdFactory().apply(acctViaNode0.get())))
+                        .has(accountWith().balance(ONE_HBAR))),
+                sourcingContextual(spec -> getAccountInfo(
+                                asAccountString(spec.accountIdFactory().apply(acctViaNode3.get())))
+                        .has(accountWith().balance(ONE_HBAR))));
     }
 
     /**
      * Builds a gap-topology config from the embedded network (nodes 0 and 3 only, skipping 1 and 2),
-     * writes it to a fresh working directory, and copies the genesis key material.
+     * writes it to a fresh working directory, copies the genesis key material, and populates the
+     * node account string references for use in routing subsequent commands.
      */
     private static void setupGapWorkDir(
-            AtomicReference<String> gapConfigPath, AtomicReference<String> gapWorkDirPath) throws IOException {
+            AtomicReference<String> gapConfigPath,
+            AtomicReference<String> gapWorkDirPath,
+            AtomicReference<String> node0Account,
+            AtomicReference<String> node3Account) throws IOException {
         final var defaultWorkDir = Path.of(DEFAULT_WORKING_DIR.get());
 
         // Read the embedded network's config to get actual host:port info
@@ -99,6 +127,8 @@ public class NodeRoutingRegressionTest {
 
         // Take nodes at indices 0 and 3: their nodeIds skip 1 and 2, so accounts are non-sequential
         final var gapNodes = List.of(allNodes.get(0), allNodes.get(3));
+        node0Account.set(String.valueOf(gapNodes.get(0).getAccount()));
+        node3Account.set(String.valueOf(gapNodes.get(1).getAccount()));
 
         final var gapNet = new NetConfig();
         gapNet.setShard(embeddedNet.getShard());
@@ -129,13 +159,5 @@ public class NodeRoutingRegressionTest {
 
         gapConfigPath.set(configFile.toString());
         gapWorkDirPath.set(gapDir.toString());
-    }
-
-    private static NodeConfig nodeConfig(int id, long account, String ip) {
-        final var n = new NodeConfig();
-        n.setId(id);
-        n.setAccount(account);
-        n.setIpv4Addr(ip);
-        return n;
     }
 }

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
@@ -7,14 +7,14 @@ import static com.hedera.services.bdd.spec.HapiPropertySource.asAccountString;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
-import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doAdhoc;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.yahcli.test.YahcliTestBase.REGRESSION;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.DEFAULT_WORKING_DIR;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.TEST_NETWORK;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.newAccountCapturer;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliAccounts;
-import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.hedera.services.bdd.junit.HapiTest;
@@ -74,7 +74,7 @@ public class NodeRoutingRegressionTest {
         final var acctViaNode3 = new AtomicLong();
 
         return hapiTest(
-                doingContextual(spec -> {
+                doAdhoc(() -> {
                     try {
                         setupGapWorkDir(gapConfigPath, gapWorkDirPath, node0Account, node3Account);
                     } catch (IOException e) {
@@ -82,13 +82,13 @@ public class NodeRoutingRegressionTest {
                     }
                 }),
                 // Create an account routed explicitly to node 0 (account 3 in gap topology)
-                sourcingContextual(spec -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
+                doAdhoc(() -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
                         .withConfigLoc(gapConfigPath.get())
                         .withWorkingDir(gapWorkDirPath.get())
                         .withNodeAccount(node0Account.get())
                         .exposingOutputTo(newAccountCapturer(acctViaNode0::set))),
                 // Create an account routed explicitly to node 3 (account 6 in gap topology — the gap node)
-                sourcingContextual(spec -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
+                doAdhoc(() -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
                         .withConfigLoc(gapConfigPath.get())
                         .withWorkingDir(gapWorkDirPath.get())
                         .withNodeAccount(node3Account.get())
@@ -111,7 +111,8 @@ public class NodeRoutingRegressionTest {
             AtomicReference<String> gapConfigPath,
             AtomicReference<String> gapWorkDirPath,
             AtomicReference<String> node0Account,
-            AtomicReference<String> node3Account) throws IOException {
+            AtomicReference<String> node3Account)
+            throws IOException {
         final var defaultWorkDir = Path.of(DEFAULT_WORKING_DIR.get());
 
         // Read the embedded network's config to get actual host:port info
@@ -135,7 +136,7 @@ public class NodeRoutingRegressionTest {
         gapNet.setRealm(embeddedNet.getRealm());
         gapNet.setDefaultPayer(embeddedNet.getDefaultPayer());
         gapNet.setNodes(gapNodes);
-        gapNet.setDefaultNodeAccount((int) gapNodes.get(0).getAccount());
+        gapNet.setDefaultNodeAccount((int) gapNodes.getFirst().getAccount());
 
         final var gapGlobal = new GlobalConfig();
         gapGlobal.setNetworks(Map.of(TEST_NETWORK, gapNet));

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
@@ -8,6 +8,7 @@ import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountInfoAsserts.accountWith;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doAdhoc;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
 import static com.hedera.services.yahcli.test.YahcliTestBase.REGRESSION;
@@ -83,13 +84,13 @@ public class NodeRoutingRegressionTest {
                     }
                 }),
                 // Create an account routed explicitly to node 0 (account 3 in gap topology)
-                doAdhoc(() -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
+                sourcing(() -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
                         .withConfigLoc(gapConfigPath.get())
                         .withWorkingDir(gapWorkDirPath.get())
                         .withNodeAccount(node0Account.get())
                         .exposingOutputTo(newAccountCapturer(acctViaNode0::set))),
                 // Create an account routed explicitly to node 3 (account 6 in gap topology — the gap node)
-                doAdhoc(() -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
+                sourcing(() -> yahcliAccounts("create", "-d", "hbar", "-a", "1")
                         .withConfigLoc(gapConfigPath.get())
                         .withWorkingDir(gapWorkDirPath.get())
                         .withNodeAccount(node3Account.get())

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
@@ -1,0 +1,173 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.yahcli.test.regression;
+
+import static com.hedera.services.bdd.junit.hedera.utils.WorkingDirUtils.guaranteedExtantDir;
+import static com.hedera.services.bdd.junit.hedera.utils.WorkingDirUtils.rm;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
+import static com.hedera.services.yahcli.test.YahcliTestBase.REGRESSION;
+import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.DEFAULT_WORKING_DIR;
+import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.TEST_NETWORK;
+import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliIvy;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.spec.props.NodeConnectInfo;
+import com.hedera.services.yahcli.config.domain.GlobalConfig;
+import com.hedera.services.yahcli.config.domain.NetConfig;
+import com.hedera.services.yahcli.config.domain.NodeConfig;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+import org.yaml.snakeyaml.LoaderOptions;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+/**
+ * Regression for the bug where {@link NetConfig#toSpecProperties()} emitted {@code #nodeId} suffixes
+ * in the {@code nodes} property, causing {@link NodeConnectInfo} to fall back to sequential account
+ * numbering instead of parsing the real account literals.
+ *
+ * <p>On mainnet, retired nodes create gaps in the DAB nodeId sequence (e.g. nodeIds 2 and 3 are
+ * retired), so real accounts are non-sequential (3, 4, 7, 8, 9, …). Sequential fallback numbering
+ * (3, 4, 5, 6, 7, …) diverges at the first gap, routing gRPC calls to the wrong node, which then
+ * rejects transactions with {@code INVALID_NODE_ACCOUNT}.
+ */
+@Tag(REGRESSION)
+public class NodeRoutingRegressionTest {
+
+    /**
+     * Reproduces the mainnet topology where nodeIds skip retired nodes 2 and 3, yielding
+     * non-sequential accounts (3, 4, 7). Without the fix, {@code toSpecProperties()} includes
+     * {@code #id} suffixes that prevent {@link NodeConnectInfo} from parsing the account literal,
+     * causing it to fall back to sequential numbering and assign account 5 to the third node
+     * (which is actually account 7).
+     */
+    @HapiTest
+    final Stream<DynamicTest> toSpecPropertiesProducesCorrectAccountsForNonSequentialNodeIds() {
+        return hapiTest(doingContextual(spec -> {
+            // Simulate mainnet topology: nodeIds 0, 1, 4 (gaps at retired nodeIds 2 and 3)
+            // Real accounts: 3, 4, 7 — sequential fallback would give: 3, 4, 5 (wrong for node 4)
+            final var netConfig = new NetConfig();
+            netConfig.setNodes(List.of(
+                    nodeConfig(0, 3, "35.237.208.135"),
+                    nodeConfig(1, 4, "35.236.222.232"),
+                    nodeConfig(4, 7, "34.94.94.224")));
+
+            final var nodesValue = netConfig.toSpecProperties().get("nodes");
+
+            assertFalse(
+                    nodesValue.contains("#"),
+                    "nodes property must not contain #id suffixes — they prevent NodeConnectInfo"
+                            + " from parsing account literals: " + nodesValue);
+
+            final var entries = nodesValue.split(",");
+            assertEquals(3, entries.length);
+            assertEquals(7L, new NodeConnectInfo(entries[2]).getAccount().getAccountNum(),
+                    "Third node (nodeId=4) must parse as account 7, not sequential fallback 5");
+        }));
+    }
+
+    /**
+     * Verifies that a crypto transfer actually succeeds when the yahcli config uses nodes with
+     * non-sequential nodeIds (a gap topology). Uses nodes 0 and 3 from the embedded 4-node
+     * network (nodeIds 0 and 3, accounts 3 and 6, skipping nodeIds 1 and 2).
+     *
+     * <p>Without the fix, {@code toSpecProperties()} includes {@code #id} suffixes, causing
+     * {@link NodeConnectInfo} to fall back to sequential accounts 3 and 4. When {@code nodeAccounts}
+     * (built from {@code toNodeInfos()}, which correctly strips suffixes) cycles to account 6,
+     * {@code HapiClients.stubId()} finds no stub for account 6 and throws, causing yahcli to exit
+     * non-zero and the test to fail.
+     *
+     * <p>With the fix, stubs are keyed by accounts 3 and 6 correctly, so routing to account 6
+     * succeeds and the crypto transfer completes.
+     */
+    @HapiTest
+    final Stream<DynamicTest> cryptoTransferSucceedsWhenNodeIdsHaveGaps() {
+        final var gapConfigPath = new AtomicReference<String>();
+        final var gapWorkDirPath = new AtomicReference<String>();
+
+        return hapiTest(
+                doingContextual(spec -> {
+                    try {
+                        setupGapWorkDir(gapConfigPath, gapWorkDirPath);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }),
+                sourcingContextual(spec -> yahcliIvy("scenarios", "--crypto")
+                        .withConfigLoc(gapConfigPath.get())
+                        .withWorkingDir(gapWorkDirPath.get())));
+    }
+
+    /**
+     * Builds a gap-topology config from the embedded network (nodes 0 and 3 only, skipping 1 and 2),
+     * writes it to a fresh working directory, and copies the genesis key material.
+     */
+    private static void setupGapWorkDir(
+            AtomicReference<String> gapConfigPath, AtomicReference<String> gapWorkDirPath) throws IOException {
+        final var defaultWorkDir = Path.of(DEFAULT_WORKING_DIR.get());
+
+        // Read the embedded network's config to get actual host:port info
+        final var embeddedConfigFile = defaultWorkDir.resolve("config.yml");
+        final var yamlIn = new Yaml(new Constructor(GlobalConfig.class, new LoaderOptions()));
+        final GlobalConfig embeddedGlobal;
+        try (final var in = Files.newInputStream(embeddedConfigFile)) {
+            embeddedGlobal = yamlIn.load(in);
+        }
+        final var embeddedNet = embeddedGlobal.getNetworks().get(TEST_NETWORK);
+        final var allNodes = embeddedNet.getNodes();
+        assertTrue(allNodes.size() >= 4, "Expected at least 4 embedded nodes to form a gap topology");
+
+        // Take nodes at indices 0 and 3: their nodeIds skip 1 and 2, so accounts are non-sequential
+        final var gapNodes = List.of(allNodes.get(0), allNodes.get(3));
+
+        final var gapNet = new NetConfig();
+        gapNet.setShard(embeddedNet.getShard());
+        gapNet.setRealm(embeddedNet.getRealm());
+        gapNet.setDefaultPayer(embeddedNet.getDefaultPayer());
+        gapNet.setNodes(gapNodes);
+        gapNet.setDefaultNodeAccount((int) gapNodes.get(0).getAccount());
+
+        final var gapGlobal = new GlobalConfig();
+        gapGlobal.setNetworks(Map.of(TEST_NETWORK, gapNet));
+        gapGlobal.setDefaultNetwork(TEST_NETWORK);
+
+        // Set up a fresh working directory for the gap scenario
+        final var gapDir = Path.of("build", "yahcli-gap-routing-test").toAbsolutePath();
+        rm(gapDir);
+        final var keysDir = guaranteedExtantDir(gapDir.resolve(TEST_NETWORK).resolve("keys"));
+
+        // Copy genesis key material from the default working directory
+        final var srcKeys = defaultWorkDir.resolve(TEST_NETWORK).resolve("keys");
+        Files.copy(srcKeys.resolve("account2.pem"), keysDir.resolve("account2.pem"));
+        Files.copy(srcKeys.resolve("account2.pass"), keysDir.resolve("account2.pass"));
+
+        // Write the gap config.yml
+        final var yamlOut = new Yaml();
+        final var doc = yamlOut.dumpAs(gapGlobal, org.yaml.snakeyaml.nodes.Tag.MAP, null);
+        final var configFile = gapDir.resolve("config.yml");
+        Files.writeString(configFile, doc);
+
+        gapConfigPath.set(configFile.toString());
+        gapWorkDirPath.set(gapDir.toString());
+    }
+
+    private static NodeConfig nodeConfig(int id, long account, String ip) {
+        final var n = new NodeConfig();
+        n.setId(id);
+        n.setAccount(account);
+        n.setIpv4Addr(ip);
+        return n;
+    }
+}

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
@@ -47,38 +47,6 @@ import org.yaml.snakeyaml.constructor.Constructor;
 public class NodeRoutingRegressionTest {
 
     /**
-     * Reproduces the mainnet topology where nodeIds skip retired nodes 2 and 3, yielding
-     * non-sequential accounts (3, 4, 7). Without the fix, {@code toSpecProperties()} includes
-     * {@code #id} suffixes that prevent {@link NodeConnectInfo} from parsing the account literal,
-     * causing it to fall back to sequential numbering and assign account 5 to the third node
-     * (which is actually account 7).
-     */
-    @HapiTest
-    final Stream<DynamicTest> toSpecPropertiesProducesCorrectAccountsForNonSequentialNodeIds() {
-        return hapiTest(doingContextual(spec -> {
-            // Simulate mainnet topology: nodeIds 0, 1, 4 (gaps at retired nodeIds 2 and 3)
-            // Real accounts: 3, 4, 7 — sequential fallback would give: 3, 4, 5 (wrong for node 4)
-            final var netConfig = new NetConfig();
-            netConfig.setNodes(List.of(
-                    nodeConfig(0, 3, "35.237.208.135"),
-                    nodeConfig(1, 4, "35.236.222.232"),
-                    nodeConfig(4, 7, "34.94.94.224")));
-
-            final var nodesValue = netConfig.toSpecProperties().get("nodes");
-
-            assertFalse(
-                    nodesValue.contains("#"),
-                    "nodes property must not contain #id suffixes — they prevent NodeConnectInfo"
-                            + " from parsing account literals: " + nodesValue);
-
-            final var entries = nodesValue.split(",");
-            assertEquals(3, entries.length);
-            assertEquals(7L, new NodeConnectInfo(entries[2]).getAccount().getAccountNum(),
-                    "Third node (nodeId=4) must parse as account 7, not sequential fallback 5");
-        }));
-    }
-
-    /**
      * Verifies that a crypto transfer actually succeeds when the yahcli config uses nodes with
      * non-sequential nodeIds (a gap topology). Uses nodes 0 and 3 from the embedded 4-node
      * network (nodeIds 0 and 3, accounts 3 and 6, skipping nodeIds 1 and 2).

--- a/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
+++ b/hedera-node/yahcli/src/test/java/com/hedera/services/yahcli/test/regression/NodeRoutingRegressionTest.java
@@ -16,6 +16,7 @@ import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.TEST_NETWORK;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.newAccountCapturer;
 import static com.hedera.services.yahcli.test.bdd.YahcliVerbs.yahcliAccounts;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.yaml.snakeyaml.nodes.Tag.MAP;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import com.hedera.services.bdd.spec.props.NodeConnectInfo;
@@ -54,7 +55,7 @@ public class NodeRoutingRegressionTest {
 
     /**
      * Verifies that account-creation requests succeed when routed explicitly to both nodes in a
-     * gap topology. Uses nodes 0 and 3 from the embedded 4-node network (nodeIds 0 and 3,
+     * gap topology. Uses nodes 0 and 3 from the test 4-node network (nodeIds 0 and 3,
      * accounts 3 and 6, skipping nodeIds 1 and 2).
      *
      * <p>Without the fix, {@code toSpecProperties()} includes {@code #id} suffixes, causing
@@ -103,7 +104,7 @@ public class NodeRoutingRegressionTest {
     }
 
     /**
-     * Builds a gap-topology config from the embedded network (nodes 0 and 3 only, skipping 1 and 2),
+     * Builds a gap-topology config from the network (nodes 0 and 3 only, skipping 1 and 2),
      * writes it to a fresh working directory, copies the genesis key material, and populates the
      * node account string references for use in routing subsequent commands.
      */
@@ -115,16 +116,16 @@ public class NodeRoutingRegressionTest {
             throws IOException {
         final var defaultWorkDir = Path.of(DEFAULT_WORKING_DIR.get());
 
-        // Read the embedded network's config to get actual host:port info
-        final var embeddedConfigFile = defaultWorkDir.resolve("config.yml");
+        // Read the network's config to get actual host:port info
+        final var currentConfigFile = defaultWorkDir.resolve("config.yml");
         final var yamlIn = new Yaml(new Constructor(GlobalConfig.class, new LoaderOptions()));
-        final GlobalConfig embeddedGlobal;
-        try (final var in = Files.newInputStream(embeddedConfigFile)) {
-            embeddedGlobal = yamlIn.load(in);
+        final GlobalConfig global;
+        try (final var in = Files.newInputStream(currentConfigFile)) {
+            global = yamlIn.load(in);
         }
-        final var embeddedNet = embeddedGlobal.getNetworks().get(TEST_NETWORK);
-        final var allNodes = embeddedNet.getNodes();
-        assertTrue(allNodes.size() >= 4, "Expected at least 4 embedded nodes to form a gap topology");
+        final var network = global.getNetworks().get(TEST_NETWORK);
+        final var allNodes = network.getNodes();
+        assertTrue(allNodes.size() >= 4, "Expected at least 4 nodes to form a gap topology");
 
         // Take nodes at indices 0 and 3: their nodeIds skip 1 and 2, so accounts are non-sequential
         final var gapNodes = List.of(allNodes.get(0), allNodes.get(3));
@@ -132,9 +133,9 @@ public class NodeRoutingRegressionTest {
         node3Account.set(String.valueOf(gapNodes.get(1).getAccount()));
 
         final var gapNet = new NetConfig();
-        gapNet.setShard(embeddedNet.getShard());
-        gapNet.setRealm(embeddedNet.getRealm());
-        gapNet.setDefaultPayer(embeddedNet.getDefaultPayer());
+        gapNet.setShard(network.getShard());
+        gapNet.setRealm(network.getRealm());
+        gapNet.setDefaultPayer(network.getDefaultPayer());
         gapNet.setNodes(gapNodes);
         gapNet.setDefaultNodeAccount((int) gapNodes.getFirst().getAccount());
 
@@ -154,7 +155,7 @@ public class NodeRoutingRegressionTest {
 
         // Write the gap config.yml
         final var yamlOut = new Yaml();
-        final var doc = yamlOut.dumpAs(gapGlobal, org.yaml.snakeyaml.nodes.Tag.MAP, null);
+        final var doc = yamlOut.dumpAs(gapGlobal, MAP, null);
         final var configFile = gapDir.resolve("config.yml");
         Files.writeString(configFile, doc);
 


### PR DESCRIPTION
**Description:** 

`NodeConfig.toString()` produces strings matching "ip:shard.realm.account#nodeId". `NodeConnectInfo`'s `ID_LITERAL_PATTERN (\d+[.]\d+[.]\d+)` fails to match anything containing `#`, so it falls back to assigning sequential stub account numbers (3, 4, 5, …) instead of parsing the real account literals.

The fix strips the `#nodeId` suffix inside `NetConfig.toSpecProperties()` before building the nodes property string. `toNodeInfos()` already did this correctly; `toSpecProperties()` did not.

Two regression tests are added: a unit test that asserts the correct account is resolved for any network topology containing gaps between node IDs; and an integration test that runs yahcli with a gap derived from the test network (nodes 0 and 3 only, skipping nodeIds 1 and 2), verifying that operations sent to each node succeed. 