### PR TITLE
fix: validate migration-root-hash vote bodies and harden vote tallying and storage ordering

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/WritableBlockRecordStore.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/WritableBlockRecordStore.java
@@ -29,11 +29,26 @@ public class WritableBlockRecordStore extends ReadableBlockRecordStore {
         return writableBlockInfo.get();
     }
 
-    public boolean putVoteIfAbsent(final long nodeId, @NonNull final MigrationRootHashVoteTransactionBody vote) {
+    /**
+     * Records the given node's vote if it has not already voted and the stored vote list is below the supplied
+     * bound, returning whether the vote was stored.
+     *
+     * @param nodeId the submitting node's id
+     * @param vote the vote body
+     * @param maxVotes the maximum number of votes to retain, sized to the active roster by the caller; once the
+     *     stored list reaches this bound no further votes are accepted, so a caller that fails to validate the
+     *     submitting node against the roster cannot grow this consensus-critical singleton without limit
+     * @return true if the vote was stored, false if the node already voted or the bound was reached
+     */
+    public boolean putVoteIfAbsent(
+            final long nodeId, @NonNull final MigrationRootHashVoteTransactionBody vote, final int maxVotes) {
         requireNonNull(vote);
         final var blockInfo = getLastBlockInfo();
         if (blockInfo.migrationRootHashVotes().stream()
                 .anyMatch(existing -> existing.nodeIdOrElse(NodeId.DEFAULT).id() == nodeId)) {
+            return false;
+        }
+        if (blockInfo.migrationRootHashVotes().size() >= maxVotes) {
             return false;
         }
         final var votes = new ArrayList<>(blockInfo.migrationRootHashVotes());

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/handlers/MigrationRootHashVoteHandler.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/records/handlers/MigrationRootHashVoteHandler.java
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.records.handlers;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.node.app.hapi.utils.CommonUtils.sha384DigestOrThrow;
 import static java.util.Objects.requireNonNull;
 
 import com.hedera.hapi.block.internal.WrappedRecordFileBlockHashes;
 import com.hedera.hapi.node.state.roster.RosterEntry;
-import com.hedera.hapi.platform.state.NodeId;
 import com.hedera.hapi.services.auxiliary.blockrecords.MigrationRootHashVoteTransactionBody;
 import com.hedera.node.app.blocks.impl.IncrementalStreamingHasher;
 import com.hedera.node.app.records.BlockRecordManager;
@@ -37,6 +37,11 @@ import org.hiero.consensus.roster.ReadableRosterStore;
 public class MigrationRootHashVoteHandler implements TransactionHandler {
     private static final Logger log = LogManager.getLogger(MigrationRootHashVoteHandler.class);
 
+    private static final int SHA_384_HASH_LENGTH = 48;
+    // Far beyond any realistic number of wrapped record blocks; also keeps the leaf count clear of
+    // overflow as it is incremented per queued hash during finalization.
+    private static final long MAX_INTERMEDIATE_LEAF_COUNT = 1L << 40;
+
     private final BlockRecordManager blockRecordManager;
 
     @Inject
@@ -47,6 +52,12 @@ public class MigrationRootHashVoteHandler implements TransactionHandler {
     @Override
     public void pureChecks(@NonNull final PureChecksContext context) throws PreCheckException {
         requireNonNull(context);
+        final var op = context.body().migrationRootHashVoteOrThrow();
+        // Reject structurally inconsistent vote bodies up front so they are never stored, tallied, or
+        // fed into the streaming hasher during finalization.
+        if (!isStructurallyValid(op)) {
+            throw new PreCheckException(INVALID_TRANSACTION_BODY);
+        }
     }
 
     @Override
@@ -74,11 +85,8 @@ public class MigrationRootHashVoteHandler implements TransactionHandler {
                         .map(Bytes::toHex)
                         .collect(Collectors.joining(", ")),
                 op.wrappedIntermediateBlockRootsLeafCount());
-        if (!store.putVoteIfAbsent(nodeId, op)) {
-            log.info("Ignoring duplicate migration root hash vote from node{}", nodeId);
-            return;
-        }
-
+        // Confirm the submitting node is an active-roster member with positive weight BEFORE persisting
+        // its vote, so an ineligible node cannot accumulate entries in the durable vote list.
         final var rosterStore = context.storeFactory().readableStore(ReadableRosterStore.class);
         final var activeRoster = rosterStore.getActiveRoster();
         if (activeRoster == null || activeRoster.rosterEntries().isEmpty()) {
@@ -86,7 +94,7 @@ public class MigrationRootHashVoteHandler implements TransactionHandler {
         }
         final var nodeWeight = activeRoster.rosterEntries().stream()
                 .filter(entry -> entry.nodeId() == nodeId)
-                .mapToLong(entry -> entry.weight())
+                .mapToLong(RosterEntry::weight)
                 .findFirst()
                 .orElse(0L);
         if (nodeWeight <= 0) {
@@ -105,14 +113,24 @@ public class MigrationRootHashVoteHandler implements TransactionHandler {
             return;
         }
 
+        if (!store.putVoteIfAbsent(nodeId, op, activeRoster.rosterEntries().size())) {
+            log.info("Ignoring duplicate migration root hash vote from node{}", nodeId);
+            return;
+        }
+
         final var weightByNode = activeRoster.rosterEntries().stream()
                 .collect(Collectors.toMap(RosterEntry::nodeId, RosterEntry::weight));
         final var tallyByVote = new HashMap<MigrationRootHashVoteTransactionBody, Long>();
-        for (final var vote : store.votes()) {
-            final var votingNodeId = vote.nodeIdOrElse(NodeId.DEFAULT).id();
+        for (final var storedVote : store.votes()) {
+            // Skip stored entries that carry no vote body or no node id, so they cannot be miscounted
+            // toward this vote (a missing node id would otherwise default to node 0 and be credited its weight)
+            if (!storedVote.hasVote() || !storedVote.hasNodeId()) {
+                continue;
+            }
+            final var votingNodeId = storedVote.nodeIdOrThrow().id();
             final var votingWeight = weightByNode.getOrDefault(votingNodeId, 0L);
             if (votingWeight > 0) {
-                tallyByVote.merge(vote.voteOrElse(op), votingWeight, Long::sum);
+                tallyByVote.merge(storedVote.voteOrThrow(), votingWeight, Long::sum);
             }
         }
         final var tallyWeight = Optional.ofNullable(tallyByVote.get(op)).orElse(0L);
@@ -124,6 +142,15 @@ public class MigrationRootHashVoteHandler implements TransactionHandler {
                 totalWeight);
         // Network consensus requires at least (totalWeight / 3) + 1
         if (tallyWeight * 3 <= totalWeight) {
+            return;
+        }
+
+        // Defense-in-depth: never feed a structurally inconsistent winning vote into the streaming hasher,
+        // which would otherwise fold past the available pending state and crash the handle thread.
+        if (!isStructurallyValid(op)) {
+            log.error(
+                    "Ignoring migration root hash vote finalization from node{} because the winning vote body is structurally invalid",
+                    nodeId);
             return;
         }
 
@@ -170,5 +197,34 @@ public class MigrationRootHashVoteHandler implements TransactionHandler {
                 previousWrappedRecordBlockRootHash.toHex(),
                 finalizedIntermediateState.stream().map(Bytes::toHex).collect(Collectors.joining(", ")),
                 finalizedLeafCount);
+    }
+
+    /**
+     * Returns whether a vote body is internally consistent: both the previous root hash and every
+     * intermediate-state hash must be the expected SHA-384 length, the leaf count must be a sane
+     * non-negative value, and the number of intermediate hashes must equal the number of set bits in
+     * the leaf count (the pending-subtree invariant the streaming hasher relies on).
+     *
+     * @param op the vote body
+     * @return true if the body is structurally consistent
+     */
+    private static boolean isStructurallyValid(@NonNull final MigrationRootHashVoteTransactionBody op) {
+        if (op.previousWrappedRecordBlockRootHash().length() != SHA_384_HASH_LENGTH) {
+            return false;
+        }
+        final var leafCount = op.wrappedIntermediateBlockRootsLeafCount();
+        if (leafCount < 0 || leafCount > MAX_INTERMEDIATE_LEAF_COUNT) {
+            return false;
+        }
+        final var intermediateHashes = op.wrappedIntermediatePreviousBlockRootHashes();
+        if (intermediateHashes.size() != Long.bitCount(leafCount)) {
+            return false;
+        }
+        for (final var hash : intermediateHashes) {
+            if (hash.length() != SHA_384_HASH_LENGTH) {
+                return false;
+            }
+        }
+        return true;
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/WritableBlockRecordStoreTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/WritableBlockRecordStoreTest.java
@@ -29,8 +29,30 @@ class WritableBlockRecordStoreTest {
                 .wrappedIntermediateBlockRootsLeafCount(0)
                 .build();
 
-        assertThat(subject.putVoteIfAbsent(0L, vote)).isTrue();
-        assertThat(subject.putVoteIfAbsent(1L, vote)).isTrue();
+        assertThat(subject.putVoteIfAbsent(0L, vote, 3)).isTrue();
+        assertThat(subject.putVoteIfAbsent(1L, vote, 3)).isTrue();
+        assertThat(subject.votes()).hasSize(2);
+    }
+
+    @Test
+    void doesNotAccumulateVotesBeyondTheSuppliedBound() {
+        final var blockInfoRef = new AtomicReference<>(BlockInfo.newBuilder()
+                .migrationRootHashVotes(java.util.List.of())
+                .migrationWrappedHashes(java.util.List.of())
+                .build());
+        final var state = new FunctionWritableSingletonState<>(
+                BLOCKS_STATE_ID, BLOCKS_STATE_LABEL, blockInfoRef::get, blockInfoRef::set);
+        final var writableStates = MapWritableStates.builder().state(state).build();
+        final var subject = new WritableBlockRecordStore(writableStates);
+        final var vote = MigrationRootHashVoteTransactionBody.newBuilder()
+                .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                .wrappedIntermediateBlockRootsLeafCount(0)
+                .build();
+
+        assertThat(subject.putVoteIfAbsent(0L, vote, 2)).isTrue();
+        assertThat(subject.putVoteIfAbsent(1L, vote, 2)).isTrue();
+        // The list is now at the bound, so a vote from a further node is rejected rather than stored
+        assertThat(subject.putVoteIfAbsent(2L, vote, 2)).isFalse();
         assertThat(subject.votes()).hasSize(2);
     }
 

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/handlers/MigrationRootHashVoteHandlerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/records/handlers/MigrationRootHashVoteHandlerTest.java
@@ -2,9 +2,13 @@
 package com.hedera.node.app.records.handlers;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -20,6 +24,7 @@ import com.hedera.node.app.records.WritableBlockRecordStore;
 import com.hedera.node.app.spi.info.NodeInfo;
 import com.hedera.node.app.spi.store.StoreFactory;
 import com.hedera.node.app.spi.workflows.HandleContext;
+import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.PureChecksContext;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
@@ -67,9 +72,113 @@ class MigrationRootHashVoteHandlerTest {
     }
 
     @Test
-    void pureChecksAndPreHandleDoNothing() {
-        assertDoesNotThrow(() -> subject.pureChecks(pureChecksContext));
+    void preHandleDoesNothing() {
         assertDoesNotThrow(() -> subject.preHandle(preHandleContext));
+    }
+
+    @Test
+    void pureChecksAcceptsWellFormedVote() {
+        // 48-byte previous hash; leafCount 0 -> bitCount(0) == 0 -> empty intermediate list
+        lenient()
+                .when(pureChecksContext.body())
+                .thenReturn(bodyFor(MigrationRootHashVoteTransactionBody.newBuilder()
+                        .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                        .wrappedIntermediateBlockRootsLeafCount(0)
+                        .build()));
+
+        assertDoesNotThrow(() -> subject.pureChecks(pureChecksContext));
+    }
+
+    @Test
+    void pureChecksRejectsWrongLengthPreviousHash() {
+        given(pureChecksContext.body())
+                .willReturn(bodyFor(MigrationRootHashVoteTransactionBody.newBuilder()
+                        .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[47])) // not SHA-384 (48)
+                        .wrappedIntermediateBlockRootsLeafCount(0)
+                        .build()));
+
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(pureChecksContext));
+    }
+
+    @Test
+    void pureChecksRejectsWrongLengthIntermediateHash() {
+        // leafCount 1 -> bitCount(1) == 1 -> exactly one intermediate hash expected, but it is the wrong length
+        given(pureChecksContext.body())
+                .willReturn(bodyFor(MigrationRootHashVoteTransactionBody.newBuilder()
+                        .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                        .wrappedIntermediatePreviousBlockRootHashes(List.of(Bytes.wrap(new byte[47])))
+                        .wrappedIntermediateBlockRootsLeafCount(1)
+                        .build()));
+
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(pureChecksContext));
+    }
+
+    @Test
+    void pureChecksRejectsIntermediateListSizeMismatchedWithLeafCount() {
+        // leafCount 0 -> bitCount(0) == 0 expected, but one element is supplied -> structural mismatch
+        given(pureChecksContext.body())
+                .willReturn(bodyFor(MigrationRootHashVoteTransactionBody.newBuilder()
+                        .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                        .wrappedIntermediatePreviousBlockRootHashes(List.of(Bytes.wrap(new byte[48])))
+                        .wrappedIntermediateBlockRootsLeafCount(0)
+                        .build()));
+
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(pureChecksContext));
+    }
+
+    @Test
+    void pureChecksRejectsOutOfRangeLeafCount() {
+        // Long.MIN_VALUE has bitCount 1, so the (size == bitCount) check still passes with one element,
+        // but the leaf count itself is nonsensical (negative as signed / astronomically large as unsigned)
+        given(pureChecksContext.body())
+                .willReturn(bodyFor(MigrationRootHashVoteTransactionBody.newBuilder()
+                        .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                        .wrappedIntermediatePreviousBlockRootHashes(List.of(Bytes.wrap(new byte[48])))
+                        .wrappedIntermediateBlockRootsLeafCount(Long.MIN_VALUE)
+                        .build()));
+
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(pureChecksContext));
+    }
+
+    @Test
+    void pureChecksRejectsEmptyPreviousHash() {
+        // an absent/empty previous hash is not a valid SHA-384 (48-byte) digest
+        given(pureChecksContext.body())
+                .willReturn(bodyFor(MigrationRootHashVoteTransactionBody.newBuilder()
+                        .previousWrappedRecordBlockRootHash(Bytes.EMPTY)
+                        .wrappedIntermediateBlockRootsLeafCount(0)
+                        .build()));
+
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(pureChecksContext));
+    }
+
+    @Test
+    void pureChecksRejectsOversizedIntermediateList() {
+        // leafCount 1 -> bitCount(1) == 1 expected, but two elements are supplied -> structural mismatch
+        given(pureChecksContext.body())
+                .willReturn(bodyFor(MigrationRootHashVoteTransactionBody.newBuilder()
+                        .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                        .wrappedIntermediatePreviousBlockRootHashes(
+                                List.of(Bytes.wrap(new byte[48]), Bytes.wrap(new byte[48])))
+                        .wrappedIntermediateBlockRootsLeafCount(1)
+                        .build()));
+
+        assertThrows(PreCheckException.class, () -> subject.pureChecks(pureChecksContext));
+    }
+
+    @Test
+    void pureChecksAcceptsValidNonZeroLeafCount() {
+        // leafCount 3 (binary 11) -> bitCount == 2 -> exactly two 48-byte intermediate hashes
+        lenient()
+                .when(pureChecksContext.body())
+                .thenReturn(bodyFor(MigrationRootHashVoteTransactionBody.newBuilder()
+                        .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                        .wrappedIntermediatePreviousBlockRootHashes(
+                                List.of(Bytes.wrap(new byte[48]), Bytes.wrap(new byte[48])))
+                        .wrappedIntermediateBlockRootsLeafCount(3)
+                        .build()));
+
+        assertDoesNotThrow(() -> subject.pureChecks(pureChecksContext));
     }
 
     @Test
@@ -82,7 +191,7 @@ class MigrationRootHashVoteHandlerTest {
 
         assertDoesNotThrow(() -> subject.handle(context));
 
-        verify(store, never()).putVoteIfAbsent(anyLong(), any());
+        verify(store, never()).putVoteIfAbsent(anyLong(), any(), anyInt());
     }
 
     @Test
@@ -109,7 +218,7 @@ class MigrationRootHashVoteHandlerTest {
         given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
         given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
         given(store.isVotingComplete()).willReturn(false);
-        given(store.putVoteIfAbsent(NODE_ID, vote)).willReturn(true);
+        given(store.putVoteIfAbsent(eq(NODE_ID), eq(vote), anyInt())).willReturn(true);
         given(rosterStore.getActiveRoster()).willReturn(activeRoster);
         given(store.votes())
                 .willReturn(List.of(NodeMigrationRootHashVote.newBuilder()
@@ -136,9 +245,15 @@ class MigrationRootHashVoteHandlerTest {
         given(context.body()).willReturn(body);
         given(context.creatorInfo()).willReturn(nodeInfo);
         given(nodeInfo.nodeId()).willReturn(NODE_ID);
+        // an eligible submitter, so the flow reaches the duplicate check before returning
+        final var activeRoster = new Roster(List.of(
+                RosterEntry.newBuilder().nodeId(NODE_ID).weight(1L).build(),
+                RosterEntry.newBuilder().nodeId(1L).weight(1L).build()));
         given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
+        given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
         given(store.isVotingComplete()).willReturn(false);
-        given(store.putVoteIfAbsent(NODE_ID, vote)).willReturn(false);
+        given(rosterStore.getActiveRoster()).willReturn(activeRoster);
+        given(store.putVoteIfAbsent(eq(NODE_ID), eq(vote), anyInt())).willReturn(false);
 
         assertDoesNotThrow(() -> subject.handle(context));
 
@@ -164,7 +279,7 @@ class MigrationRootHashVoteHandlerTest {
         given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
         given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
         given(store.isVotingComplete()).willReturn(false);
-        given(store.putVoteIfAbsent(NODE_ID, vote)).willReturn(true);
+        given(store.putVoteIfAbsent(eq(NODE_ID), eq(vote), anyInt())).willReturn(true);
         given(rosterStore.getActiveRoster()).willReturn(activeRoster);
         given(store.votes())
                 .willReturn(List.of(NodeMigrationRootHashVote.newBuilder()
@@ -193,7 +308,6 @@ class MigrationRootHashVoteHandlerTest {
         given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
         given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
         given(store.isVotingComplete()).willReturn(false);
-        given(store.putVoteIfAbsent(NODE_ID, vote)).willReturn(true);
         given(rosterStore.getActiveRoster()).willReturn(null);
 
         assertDoesNotThrow(() -> subject.handle(context));
@@ -218,7 +332,6 @@ class MigrationRootHashVoteHandlerTest {
         given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
         given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
         given(store.isVotingComplete()).willReturn(false);
-        given(store.putVoteIfAbsent(NODE_ID, vote)).willReturn(true);
         given(rosterStore.getActiveRoster()).willReturn(emptyActiveRoster);
 
         assertDoesNotThrow(() -> subject.handle(context));
@@ -246,7 +359,6 @@ class MigrationRootHashVoteHandlerTest {
         given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
         given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
         given(store.isVotingComplete()).willReturn(false);
-        given(store.putVoteIfAbsent(NODE_ID, vote)).willReturn(true);
         given(rosterStore.getActiveRoster()).willReturn(activeRoster);
 
         assertDoesNotThrow(() -> subject.handle(context));
@@ -273,7 +385,6 @@ class MigrationRootHashVoteHandlerTest {
         given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
         given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
         given(store.isVotingComplete()).willReturn(false);
-        given(store.putVoteIfAbsent(NODE_ID, vote)).willReturn(true);
         given(rosterStore.getActiveRoster()).willReturn(activeRoster);
 
         assertDoesNotThrow(() -> subject.handle(context));
@@ -311,7 +422,7 @@ class MigrationRootHashVoteHandlerTest {
         given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
         given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
         given(store.isVotingComplete()).willReturn(false);
-        given(store.putVoteIfAbsent(NODE_ID, vote)).willReturn(true);
+        given(store.putVoteIfAbsent(eq(NODE_ID), eq(vote), anyInt())).willReturn(true);
         given(rosterStore.getActiveRoster()).willReturn(activeRoster);
         given(store.votes())
                 .willReturn(List.of(
@@ -328,5 +439,176 @@ class MigrationRootHashVoteHandlerTest {
         assertDoesNotThrow(() -> subject.handle(context));
 
         verify(store).applyFinalizedValuesAndMarkComplete(any(), any(), anyLong());
+    }
+
+    @Test
+    void handleDoesNotCreditBodilessStoredVoteToTally() {
+        final var vote = MigrationRootHashVoteTransactionBody.newBuilder()
+                .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                .wrappedIntermediateBlockRootsLeafCount(0)
+                .build();
+        final var body = bodyFor(vote);
+        final var queuedHashes = MigrationWrappedHashes.newBuilder()
+                .blockNumber(1L)
+                .consensusTimestampHash(Bytes.wrap(new byte[48]))
+                .outputItemsTreeRootHash(Bytes.wrap(new byte[48]))
+                .build();
+        // submitter (node 0) + two other weight-1 nodes, total 3; threshold is tally*3 > 3, i.e. tally >= 2
+        final var activeRoster = new Roster(List.of(
+                RosterEntry.newBuilder().nodeId(NODE_ID).weight(1L).build(),
+                RosterEntry.newBuilder().nodeId(1L).weight(1L).build(),
+                RosterEntry.newBuilder().nodeId(2L).weight(1L).build()));
+
+        given(context.storeFactory()).willReturn(storeFactory);
+        given(context.body()).willReturn(body);
+        given(context.creatorInfo()).willReturn(nodeInfo);
+        given(nodeInfo.nodeId()).willReturn(NODE_ID);
+        given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
+        given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
+        given(store.isVotingComplete()).willReturn(false);
+        given(store.putVoteIfAbsent(eq(NODE_ID), eq(vote), anyInt())).willReturn(true);
+        given(rosterStore.getActiveRoster()).willReturn(activeRoster);
+        // node 1's stored vote carries NO body; its weight must not be credited to the submitter's op
+        given(store.votes())
+                .willReturn(List.of(
+                        NodeMigrationRootHashVote.newBuilder()
+                                .nodeId(new NodeId(NODE_ID))
+                                .vote(vote)
+                                .build(),
+                        NodeMigrationRootHashVote.newBuilder()
+                                .nodeId(new NodeId(1L))
+                                .build()));
+        lenient().when(store.wrappedHashesInOrder()).thenReturn(List.of(queuedHashes));
+
+        assertDoesNotThrow(() -> subject.handle(context));
+
+        // Only the submitter's own weight (1) backs the op -> below 1/3 -> must not finalize
+        verify(store, never()).applyFinalizedValuesAndMarkComplete(any(), any(), anyLong());
+    }
+
+    @Test
+    void handleDoesNotCreditNodeIdlessStoredVoteToTally() {
+        final var vote = MigrationRootHashVoteTransactionBody.newBuilder()
+                .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                .wrappedIntermediateBlockRootsLeafCount(0)
+                .build();
+        final var body = bodyFor(vote);
+        final var queuedHashes = MigrationWrappedHashes.newBuilder()
+                .blockNumber(1L)
+                .consensusTimestampHash(Bytes.wrap(new byte[48]))
+                .outputItemsTreeRootHash(Bytes.wrap(new byte[48]))
+                .build();
+        // submitter (node 0) + two other weight-1 nodes, total 3; threshold is tally*3 > 3, i.e. tally >= 2
+        final var activeRoster = new Roster(List.of(
+                RosterEntry.newBuilder().nodeId(NODE_ID).weight(1L).build(),
+                RosterEntry.newBuilder().nodeId(1L).weight(1L).build(),
+                RosterEntry.newBuilder().nodeId(2L).weight(1L).build()));
+
+        given(context.storeFactory()).willReturn(storeFactory);
+        given(context.body()).willReturn(body);
+        given(context.creatorInfo()).willReturn(nodeInfo);
+        given(nodeInfo.nodeId()).willReturn(NODE_ID);
+        given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
+        given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
+        given(store.isVotingComplete()).willReturn(false);
+        given(store.putVoteIfAbsent(eq(NODE_ID), eq(vote), anyInt())).willReturn(true);
+        given(rosterStore.getActiveRoster()).willReturn(activeRoster);
+        // a stored entry that carries a vote but NO node id; without the guard it defaults to
+        // NodeId.DEFAULT (id 0) and is miscredited with node 0's weight, doubling the submitter's tally
+        given(store.votes())
+                .willReturn(List.of(
+                        NodeMigrationRootHashVote.newBuilder()
+                                .nodeId(new NodeId(NODE_ID))
+                                .vote(vote)
+                                .build(),
+                        NodeMigrationRootHashVote.newBuilder().vote(vote).build()));
+        lenient().when(store.wrappedHashesInOrder()).thenReturn(List.of(queuedHashes));
+
+        assertDoesNotThrow(() -> subject.handle(context));
+
+        // the node-id-less entry must not alias to node 0 -> only the submitter's own weight (1) backs
+        // the op -> below the 1/3 threshold -> must not finalize
+        verify(store, never()).applyFinalizedValuesAndMarkComplete(any(), any(), anyLong());
+    }
+
+    @Test
+    void handleDoesNotStoreVoteFromZeroWeightNode() {
+        final var vote = MigrationRootHashVoteTransactionBody.newBuilder()
+                .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                .wrappedIntermediateBlockRootsLeafCount(0)
+                .build();
+        final var body = bodyFor(vote);
+        // the submitting node has zero weight in the active roster -> ineligible to vote
+        final var activeRoster = new Roster(List.of(
+                RosterEntry.newBuilder().nodeId(NODE_ID).weight(0L).build(),
+                RosterEntry.newBuilder().nodeId(1L).weight(1L).build()));
+
+        given(context.storeFactory()).willReturn(storeFactory);
+        given(context.body()).willReturn(body);
+        given(context.creatorInfo()).willReturn(nodeInfo);
+        given(nodeInfo.nodeId()).willReturn(NODE_ID);
+        given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
+        given(store.isVotingComplete()).willReturn(false);
+        lenient().when(storeFactory.readableStore(ReadableRosterStore.class)).thenReturn(rosterStore);
+        lenient().when(rosterStore.getActiveRoster()).thenReturn(activeRoster);
+
+        assertDoesNotThrow(() -> subject.handle(context));
+
+        // an ineligible (zero-weight) node's vote must not be persisted
+        verify(store, never()).putVoteIfAbsent(anyLong(), any(), anyInt());
+    }
+
+    @Test
+    void handleDoesNotHaltOnStructurallyInconsistentVote() {
+        // Defense-in-depth check on the consensus handle thread.
+        //
+        // The streaming hasher reconstructs its pending-subtree state from (intermediateHashes, leafCount)
+        // and assumes the number of pending hashes equals Long.bitCount(leafCount). Here leafCount is 1
+        // (one pending subtree expected) but the intermediate-hash list is empty, so the very first fold-up
+        // during finalization pops from an empty list and raises an unchecked exception.
+        //
+        // Such a body is normally rejected upstream during semantic checks, so it should never reach handle()
+        // on the common path. But handle() reconstructs the tally and the hasher from durable state rather
+        // than from the freshly-checked body, so it must not assume the inputs are well-formed: a malformed
+        // vote that does reach finalization must be ignored gracefully, never crash the handle thread, and
+        // never be written into canonical state.
+        final var vote = MigrationRootHashVoteTransactionBody.newBuilder()
+                .previousWrappedRecordBlockRootHash(Bytes.wrap(new byte[48]))
+                .wrappedIntermediateBlockRootsLeafCount(1)
+                .build();
+        final var body = bodyFor(vote);
+        final var queuedHashes = MigrationWrappedHashes.newBuilder()
+                .blockNumber(1L)
+                .consensusTimestampHash(Bytes.wrap(new byte[48]))
+                .outputItemsTreeRootHash(Bytes.wrap(new byte[48]))
+                .build();
+        // single-node roster, so the lone vote already exceeds the 1/3 threshold and finalization is attempted
+        final var activeRoster = new Roster(
+                List.of(RosterEntry.newBuilder().nodeId(NODE_ID).weight(1L).build()));
+
+        given(context.storeFactory()).willReturn(storeFactory);
+        given(context.body()).willReturn(body);
+        given(context.creatorInfo()).willReturn(nodeInfo);
+        given(nodeInfo.nodeId()).willReturn(NODE_ID);
+        given(storeFactory.writableStore(WritableBlockRecordStore.class)).willReturn(store);
+        given(storeFactory.readableStore(ReadableRosterStore.class)).willReturn(rosterStore);
+        given(store.isVotingComplete()).willReturn(false);
+        given(store.putVoteIfAbsent(eq(NODE_ID), eq(vote), anyInt())).willReturn(true);
+        given(rosterStore.getActiveRoster()).willReturn(activeRoster);
+        given(store.votes())
+                .willReturn(List.of(NodeMigrationRootHashVote.newBuilder()
+                        .nodeId(new NodeId(NODE_ID))
+                        .vote(vote)
+                        .build()));
+        lenient().when(store.wrappedHashesInOrder()).thenReturn(List.of(queuedHashes));
+
+        // a malformed vote must not crash the handle thread...
+        assertDoesNotThrow(() -> subject.handle(context));
+        // ...and must not be finalized into canonical state
+        verify(store, never()).applyFinalizedValuesAndMarkComplete(any(), any(), anyLong());
+    }
+
+    private static TransactionBody bodyFor(final MigrationRootHashVoteTransactionBody vote) {
+        return TransactionBody.newBuilder().migrationRootHashVote(vote).build();
     }
 }


### PR DESCRIPTION
Forward-port of #27098 (`release/0.76`) to `release/0.77`.
