### PR TITLE
fix: don't advance beneficiary stake metadata for rewards redirected from a deleted account

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakePeriodManager.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakePeriodManager.java
@@ -98,6 +98,20 @@ public class StakePeriodManager {
     }
 
     /**
+     * Returns whether the given account is rewardable on its own stake this period, based on its
+     * effective stake period start. This is the single source of truth for own-stake reward
+     * eligibility, shared by {@link StakeRewardCalculatorImpl#computePendingReward} and the
+     * stake-metadata bookkeeping in {@code StakingRewardsHandlerImpl}.
+     * @param account the account
+     * @param networkRewards the network rewards
+     * @return true if the account is rewardable on its own stake this period
+     */
+    public boolean isRewardable(
+            @NonNull final Account account, @NonNull final ReadableNetworkStakingRewardsStore networkRewards) {
+        return isRewardable(effectivePeriod(account.stakePeriodStart()), networkRewards);
+    }
+
+    /**
      * Returns the first stake period that is not rewardable. This is used to determine
      * if an account is eligible for a reward, as soon as staking rewards are activated.
      * @param rewardsStore the network rewards store

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeRewardCalculatorImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakeRewardCalculatorImpl.java
@@ -37,8 +37,7 @@ public class StakeRewardCalculatorImpl implements StakeRewardCalculator {
             @NonNull final WritableStakingInfoStore stakingInfoStore,
             @NonNull final ReadableNetworkStakingRewardsStore rewardsStore,
             @NonNull final Instant consensusNow) {
-        final var effectiveStart = stakePeriodManager.effectivePeriod(account.stakePeriodStart());
-        if (!stakePeriodManager.isRewardable(effectiveStart, rewardsStore)) {
+        if (!stakePeriodManager.isRewardable(account, rewardsStore)) {
             return 0;
         }
 
@@ -49,6 +48,7 @@ public class StakeRewardCalculatorImpl implements StakeRewardCalculator {
         if (stakingInfo != null && stakingInfo.deleted()) {
             return 0;
         }
+        final var effectiveStart = stakePeriodManager.effectivePeriod(account.stakePeriodStart());
         final var rewardOffered =
                 computeRewardFromDetails(account, stakingInfo, stakePeriodManager.currentStakePeriod(), effectiveStart);
         return account.declineReward() ? 0 : rewardOffered;

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -320,7 +319,19 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
 
             // If the account is rewarded. The reward can also be zero, if the account has zero stake
             final var rewardSituation = paidRewards.containsKey(id);
-            final var reward = paidRewards.getOrDefault(id, 0L);
+            // paidRewards is keyed by the account that RECEIVES the tinybars. A deleted account's
+            // reward is redirected to (and recorded under) its beneficiary
+            // (StakingRewardsDistributor#payRewardsIfPending); such a redirected reward must not be
+            // treated as one the beneficiary earned on its own stake, or the beneficiary's
+            // stakePeriodStart is moved back a period and it collects an unearned reward from 0.0.800
+            // next period. We re-derive eligibility here rather than at the source because a reward
+            // paid in a SCHEDULED child dispatch reaches us only as a (recipient, amount) pair, with
+            // the earner's identity already stripped. Own-stake rewardability is necessary but not
+            // sufficient for a positive reward (declineReward / deleted node / sub-hbar stake earn
+            // zero); advancing metadata in those cases is harmless, as such an account collects
+            // nothing next period regardless.
+            final var rewardableOnOwnStake = wasRewardableOnOwnStake(originalAccount, stakingRewardStore);
+            final var reward = rewardableOnOwnStake ? paidRewards.getOrDefault(id, 0L) : 0L;
 
             // If account chose to change decline reward field or stakeId field, we don't need
             // to update stakeAtStartOfLastRewardedPeriod because it is not rewarded for that period
@@ -332,7 +343,7 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
                 copy.stakeAtStartOfLastRewardedPeriod(NOT_REWARDED_SINCE_LAST_STAKING_META_CHANGE);
                 writableStore.put(copy.build());
             } else if (shouldUpdateStakeAtStartOfLastRewardPeriod(
-                    originalAccount, rewardSituation, reward, stakingRewardStore, consensusNow)) {
+                    originalAccount, rewardSituation, reward, stakingRewardStore)) {
                 final var copy = modifiedAccount.copyBuilder();
                 copy.stakeAtStartOfLastRewardedPeriod(roundedToHbar(totalStake(originalAccount)));
                 writableStore.put(copy.build());
@@ -341,13 +352,10 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
             // Get latest account from store again since it is modified before
             modifiedAccount = writableStore.get(id);
 
-            // Update stakePeriodStart if account is rewarded or if reward is zero and account has zero stake
-            // If the account is autoCreated it will not be rewarded
-            final var wasRewarded = rewardSituation
-                    && (reward > 0
-                            || (reward == 0
-                                    && earnedZeroRewardsBecauseOfZeroStake(
-                                            originalAccount, stakingRewardStore, consensusNow)));
+            // Advance stakePeriodStart only if this account was rewardable on its own stake. This
+            // also covers rewardable accounts that earned zero because they had zero whole-hbar
+            // stake, while excluding redirected-only rewards and accounts with no original value.
+            final var wasRewarded = rewardSituation && rewardableOnOwnStake;
             final var stakePeriodStart = stakePeriodManager.startUpdateFor(
                     originalAccount, modifiedAccount, wasRewarded, containStakeMetaChanges);
             if (stakePeriodStart != -1) {
@@ -373,11 +381,27 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
      * @return whether the zero rewards were due to having zero stake
      */
     private boolean earnedZeroRewardsBecauseOfZeroStake(
-            @NonNull final Account account,
-            @NonNull final ReadableNetworkStakingRewardsStore stakingRewardStore,
-            @NonNull final Instant consensusNow) {
-        return Objects.requireNonNull(account).stakePeriodStart()
-                < stakePeriodManager.firstNonRewardableStakePeriod(stakingRewardStore);
+            @NonNull final Account account, @NonNull final ReadableNetworkStakingRewardsStore stakingRewardStore) {
+        return stakePeriodManager.isRewardable(account, stakingRewardStore);
+    }
+
+    /**
+     * Returns whether the given account is rewardable on its own stake this period; i.e., whether a
+     * reward recorded against it could reflect its own stake rather than one redirected to it as the
+     * beneficiary of a deleted account. Delegates to the eligibility gate shared with
+     * {@link StakeRewardCalculatorImpl#computePendingReward} (see
+     * {@link StakePeriodManager#isRewardable(Account, ReadableNetworkStakingRewardsStore)}). This is a
+     * necessary condition for having earned a positive own reward, not a sufficient one: a rewardable
+     * account may still earn zero if it declines rewards, stakes to a deleted node, or holds less than
+     * one whole hbar.
+     *
+     * @param account the (original) account being reviewed, possibly null if created this transaction
+     * @param stakingRewardStore the network staking rewards store
+     * @return true if the account is rewardable on its own stake this period
+     */
+    private boolean wasRewardableOnOwnStake(
+            @Nullable final Account account, @NonNull final ReadableNetworkStakingRewardsStore stakingRewardStore) {
+        return account != null && stakePeriodManager.isRewardable(account, stakingRewardStore);
     }
 
     private void adjustNodeStakes(
@@ -425,21 +449,20 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
      * @param isRewarded if the account is rewarded
      * @param reward the reward amount
      * @param stakingRewardStore the staking reward store
-     * @param consensusNow the consensus time
      * @return true if the account need to update stakeAtStartOfLastRewardedPeriod, false otherwise
      */
     public boolean shouldUpdateStakeAtStartOfLastRewardPeriod(
             @Nullable final Account account,
             final boolean isRewarded,
             final long reward,
-            @NonNull final ReadableNetworkStakingRewardsStore stakingRewardStore,
-            @NonNull final Instant consensusNow) {
+            @NonNull final ReadableNetworkStakingRewardsStore stakingRewardStore) {
         if (account == null
                 || account.stakedNodeIdOrElse(SENTINEL_NODE_ID) == SENTINEL_NODE_ID
-                || account.declineReward()) {
+                || account.declineReward()
+                || account.stakePeriodStart() < 0) {
             // If the account is created in this transaction, or it is not staking to a node,
-            // or it has chosen to decline reward, we don't need to remember stakeStart,
-            // because it can't receive reward today
+            // it has chosen to decline reward, or its stake period start is not initialized,
+            // we don't need to remember stakeStart, because it can't receive reward today
             return false;
         }
         if (!isRewarded) {
@@ -466,7 +489,7 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
             // scenarios 1 and 3, but not 2 and 4. (As noted below, in scenario 2 we want to
             // preserve an already-recorded memory of her stake at the beginning of this period.
             // In scenario 4 there is no point in recording anything---her stake will go unused.)
-            if (earnedZeroRewardsBecauseOfZeroStake(account, stakingRewardStore, consensusNow)) {
+            if (earnedZeroRewardsBecauseOfZeroStake(account, stakingRewardStore)) {
                 return true;
             }
             if (account.stakeAtStartOfLastRewardedPeriod() != NOT_REWARDED_SINCE_LAST_STAKING_META_CHANGE) {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakeRewardCalculatorImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakeRewardCalculatorImplTest.java
@@ -176,8 +176,7 @@ class StakeRewardCalculatorImplTest {
 
     @Test
     void withNonRewardableConsensusTime() {
-        given(stakePeriodManager.effectivePeriod(account.stakePeriodStart())).willReturn(1L);
-        given(stakePeriodManager.isRewardable(1L, stakingRewardsStore)).willReturn(false);
+        given(stakePeriodManager.isRewardable(account, stakingRewardsStore)).willReturn(false);
 
         var reward = subject.computePendingReward(account, stakingInfoStore, stakingRewardsStore, consensusTime);
 
@@ -189,6 +188,7 @@ class StakeRewardCalculatorImplTest {
                 .willReturn(TODAY_NUMBER);
         willCallRealMethod().given(stakePeriodManager).effectivePeriod(anyLong());
         willCallRealMethod().given(stakePeriodManager).isRewardable(anyLong(), any());
+        willCallRealMethod().given(stakePeriodManager).isRewardable(any(Account.class), any());
     }
 
     private static List<Long> newRewardHistory() {

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
@@ -353,14 +353,13 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
     void earningZeroRewardsWithStartBeforeLastNonRewardableStillUpdatesSASOLARP() {
         final var account = mock(Account.class);
         final var manager = mock(StakePeriodManager.class);
-        given(manager.firstNonRewardableStakePeriod(readableRewardsStore)).willReturn(3L);
+        given(manager.isRewardable(account, readableRewardsStore)).willReturn(true);
         given(account.stakePeriodStart()).willReturn(2L);
 
         final StakingRewardsHandlerImpl impl =
                 new StakingRewardsHandlerImpl(rewardsPayer, manager, stakeInfoHelper, entityIdFactory);
 
-        assertThat(impl.shouldUpdateStakeAtStartOfLastRewardPeriod(
-                        account, true, 0L, readableRewardsStore, consensusInstant))
+        assertThat(impl.shouldUpdateStakeAtStartOfLastRewardPeriod(account, true, 0L, readableRewardsStore))
                 .isTrue();
     }
 
@@ -1012,6 +1011,205 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
         assertThat(rewards).containsEntry(ownerId, 178900L);
         // And the child dispatch's mapping was folded into the root builder.
         assertThat(rootBeneficiaries).containsEntry(payerId, ownerId);
+    }
+
+    @Test
+    void deletedAccountRewardRedirectDoesNotAdvanceBeneficiaryStakeMetadata() {
+        final var accountBalance = 555L * HBARS_TO_TINYBARS;
+        final var ownerBalance = 111L * HBARS_TO_TINYBARS;
+        final var currentStakePeriod = stakePeriodStart + 2;
+        // The deleted account is rewardable (it began staking two periods ago) ...
+        final var payerAccountBefore = new AccountCustomizer()
+                .withAccount(account)
+                .withBalance(accountBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedNodeId(0L)
+                .build();
+        // ... while its beneficiary only began staking in the current period, so the beneficiary is
+        // NOT yet rewardable on its own stake.
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(ownerBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(currentStakePeriod)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedNodeId(0L)
+                .build();
+        addToState(Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore));
+
+        writableAccountStore.put(payerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(0)
+                .stakedNodeId(0L)
+                .deleted(true)
+                .build());
+        writableAccountStore.put(ownerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(ownerBalance + accountBalance)
+                .stakedNodeId(0L)
+                .build());
+        writableAccountStore.put(Account.newBuilder()
+                .accountId(AccountID.newBuilder().accountNum(800).build())
+                .tinybarBalance(123L * HBARS_TO_TINYBARS)
+                .build());
+
+        given(context.consensusTime())
+                .willReturn(LocalDate.ofEpochDay(currentStakePeriod)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
+                .willReturn(recordBuilder);
+        given(recordBuilder.getNumberOfDeletedAccounts()).willReturn(1);
+        given(recordBuilder.getDeletedAccountBeneficiaryFor(payerId)).willReturn(ownerId);
+        stakePeriodManager.setCurrentStakePeriodFor(context.consensusTime());
+        mockEntityIdFactory();
+
+        final var rewards = subject.applyStakingRewards(context, Collections.emptySet(), emptyMap());
+        final var beneficiary = writableAccountStore.get(ownerId);
+
+        // The deleted account's earned reward is still forwarded to, and recorded against, the
+        // beneficiary -- this part is intended and must be preserved.
+        assertThat(rewards).containsEntry(ownerId, 178900L);
+        assertThat(writableAccountStore.get(payerId).deleted()).isTrue();
+        assertThat(beneficiary.tinybarBalance()).isEqualTo(ownerBalance + accountBalance + 178900L);
+
+        // But the redirect must NOT advance the beneficiary's own staking metadata: its
+        // stakePeriodStart stays put (not moved back to currentStakePeriod - 1) and its
+        // stakeAtStartOfLastRewardedPeriod is left untouched.
+        assertThat(beneficiary.stakePeriodStart()).isEqualTo(currentStakePeriod);
+        assertThat(beneficiary.stakeAtStartOfLastRewardedPeriod()).isEqualTo(-1L);
+
+        // Consequently the beneficiary is still not rewardable in the next period, so it collects no
+        // unearned reward from the staking reward account.
+        final var nextPeriodInstant = LocalDate.ofEpochDay(currentStakePeriod + 1)
+                .atStartOfDay(ZoneOffset.UTC)
+                .toInstant();
+        stakePeriodManager.setCurrentStakePeriodFor(nextPeriodInstant);
+        final var nextPeriodReward = stakeRewardCalculator.computePendingReward(
+                beneficiary, writableStakingInfoStore, readableRewardsStore, nextPeriodInstant);
+        assertThat(nextPeriodReward).isZero();
+    }
+
+    @Test
+    void prepaidRedirectedRewardDoesNotAdvanceBeneficiaryStakeMetadata() {
+        final var ownerInitialBalance = 111L * HBARS_TO_TINYBARS;
+        final var redirectedReward = 178900L;
+        final var currentStakePeriod = stakePeriodStart + 2;
+        // A scheduled CryptoDelete handled in a child dispatch pays a deleted account's reward to
+        // this beneficiary and reports it (keyed by the beneficiary) as a pre-paid reward to the
+        // parent. The beneficiary only began staking in the current period, so it is not rewardable
+        // on its own stake; the pre-paid redirected reward must not advance its stake metadata.
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(ownerInitialBalance + redirectedReward)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(currentStakePeriod)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedNodeId(0L)
+                .build();
+        addToState(Map.of(ownerId, ownerAccountBefore));
+
+        given(context.consensusTime())
+                .willReturn(LocalDate.ofEpochDay(currentStakePeriod)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
+                .willReturn(recordBuilder);
+        stakePeriodManager.setCurrentStakePeriodFor(context.consensusTime());
+        mockEntityIdFactory();
+
+        subject.applyStakingRewards(context, Collections.emptySet(), Map.of(ownerId, redirectedReward));
+
+        final var beneficiary = writableAccountStore.get(ownerId);
+        assertThat(beneficiary.stakePeriodStart()).isEqualTo(currentStakePeriod);
+        assertThat(beneficiary.stakeAtStartOfLastRewardedPeriod()).isEqualTo(-1L);
+    }
+
+    @Test
+    void prepaidRedirectedRewardDoesNotInitializeBeneficiaryStakeMetadata() {
+        final var ownerInitialBalance = 111L * HBARS_TO_TINYBARS;
+        final var redirectedReward = 178900L;
+        final var currentStakePeriod = stakePeriodStart + 2;
+        // A stakePeriodStart of -1 means the beneficiary was never rewardable on its own stake.
+        // Receiving a reward redirected by a scheduled child dispatch must not initialize either
+        // field used to track its own staking reward history.
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(ownerInitialBalance + redirectedReward)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(-1L)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedNodeId(0L)
+                .build();
+        addToState(Map.of(ownerId, ownerAccountBefore));
+
+        given(context.consensusTime())
+                .willReturn(LocalDate.ofEpochDay(currentStakePeriod)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
+                .willReturn(recordBuilder);
+        stakePeriodManager.setCurrentStakePeriodFor(context.consensusTime());
+        mockEntityIdFactory();
+
+        subject.applyStakingRewards(context, Collections.emptySet(), Map.of(ownerId, redirectedReward));
+
+        final var beneficiary = writableAccountStore.get(ownerId);
+        assertThat(beneficiary.stakePeriodStart()).isEqualTo(-1L);
+        assertThat(beneficiary.stakeAtStartOfLastRewardedPeriod()).isEqualTo(-1L);
+    }
+
+    @Test
+    void prepaidRewardForAccountWithNoOriginalValueIsHandledSafely() {
+        final var beneficiaryBalance = 111L * HBARS_TO_TINYBARS;
+        // Must be zero: with a positive amount the reverted (pre-fix) code short-circuits wasRewarded
+        // on reward > 0 and never reaches earnedZeroRewardsBecauseOfZeroStake(null, ...), so the NPE
+        // this test guards would not be exercised.
+        final var redirectedReward = 0L;
+        final var currentStakePeriod = stakePeriodStart + 2;
+        // Defense-in-depth: a reward may be recorded (keyed by the beneficiary) for an account with no
+        // original value -- i.e. one created during this same transaction. Such an account was not
+        // rewarded for a prior period, so its stake metadata must not be advanced, and the rewardability
+        // gate must not dereference the null original.
+        final var beneficiaryModified = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(beneficiaryBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(currentStakePeriod)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedNodeId(0L)
+                .build();
+        // Seed only the staking reward account; the beneficiary exists solely as a modification, so its
+        // original value is null.
+        addToState(Map.of());
+        writableAccountStore.put(beneficiaryModified);
+
+        given(context.consensusTime())
+                .willReturn(LocalDate.ofEpochDay(currentStakePeriod)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
+                .willReturn(recordBuilder);
+        stakePeriodManager.setCurrentStakePeriodFor(context.consensusTime());
+        mockEntityIdFactory();
+
+        // Must not throw (previously NPE'd on the null original) and must not advance stake metadata.
+        subject.applyStakingRewards(context, Collections.emptySet(), Map.of(ownerId, redirectedReward));
+
+        final var beneficiary = writableAccountStore.get(ownerId);
+        assertThat(beneficiary.stakePeriodStart()).isEqualTo(currentStakePeriod);
+        assertThat(beneficiary.stakeAtStartOfLastRewardedPeriod()).isEqualTo(-1L);
     }
 
     @Test


### PR DESCRIPTION
> Migrated from the private `hashgraph/private-hedera-services` repository.

> Original source commit: `4a84c8cbc521056df15d653b126bdc7c82938d90`

> This commit preserves the original author and author timestamp.

## Summary
A staking account deleted while it has a pending reward has that reward redirected to its beneficiary and recorded in `paidRewards` under the **beneficiary's** id (`StakingRewardsDistributor#payRewardsIfPending`). `StakingRewardsHandlerImpl` then treated *any* reward recorded against an account as one the account earned on its **own** stake, so it rewrote the beneficiary's `stakePeriodStart` to the previous period (`current − 1`). 

## Root cause
`paidRewards` is keyed by the account that **receives** the tinybars, not the one that earned them. For a redirected reward those differ, but `adjustStakeMetadata` couldn't tell them apart — it advanced the recipient's stake metadata (`stakePeriodStart`, `stakeAtStartOfLastRewardedPeriod`) whenever a reward was recorded against it, regardless of whether the recipient was itself rewardable.

Why re-derive eligibility in the handler instead of at the redirect source: a reward paid in a **scheduled child dispatch** reaches the handler only as a `(recipient, amount)` pair — the earner's identity is already stripped — so own-stake eligibility can't be carried down and must be recomputed here.

## Fix
- **Single eligibility gate.** Add `StakePeriodManager.isRewardable(Account, ReadableNetworkStakingRewardsStore)` as the one source of truth for own-stake reward eligibility, and route `StakeRewardCalculatorImpl#computePendingReward` through it (pure refactor — same result).
- **Advance metadata only for own-stake rewards.** In `adjustStakeMetadata`, gate the recorded `reward` behind a new `wasRewardableOnOwnStake(originalAccount, …)` check. A reward now advances the recipient's stake metadata only when the recipient was actually rewardable on its own stake; a redirected reward no longer moves the beneficiary's `stakePeriodStart`.
- **Null-original hardening.** Require a non-null original account in the `wasRewarded` computation. Auto-created / same-transaction accounts have a null original; this prevents an NPE in the eligibility check and avoids advancing metadata for accounts not rewarded in a prior period.

Own-stake rewardability is *necessary but not sufficient* for a positive reward — `declineReward`, a deleted node, or sub-hbar stake still earn zero — but advancing metadata in those cases is harmless, since such an account collects nothing next period regardless.