### PR TITLE
fix: reject token transfers in query payments

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/query/QueryChecker.java
@@ -7,6 +7,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_PAYER_BALA
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_QUERY_HEADER;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_RECEIVING_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
@@ -116,6 +117,14 @@ public class QueryChecker {
         final var txBody = transactionInfo.txBody();
         final var pureChecksContext = new PureChecksContextImpl(txBody, dispatcher);
         cryptoTransferHandler.pureChecks(pureChecksContext);
+
+        // A query payment must be a pure HBAR transfer to the node. Token transfers in the payment are not
+        // validated on the query path (no token-sender signature, association, KYC, freeze, or balance checks),
+        // so a payment whose token leg is doomed at consensus would still let the query be answered without the
+        // node collecting its fee. Reject any token transfers here rather than answer such a query.
+        if (!txBody.cryptoTransferOrThrow().tokenTransfers().isEmpty()) {
+            throw new PreCheckException(INVALID_QUERY_HEADER);
+        }
 
         for (final var accountAmount :
                 txBody.cryptoTransferOrThrow().transfersOrThrow().accountAmounts()) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/query/QueryCheckerTest.java
@@ -9,6 +9,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_ACCOUNT_BA
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_QUERY_HEADER;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_RECEIVING_NODE_ACCOUNT;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.estimatedFee;
@@ -27,6 +28,8 @@ import static org.mockito.Mockito.when;
 import com.hedera.hapi.node.base.AccountAmount;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenTransferList;
 import com.hedera.hapi.node.base.TransactionID;
 import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.state.token.Account;
@@ -289,6 +292,39 @@ class QueryCheckerTest extends AppTestBase {
             assertThatThrownBy(() -> checker.validateCryptoTransfer(store, transactionInfo, configuration))
                     .isInstanceOf(PreCheckException.class)
                     .has(responseCode(INVALID_ACCOUNT_AMOUNTS));
+        }
+
+        @Test
+        void testValidateCryptoTransferRejectsTokenTransfers() {
+            // A query payment must be a pure HBAR transfer; a payment carrying token transfers is rejected,
+            // because the query path does not validate the token leg (signatures, association, balance).
+            final var tokenLeg = TokenTransferList.newBuilder()
+                    .token(TokenID.newBuilder().tokenNum(1234L).build())
+                    .transfers(
+                            AccountAmount.newBuilder()
+                                    .accountID(ERIN.accountID())
+                                    .amount(-1L)
+                                    .build(),
+                            AccountAmount.newBuilder()
+                                    .accountID(ALICE.accountID())
+                                    .amount(1L)
+                                    .build())
+                    .build();
+            final var txBody = TransactionBody.newBuilder()
+                    .transactionID(TransactionID.newBuilder()
+                            .accountID(AccountID.DEFAULT)
+                            .build())
+                    .cryptoTransfer(CryptoTransferTransactionBody.newBuilder()
+                            .transfers(TransferList.newBuilder().build())
+                            .tokenTransfers(tokenLeg)
+                            .build())
+                    .build();
+            final var transactionInfo = new TransactionInfo(
+                    SignedTransaction.DEFAULT, txBody, SignatureMap.DEFAULT, Bytes.EMPTY, CRYPTO_TRANSFER, null);
+
+            assertThatThrownBy(() -> checker.validateCryptoTransfer(store, transactionInfo, configuration))
+                    .isInstanceOf(PreCheckException.class)
+                    .has(responseCode(INVALID_QUERY_HEADER));
         }
     }
 

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/QueryPaymentSuite.java
@@ -8,10 +8,14 @@ import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overriding;
 import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_PAYER_BALANCE;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_QUERY_HEADER;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_RECEIVING_NODE_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.OK;
 
@@ -20,6 +24,7 @@ import com.hedera.services.bdd.junit.LeakyEmbeddedHapiTest;
 import com.hedera.services.bdd.spec.HapiSpec;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
+import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TransferList;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
@@ -129,6 +134,34 @@ public class QueryPaymentSuite {
                         .setNode(NODE)
                         .fee(10L)
                         .hasAnswerOnlyPrecheck(INVALID_RECEIVING_NODE_ACCOUNT));
+    }
+
+    // A query payment must be a pure HBAR transfer; a payment carrying token transfers is rejected at precheck,
+    // because the query path does not validate the token leg (signatures, association, balance).
+    @HapiTest
+    final Stream<DynamicTest> queryPaymentWithTokenTransfersIsRejected() {
+        return hapiTest(
+                cryptoCreate("a").balance(ONE_HUNDRED_HBARS),
+                cryptoCreate("b").balance(ONE_HBAR),
+                tokenCreate("t").treasury("a").initialSupply(1000L),
+                getAccountInfo(GENESIS)
+                        .withPayment(cryptoTransfer((spec, builder) -> {
+                                    final var payer = spec.registry().getAccountID("a");
+                                    final var receiver = spec.registry().getAccountID("b");
+                                    final var node = asAccount(spec, Long.parseLong(NODE));
+                                    final var token = spec.registry().getTokenID("t");
+                                    builder.setTransfers(TransferList.newBuilder()
+                                            .addAccountAmounts(adjust(payer, -ONE_HBAR))
+                                            .addAccountAmounts(adjust(node, ONE_HBAR)));
+                                    builder.addTokenTransfers(TokenTransferList.newBuilder()
+                                            .setToken(token)
+                                            .addTransfers(adjust(payer, -1L))
+                                            .addTransfers(adjust(receiver, 1L)));
+                                })
+                                .payingWith("a")
+                                .signedBy("a"))
+                        .setNode(NODE)
+                        .hasAnswerOnlyPrecheck(INVALID_QUERY_HEADER));
     }
 
     private TransferList multiAccountPaymentToNode003(HapiSpec spec, String first, String second, long amount) {


### PR DESCRIPTION
> Migrated from the private `hashgraph/private-hedera-services` repository.

> Original source commit: `0e8aefdc9dc618ddb52fbfd710fd9c17cc54becb`

> This commit preserves the original author and author timestamp.

**Description**:

This PR rejects any query payment that carries token transfers, at query-time pre-check:

- In `QueryChecker.validateCryptoTransfer`, after `pureChecks`, throw `PreCheckException(INVALID_QUERY_HEADER)` if `cryptoTransferOrThrow().tokenTransfers()` is non-empty.
- The check is query-specific — it is **not** added to the shared `CryptoTransferHandler.pureChecks`, so normal token transfers are unaffected.

- Tests:
  - Unit — `QueryCheckerTest.testValidateCryptoTransferRejectsTokenTransfers` (rejected with `INVALID_QUERY_HEADER`); full class passes.
  - HAPI — `QueryPaymentSuite.queryPaymentWithTokenTransfersIsRejected` (`hasAnswerOnlyPrecheck(INVALID_QUERY_HEADER)`); the existing positive HBAR / multi-beneficiary cases still pass.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
