### PR TITLE
fix: enforce contract trace-data limit for batch and scheduled calls

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/Savepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/Savepoint.java
@@ -47,15 +47,13 @@ public interface Savepoint extends BuilderSink {
      * @param txnCategory the category of transaction initiating the new builder
      * @param customizer the customizer to apply when externalizing the builder
      * @param streamMode the mode of the stream
-     * @param isBaseBuilder whether the builder is the base builder for a stack
      * @return the new builder
      */
-    StreamBuilder createBuilder(
+    StreamBuilder createNonBaseBuilder(
             @NonNull ReversingBehavior reversingBehavior,
             @NonNull HandleContext.TransactionCategory txnCategory,
             @NonNull StreamBuilder.SignedTxCustomizer customizer,
-            @NonNull StreamMode streamMode,
-            boolean isBaseBuilder);
+            @NonNull StreamMode streamMode);
 
     /**
      * Tracks the given amount of fees collected into node accounts in this savepoint.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/SavepointStackImpl.java
@@ -87,6 +87,9 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
 
     private final StreamMode streamMode;
 
+    // Per-dispatch trace-data cap; inherited by child stacks so batched/scheduled calls enforce the same limit
+    private final int maxSerializedTraceDataBytes;
+
     private int numPresetIds;
     private int noncesToSkipPerPresetId;
     private boolean presetIdsAllowed;
@@ -163,11 +166,12 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
         this.immediateStateChangeListener = requireNonNull(immediateStateChangeListener);
         this.boundaryStateChangeListener = requireNonNull(boundaryStateChangeListener);
         this.streamMode = requireNonNull(streamMode);
+        this.maxSerializedTraceDataBytes = maxSerializedTraceDataBytes;
         builderSink = new BuilderSinkImpl(maxBuildersBeforeUser, maxBuildersAfterUser + 1);
         presetIdsAllowed = true;
         noncesToSkipPerPresetId = maxBuildersBeforeUser + maxBuildersAfterUser;
         setupFirstSavepoint(USER);
-        baseBuilder = createRootBaseBuilder(maxSerializedTraceDataBytes);
+        baseBuilder = createBaseBuilder(REVERSIBLE, USER, NOOP_SIGNED_TX_CUSTOMIZER);
     }
 
     /**
@@ -191,11 +195,12 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
         requireNonNull(category);
         this.streamMode = requireNonNull(streamMode);
         this.state = requireNonNull(parent);
+        this.maxSerializedTraceDataBytes = parent.maxSerializedTraceDataBytes;
         this.builderSink = null;
         this.immediateStateChangeListener = null;
         this.boundaryStateChangeListener = null;
         setupFirstSavepoint(category);
-        baseBuilder = peek().createBuilder(reversingBehavior, category, customizer, streamMode, true);
+        baseBuilder = createBaseBuilder(reversingBehavior, category, customizer);
         presetIdsAllowed = false;
     }
 
@@ -466,7 +471,7 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
      * @return the new stream builder
      */
     public StreamBuilder createRemovableChildBuilder() {
-        return peek().createBuilder(REMOVABLE, CHILD, NOOP_SIGNED_TX_CUSTOMIZER, streamMode, false);
+        return peek().createNonBaseBuilder(REMOVABLE, CHILD, NOOP_SIGNED_TX_CUSTOMIZER, streamMode);
     }
 
     /**
@@ -475,7 +480,7 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
      * @return the new stream builder
      */
     public StreamBuilder createReversibleChildBuilder() {
-        return peek().createBuilder(REVERSIBLE, CHILD, NOOP_SIGNED_TX_CUSTOMIZER, streamMode, false);
+        return peek().createNonBaseBuilder(REVERSIBLE, CHILD, NOOP_SIGNED_TX_CUSTOMIZER, streamMode);
     }
 
     /**
@@ -484,7 +489,7 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
      * @return the new stream builder
      */
     public StreamBuilder createIrreversiblePrecedingBuilder() {
-        return peek().createBuilder(IRREVERSIBLE, PRECEDING, NOOP_SIGNED_TX_CUSTOMIZER, streamMode, false);
+        return peek().createNonBaseBuilder(IRREVERSIBLE, PRECEDING, NOOP_SIGNED_TX_CUSTOMIZER, streamMode);
     }
 
     /**
@@ -644,20 +649,26 @@ public class SavepointStackImpl implements HandleContext.SavepointStack, State {
         }
     }
 
-    private StreamBuilder createRootBaseBuilder(final int maxSerializedTraceDataBytes) {
+    private StreamBuilder createBaseBuilder(
+            @NonNull final StreamBuilder.ReversingBehavior reversingBehavior,
+            @NonNull final TransactionCategory category,
+            @NonNull final StreamBuilder.SignedTxCustomizer customizer) {
         final var builder =
                 switch (streamMode) {
                     case RECORDS ->
-                        new RecordStreamBuilder(
-                                REVERSIBLE, NOOP_SIGNED_TX_CUSTOMIZER, USER, maxSerializedTraceDataBytes);
+                        new RecordStreamBuilder(reversingBehavior, customizer, category, maxSerializedTraceDataBytes);
                     case BLOCKS ->
-                        new BlockStreamBuilder(
-                                REVERSIBLE, NOOP_SIGNED_TX_CUSTOMIZER, USER, maxSerializedTraceDataBytes);
+                        new BlockStreamBuilder(reversingBehavior, customizer, category, maxSerializedTraceDataBytes);
                     case BOTH ->
-                        new PairedStreamBuilder(
-                                REVERSIBLE, NOOP_SIGNED_TX_CUSTOMIZER, USER, maxSerializedTraceDataBytes);
+                        new PairedStreamBuilder(reversingBehavior, customizer, category, maxSerializedTraceDataBytes);
                 };
-        peek().addFollowingOrThrow(builder);
+        if (!customizer.isSuppressed()) {
+            // Other code is a bit simpler when we always put the base builder for a stack in its
+            // "following" list, even if the stack is child stack for a preceding child dispatch;
+            // the base builder will still end up in the correct relative position in the parent
+            // sink because of how FirstChildSavepoint implements #commitBuilders()
+            peek().addFollowingOrThrow(builder);
+        }
         return builder;
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/AbstractSavepoint.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/stack/savepoints/AbstractSavepoint.java
@@ -102,12 +102,11 @@ public abstract class AbstractSavepoint extends BuilderSinkImpl implements Savep
     }
 
     @Override
-    public StreamBuilder createBuilder(
+    public StreamBuilder createNonBaseBuilder(
             @NonNull final StreamBuilder.ReversingBehavior reversingBehavior,
             @NonNull final HandleContext.TransactionCategory txnCategory,
             @NonNull final StreamBuilder.SignedTxCustomizer customizer,
-            @NonNull final StreamMode streamMode,
-            final boolean isBaseBuilder) {
+            @NonNull final StreamMode streamMode) {
         requireNonNull(reversingBehavior);
         requireNonNull(txnCategory);
         requireNonNull(customizer);
@@ -118,11 +117,7 @@ public abstract class AbstractSavepoint extends BuilderSinkImpl implements Savep
                     case BOTH -> new PairedStreamBuilder(reversingBehavior, customizer, txnCategory);
                 };
         if (!customizer.isSuppressed()) {
-            // Other code is a bit simpler when we always put the base builder for a stack in its
-            // "following" list, even if the stack is child stack for a preceding child dispatch;
-            // the base builder will still end up in the correct relative position in the parent
-            // sink because of how FirstChildSavepoint implements #commitBuilders()
-            if (txnCategory == PRECEDING && !isBaseBuilder) {
+            if (txnCategory == PRECEDING) {
                 addPrecedingOrThrow(builder);
             } else {
                 addFollowingOrThrow(builder);

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/savepoints/FirstRootSavepointTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/stack/savepoints/FirstRootSavepointTest.java
@@ -30,7 +30,7 @@ class FirstRootSavepointTest {
     void usesBlockStreamBuilderForBlocksStreamMode() {
         givenSubjectWithCapacities(1, 2);
 
-        final var builder = subject.createBuilder(REVERSIBLE, CHILD, NOOP_SIGNED_TX_CUSTOMIZER, BLOCKS, false);
+        final var builder = subject.createNonBaseBuilder(REVERSIBLE, CHILD, NOOP_SIGNED_TX_CUSTOMIZER, BLOCKS);
 
         assertThat(builder).isInstanceOf(BlockStreamBuilder.class);
     }

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/RecordsSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/records/RecordsSuite.java
@@ -4,10 +4,12 @@ package com.hedera.services.bdd.suites.contract.records;
 import static com.hedera.node.config.types.StreamMode.RECORDS;
 import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION;
 import static com.hedera.services.bdd.junit.TestTags.ADHOC;
+import static com.hedera.services.bdd.junit.TestTags.ATOMIC_BATCH;
 import static com.hedera.services.bdd.junit.TestTags.SMART_CONTRACT;
 import static com.hedera.services.bdd.spec.HapiPropertySource.asAccount;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
@@ -30,6 +32,7 @@ import static com.hedera.services.bdd.suites.HapiSuite.SECP_256K1_SOURCE_KEY;
 import static com.hedera.services.bdd.suites.contract.Utils.asInstant;
 import static com.hedera.services.bdd.suites.contract.leaky.LeakyContractTestsSuite.RECEIVER;
 import static com.hedera.services.bdd.suites.crypto.CryptoCreateSuite.ACCOUNT;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INSUFFICIENT_GAS;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.RECORD_NOT_FOUND;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -105,6 +108,36 @@ public class RecordsSuite {
                         .hasKnownStatus(INSUFFICIENT_GAS)
                         .via(txName),
                 getTxnRecord(txName));
+    }
+
+    @HapiTest
+    @Tag(ADHOC)
+    @Tag(ATOMIC_BATCH)
+    @DisplayName("Oversized contract actions are clipped for a batch-inner call, just as for a top-level call")
+    final Stream<DynamicTest> oversizedContractActionsAreClippedInsideAtomicBatch() {
+        final var contract = "ClipCandidate";
+        final var innerTxn = "clipCandidateBatchInnerLargeCalldata";
+        final var batchOperator = "batchOperator";
+
+        // The identical call is rejected at the trace-data cap as a top-level transaction; wrapping it in an
+        // atomic batch must not let it bypass the cap, so the inner call fails and the whole batch rolls back.
+        return hapiTest(
+                streamMustIncludeNoFailuresFrom(noContractActionSidecarFor(innerTxn)),
+                cryptoCreate(batchOperator).balance(ONE_HUNDRED_HBARS),
+                uploadInitCode(contract),
+                contractCreate(contract),
+                atomicBatch(contractCall(
+                                        contract,
+                                        "loopLargeCalldata",
+                                        BigInteger.valueOf(5),
+                                        BigInteger.valueOf(131_072))
+                                .gas(14_000_000L)
+                                .hasKnownStatus(INSUFFICIENT_GAS)
+                                .batchKey(batchOperator)
+                                .via(innerTxn))
+                        .payingWith(batchOperator)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED),
+                getTxnRecord(innerTxn));
     }
 
     @HapiTest


### PR DESCRIPTION
> Migrated from the private `hashgraph/private-hedera-services` repository.

> Original source commit: `6587a5ceb9ad1febbae5ad7e585c5999694bbfdb`

> This commit preserves the original author and author timestamp.

**Description**:
The `contracts.maxSerializedTraceDataBytes` cap added in #26434 is only wired into the top-level transaction's stream builder. A contract call inside an atomic batch runs as a child dispatch whose base builder was created without a limit, so it slips past the check: it commits its storage writes and streams trace data well past the configured cap, whereas the same call at top level is rejected with `INSUFFICIENT_GAS` and rolled back. Scheduled contract calls have the same gap.

This threads the configured cap down into child stacks, so a batch-inner or scheduled call is held to the same per-transaction limit as a top-level call. Each batch-inner transaction is already charged as top-level, so giving it its own cap keeps the semantics consistent.

While in here I also folded the near-identical root and child base-builder construction into a single `createBaseBuilder`, and dropped the now-unused `isBaseBuilder` flag from `Savepoint.createBuilder`.

### Testing
Added `RecordsSuite.oversizedContractActionsAreClippedInsideAtomicBatch`, a batched version of the existing top-level clip test, expecting the inner call to fail with `INSUFFICIENT_GAS` and the batch with `INNER_TRANSACTION_FAILED`. Confirmed it fails without this change and passes with it. Existing savepoint-stack unit tests still pass.