### PR TITLE
fix: make prng and exchange rate contracts stateless

### DIFF
--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/ExchangeRateSystemContract.java
@@ -16,6 +16,7 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import java.math.BigInteger;
 import java.util.Optional;
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.bytes.Bytes32;
 import org.hyperledger.besu.datatypes.Address;
@@ -23,6 +24,7 @@ import org.hyperledger.besu.evm.frame.ExceptionalHaltReason;
 import org.hyperledger.besu.evm.frame.MessageFrame;
 import org.hyperledger.besu.evm.gascalculator.GasCalculator;
 
+@Singleton
 public class ExchangeRateSystemContract extends AbstractFullContract implements HederaSystemContract {
     private static final String PRECOMPILE_NAME = "ExchangeRate";
     private static final BigIntegerType WORD_DECODER = TypeFactory.create("uint256");
@@ -39,8 +41,6 @@ public class ExchangeRateSystemContract extends AbstractFullContract implements 
             .contractNum(numberOfLongZero(Address.fromHexString(EXCHANGE_RATE_SYSTEM_CONTRACT_ADDRESS)))
             .build();
 
-    private long gasRequirement;
-
     @Inject
     public ExchangeRateSystemContract(@NonNull final GasCalculator gasCalculator) {
         super(PRECOMPILE_NAME, gasCalculator);
@@ -52,18 +52,18 @@ public class ExchangeRateSystemContract extends AbstractFullContract implements 
             @NonNull ContractID contractID, @NonNull Bytes input, @NonNull MessageFrame messageFrame) {
         requireNonNull(input);
         requireNonNull(messageFrame);
+        final long gasRequirement = contractsConfigOf(messageFrame).precompileExchangeRateGasCost();
         try {
             validateTrue(input.size() >= 4, INVALID_TRANSACTION_BODY);
-            gasRequirement = contractsConfigOf(messageFrame).precompileExchangeRateGasCost();
             final var selector = input.getInt(0);
             final var amount = biValueFrom(input);
             final var activeRate = proxyUpdaterFor(messageFrame).currentExchangeRate();
             final var result =
                     switch (selector) {
-                        case TO_TINYBARS_SELECTOR -> padded(
-                                ConversionUtils.fromAToB(amount, activeRate.hbarEquiv(), activeRate.centEquiv()));
-                        case TO_TINYCENTS_SELECTOR -> padded(
-                                ConversionUtils.fromAToB(amount, activeRate.centEquiv(), activeRate.hbarEquiv()));
+                        case TO_TINYBARS_SELECTOR ->
+                            padded(ConversionUtils.fromAToB(amount, activeRate.hbarEquiv(), activeRate.centEquiv()));
+                        case TO_TINYCENTS_SELECTOR ->
+                            padded(ConversionUtils.fromAToB(amount, activeRate.centEquiv(), activeRate.hbarEquiv()));
                         default -> null;
                     };
             requireNonNull(result);

--- a/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/PrngSystemContract.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/main/java/com/hedera/node/app/service/contract/impl/exec/systemcontracts/PrngSystemContract.java
@@ -58,7 +58,6 @@ public class PrngSystemContract extends AbstractFullContract implements HederaSy
     public static final ContractID PRNG_CONTRACT_ID = ContractID.newBuilder()
             .contractNum(numberOfLongZero(Address.fromHexString(PRNG_PRECOMPILE_ADDRESS)))
             .build();
-    private long gasRequirement;
 
     @Inject
     public PrngSystemContract(@NonNull final GasCalculator gasCalculator) {
@@ -72,7 +71,7 @@ public class PrngSystemContract extends AbstractFullContract implements HederaSy
         requireNonNull(frame);
 
         // compute the gas requirement
-        gasRequirement = calculateGas(frame);
+        final long gasRequirement = calculateGas(frame);
 
         try {
             validateTrue(input.size() >= 4, INVALID_TRANSACTION_BODY);
@@ -82,12 +81,12 @@ public class PrngSystemContract extends AbstractFullContract implements HederaSy
             final var result = PrecompiledContract.PrecompileContractResult.success(randomNum);
 
             // create a child record
-            createSuccessfulRecord(frame, randomNum, contractID);
+            createSuccessfulRecord(frame, randomNum, contractID, gasRequirement);
 
             return new FullResult(result, gasRequirement, null);
         } catch (InvalidTransactionException e) {
             // This error is caused by the user sending in the wrong selector
-            createFailedRecord(frame, e.getResponseCode(), contractID);
+            createFailedRecord(frame, e.getResponseCode(), contractID, gasRequirement);
             return new FullResult(
                     PrecompiledContract.PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(INVALID_OPERATION)),
                     gasRequirement,
@@ -95,7 +94,7 @@ public class PrngSystemContract extends AbstractFullContract implements HederaSy
         } catch (Exception e) {
             // Log a warning as this error will be caused by insufficient entropy
             log.warn("Internal precompile failure", e);
-            createFailedRecord(frame, FAIL_INVALID, contractID);
+            createFailedRecord(frame, FAIL_INVALID, contractID, gasRequirement);
             return new FullResult(
                     PrecompiledContract.PrecompileContractResult.halt(Bytes.EMPTY, Optional.of(INVALID_OPERATION)),
                     gasRequirement,
@@ -104,7 +103,10 @@ public class PrngSystemContract extends AbstractFullContract implements HederaSy
     }
 
     void createSuccessfulRecord(
-            @NonNull MessageFrame frame, @NonNull final Bytes randomNum, @NonNull final ContractID contractID) {
+            @NonNull MessageFrame frame,
+            @NonNull final Bytes randomNum,
+            @NonNull final ContractID contractID,
+            final long gasRequirement) {
         if (!frame.isStatic()) {
             requireNonNull(frame);
             requireNonNull(randomNum);
@@ -135,7 +137,8 @@ public class PrngSystemContract extends AbstractFullContract implements HederaSy
     void createFailedRecord(
             @NonNull MessageFrame frame,
             @NonNull final ResponseCodeEnum responseCode,
-            @NonNull final ContractID contractID) {
+            @NonNull final ContractID contractID,
+            final long gasRequirement) {
         if (!frame.isStatic()) {
             requireNonNull(frame);
             requireNonNull(contractID);

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/ExchangeRateSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/ExchangeRateSystemContractTest.java
@@ -32,6 +32,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class ExchangeRateSystemContractTest {
+    private static final long GAS_COST = 100L;
+    private static final long UPDATED_GAS_COST = 250L;
+
     @Mock
     private GasCalculator gasCalculator;
 
@@ -52,6 +55,8 @@ class ExchangeRateSystemContractTest {
     void setUp() {
         subject = new ExchangeRateSystemContract(gasCalculator);
         frameUtils = Mockito.mockStatic(FrameUtils.class);
+        frameUtils.when(() -> contractsConfigOf(frame)).thenReturn(contractsConfig);
+        given(contractsConfig.precompileExchangeRateGasCost()).willReturn(GAS_COST);
     }
 
     @AfterEach
@@ -108,6 +113,30 @@ class ExchangeRateSystemContractTest {
     }
 
     @Test
+    void chargesConfiguredGasWhenSelectorIsTruncated() {
+        // The configured cost applies even where validation fails before any conversion happens
+        final var fragmentSelector = Bytes.of(0xab);
+        final var result = subject.computeFully(EXCHANGE_RATE_CONTRACT_ID, fragmentSelector, frame);
+        assertThat(result.gasRequirement()).isEqualTo(GAS_COST);
+    }
+
+    @Test
+    void gasRequirementIsRecomputedPerInvocation() {
+        givenRate(someRate);
+
+        // a successful conversion reports the configured cost...
+        final var successful =
+                subject.computeFully(EXCHANGE_RATE_CONTRACT_ID, tinycentsInput(someTinycentAmount), frame);
+        assertThat(successful.gasRequirement()).isEqualTo(GAS_COST);
+
+        // ...and a later call reports the cost configured for its own frame, even where validation
+        // fails before any conversion happens
+        given(contractsConfig.precompileExchangeRateGasCost()).willReturn(UPDATED_GAS_COST);
+        final var truncated = subject.computeFully(EXCHANGE_RATE_CONTRACT_ID, Bytes.of(0xab), frame);
+        assertThat(truncated.gasRequirement()).isEqualTo(UPDATED_GAS_COST);
+    }
+
+    @Test
     void selectorMustBeRecognized() {
         final var fragmentSelector = Bytes.of((byte) 0xab, (byte) 0xab, (byte) 0xab, (byte) 0xab);
         final var input = Bytes.concatenate(fragmentSelector, Bytes32.ZERO);
@@ -149,8 +178,6 @@ class ExchangeRateSystemContractTest {
     private void givenRate(final ExchangeRate rate) {
         frameUtils.when(() -> proxyUpdaterFor(frame)).thenReturn(updater);
         given(updater.currentExchangeRate()).willReturn(rate);
-        frameUtils.when(() -> contractsConfigOf(frame)).thenReturn(contractsConfig);
-        given(contractsConfig.precompileExchangeRateGasCost()).willReturn(0L);
     }
 
     private static final int someHbarEquiv = 120;

--- a/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/PrngSystemContractTest.java
+++ b/hedera-node/hedera-smart-contract-service-impl/src/test/java/com/hedera/node/app/service/contract/impl/test/exec/systemcontracts/PrngSystemContractTest.java
@@ -17,6 +17,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.when;
 
 import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.contract.ContractFunctionResult;
 import com.hedera.node.app.service.contract.impl.exec.gas.SystemContractGasCalculator;
 import com.hedera.node.app.service.contract.impl.exec.scope.SystemContractOperations;
 import com.hedera.node.app.service.contract.impl.exec.systemcontracts.FullResult;
@@ -30,6 +31,7 @@ import com.hedera.node.config.testfixtures.HederaTestConfigBuilder;
 import com.swirlds.config.api.Configuration;
 import java.util.ArrayDeque;
 import java.util.Deque;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.tuweni.bytes.Bytes;
 import org.hyperledger.besu.datatypes.Address;
 import org.hyperledger.besu.evm.frame.MessageFrame;
@@ -38,6 +40,7 @@ import org.hyperledger.besu.evm.precompile.PrecompiledContract.PrecompileContrac
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -75,6 +78,12 @@ class PrngSystemContractTest {
 
     @Mock
     private MessageFrame initialFrame;
+
+    @Mock
+    private MessageFrame queryFrame;
+
+    @Mock
+    private ProxyWorldUpdater queryWorldUpdater;
 
     @Mock
     private SystemContractGasCalculator systemContractGasCalculator;
@@ -192,6 +201,82 @@ class PrngSystemContractTest {
 
         // then:
         assertEqualContractResult(PRECOMPILE_CONTRACT_FAILED_RESULT, actual, GAS_REQUIRED);
+    }
+
+    @Test
+    void eachFrameIsPricedIndependentlyWhenCallsAreNested() {
+        // given: a mutable call, priced off the canonical UTIL_PRNG requirement...
+        givenCommon();
+        commonMocks();
+        given(messageFrame.isStatic()).willReturn(false);
+        given(systemContractGasCalculator.canonicalGasRequirement(any())).willReturn(GAS_REQUIRED);
+
+        // ...and a nested static call, priced off the view requirement instead
+        final Deque<MessageFrame> queryStack = new ArrayDeque<>();
+        queryStack.push(initialFrame);
+        queryStack.addFirst(queryFrame);
+        given(queryFrame.getMessageFrameStack()).willReturn(queryStack);
+        given(queryFrame.isStatic()).willReturn(true);
+        given(queryFrame.getWorldUpdater()).willReturn(queryWorldUpdater);
+        given(queryWorldUpdater.entropy()).willReturn(EXPECTED_RANDOM_NUMBER);
+        given(proxyWorldUpdater.entropy()).willAnswer(_ -> {
+            subject.computeFully(PRNG_CONTRACT_ID, PSEUDO_RANDOM_SYSTEM_CONTRACT_ADDRESS, queryFrame);
+            return EXPECTED_RANDOM_NUMBER;
+        });
+
+        final var recordCaptor = ArgumentCaptor.forClass(ContractFunctionResult.class);
+        when(systemContractOperations.dispatch(any(), any(), any(), any())).thenReturn(streamBuilder);
+        when(streamBuilder.contractCallResult(recordCaptor.capture())).thenReturn(streamBuilder);
+        when(streamBuilder.entropyBytes(any())).thenReturn(streamBuilder);
+
+        // when:
+        var actual = subject.computeFully(PRNG_CONTRACT_ID, PSEUDO_RANDOM_SYSTEM_CONTRACT_ADDRESS, messageFrame);
+
+        // then: the outer call and its record both report the mutable frame's price
+        assertEqualContractResult(PRECOMPILE_CONTRACT_SUCCESS_RESULT, actual, GAS_REQUIRED);
+        assertEquals(GAS_REQUIRED, recordCaptor.getValue().gasUsed());
+    }
+
+    @Test
+    void eachFrameIsPricedIndependentlyUnderConcurrentUse() throws Exception {
+        givenCommon();
+        commonMocks();
+        given(messageFrame.isStatic()).willReturn(false);
+        given(proxyWorldUpdater.entropy()).willReturn(EXPECTED_RANDOM_NUMBER);
+        given(systemContractGasCalculator.canonicalGasRequirement(any())).willReturn(GAS_REQUIRED);
+
+        final Deque<MessageFrame> queryStack = new ArrayDeque<>();
+        queryStack.push(initialFrame);
+        queryStack.addFirst(queryFrame);
+        given(queryFrame.getMessageFrameStack()).willReturn(queryStack);
+        given(queryFrame.isStatic()).willReturn(true);
+        given(queryFrame.getWorldUpdater()).willReturn(queryWorldUpdater);
+        given(queryWorldUpdater.entropy()).willReturn(EXPECTED_RANDOM_NUMBER);
+
+        when(systemContractOperations.dispatch(any(), any(), any(), any())).thenReturn(streamBuilder);
+        when(streamBuilder.contractCallResult(any())).thenReturn(streamBuilder);
+        when(streamBuilder.entropyBytes(any())).thenReturn(streamBuilder);
+
+        final var iterations = 2_000;
+        final var stop = new AtomicBoolean(false);
+        final var queryThread = new Thread(() -> {
+            while (!stop.get()) {
+                subject.computeFully(PRNG_CONTRACT_ID, PSEUDO_RANDOM_SYSTEM_CONTRACT_ADDRESS, queryFrame);
+            }
+        });
+        queryThread.setDaemon(true);
+        queryThread.start();
+        try {
+            for (int i = 0; i < iterations; i++) {
+                final var actual =
+                        subject.computeFully(PRNG_CONTRACT_ID, PSEUDO_RANDOM_SYSTEM_CONTRACT_ADDRESS, messageFrame);
+                assertEquals(
+                        GAS_REQUIRED, actual.gasRequirement(), "Gas requirement should be the mutable frame's price");
+            }
+        } finally {
+            stop.set(true);
+            queryThread.join();
+        }
     }
 
     private void givenInitialFrame() {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/precompile/PrngPrecompileSuite.java
@@ -13,6 +13,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
 import static com.hedera.services.bdd.spec.utilops.CustomSpecAssert.allRunFor;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcing;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.withOpContext;
 import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
@@ -22,11 +23,13 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_CONTRA
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import com.hedera.services.bdd.junit.HapiTest;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import org.apache.tuweni.bytes.Bytes;
 import org.hiero.base.utility.CommonUtils;
@@ -36,6 +39,13 @@ import org.junit.jupiter.api.Tag;
 @Tag(SMART_CONTRACT)
 public class PrngPrecompileSuite {
     private static final long GAS_TO_OFFER = 400_000L;
+    // What a static frame is charged: viewGasRequirement() divides the TOKEN_INFO canonical price by a
+    // hard-coded gas price, so it is stable across exchange rate and congestion
+    private static final long VIEW_GAS_REQUIREMENT = 2607L;
+    // What a mutable frame is charged: max(canonicalGasRequirement(UTIL_PRNG), viewGasRequirement()).
+    // Unlike the above, this tracks the fee schedule's ContractCall gas price and the congestion
+    // multiplier, so it needs updating if either changes; from multiplier 10 up it floors at the view value
+    private static final long CANONICAL_PRNG_GAS_REQUIREMENT = 15_284L;
     private static final String THE_GRACEFULLY_FAILING_PRNG_CONTRACT = "GracefullyFailingPrng";
     private static final String THE_PRNG_CONTRACT = "PrngSystemContract";
     private static final String BOB = "bob";
@@ -209,6 +219,39 @@ public class PrngPrecompileSuite {
                                 .contractCallResult(resultWith()
                                         .resultViaFunctionName(
                                                 GET_SEED, prng, isRandomResult(new Object[] {new byte[32]})))));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> prngChildRecordReportsCanonicalGasRequirement() {
+        final var prng = THE_PRNG_CONTRACT;
+        final var firstCall = "firstCall";
+        final var secondCall = "secondCall";
+        final AtomicLong firstChildGasUsed = new AtomicLong();
+        return hapiTest(
+                cryptoCreate(BOB),
+                uploadInitCode(prng),
+                contractCreate(prng),
+                contractCall(prng, GET_SEED).gas(GAS_TO_OFFER).payingWith(BOB).via(firstCall),
+                getTxnRecord(firstCall)
+                        .andAllChildRecords()
+                        .hasNonStakingChildRecordCount(1)
+                        .hasChildRecords(
+                                recordWith().contractCallResult(resultWith().gasUsed(CANONICAL_PRNG_GAS_REQUIREMENT)))
+                        .exposingAllTo(records -> firstChildGasUsed.set(
+                                records.getLast().getContractCallResult().getGasUsed())),
+                doingContextual(_ -> assertNotEquals(
+                        VIEW_GAS_REQUIREMENT,
+                        firstChildGasUsed.get(),
+                        "A mutable PRNG call must be charged the canonical UTIL_PRNG gas, not the view gas")),
+                // Repeat after a view execution: mutable calls are consistently priced off the
+                // canonical requirement
+                contractCallLocal(prng, GET_SEED).gas(GAS_TO_OFFER),
+                contractCall(prng, GET_SEED).gas(GAS_TO_OFFER).payingWith(BOB).via(secondCall),
+                getTxnRecord(secondCall)
+                        .andAllChildRecords()
+                        .hasNonStakingChildRecordCount(1)
+                        .hasChildRecords(
+                                recordWith().contractCallResult(resultWith().gasUsed(firstChildGasUsed::get))));
     }
 
     @HapiTest


### PR DESCRIPTION
> Migrated from the private `hashgraph/private-hedera-services` repository.

> Original source commit: `758ef6c3bf50beb196e1357a26399fccad10298e`

> This commit preserves the original author and author timestamp.


**Description**:

Make `PrngSystemContract` and `ExchangeRateSystemContract` stateless by replacing their mutable `gasRequirement` instance fields with method-local values. Both classes now hold only static final state, so the single instance each one contributes to the shared system-contract map carries no per-call data.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)

