### PR TITLE
chore(ci): update XTS optional test slack report colors

### DIFF
--- a/.github/workflows/106-disp-xts-optional-tests.yaml
+++ b/.github/workflows/106-disp-xts-optional-tests.yaml
@@ -206,6 +206,7 @@ jobs:
 
       - name: Build Success Slack Payload
         env:
+          SLACK_COLOR: "#0000FF"
           XTS_INFO: ${{ needs.candidate-info.outputs.xts-info }}
           FETCH_XTS_CANDIDATE_RESULT: ${{ needs.candidate-info.result }}
           XTS_EXECUTION_RESULT: ${{ needs.xts-optional-execution.result }}
@@ -304,6 +305,7 @@ jobs:
       - name: Build Test Failure Slack Payload
         if: ${{ steps.report-category.outputs.category == 'test' }}
         env:
+          SLACK_COLOR: "#FF8C00"
           XTS_INFO: "${{ needs.candidate-info.outputs.xts-info || '' }}"
           FETCH_XTS_CANDIDATE_RESULT: ${{ needs.candidate-info.result }}
           XTS_EXECUTION_RESULT: ${{ needs.xts-optional-execution.result }}

--- a/.github/workflows/900-cron-extended-test-suite.yaml
+++ b/.github/workflows/900-cron-extended-test-suite.yaml
@@ -528,6 +528,7 @@ jobs:
 
       - name: Build Success Slack Payload
         env:
+          SLACK_COLOR: "#00FF00"
           XTS_INFO: ${{ needs.fetch-xts-candidate.outputs.xts-info }}
           FETCH_XTS_CANDIDATE_RESULT: ${{ needs.fetch-xts-candidate.result }}
           XTS_EXECUTION_RESULT: ${{ needs.xts-execution.result }}
@@ -697,6 +698,7 @@ jobs:
       - name: Build Test Failure Slack Payload
         if: ${{ steps.report-category.outputs.category == 'test' }}
         env:
+          SLACK_COLOR: "#FF0000"
           XTS_INFO: "${{ needs.fetch-xts-candidate.outputs.xts-info  || ''}}"
           FETCH_XTS_CANDIDATE_RESULT: ${{ needs.fetch-xts-candidate.result }}
           XTS_EXECUTION_RESULT: ${{ needs.xts-execution.result }}

--- a/.github/workflows/templates/slack-xts-success-detailed.json.tpl
+++ b/.github/workflows/templates/slack-xts-success-detailed.json.tpl
@@ -1,7 +1,7 @@
 {
   "attachments": [
     {
-      "color": "#00FF00",
+      "color": {{ getenv "SLACK_COLOR" "#00FF00" | data.ToJSON }},
       "blocks": [
         {
           "type": "header",

--- a/.github/workflows/templates/slack-xts-test-failure-detailed.json.tpl
+++ b/.github/workflows/templates/slack-xts-test-failure-detailed.json.tpl
@@ -1,7 +1,7 @@
 {
   "attachments": [
     {
-      "color": "#FF0000",
+      "color": {{ getenv "SLACK_COLOR" "#FF0000" | data.ToJSON }},
       "blocks": [
         {
           "type": "header",


### PR DESCRIPTION
**Description**:

Update the XTS Optional Tests Slack report to new colors:
- Blue for passing
- Orange for failure (same as env failure in MATS)

**Related Issue(s)**:

Implements #27110
