### PR TITLE
fix: guard node upgrade against a non-freeze state

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/Hedera.java
@@ -19,6 +19,7 @@ import static com.hedera.node.config.types.StreamMode.BOTH;
 import static com.hedera.node.config.types.StreamMode.RECORDS;
 import static com.swirlds.platform.system.InitTrigger.GENESIS;
 import static com.swirlds.platform.system.InitTrigger.RECONNECT;
+import static com.swirlds.platform.system.InitTrigger.RESTART;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Objects.requireNonNull;
 import static java.util.concurrent.CompletableFuture.completedFuture;
@@ -29,9 +30,13 @@ import static org.hiero.consensus.platformstate.PlatformStateAccessor.GENESIS_RO
 import static org.hiero.consensus.platformstate.PlatformStateUtils.creationSemanticVersionOf;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.freezeTimeOf;
 import static org.hiero.consensus.platformstate.PlatformStateUtils.lastFrozenTimeOf;
+import static org.hiero.consensus.platformstate.PlatformStateUtils.roundOf;
 import static org.hiero.consensus.platformstate.V0540PlatformStateSchema.PLATFORM_STATE_STATE_ID;
 import static org.hiero.consensus.roster.RosterUtils.rosterFrom;
+import static org.hiero.consensus.system.SystemExitCode.UPGRADE_FROM_NON_FREEZE_STATE;
+import static org.hiero.consensus.system.SystemExitUtils.exitSystem;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.hedera.cryptography.hints.HintsLibraryBridge;
 import com.hedera.cryptography.wraps.WRAPSLibraryBridge;
 import com.hedera.hapi.block.stream.output.StateChanges;
@@ -784,6 +789,7 @@ public final class Hedera implements SwirldMain, AppContext.Gossip, StaleEventCo
                     version);
             throw new IllegalStateException("Cannot downgrade from " + deserializedVersion + " to " + version);
         }
+        assertFreezeStateOnUpgrade(state, trigger, deserializedVersion, version);
         try {
             migrateSchemas(state, deserializedVersion, trigger, platformConfig);
             logConfiguration();
@@ -797,6 +803,49 @@ public final class Hedera implements SwirldMain, AppContext.Gossip, StaleEventCo
                     freezeTimeOf(state),
                     lastFrozenTimeOf(state));
         }
+    }
+
+    /**
+     * Fails fast if the node is attempting a software upgrade while resuming from a state that is not a freeze state.
+     * A coordinated upgrade always resumes from the freeze state written at the freeze boundary; every node migrates
+     * from that identical state, which is what keeps the post-migration root hash consistent across the network.
+     * Migrating from any other saved state produces a divergent hash, i.e. an ISS.
+     *
+     * @param state the loaded state
+     * @param trigger the startup trigger
+     * @param deserializedVersion the software version of the loaded state, or null at genesis
+     * @param currentVersion the current node software version
+     */
+    @VisibleForTesting
+    static void assertFreezeStateOnUpgrade(
+            @NonNull final State state,
+            @NonNull final InitTrigger trigger,
+            @Nullable final SemanticVersion deserializedVersion,
+            @NonNull final SemanticVersion currentVersion) {
+        final var isUpgrade = SEMANTIC_VERSION_COMPARATOR.compare(currentVersion, deserializedVersion) > 0;
+        if (isUpgrade && trigger == RESTART && !isFreezeState(state)) {
+            final var message = "Cannot upgrade from " + deserializedVersion + " to " + currentVersion
+                    + " while resuming from a non-freeze state at round " + roundOf(state)
+                    + "; an upgrade must resume from the network freeze state."
+                    + " Restore state from a healthy node before upgrading.";
+            logger.fatal(message);
+            exitSystem(UPGRADE_FROM_NON_FREEZE_STATE, message);
+            // Not reachable in production, where the JVM exits above; reachable in tests that mock the system exit
+            throw new IllegalStateException(message);
+        }
+    }
+
+    /**
+     * Returns whether the given state is a freeze state, i.e. the last state saved before a network freeze. Only a
+     * freeze state has a non-null {@code freezeTime} equal to its {@code lastFrozenTime}, since that equality is
+     * committed to disk atomically with the freeze-state save.
+     *
+     * @param state the state to check
+     * @return true if the state is a freeze state
+     */
+    private static boolean isFreezeState(@NonNull final State state) {
+        final var freezeTime = freezeTimeOf(state);
+        return freezeTime != null && freezeTime.equals(lastFrozenTimeOf(state));
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/HederaFreezeStateUpgradeGuardTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/HederaFreezeStateUpgradeGuardTest.java
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.hiero.consensus.platformstate.V0540PlatformStateSchema.PLATFORM_STATE_STATE_ID;
+import static org.hiero.consensus.system.SystemExitCode.UPGRADE_FROM_NON_FREEZE_STATE;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mockStatic;
+
+import com.hedera.hapi.node.base.SemanticVersion;
+import com.hedera.hapi.node.base.Timestamp;
+import com.hedera.hapi.platform.state.PlatformState;
+import com.hedera.node.app.fixtures.state.FakeState;
+import com.swirlds.platform.system.InitTrigger;
+import com.swirlds.state.State;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.hiero.consensus.platformstate.PlatformStateService;
+import org.hiero.consensus.system.SystemExitUtils;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * Tests the guard that refuses to upgrade a node from a saved state that is not a freeze state. Migrating from a
+ * non-freeze state on upgrade produces a root hash that diverges from the rest of the network (an ISS), so the guard
+ * instead logs a fatal error and cancels node startup via {@link SystemExitUtils#exitSystem}.
+ */
+class HederaFreezeStateUpgradeGuardTest {
+    private static final SemanticVersion PREVIOUS_VERSION =
+            SemanticVersion.newBuilder().major(0).minor(67).patch(0).build();
+    private static final SemanticVersion CURRENT_VERSION =
+            SemanticVersion.newBuilder().major(0).minor(68).patch(0).build();
+    private static final Timestamp FREEZE_TIME =
+            Timestamp.newBuilder().seconds(1_700_000_000L).build();
+
+    @Test
+    void cancelsStartupOnUpgradeRestartFromNonFreezeState() {
+        assertStartupCancelled(stateWith(null, null), InitTrigger.RESTART, PREVIOUS_VERSION, CURRENT_VERSION);
+    }
+
+    @Test
+    void cancelsStartupWhenFreezeScheduledButNotReached() {
+        // freezeTime is set but lastFrozenTime never caught up to it, so the network did not freeze in this state
+        assertStartupCancelled(stateWith(FREEZE_TIME, null), InitTrigger.RESTART, PREVIOUS_VERSION, CURRENT_VERSION);
+    }
+
+    @Test
+    void allowsUpgradeRestartFromFreezeState() {
+        assertStartupAllowed(
+                stateWith(FREEZE_TIME, FREEZE_TIME), InitTrigger.RESTART, PREVIOUS_VERSION, CURRENT_VERSION);
+    }
+
+    @Test
+    void allowsReconnectFromNonFreezeState() {
+        assertStartupAllowed(stateWith(null, null), InitTrigger.RECONNECT, PREVIOUS_VERSION, CURRENT_VERSION);
+    }
+
+    @Test
+    void allowsSameVersionRestartFromNonFreezeState() {
+        assertStartupAllowed(stateWith(null, null), InitTrigger.RESTART, CURRENT_VERSION, CURRENT_VERSION);
+    }
+
+    @Test
+    void allowsGenesisWithNoDeserializedVersion() {
+        assertStartupAllowed(stateWith(null, null), InitTrigger.GENESIS, null, CURRENT_VERSION);
+    }
+
+    private static void assertStartupCancelled(
+            final State state,
+            final InitTrigger trigger,
+            @Nullable final SemanticVersion deserializedVersion,
+            final SemanticVersion currentVersion) {
+        try (MockedStatic<SystemExitUtils> systemExit = mockStatic(SystemExitUtils.class)) {
+            // exitSystem is mocked so the JVM does not exit; the subsequent throw provides the assertable control flow
+            assertThatThrownBy(() ->
+                            Hedera.assertFreezeStateOnUpgrade(state, trigger, deserializedVersion, currentVersion))
+                    .isInstanceOf(IllegalStateException.class);
+            systemExit.verify(() -> SystemExitUtils.exitSystem(eq(UPGRADE_FROM_NON_FREEZE_STATE), anyString()));
+        }
+    }
+
+    private static void assertStartupAllowed(
+            final State state,
+            final InitTrigger trigger,
+            @Nullable final SemanticVersion deserializedVersion,
+            final SemanticVersion currentVersion) {
+        try (MockedStatic<SystemExitUtils> systemExit = mockStatic(SystemExitUtils.class)) {
+            assertThatCode(() -> Hedera.assertFreezeStateOnUpgrade(state, trigger, deserializedVersion, currentVersion))
+                    .doesNotThrowAnyException();
+            systemExit.verifyNoInteractions();
+        }
+    }
+
+    private static State stateWith(@Nullable final Timestamp freezeTime, @Nullable final Timestamp lastFrozenTime) {
+        final var platformState = PlatformState.newBuilder()
+                .freezeTime(freezeTime)
+                .lastFrozenTime(lastFrozenTime)
+                .build();
+        return new FakeState()
+                .addService(
+                        PlatformStateService.NAME,
+                        Map.of(PLATFORM_STATE_STATE_ID, new AtomicReference<>(platformState)));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/SwirldsLogValidator.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/support/validators/SwirldsLogValidator.java
@@ -71,7 +71,10 @@ public class SwirldsLogValidator {
                 List.of("jvmPauseDetectorThread detected JVM paused"),
                 // Transient backpressure under load, e.g. while a node constructs WRAPS proofs
                 List.of("HealthMonitorLogger", "has been unhealthy for"),
-                List.of("DefaultSignedStateSentinel", "Old signed state detected"));
+                List.of("DefaultSignedStateSentinel", "Old signed state detected"),
+                // A node deliberately exits at startup when it detects an upgrade from a non-freeze state
+                // (see Hedera#assertFreezeStateOnUpgrade), exercised by UpgradeFromNonFreezeStateTest
+                List.of("SystemExitPayload", "UPGRADE_FROM_NON_FREEZE_STATE"));
 
         private int numProblems = 0;
         private int linesSinceInitialProblem = -1;

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/regression/system/MixedOpsNodeDeathReconnectTest.java
@@ -4,17 +4,21 @@ package com.hedera.services.bdd.suites.regression.system;
 import static com.hedera.services.bdd.junit.TestTags.ND_RECONNECT;
 import static com.hedera.services.bdd.junit.hedera.NodeSelector.byNodeId;
 import static com.hedera.services.bdd.spec.HapiSpec.defaultHapiSpec;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertHgcaaLogContainsText;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.logIt;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sleepFor;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForActive;
-import static com.hedera.services.bdd.suites.regression.system.LifecycleTest.RESTART_TO_ACTIVE_TIMEOUT;
 import static com.hedera.services.bdd.suites.regression.system.MixedOperations.burstOfTps;
 
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.junit.OrderedInIsolation;
 import com.hedera.services.bdd.spec.utilops.FakeNmt;
+import java.time.Duration;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 
 /**
@@ -23,11 +27,15 @@ import org.junit.jupiter.api.Tag;
  * submits the same burst of mixed operations again.
  */
 @Tag(ND_RECONNECT)
+@OrderedInIsolation
 public class MixedOpsNodeDeathReconnectTest implements LifecycleTest {
 
     /** Subprocess node id 2 — classic operator account 0.0.5 ({@code setNode("5")}). */
     private static final long RECONNECT_NODE_ID = 2L;
 
+    private static final long UPGRADING_NODE_ID = 1L;
+
+    @Order(1)
     @HapiTest
     final Stream<DynamicTest> reconnectMixedOps() {
         return defaultHapiSpec("RestartMixedOps")
@@ -49,5 +57,36 @@ public class MixedOpsNodeDeathReconnectTest implements LifecycleTest {
                         // Run some more transactions
                         burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
                         cryptoCreate("somebody").setNode("5"));
+    }
+
+    /**
+     * A node restarted at a newer software version while its
+     * latest on-disk saved state is a non-freeze state must refuse to start. Migrating from a non-freeze state on upgrade
+     * produces a root hash that diverges from the rest of the network (an ISS); the guard in
+     * {@code Hedera#assertFreezeStateOnUpgrade} instead logs a fatal error and exits the node via
+     * {@code SystemExitUtils.exitSystem}.
+     *
+     * <p>The guard only fires on an upgrade — a same-version restart from a non-freeze state is normal crash recovery and
+     * must still succeed. Uses an isolated per-method subprocess network because the guarded node deliberately exits and
+     * never rejoins.
+     */
+    @Order(2)
+    @HapiTest
+    final Stream<DynamicTest> nodeExitsWhenUpgradingFromNonFreezeState() {
+        return hapiTest(
+                // Advance rounds so a non-freeze state (first-round-after-genesis / periodic snapshot) is written to
+                // disk, without ever freezing the network.
+                burstOfTps(MIXED_OPS_BURST_TPS, MIXED_OPS_BURST_DURATION),
+                // Take the node down abnormally (no freeze), so its latest on-disk state is a non-freeze state.
+                FakeNmt.shutdownWithin(byNodeId(UPGRADING_NODE_ID), SHUTDOWN_TIMEOUT),
+                // Bring it back at a higher config version, i.e. an upgrade that resumes from that non-freeze state.
+                // The guard exits the node during state initialization, before it binds any gossip port, so the
+                // reconnect-oriented PORT_UNBINDING_WAIT_PERIOD used by node-death tests is unnecessary here.
+                FakeNmt.restartWithConfigVersion(byNodeId(UPGRADING_NODE_ID), CURRENT_CONFIG_VERSION.get() + 1),
+                // The node must log the fatal guard message and exit instead of joining the network.
+                assertHgcaaLogContainsText(
+                        byNodeId(UPGRADING_NODE_ID),
+                        "while resuming from a non-freeze state at round",
+                        Duration.ofSeconds(60)));
     }
 }

--- a/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/system/SystemExitCode.java
+++ b/platform-sdk/consensus-utility/src/main/java/org/hiero/consensus/system/SystemExitCode.java
@@ -30,6 +30,10 @@ public enum SystemExitCode {
      */
     NODE_ID_NOT_PROVIDED(205),
     /**
+     * The node attempted a software upgrade while resuming from a state that is not a freeze state.
+     */
+    UPGRADE_FROM_NON_FREEZE_STATE(206),
+    /**
      * An exit was called but no code was supplied
      */
     NO_EXIT_CODE(254),


### PR DESCRIPTION
**Description**:
On a RESTART where the running version is newer than the loaded state's
version, verify the loaded state is a freeze state; if it is not, log a
fatal error and exit instead of migrating. Migrating from a non-freeze
state on upgrade produces a state hash that diverges from the network
(an ISS) — as seen when a node was brought up on a new release without
downloading the post-freeze state.

- add SystemExitCode.UPGRADE_FROM_NON_FREEZE_STATE (206)
- unit test for the guard's trigger/gating (upgrade+RESTART only)
- subprocess HAPI test reproducing the node exit

Closes #27030
Closes #27031
