### PR TITLE
fix: reject duplicate non-repeated fields when extracting query payment bytes

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/ProtobufUtils.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/util/ProtobufUtils.java
@@ -46,6 +46,12 @@ public class ProtobufUtils {
         if (ProtoWriterTools.wireType(field) != ProtoConstants.WIRE_TYPE_DELIMITED) {
             throw new IllegalArgumentException("Cannot extract field bytes for a non-length-delimited field: " + field);
         }
+        // Scan the whole message rather than returning on the first match. A non-repeated field must
+        // occur at most once; if it occurs more than once this hand-written parser would otherwise keep
+        // the FIRST occurrence, while the canonical PBJ parse used by the rest of the query workflow keeps
+        // the LAST. To stay consistent with that canonical parse, reject the ambiguous input instead of
+        // silently picking one occurrence.
+        Bytes result = null;
         while (input.hasRemaining()) {
             final int tag;
             // hasRemaining() doesn't work very well for streaming data, it returns false only when
@@ -64,17 +70,28 @@ public class ProtobufUtils {
                 if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
                     throw new ParseException("Unexpected wire type: " + tag);
                 }
+                if (result != null) {
+                    throw new ParseException("Duplicate occurrence of non-repeated field: " + field);
+                }
                 final int length = input.readVarInt(false);
-                return input.readBytes(length);
+                result = input.readBytes(length);
             } else {
                 ProtoParserTools.skipField(input, wireType);
             }
         }
-        throw new ParseException("Field not found: " + field);
+        if (result == null) {
+            throw new ParseException("Field not found: " + field);
+        }
+        return result;
     }
 
     @NonNull
     private static Bytes extractQuery(@NonNull final ReadableSequentialData input) throws IOException, ParseException {
+        // The query is a protobuf oneof, so at most one query field may be set. As in extractFieldBytes,
+        // we scan the whole message and reject duplicates (even of different query types) rather than
+        // returning the first: keeping the first here while PBJ keeps the last would make the two parsers
+        // disagree on which query this is. Reject the ambiguous input to stay consistent.
+        Bytes result = null;
         while (input.hasRemaining()) {
             final int tag;
             // hasRemaining() doesn't work very well for streaming data, it returns false only when
@@ -93,12 +110,18 @@ public class ProtobufUtils {
                 if (wireType != ProtoConstants.WIRE_TYPE_DELIMITED) {
                     throw new ParseException("Unexpected wire type: " + tag);
                 }
+                if (result != null) {
+                    throw new ParseException("Duplicate query field");
+                }
                 final int length = input.readVarInt(false);
-                return input.readBytes(length);
+                result = input.readBytes(length);
             } else {
                 ProtoParserTools.skipField(input, wireType);
             }
         }
-        throw new ParseException("Query not found");
+        if (result == null) {
+            throw new ParseException("Query not found");
+        }
+        return result;
     }
 }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/util/ProtobufUtilsTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/util/ProtobufUtilsTest.java
@@ -1,0 +1,163 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.hedera.hapi.node.base.QueryHeader;
+import com.hedera.hapi.node.base.Transaction;
+import com.hedera.hapi.node.base.schema.QueryHeaderSchema;
+import com.hedera.hapi.node.transaction.Query;
+import com.hedera.hapi.node.transaction.Query.QueryOneOfType;
+import com.hedera.hapi.node.transaction.TransactionGetReceiptQuery;
+import com.hedera.hapi.node.transaction.schema.TransactionGetReceiptQuerySchema;
+import com.hedera.pbj.runtime.ParseException;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.io.ByteArrayOutputStream;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link ProtobufUtils#extractPaymentBytes(Bytes)}, the hand-written walker that lifts the payment
+ * transaction out of a serialized {@link Query}.
+ *
+ * <p>The walker must resolve a duplicated non-repeated field the same way as the canonical PBJ parse used by
+ * the rest of the query workflow; otherwise the payment it extracts could differ from the one the rest of the
+ * node acts on. The parser rejects such ambiguity, so the duplicate-field cases below assert a
+ * {@link ParseException} rather than returning a particular occurrence.
+ */
+class ProtobufUtilsTest {
+
+    // protobuf LEN / length-delimited wire type
+    private static final int WIRE_LEN = 2;
+
+    private static final int PAYMENT_FIELD = QueryHeaderSchema.PAYMENT.number();
+    private static final int HEADER_FIELD = TransactionGetReceiptQuerySchema.HEADER.number();
+    private static final int RECEIPT_FIELD = QueryOneOfType.TRANSACTION_GET_RECEIPT.protoOrdinal();
+
+    private static final Bytes PAYMENT_A = Transaction.PROTOBUF.toBytes(Transaction.newBuilder()
+            .signedTransactionBytes(Bytes.wrap(new byte[] {1, 2, 3}))
+            .build());
+    private static final Bytes PAYMENT_B = Transaction.PROTOBUF.toBytes(Transaction.newBuilder()
+            .signedTransactionBytes(Bytes.wrap(new byte[] {7, 8, 9}))
+            .build());
+
+    @Test
+    void extractsPaymentFromWellFormedQuery() throws Exception {
+        final var payment = Transaction.newBuilder()
+                .signedTransactionBytes(Bytes.wrap(new byte[] {1, 2, 3}))
+                .build();
+        final var query = Query.newBuilder()
+                .transactionGetReceipt(TransactionGetReceiptQuery.newBuilder()
+                        .header(QueryHeader.newBuilder().payment(payment)))
+                .build();
+
+        assertEquals(
+                Transaction.PROTOBUF.toBytes(payment),
+                ProtobufUtils.extractPaymentBytes(Query.PROTOBUF.toBytes(query)));
+    }
+
+    @Test
+    void ignoresUnrelatedFieldsWhenExtracting() throws Exception {
+        // A well-formed query prefixed with an unrelated (non-query) field must still resolve correctly.
+        final var wellFormed = query(receipt(header(field(PAYMENT_FIELD, PAYMENT_A))));
+        final var withNoise = concat(field(999, Bytes.wrap(new byte[] {42})), wellFormed);
+
+        assertEquals(PAYMENT_A, ProtobufUtils.extractPaymentBytes(withNoise));
+    }
+
+    @Test
+    void rejectsDuplicatePaymentField() throws Exception {
+        // A QueryHeader whose payment field is present twice (A then B).
+        final var dupHeader = concat(field(PAYMENT_FIELD, PAYMENT_A), field(PAYMENT_FIELD, PAYMENT_B));
+        final var serialized = query(receipt(dupHeader));
+
+        // Our walker refuses the ambiguity...
+        assertThrows(ParseException.class, () -> ProtobufUtils.extractPaymentBytes(serialized));
+
+        // ...whereas the canonical PBJ parse keeps the LAST occurrence — the divergence this parser must not allow.
+        final var pbjPayment = Query.PROTOBUF
+                .parse(serialized.toReadableSequentialData())
+                .transactionGetReceiptOrThrow()
+                .headerOrThrow()
+                .paymentOrThrow();
+        assertEquals(PAYMENT_B, Transaction.PROTOBUF.toBytes(pbjPayment));
+    }
+
+    @Test
+    void rejectsDuplicateHeaderField() {
+        final var goodHeader = field(PAYMENT_FIELD, PAYMENT_A);
+        final var serialized = query(concat(field(HEADER_FIELD, goodHeader), field(HEADER_FIELD, goodHeader)));
+
+        assertThrows(ParseException.class, () -> ProtobufUtils.extractPaymentBytes(serialized));
+    }
+
+    @Test
+    void rejectsDuplicateQueryField() {
+        final var goodReceipt = receipt(header(field(PAYMENT_FIELD, PAYMENT_A)));
+        // The query oneof set twice (even to the same type) is ambiguous and must be rejected.
+        final var serialized = concat(field(RECEIPT_FIELD, goodReceipt), field(RECEIPT_FIELD, goodReceipt));
+
+        assertThrows(ParseException.class, () -> ProtobufUtils.extractPaymentBytes(serialized));
+    }
+
+    @Test
+    void throwsWhenPaymentMissing() {
+        // A valid query and header, but no payment field inside the header.
+        final var serialized = query(receipt(Bytes.EMPTY));
+
+        assertThrows(ParseException.class, () -> ProtobufUtils.extractPaymentBytes(serialized));
+    }
+
+    @Test
+    void throwsWhenQueryMissing() {
+        // Bytes that contain only a non-query field.
+        final var serialized = field(999, Bytes.wrap(new byte[] {42}));
+
+        assertThrows(ParseException.class, () -> ProtobufUtils.extractPaymentBytes(serialized));
+    }
+
+    // --- wire-format helpers: build raw protobuf bytes with full control over field occurrences ---
+
+    private static Bytes query(final Bytes receiptBytes) {
+        return field(RECEIPT_FIELD, receiptBytes);
+    }
+
+    private static Bytes receipt(final Bytes headerBytes) {
+        return field(HEADER_FIELD, headerBytes);
+    }
+
+    private static Bytes header(final Bytes paymentField) {
+        return paymentField;
+    }
+
+    /** Encode a single length-delimited field: tag (fieldNum, LEN) + varint length + value. */
+    private static Bytes field(final int fieldNum, final Bytes value) {
+        final var out = new ByteArrayOutputStream();
+        writeVarint(out, ((long) fieldNum << 3) | WIRE_LEN);
+        final byte[] v = value.toByteArray();
+        writeVarint(out, v.length);
+        out.writeBytes(v);
+        return Bytes.wrap(out.toByteArray());
+    }
+
+    private static Bytes concat(final Bytes... parts) {
+        final var out = new ByteArrayOutputStream();
+        for (final var part : parts) {
+            out.writeBytes(part.toByteArray());
+        }
+        return Bytes.wrap(out.toByteArray());
+    }
+
+    private static void writeVarint(final ByteArrayOutputStream out, long value) {
+        while (true) {
+            final int b = (int) (value & 0x7F);
+            value >>>= 7;
+            if (value != 0) {
+                out.write(b | 0x80);
+            } else {
+                out.write(b);
+                return;
+            }
+        }
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/AbstractEmbeddedHedera.java
@@ -232,6 +232,14 @@ public abstract class AbstractEmbeddedHedera implements EmbeddedHedera {
         return parseQueryResponse(responseBuffer);
     }
 
+    @Override
+    public Response sendQueryRaw(@NonNull final byte[] serializedQuery) {
+        requireNonNull(serializedQuery);
+        final var responseBuffer = BufferedData.allocate(MAX_QUERY_RESPONSE_SIZE);
+        hedera.queryWorkflow().handleQuery(Bytes.wrap(serializedQuery), responseBuffer);
+        return parseQueryResponse(responseBuffer);
+    }
+
     /**
      * If block stream is enabled, notifies the block stream manager of the state hash at the end of the round
      * given by {@code roundNumber}. (The block stream manager must have this information to construct the

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/junit/hedera/embedded/EmbeddedHedera.java
@@ -128,6 +128,17 @@ public interface EmbeddedHedera {
     Response send(@NonNull Query query, @NonNull AccountID nodeAccountId, final boolean asNodeOperator);
 
     /**
+     * Sends a query given as already-serialized bytes to the embedded node, bypassing the {@link Query} builder.
+     * This lets tests exercise wire encodings the builder cannot produce (for example a non-repeated field that
+     * appears more than once), which is otherwise impossible because the normal send path re-serializes a
+     * {@link Query} object and therefore always emits a canonical encoding.
+     *
+     * @param serializedQuery the raw, already-serialized query bytes to submit
+     * @return the response to the query
+     */
+    Response sendQueryRaw(@NonNull byte[] serializedQuery);
+
+    /**
      * Submits a transaction to the embedded node.
      * @param transaction the transaction to submit
      * @param nodeAccountId the account ID of the node to submit the transaction to

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/queries/DuplicateQueryPaymentFieldTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/queries/DuplicateQueryPaymentFieldTest.java
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.queries;
+
+import static com.hedera.services.bdd.junit.EmbeddedReason.NEEDS_STATE_ACCESS;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INVALID_QUERY_HEADER;
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import com.google.protobuf.ByteString;
+import com.hedera.services.bdd.junit.EmbeddedHapiTest;
+import com.hederahashgraph.api.proto.java.CryptoGetInfoQuery;
+import com.hederahashgraph.api.proto.java.Query;
+import com.hederahashgraph.api.proto.java.QueryHeader;
+import com.hederahashgraph.api.proto.java.ResponseType;
+import com.hederahashgraph.api.proto.java.Transaction;
+import java.io.ByteArrayOutputStream;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DynamicTest;
+
+/**
+ * Demonstrates end-to-end that the embedded node resolves a duplicated non-repeated field in a paid query the
+ * same way as the canonical parse used for the rest of the query workflow.
+ *
+ * <p>A paid query (here {@code CryptoGetInfo} with {@code ANSWER_ONLY}) carries its payment in
+ * {@code QueryHeader.payment}. The workflow lifts the payment out with a hand-written walker
+ * ({@code ProtobufUtils}) to verify and submit it, while it parses the whole query with PBJ, which keeps the
+ * <b>last</b> occurrence of a duplicated field. If the walker kept the <b>first</b> occurrence instead, a query
+ * that encodes the payment twice would have its first payment verified and submitted while the rest of the node
+ * acted on the last — the two would disagree on the payment. The walker now rejects any such duplicate, so a
+ * duplicate-payment query is refused with the {@code INVALID_QUERY_HEADER} status.
+ *
+ * <p>This runs only in embedded mode because a duplicate non-repeated field cannot be produced through the
+ * normal gRPC/builder send path — protobuf always serializes a canonical, single-occurrence encoding — so the
+ * test hands the node raw crafted bytes directly through the in-process query workflow.
+ */
+public class DuplicateQueryPaymentFieldTest {
+
+    @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
+    final Stream<DynamicTest> nodeRejectsPaidQueryWithDuplicatePaymentField() {
+        return hapiTest(doingContextual(spec -> {
+            final var paymentA = Transaction.newBuilder()
+                    .setSignedTransactionBytes(ByteString.copyFromUtf8("payment-A"))
+                    .build();
+            final var paymentB = Transaction.newBuilder()
+                    .setSignedTransactionBytes(ByteString.copyFromUtf8("payment-B"))
+                    .build();
+
+            // Control: a well-formed paid query with a SINGLE payment. It gets past the payment walker and fails
+            // later during payment verification (the payment is deliberately not a valid signed transfer), i.e.
+            // with some status other than INVALID_QUERY_HEADER.
+            final var singlePayment = Query.newBuilder()
+                    .setCryptoGetInfo(CryptoGetInfoQuery.newBuilder()
+                            .setHeader(QueryHeader.newBuilder()
+                                    .setResponseType(ResponseType.ANSWER_ONLY)
+                                    .setPayment(paymentA)))
+                    .build()
+                    .toByteArray();
+
+            // Duplicate: a QueryHeader whose payment field appears twice (A then B). Built by concatenating a
+            // header carrying (responseType, payment=A) with a header carrying (payment=B); protobuf treats the
+            // concatenation as one QueryHeader whose payment field is present twice, and PBJ keeps payment=B.
+            final var headerWithA = QueryHeader.newBuilder()
+                    .setResponseType(ResponseType.ANSWER_ONLY)
+                    .setPayment(paymentA)
+                    .build()
+                    .toByteArray();
+            final var headerWithB =
+                    QueryHeader.newBuilder().setPayment(paymentB).build().toByteArray();
+            final var duplicatePaymentHeader = concat(headerWithA, headerWithB);
+            final var duplicatePayment = lenField(
+                    Query.CRYPTOGETINFO_FIELD_NUMBER,
+                    lenField(CryptoGetInfoQuery.HEADER_FIELD_NUMBER, duplicatePaymentHeader));
+
+            final var embedded = spec.embeddedHederaOrThrow();
+            final var singleCode = embedded.sendQueryRaw(singlePayment)
+                    .getCryptoGetInfo()
+                    .getHeader()
+                    .getNodeTransactionPrecheckCode();
+            final var duplicateCode = embedded.sendQueryRaw(duplicatePayment)
+                    .getCryptoGetInfo()
+                    .getHeader()
+                    .getNodeTransactionPrecheckCode();
+
+            // The duplicate-payment query is refused by the payment walker before any verification.
+            assertEquals(INVALID_QUERY_HEADER, duplicateCode);
+            // The single-payment query is not refused by the walker — it reaches payment verification and fails
+            // there — which confirms INVALID_QUERY_HEADER above is specifically the duplicate being rejected.
+            assertNotEquals(INVALID_QUERY_HEADER, singleCode);
+        }));
+    }
+
+    /**
+     * The positive counterpart of the test above: the FIRST of the two payment occurrences is a genuinely valid,
+     * signed payment (captured from a real successful paid query), so without the fix the node would extract and
+     * verify that valid payment and answer the query — i.e. the checks would pass on an ambiguous-payment query
+     * whose canonical (PBJ, last-wins) reading names a different payment. With the fix the duplicate is refused
+     * with {@code INVALID_QUERY_HEADER} before any verification.
+     */
+    @EmbeddedHapiTest(NEEDS_STATE_ACCESS)
+    final Stream<DynamicTest> nodeRejectsPaidQueryWhoseValidFirstPaymentIsDuplicated() {
+        final AtomicReference<Query> validQuery = new AtomicReference<>();
+        return hapiTest(
+                cryptoCreate("payer").balance(ONE_HUNDRED_HBARS),
+                cryptoCreate("target"),
+                // Let the framework build a real, signed, funded ANSWER_ONLY payment; capture it. We then strip the
+                // payment from the query the framework actually sends so its transaction id is never submitted —
+                // otherwise reusing it in our raw send below would trip ingest de-duplication. The framework send
+                // therefore fails with INVALID_QUERY_HEADER (payment required but absent), which we expect.
+                getAccountInfo("target")
+                        .payingWith("payer")
+                        .hasAnswerOnlyPrecheck(INVALID_QUERY_HEADER)
+                        .withQueryMutation((query, spec) -> {
+                            if (!query.hasCryptoGetInfo()
+                                    || query.getCryptoGetInfo().getHeader().getResponseType()
+                                            != ResponseType.ANSWER_ONLY) {
+                                return query;
+                            }
+                            validQuery.set(query);
+                            return query.toBuilder()
+                                    .setCryptoGetInfo(query.getCryptoGetInfo().toBuilder()
+                                            .setHeader(query.getCryptoGetInfo().getHeader().toBuilder()
+                                                    .clearPayment()))
+                                    .build();
+                        }),
+                doingContextual(spec -> {
+                    final var valid = requireNonNull(validQuery.get(), "did not capture a paid ANSWER_ONLY query");
+                    final var cryptoGetInfo = valid.getCryptoGetInfo();
+                    final var validPayment = cryptoGetInfo.getHeader().getPayment();
+                    // A second, different payment appended after the valid one, so first != last.
+                    final var shadowPayment = Transaction.newBuilder()
+                            .setSignedTransactionBytes(ByteString.copyFromUtf8("shadow-payment"))
+                            .build();
+
+                    // A QueryHeader whose payment field appears twice: the valid payment first, the shadow last.
+                    final var headerWithValid = QueryHeader.newBuilder()
+                            .setResponseType(ResponseType.ANSWER_ONLY)
+                            .setPayment(validPayment)
+                            .build()
+                            .toByteArray();
+                    final var headerWithShadow = QueryHeader.newBuilder()
+                            .setPayment(shadowPayment)
+                            .build()
+                            .toByteArray();
+                    final var duplicatePaymentHeader = concat(headerWithValid, headerWithShadow);
+
+                    // Rebuild the CryptoGetInfoQuery preserving the queried account id, so that without the fix the
+                    // query is fully answerable once its (valid, first) payment clears.
+                    final var accountIdField = CryptoGetInfoQuery.newBuilder()
+                            .setAccountID(cryptoGetInfo.getAccountID())
+                            .build()
+                            .toByteArray();
+                    final var cryptoGetInfoBytes = concat(
+                            lenField(CryptoGetInfoQuery.HEADER_FIELD_NUMBER, duplicatePaymentHeader), accountIdField);
+                    final var duplicatePayment = lenField(Query.CRYPTOGETINFO_FIELD_NUMBER, cryptoGetInfoBytes);
+
+                    final var code = spec.embeddedHederaOrThrow()
+                            .sendQueryRaw(duplicatePayment)
+                            .getCryptoGetInfo()
+                            .getHeader()
+                            .getNodeTransactionPrecheckCode();
+                    assertEquals(INVALID_QUERY_HEADER, code);
+                }));
+    }
+
+    /** Encode a single length-delimited protobuf field: tag (fieldNumber, wire type 2) + length + value. */
+    private static byte[] lenField(final int fieldNumber, final byte[] value) {
+        final var out = new ByteArrayOutputStream();
+        writeVarint(out, ((long) fieldNumber << 3) | 2);
+        writeVarint(out, value.length);
+        out.writeBytes(value);
+        return out.toByteArray();
+    }
+
+    private static byte[] concat(final byte[] a, final byte[] b) {
+        final var out = new ByteArrayOutputStream();
+        out.writeBytes(a);
+        out.writeBytes(b);
+        return out.toByteArray();
+    }
+
+    private static void writeVarint(final ByteArrayOutputStream out, long value) {
+        while (true) {
+            final int b = (int) (value & 0x7F);
+            value >>>= 7;
+            if (value != 0) {
+                out.write(b | 0x80);
+            } else {
+                out.write(b);
+                return;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Forward-port of #27100 (`release/0.76`) to `release/0.77`.
