### PR TITLE
fix: handle two bugs in reclaiming throttle capacity

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleAccumulator.java
@@ -351,12 +351,15 @@ public class ThrottleAccumulator {
      *
      * @param n the number of transactions to consider
      * @param function the functionality type of the transactions
+     * @param useHighVolumeBucket whether the capacity was claimed against the high-volume bucket, so it is
+     * leaked back into the same bucket it was charged to
      */
-    public void leakCapacityForNOfUnscaled(final int n, @NonNull final HederaFunctionality function) {
+    public void leakCapacityForNOfUnscaled(
+            final int n, @NonNull final HederaFunctionality function, final boolean useHighVolumeBucket) {
         if (throttleType == NOOP_THROTTLE) {
             return;
         }
-        final var manager = Objects.requireNonNull(functionReqs.get(function));
+        final var manager = Objects.requireNonNull(getReqsManager(function, useHighVolumeBucket));
         manager.undoClaimedReqsFor(n);
     }
 
@@ -1041,6 +1044,28 @@ public class ThrottleAccumulator {
         return useHighVolumeBucket
                 ? hasHighVolumeThrottleFor(function) ? highVolumeFunctionReqs.get(function) : functionReqs.get(function)
                 : functionReqs.get(function);
+    }
+
+    /**
+     * Returns whether an implicit-creation claim ({@link HederaFunctionality#CRYPTO_CREATE}) carried by a
+     * transaction of the given functionality would have been routed to the high-volume bucket at claim time,
+     * mirroring {@link #shouldUseHighVolumeBucket}. Used by the reclaim path so that capacity is leaked back
+     * into the same bucket it was charged to.
+     *
+     * @param function the functionality of the transaction carrying the implicit creations
+     * @param highVolume whether the transaction was submitted as high-volume
+     * @param implicitCreationsCount the number of implicit creations
+     * @return whether the claim used the high-volume bucket
+     */
+    public boolean usesHighVolumeBucketForImplicitCreations(
+            @NonNull final HederaFunctionality function, final boolean highVolume, final int implicitCreationsCount) {
+        final boolean highVolumeEnabled =
+                configSupplier.get().getConfigData(NetworkAdminConfig.class).highVolumeThrottlesEnabled();
+        return shouldUseHighVolumeBucket(
+                highVolume && highVolumeEnabled,
+                HIGH_VOLUME_THROTTLE_FUNCTIONS.contains(function),
+                function,
+                implicitCreationsCount);
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleServiceManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/throttle/ThrottleServiceManager.java
@@ -258,14 +258,35 @@ public class ThrottleServiceManager {
      * on the frontend.
      *
      * @param numCapacity the number of implicit creations or auto associations
+     * @param hederaFunctionality the functionality whose bucket the capacity was claimed against
+     * @param useHighVolumeBucket whether the capacity was claimed against the high-volume bucket, so it is
+     * leaked back into the same bucket it was charged to
      */
-    public void reclaimFrontendThrottleCapacity(final int numCapacity, final HederaFunctionality hederaFunctionality) {
+    public void reclaimFrontendThrottleCapacity(
+            final int numCapacity, final HederaFunctionality hederaFunctionality, final boolean useHighVolumeBucket) {
         try {
-            ingestThrottle.leakCapacityForNOfUnscaled(numCapacity, hederaFunctionality);
+            ingestThrottle.leakCapacityForNOfUnscaled(numCapacity, hederaFunctionality, useHighVolumeBucket);
         } catch (Exception ignore) {
             // Ignore if the frontend bucket has already leaked all the capacity
             // used for throttling the transaction on the frontend
         }
+    }
+
+    /**
+     * Returns whether the implicit-creation capacity for the given transaction was claimed against the
+     * high-volume frontend bucket, so the reclaim can leak it back into the same bucket it was charged to.
+     *
+     * @param body the transaction body
+     * @param function the functionality of the transaction
+     * @param implicitCreationsCount the number of implicit creations
+     * @return whether the high-volume bucket was used
+     */
+    public boolean usesHighVolumeBucketForImplicitCreations(
+            @NonNull final TransactionBody body,
+            @NonNull final HederaFunctionality function,
+            final int implicitCreationsCount) {
+        return ingestThrottle.usesHighVolumeBucketForImplicitCreations(
+                function, body.highVolume(), implicitCreationsCount);
     }
 
     // override hashCode()/equals() for array fields

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManager.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManager.java
@@ -33,6 +33,7 @@ import com.hedera.node.app.throttle.ThrottleServiceManager;
 import com.hedera.node.app.workflows.OpWorkflowMetrics;
 import com.hedera.node.app.workflows.handle.Dispatch;
 import com.hedera.node.config.data.ContractsConfig;
+import com.hedera.node.config.data.EntitiesConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.EnumSet;
 import java.util.Set;
@@ -95,12 +96,7 @@ public class DispatchUsageManager {
         }
         if ((dispatch.txnCategory() == USER || dispatch.txnCategory() == NODE)
                 && dispatch.streamBuilder().status() != SUCCESS) {
-            if (canAutoCreate(function)) {
-                reclaimFailedCryptoCreateCapacity(dispatch);
-            }
-            if (canAutoAssociate(function)) {
-                reclaimFailedTokenAssociate(dispatch);
-            }
+            reclaimFailedFrontendCapacity(dispatch, function);
         }
         throttleServiceManager.saveThrottleSnapshotsAndCongestionLevelStartsTo(dispatch.stack());
     }
@@ -138,42 +134,56 @@ public class DispatchUsageManager {
     }
 
     /**
-     * Reclaims the throttle capacity for a failed dispatch that tried to implicitly
-     * perform {@link HederaFunctionality#CRYPTO_CREATE} operations.
+     * Reclaims the frontend throttle capacity for a failed dispatch that implicitly performed
+     * {@link HederaFunctionality#CRYPTO_CREATE} or {@link HederaFunctionality#TOKEN_ASSOCIATE_TO_ACCOUNT}
+     * operations.
      *
-     * @param dispatch the dispatch
+     * <p>This mirrors the claim made at ingest by {@code ThrottleAccumulator.shouldThrottleCryptoTransfer}: a
+     * transfer charges capacity for exactly one of {implicit creations, auto associations} - implicit creations
+     * take precedence, and auto associations are only charged when
+     * {@link EntitiesConfig#unlimitedAutoAssociationsEnabled()} is set. The reclaim therefore undoes exactly that
+     * one leg, and leaks implicit-creation capacity back into the same (normal or high-volume) bucket it was
+     * charged to.
+     *
+     * @param dispatch the failed dispatch
+     * @param function the functionality of the dispatch
      */
-    private void reclaimFailedCryptoCreateCapacity(@NonNull final Dispatch dispatch) {
-        final var readableAccountStore = dispatch.readableStoreFactory().readableStore(ReadableAccountStore.class);
-        final var numImplicitCreations =
-                throttleServiceManager.numImplicitCreations(dispatch.txnInfo().txBody(), readableAccountStore);
-        if (usedSelfFrontendThrottleCapacity(
-                numImplicitCreations, dispatch.txnInfo().txBody())) {
-            throttleServiceManager.reclaimFrontendThrottleCapacity(numImplicitCreations, CRYPTO_CREATE);
+    private void reclaimFailedFrontendCapacity(
+            @NonNull final Dispatch dispatch, @NonNull final HederaFunctionality function) {
+        final var txnBody = dispatch.txnInfo().txBody();
+        if (canAutoCreate(function)) {
+            final var readableAccountStore = dispatch.readableStoreFactory().readableStore(ReadableAccountStore.class);
+            final var numImplicitCreations = throttleServiceManager.numImplicitCreations(txnBody, readableAccountStore);
+            if (numImplicitCreations > 0) {
+                if (usedSelfFrontendThrottleCapacity(numImplicitCreations, txnBody)) {
+                    final var useHighVolumeBucket = throttleServiceManager.usesHighVolumeBucketForImplicitCreations(
+                            txnBody, function, numImplicitCreations);
+                    throttleServiceManager.reclaimFrontendThrottleCapacity(
+                            numImplicitCreations, CRYPTO_CREATE, useHighVolumeBucket);
+                }
+                // Implicit creations took precedence at claim time, so the auto-association leg was never
+                // charged and must not be reclaimed.
+                return;
+            }
         }
-    }
-
-    /**
-     * Reclaims the throttle capacity for a failed dispatch that tried to
-     * perform {@link HederaFunctionality#TOKEN_ASSOCIATE_TO_ACCOUNT} operations for Auto Association.
-     *
-     * @param dispatch the dispatch
-     */
-    private void reclaimFailedTokenAssociate(@NonNull final Dispatch dispatch) {
-        final var readableTokenRelStore =
-                dispatch.readableStoreFactory().readableStore(ReadableTokenRelationStore.class);
-        final var numAutoAssociations =
-                throttleServiceManager.numAutoAssociations(dispatch.txnInfo().txBody(), readableTokenRelStore);
-        if (usedSelfFrontendThrottleCapacity(
-                numAutoAssociations, dispatch.txnInfo().txBody())) {
-            throttleServiceManager.reclaimFrontendThrottleCapacity(numAutoAssociations, TOKEN_ASSOCIATE_TO_ACCOUNT);
+        if (canAutoAssociate(function)) {
+            final var readableTokenRelStore =
+                    dispatch.readableStoreFactory().readableStore(ReadableTokenRelationStore.class);
+            final var numAutoAssociations = throttleServiceManager.numAutoAssociations(txnBody, readableTokenRelStore);
+            if (numAutoAssociations > 0
+                    && dispatch.config().getConfigData(EntitiesConfig.class).unlimitedAutoAssociationsEnabled()
+                    && usedSelfFrontendThrottleCapacity(numAutoAssociations, txnBody)) {
+                // Auto associations for a CRYPTO_TRANSFER are always claimed against the normal bucket
+                throttleServiceManager.reclaimFrontendThrottleCapacity(
+                        numAutoAssociations, TOKEN_ASSOCIATE_TO_ACCOUNT, false);
+            }
         }
     }
 
     /**
      * Returns true if the transaction used frontend throttle capacity on this node.
      *
-     * @param numUsedCapacity the number of used capacity for either create ot auto associate operations
+     * @param numUsedCapacity the number of used capacity for either create or auto associate operations
      * @param txnBody         the transaction body
      * @return true if the transaction used frontend throttle capacity on this node
      */

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/throttle/ThrottleAccumulatorTest.java
@@ -242,7 +242,7 @@ public class ThrottleAccumulatorTest {
         assertFalse(subject.checkAndEnforceThrottle(
                 TRANSACTION_GET_RECEIPT, TIME_INSTANT, query, state, AccountID.DEFAULT));
         assertFalse(subject.shouldThrottleNOfUnscaled(1, CRYPTO_TRANSFER, TIME_INSTANT));
-        assertDoesNotThrow(() -> subject.leakCapacityForNOfUnscaled(1, CRYPTO_TRANSFER));
+        assertDoesNotThrow(() -> subject.leakCapacityForNOfUnscaled(1, CRYPTO_TRANSFER, false));
         assertDoesNotThrow(() -> subject.leakUnusedGasPreviouslyReserved(transactionInfo, 1L));
     }
 
@@ -1812,7 +1812,7 @@ public class ThrottleAccumulatorTest {
         subject.shouldThrottleNOfUnscaled(1, TOKEN_MINT, TIME_INSTANT);
         final var oneUsed = subject.activeThrottlesFor(TOKEN_MINT).get(0).used();
         subject.shouldThrottleNOfUnscaled(43, TOKEN_MINT, TIME_INSTANT);
-        subject.leakCapacityForNOfUnscaled(2, TOKEN_MINT);
+        subject.leakCapacityForNOfUnscaled(2, TOKEN_MINT, false);
         final var fortyTwoUsed = subject.activeThrottlesFor(TOKEN_MINT).get(0).used();
         assertEquals(42 * oneUsed, fortyTwoUsed);
     }
@@ -2391,6 +2391,92 @@ public class ThrottleAccumulatorTest {
         assertTrue(
                 subject.hasHighVolumeThrottleFor(CRYPTO_TRANSFER),
                 "Fixture should include a high-volume throttle for CRYPTO_TRANSFER");
+    }
+
+    @Test
+    void usesHighVolumeBucketForImplicitCreationsMirrorsClaimRouting() {
+        subject = new ThrottleAccumulator(
+                () -> CAPACITY_SPLIT,
+                configProvider::getConfiguration,
+                FRONTEND_THROTTLE,
+                throttleMetrics,
+                gasThrottle,
+                bytesThrottle,
+                opsDurationThrottle);
+        given(configProvider.getConfiguration()).willReturn(configuration);
+
+        // High-volume CRYPTO_TRANSFER carrying implicit creations routes to the high-volume bucket
+        assertTrue(subject.usesHighVolumeBucketForImplicitCreations(CRYPTO_TRANSFER, true, 1));
+        // Not flagged high-volume -> normal bucket
+        assertFalse(subject.usesHighVolumeBucketForImplicitCreations(CRYPTO_TRANSFER, false, 1));
+        // High-volume but no implicit creations -> normal bucket (matches shouldUseHighVolumeBucket)
+        assertFalse(subject.usesHighVolumeBucketForImplicitCreations(CRYPTO_TRANSFER, true, 0));
+        // ETHEREUM_TRANSACTION is not a high-volume function -> normal bucket even when flagged
+        assertFalse(subject.usesHighVolumeBucketForImplicitCreations(ETHEREUM_TRANSACTION, true, 1));
+    }
+
+    @Test
+    void leakCapacityForNOfUnscaledReturnsCapacityToHighVolumeBucket() throws IOException, ParseException {
+        subject = new ThrottleAccumulator(
+                () -> CAPACITY_SPLIT,
+                configProvider::getConfiguration,
+                FRONTEND_THROTTLE,
+                throttleMetrics,
+                gasThrottle,
+                bytesThrottle,
+                opsDurationThrottle);
+        given(configProvider.getConfiguration()).willReturn(configuration);
+        given(configuration.getConfigData(AccountsConfig.class)).willReturn(accountsConfig);
+        given(accountsConfig.lastThrottleExempt()).willReturn(100L);
+        given(configuration.getConfigData(ContractsConfig.class)).willReturn(contractsConfig);
+        given(contractsConfig.throttleThrottleByGas()).willReturn(false);
+        given(configuration.getConfigData(JumboTransactionsConfig.class)).willReturn(jumboTransactionsConfig);
+        given(jumboTransactionsConfig.isEnabled()).willReturn(false);
+
+        final var defs = getThrottleDefs("bootstrap/high-volume-throttles.json");
+        subject.rebuildFor(defs);
+
+        // Claim high-volume CRYPTO_CREATE capacity (routed to the high-volume bucket)
+        final var cryptoCreateBody = com.hedera.hapi.node.token.CryptoCreateTransactionBody.newBuilder()
+                .build();
+        final var highVolumeTxBody = TransactionBody.newBuilder()
+                .transactionID(TransactionID.newBuilder().accountID(PAYER_ID).build())
+                .cryptoCreateAccount(cryptoCreateBody)
+                .highVolume(true)
+                .build();
+        final var signedTx = SignedTransaction.newBuilder()
+                .bodyBytes(TransactionBody.PROTOBUF.toBytes(highVolumeTxBody))
+                .build();
+        final var highVolumeTxnInfo = new TransactionInfo(
+                signedTx,
+                highVolumeTxBody,
+                TransactionID.newBuilder().accountID(PAYER_ID).build(),
+                PAYER_ID,
+                SignatureMap.DEFAULT,
+                Bytes.EMPTY,
+                CRYPTO_CREATE,
+                null);
+        for (int i = 0; i < 200; i++) {
+            subject.checkAndEnforceThrottle(highVolumeTxnInfo, TIME_INSTANT, state, null, false);
+        }
+        final int bpsAfterClaim = subject.getHighVolumeThrottleInstantaneousUtilizationBps(CRYPTO_CREATE, TIME_INSTANT);
+        assertTrue(bpsAfterClaim > 0, "High-volume bucket should have recorded usage from the claim");
+
+        // Leaking with useHighVolumeBucket=true must return capacity to the high-volume bucket
+        subject.leakCapacityForNOfUnscaled(100, CRYPTO_CREATE, true);
+        final int bpsAfterHvLeak =
+                subject.getHighVolumeThrottleInstantaneousUtilizationBps(CRYPTO_CREATE, TIME_INSTANT);
+        assertTrue(
+                bpsAfterHvLeak < bpsAfterClaim, "Leak with useHighVolumeBucket=true must drain the high-volume bucket");
+
+        // Leaking with useHighVolumeBucket=false hits the normal bucket and must NOT touch the high-volume bucket
+        subject.leakCapacityForNOfUnscaled(100, CRYPTO_CREATE, false);
+        final int bpsAfterNormalLeak =
+                subject.getHighVolumeThrottleInstantaneousUtilizationBps(CRYPTO_CREATE, TIME_INSTANT);
+        assertEquals(
+                bpsAfterHvLeak,
+                bpsAfterNormalLeak,
+                "Leak with useHighVolumeBucket=false must not change high-volume utilization");
     }
 
     @NonNull

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManagerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/throttle/DispatchUsageManagerTest.java
@@ -7,6 +7,7 @@ import static com.hedera.hapi.node.base.HederaFunctionality.CONTRACT_CREATE;
 import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_CREATE;
 import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_TRANSFER;
 import static com.hedera.hapi.node.base.HederaFunctionality.ETHEREUM_TRANSACTION;
+import static com.hedera.hapi.node.base.HederaFunctionality.TOKEN_ASSOCIATE_TO_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.CONSENSUS_GAS_EXHAUSTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
@@ -15,8 +16,10 @@ import static com.hedera.node.app.spi.workflows.HandleContext.ConsensusThrottlin
 import static com.hedera.node.app.spi.workflows.HandleContext.ConsensusThrottling.ON;
 import static java.util.Objects.requireNonNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.never;
@@ -325,7 +328,7 @@ class DispatchUsageManagerTest {
 
         subject.finalizeAndSaveUsage(dispatch);
 
-        verify(throttleServiceManager).reclaimFrontendThrottleCapacity(1, CRYPTO_CREATE);
+        verify(throttleServiceManager).reclaimFrontendThrottleCapacity(1, CRYPTO_CREATE, false);
         verify(throttleServiceManager).saveThrottleSnapshotsAndCongestionLevelStartsTo(stack);
     }
 
@@ -343,7 +346,7 @@ class DispatchUsageManagerTest {
 
         subject.finalizeAndSaveUsage(dispatch);
 
-        verify(throttleServiceManager, never()).reclaimFrontendThrottleCapacity(anyInt(), any());
+        verify(throttleServiceManager, never()).reclaimFrontendThrottleCapacity(anyInt(), any(), anyBoolean());
         verify(throttleServiceManager).saveThrottleSnapshotsAndCongestionLevelStartsTo(stack);
     }
 
@@ -363,8 +366,104 @@ class DispatchUsageManagerTest {
 
         subject.finalizeAndSaveUsage(dispatch);
 
-        verify(throttleServiceManager, never()).reclaimFrontendThrottleCapacity(anyInt(), any());
+        verify(throttleServiceManager, never()).reclaimFrontendThrottleCapacity(anyInt(), any(), anyBoolean());
         verify(throttleServiceManager).saveThrottleSnapshotsAndCongestionLevelStartsTo(stack);
+    }
+
+    @Test
+    void reclaimsHighVolumeFrontendCapacityOnFailedImplicitCreation() {
+        given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.USER);
+        given(dispatch.txnInfo()).willReturn(CRYPTO_TRANSFER_TXN_INFO);
+        given(dispatch.streamBuilder()).willReturn(recordBuilder);
+        given(recordBuilder.status()).willReturn(INVALID_ACCOUNT_AMOUNTS);
+        given(dispatch.stack()).willReturn(stack);
+        given(dispatch.readableStoreFactory()).willReturn(readableStoreFactory);
+        given(readableStoreFactory.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
+        given(throttleServiceManager.numImplicitCreations(NONDESCRIPT_TXN_BODY, readableAccountStore))
+                .willReturn(2);
+        given(networkInfo.selfNodeInfo()).willReturn(selfNodeInfo);
+        given(selfNodeInfo.accountId()).willReturn(CREATOR_ACCOUNT_ID);
+        given(throttleServiceManager.usesHighVolumeBucketForImplicitCreations(NONDESCRIPT_TXN_BODY, CRYPTO_TRANSFER, 2))
+                .willReturn(true);
+
+        subject.finalizeAndSaveUsage(dispatch);
+
+        // The claim used the high-volume bucket, so the reclaim must leak it back into the high-volume bucket
+        verify(throttleServiceManager).reclaimFrontendThrottleCapacity(2, CRYPTO_CREATE, true);
+        verify(throttleServiceManager, never())
+                .reclaimFrontendThrottleCapacity(anyInt(), eq(TOKEN_ASSOCIATE_TO_ACCOUNT), anyBoolean());
+    }
+
+    @Test
+    void reclaimsOnlyImplicitCreationCapacityAndSkipsAutoAssociationWhenImplicitCreationsPresent() {
+        given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.USER);
+        given(dispatch.txnInfo()).willReturn(CRYPTO_TRANSFER_TXN_INFO);
+        given(dispatch.streamBuilder()).willReturn(recordBuilder);
+        given(recordBuilder.status()).willReturn(INVALID_ACCOUNT_AMOUNTS);
+        given(dispatch.stack()).willReturn(stack);
+        given(dispatch.readableStoreFactory()).willReturn(readableStoreFactory);
+        given(readableStoreFactory.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
+        given(throttleServiceManager.numImplicitCreations(NONDESCRIPT_TXN_BODY, readableAccountStore))
+                .willReturn(1);
+        given(networkInfo.selfNodeInfo()).willReturn(selfNodeInfo);
+        given(selfNodeInfo.accountId()).willReturn(CREATOR_ACCOUNT_ID);
+
+        subject.finalizeAndSaveUsage(dispatch);
+
+        verify(throttleServiceManager).reclaimFrontendThrottleCapacity(1, CRYPTO_CREATE, false);
+        // Implicit creations take precedence at claim time, so the auto-association leg must not even be evaluated
+        verify(throttleServiceManager, never()).numAutoAssociations(any(), any());
+        verify(throttleServiceManager, never())
+                .reclaimFrontendThrottleCapacity(anyInt(), eq(TOKEN_ASSOCIATE_TO_ACCOUNT), anyBoolean());
+    }
+
+    @Test
+    void reclaimsTokenAssociateCapacityWhenNoImplicitCreationsAndUnlimitedAutoAssociationsEnabled() {
+        given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.USER);
+        given(dispatch.txnInfo()).willReturn(CRYPTO_TRANSFER_TXN_INFO);
+        given(dispatch.streamBuilder()).willReturn(recordBuilder);
+        given(recordBuilder.status()).willReturn(INVALID_ACCOUNT_AMOUNTS);
+        given(dispatch.stack()).willReturn(stack);
+        given(dispatch.config()).willReturn(DEFAULT_CONFIG);
+        given(dispatch.readableStoreFactory()).willReturn(readableStoreFactory);
+        given(readableStoreFactory.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
+        given(throttleServiceManager.numImplicitCreations(NONDESCRIPT_TXN_BODY, readableAccountStore))
+                .willReturn(0);
+        given(throttleServiceManager.numAutoAssociations(eq(NONDESCRIPT_TXN_BODY), any()))
+                .willReturn(3);
+        given(networkInfo.selfNodeInfo()).willReturn(selfNodeInfo);
+        given(selfNodeInfo.accountId()).willReturn(CREATOR_ACCOUNT_ID);
+
+        subject.finalizeAndSaveUsage(dispatch);
+
+        // Auto associations are always claimed against the normal bucket, so the reclaim passes false
+        verify(throttleServiceManager).reclaimFrontendThrottleCapacity(3, TOKEN_ASSOCIATE_TO_ACCOUNT, false);
+        verify(throttleServiceManager, never())
+                .reclaimFrontendThrottleCapacity(anyInt(), eq(CRYPTO_CREATE), anyBoolean());
+    }
+
+    @Test
+    void doesNotReclaimTokenAssociateWhenUnlimitedAutoAssociationsDisabled() {
+        final var configWithFlagOff = HederaTestConfigBuilder.create()
+                .withValue("entities.unlimitedAutoAssociationsEnabled", "false")
+                .getOrCreateConfig();
+        given(dispatch.txnCategory()).willReturn(HandleContext.TransactionCategory.USER);
+        given(dispatch.txnInfo()).willReturn(CRYPTO_TRANSFER_TXN_INFO);
+        given(dispatch.streamBuilder()).willReturn(recordBuilder);
+        given(recordBuilder.status()).willReturn(INVALID_ACCOUNT_AMOUNTS);
+        given(dispatch.stack()).willReturn(stack);
+        given(dispatch.config()).willReturn(configWithFlagOff);
+        given(dispatch.readableStoreFactory()).willReturn(readableStoreFactory);
+        given(readableStoreFactory.readableStore(ReadableAccountStore.class)).willReturn(readableAccountStore);
+        given(throttleServiceManager.numImplicitCreations(NONDESCRIPT_TXN_BODY, readableAccountStore))
+                .willReturn(0);
+        given(throttleServiceManager.numAutoAssociations(eq(NONDESCRIPT_TXN_BODY), any()))
+                .willReturn(3);
+
+        subject.finalizeAndSaveUsage(dispatch);
+
+        // The claim never charged TOKEN_ASSOCIATE capacity because the flag was off, so nothing is reclaimed
+        verify(throttleServiceManager, never()).reclaimFrontendThrottleCapacity(anyInt(), any(), anyBoolean());
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/FrontendThrottleReclaimTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/FrontendThrottleReclaimTest.java
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.throttling;
+
+import static com.hedera.services.bdd.junit.ContextRequirement.THROTTLE_OVERRIDES;
+import static com.hedera.services.bdd.junit.EmbeddedReason.NEEDS_STATE_ACCESS;
+import static com.hedera.services.bdd.junit.TestTags.TOKEN;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.moving;
+import static com.hedera.services.bdd.spec.transactions.token.TokenMovement.movingHbar;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.suites.HapiSuite.CIVILIAN_PAYER;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.BUSY;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BALANCE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.THROTTLED_AT_CONSENSUS;
+import static com.hederahashgraph.api.proto.java.TokenType.FUNGIBLE_COMMON;
+
+import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Integration tests for the frontend (ingest) throttle capacity reclaim performed by
+ * {@code DispatchUsageManager.finalizeAndSaveUsage} when an auto-creating transaction passes the frontend
+ * throttle but fails at consensus. The reclaim must return capacity to exactly the bucket that was charged, and
+ * only that bucket.
+ *
+ * <p>Both scenarios follow the same shape: constrain one frontend bucket to a single logical operation, prove
+ * it is saturated, run a transaction that fails at consensus, then assert that capacity comes back only to the
+ * bucket that was actually charged. They run in embedded mode so there is a single frontend throttle to observe,
+ * and the throttled transactions are paid by {@link com.hedera.services.bdd.suites.HapiSuite#CIVILIAN_PAYER}
+ * because system accounts are exempt from throttling.
+ */
+@Tag(TOKEN)
+public class FrontendThrottleReclaimTest {
+
+    /**
+     * A high-volume {@code CRYPTO_TRANSFER} auto-creation claims its implicit {@code CRYPTO_CREATE} against the
+     * high-volume bucket, so on consensus failure the reclaim must return that capacity to the high-volume
+     * bucket and leave the normal bucket untouched. Both buckets are constrained to a single operation so the
+     * routing is fully observable: the normal bucket stays saturated (its probe is throttled) while the
+     * high-volume bucket is credited back (its probe is admitted).
+     */
+    @LeakyEmbeddedHapiTest(
+            reason = NEEDS_STATE_ACCESS,
+            requirement = {THROTTLE_OVERRIDES},
+            throttles = "testSystemFiles/frontend-reclaim-hv-create-throttles.json")
+    @DisplayName("Failed high-volume auto-creation refunds the high-volume bucket, not the normal bucket")
+    final Stream<DynamicTest> failedHighVolumeAutoCreationRefundsHighVolumeBucketNotNormalBucket() {
+        return hapiTest(
+                cryptoCreate(CIVILIAN_PAYER).balance(ONE_MILLION_HBARS),
+                cryptoCreate("poorSender").balance(1L),
+                newKeyNamed("saturateAlias"),
+                newKeyNamed("sanityAlias"),
+                newKeyNamed("failAlias"),
+                newKeyNamed("normalProbeAlias"),
+                newKeyNamed("hvProbeAlias"),
+                // 1) Saturate the normal CryptoCreate bucket with one successful (non-high-volume) auto-creation.
+                cryptoTransfer(movingHbar(ONE_HBAR).between(CIVILIAN_PAYER, "saturateAlias"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER),
+                // 2) Confirm the normal bucket is saturated: a second normal auto-creation is throttled at ingest.
+                cryptoTransfer(movingHbar(ONE_HBAR).between(CIVILIAN_PAYER, "sanityAlias"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER)
+                        .hasPrecheck(BUSY),
+                // 3) Fail a high-volume auto-creation at consensus. It claims the high-volume CryptoCreate bucket
+                //    at ingest, so its reclaim must return capacity there.
+                cryptoTransfer(movingHbar(ONE_HUNDRED_HBARS).between("poorSender", "failAlias"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER, "poorSender")
+                        .withHighVolume()
+                        .hasKnownStatus(INSUFFICIENT_ACCOUNT_BALANCE),
+                // 4) Normal-bucket probe: the failed transfer never charged the normal bucket, so it stays saturated.
+                cryptoTransfer(movingHbar(ONE_HBAR).between(CIVILIAN_PAYER, "normalProbeAlias"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER)
+                        .hasPrecheck(BUSY),
+                // 5) High-volume-bucket probe: the failed transfer charged and then reclaimed the high-volume
+                //    bucket, so it has capacity again and is admitted at ingest. Only the frontend (precheck)
+                //    result matters here; the consensus outcome may be SUCCESS or (backend-)throttled.
+                cryptoTransfer(movingHbar(ONE_HBAR).between(CIVILIAN_PAYER, "hvProbeAlias"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER)
+                        .withHighVolume()
+                        .hasPrecheck(OK)
+                        .hasKnownStatusFrom(SUCCESS, THROTTLED_AT_CONSENSUS));
+    }
+
+    /**
+     * A {@code CRYPTO_TRANSFER} that both auto-creates an account and auto-associates a token claims only its
+     * implicit {@code CRYPTO_CREATE} capacity (implicit creations take precedence over auto associations at
+     * claim time). On consensus failure the reclaim must return capacity to exactly that charged leg and to
+     * nothing else. Both the {@code CRYPTO_CREATE} and {@code TOKEN_ASSOCIATE_TO_ACCOUNT} buckets are constrained
+     * to a single operation so the routing is fully observable: the auto-association bucket stays saturated (its
+     * probe is throttled) because it was never charged, while the charged CryptoCreate leg is credited back (its
+     * probe is admitted).
+     */
+    @LeakyEmbeddedHapiTest(
+            reason = NEEDS_STATE_ACCESS,
+            requirement = {THROTTLE_OVERRIDES},
+            throttles = "testSystemFiles/frontend-reclaim-assoc-throttles.json")
+    @DisplayName("Failed auto-creating transfer does not refund the auto-association bucket")
+    final Stream<DynamicTest> failedAutoCreationDoesNotRefundAutoAssociationBucket() {
+        return hapiTest(
+                cryptoCreate(CIVILIAN_PAYER).balance(ONE_MILLION_HBARS),
+                cryptoCreate("treasury").balance(ONE_HUNDRED_HBARS),
+                tokenCreate("tok")
+                        .tokenType(FUNGIBLE_COMMON)
+                        .initialSupply(1000L)
+                        .treasury("treasury"),
+                cryptoCreate("saturateReceiver").maxAutomaticTokenAssociations(1),
+                cryptoCreate("sanityReceiver").maxAutomaticTokenAssociations(1),
+                cryptoCreate("failReceiver").maxAutomaticTokenAssociations(1),
+                cryptoCreate("probeReceiver").maxAutomaticTokenAssociations(1),
+                cryptoCreate("poorSender").balance(1L),
+                newKeyNamed("failAlias"),
+                newKeyNamed("createProbeAlias"),
+                // 1) Saturate the TokenAssociateToAccount bucket with one successful auto-association.
+                cryptoTransfer(moving(1L, "tok").between("treasury", "saturateReceiver"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER, "treasury"),
+                // 2) Confirm saturation: a second auto-association is throttled at ingest.
+                cryptoTransfer(moving(1L, "tok").between("treasury", "sanityReceiver"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER, "treasury")
+                        .hasPrecheck(BUSY),
+                // 3) Fail a transfer that has BOTH an implicit creation and an auto association. At ingest it
+                //    claims only CryptoCreate (implicit creations take precedence), so its reclaim must leave
+                //    the TokenAssociateToAccount bucket untouched.
+                cryptoTransfer(
+                                movingHbar(ONE_HUNDRED_HBARS).between("poorSender", "failAlias"),
+                                moving(1L, "tok").between("treasury", "failReceiver"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER, "poorSender", "treasury")
+                        .hasKnownStatus(INSUFFICIENT_ACCOUNT_BALANCE),
+                // 4) Associate-bucket probe: it was never charged by the failed transfer, so it stays saturated.
+                cryptoTransfer(moving(1L, "tok").between("treasury", "probeReceiver"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER, "treasury")
+                        .hasPrecheck(BUSY),
+                // 5) CryptoCreate-bucket probe: the failed transfer charged and then reclaimed the CryptoCreate
+                //    bucket, so it has capacity again and an implicit-creation transfer is admitted at ingest.
+                //    Only the frontend (precheck) result matters here; the consensus outcome may be SUCCESS or
+                //    (backend-)throttled.
+                cryptoTransfer(movingHbar(ONE_HBAR).between(CIVILIAN_PAYER, "createProbeAlias"))
+                        .payingWith(CIVILIAN_PAYER)
+                        .signedBy(CIVILIAN_PAYER)
+                        .hasPrecheck(OK)
+                        .hasKnownStatusFrom(SUCCESS, THROTTLED_AT_CONSENSUS));
+    }
+}

--- a/hedera-node/test-clients/src/main/resources/testSystemFiles/frontend-reclaim-assoc-throttles.json
+++ b/hedera-node/test-clients/src/main/resources/testSystemFiles/frontend-reclaim-assoc-throttles.json
@@ -1,0 +1,44 @@
+{
+  "buckets": [
+    {
+      "name": "ReclaimAssociateLimit",
+      "burstPeriod": 1,
+      "throttleGroups": [
+        {
+          "opsPerSec": 1,
+          "operations": ["TokenAssociateToAccount"]
+        }
+      ]
+    },
+    {
+      "name": "ReclaimCreateLimit",
+      "burstPeriod": 1,
+      "throttleGroups": [
+        {
+          "opsPerSec": 1,
+          "operations": ["CryptoCreate"]
+        }
+      ]
+    },
+    {
+      "name": "ReclaimPassthroughLimit",
+      "burstPeriod": 1,
+      "throttleGroups": [
+        {
+          "opsPerSec": 10000,
+          "operations": ["CryptoTransfer"]
+        }
+      ]
+    },
+    {
+      "name": "MiscQueryLimits",
+      "burstPeriod": 1,
+      "throttleGroups": [
+        {
+          "opsPerSec": 100000,
+          "operations": ["TransactionGetReceipt", "FileGetContents"]
+        }
+      ]
+    }
+  ]
+}

--- a/hedera-node/test-clients/src/main/resources/testSystemFiles/frontend-reclaim-hv-create-throttles.json
+++ b/hedera-node/test-clients/src/main/resources/testSystemFiles/frontend-reclaim-hv-create-throttles.json
@@ -1,0 +1,54 @@
+{
+  "buckets": [
+    {
+      "name": "ReclaimNormalCreateLimit",
+      "burstPeriod": 1,
+      "throttleGroups": [
+        {
+          "opsPerSec": 1,
+          "operations": [
+            "CryptoCreate"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ReclaimHighVolumeCreateLimit",
+      "burstPeriod": 1,
+      "highVolume": true,
+      "throttleGroups": [
+        {
+          "opsPerSec": 1,
+          "operations": [
+            "CryptoCreate"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "ReclaimPassthroughLimit",
+      "burstPeriod": 1,
+      "throttleGroups": [
+        {
+          "opsPerSec": 10000,
+          "operations": [
+            "CryptoTransfer"
+          ]
+        }
+      ]
+    },
+    {
+      "name": "MiscQueryLimits",
+      "burstPeriod": 1,
+      "throttleGroups": [
+        {
+          "opsPerSec": 100000,
+          "operations": [
+            "TransactionGetReceipt",
+            "FileGetContents"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
> Migrated from the private `hashgraph/private-hedera-services` repository.

> Original source commit: `d78bb91815d8f0d62d9cb2e7bf5180a97e7d6097`

> This commit preserves the original author and author timestamp.

**Description**:

1. **High-volume bucket routing.** `ThrottleAccumulator.leakCapacityForNOfUnscaled` now takes a `useHighVolumeBucket` flag and resolves the manager via `getReqsManager` (the same routing the claim uses), so an implicit `CRYPTO_CREATE` charged against the high-volume bucket is refunded there instead of into the shared normal buckets. `ThrottleServiceManager` threads the flag through and exposes `usesHighVolumeBucketForImplicitCreations`, which reconstructs the exact routing decision made at claim time.
 
2. **Create-vs-associate precedence + config gate.** The reclaim in `DispatchUsageManager` now mirrors `shouldThrottleCryptoTransfer`'s `if / else-if`. It reclaims exactly one of {implicit creations, auto associations}, implicit creations take precedence and only reclaims `TOKEN_ASSOCIATE_TO_ACCOUNT` when `entities.unlimitedAutoAssociationsEnabled` is set, matching the charge side.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
