### PR TITLE
fix: fold beneficiary mappings into the root builder at staking finalization

### DIFF
--- a/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/DeleteCapableTransactionStreamBuilder.java
+++ b/hedera-node/hedera-app-spi/src/main/java/com/hedera/node/app/spi/workflows/record/DeleteCapableTransactionStreamBuilder.java
@@ -5,6 +5,7 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.HederaFunctionality;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.function.BiConsumer;
 
 /**
  * Base record builder for any transaction that can delete accounts or contracts. These include,
@@ -44,4 +45,16 @@ public interface DeleteCapableTransactionStreamBuilder extends StreamBuilder {
      */
     void addBeneficiaryForDeletedAccount(
             @NonNull AccountID deletedAccountID, @NonNull AccountID beneficiaryForDeletedAccount);
+
+    /**
+     * Visits every {@code (deletedAccountId -> beneficiaryAccountId)} entry recorded on this builder.
+     *
+     * <p>This is needed at root staking-reward finalization to fold in the beneficiaries recorded by
+     * child dispatches (for example, the inner {@code CryptoDelete}, {@code ContractDelete}, or EVM
+     * self-destruct of an atomic batch, each of which records on its own dispatch's builder rather than
+     * the root builder that the reward redirect consults).
+     *
+     * @param action the action to invoke for each deleted-account/beneficiary pair
+     */
+    void forEachDeletedAccountBeneficiary(@NonNull BiConsumer<AccountID, AccountID> action);
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
@@ -128,6 +128,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.apache.logging.log4j.LogManager;
@@ -1470,6 +1471,12 @@ public class BlockStreamBuilder
     @Nullable
     public AccountID getDeletedAccountBeneficiaryFor(@NonNull final AccountID deletedAccountID) {
         return deletedAccountBeneficiaries.get(deletedAccountID);
+    }
+
+    @Override
+    public void forEachDeletedAccountBeneficiary(@NonNull final BiConsumer<AccountID, AccountID> action) {
+        requireNonNull(action);
+        deletedAccountBeneficiaries.forEach(action);
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/PairedStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/PairedStreamBuilder.java
@@ -71,6 +71,7 @@ import edu.umd.cs.findbugs.annotations.Nullable;
 import java.time.Instant;
 import java.util.List;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 
 /**
@@ -736,6 +737,11 @@ public class PairedStreamBuilder
     @Override
     public AccountID getDeletedAccountBeneficiaryFor(@NonNull AccountID deletedAccountID) {
         return recordStreamBuilder.getDeletedAccountBeneficiaryFor(deletedAccountID);
+    }
+
+    @Override
+    public void forEachDeletedAccountBeneficiary(@NonNull final BiConsumer<AccountID, AccountID> action) {
+        recordStreamBuilder.forEachDeletedAccountBeneficiary(action);
     }
 
     @Override

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/record/RecordStreamBuilder.java
@@ -96,6 +96,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BiConsumer;
 import java.util.function.Predicate;
 import org.hiero.base.crypto.DigestType;
 
@@ -1387,6 +1388,12 @@ public class RecordStreamBuilder
     @Nullable
     public AccountID getDeletedAccountBeneficiaryFor(@NonNull final AccountID deletedAccountID) {
         return deletedAccountBeneficiaries.get(deletedAccountID);
+    }
+
+    @Override
+    public void forEachDeletedAccountBeneficiary(@NonNull final BiConsumer<AccountID, AccountID> action) {
+        requireNonNull(action);
+        deletedAccountBeneficiaries.forEach(action);
     }
 
     /**

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockStreamBuilderTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/BlockStreamBuilderTest.java
@@ -43,7 +43,9 @@ import com.hedera.hapi.streams.ContractActionType;
 import com.hedera.node.app.blocks.impl.BlockStreamBuilder;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -304,5 +306,24 @@ public class BlockStreamBuilderTest {
         return new BlockStreamBuilder(REVERSIBLE, NOOP_SIGNED_TX_CUSTOMIZER, USER)
                 .signedTx(signedTx)
                 .serializedSignedTx(signedTxBytes);
+    }
+
+    @Test
+    void tracksAndEnumeratesDeletedAccountBeneficiaries() {
+        final var deletedA = AccountID.newBuilder().accountNum(1001).build();
+        final var beneficiaryA = AccountID.newBuilder().accountNum(1002).build();
+        final var deletedB = AccountID.newBuilder().accountNum(1003).build();
+        final var beneficiaryB = AccountID.newBuilder().accountNum(1004).build();
+
+        final var builder = new BlockStreamBuilder(REVERSIBLE, NOOP_SIGNED_TX_CUSTOMIZER, USER);
+        builder.addBeneficiaryForDeletedAccount(deletedA, beneficiaryA);
+        builder.addBeneficiaryForDeletedAccount(deletedB, beneficiaryB);
+
+        assertThat(builder.getNumberOfDeletedAccounts()).isEqualTo(2);
+        assertThat(builder.getDeletedAccountBeneficiaryFor(deletedB)).isEqualTo(beneficiaryB);
+
+        final Map<AccountID, AccountID> visited = new HashMap<>();
+        builder.forEachDeletedAccountBeneficiary(visited::put);
+        assertThat(visited).hasSize(2).containsEntry(deletedA, beneficiaryA).containsEntry(deletedB, beneficiaryB);
     }
 }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.service.token.impl.handlers.staking;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.REVERTED_SUCCESS;
 import static com.hedera.node.app.service.token.api.AccountSummariesApi.SENTINEL_NODE_ID;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakeIdChangeType.FROM_ACCOUNT_TO_ACCOUNT;
 import static com.hedera.node.app.service.token.impl.handlers.staking.StakingRewardsHelper.getAllRewardReceivers;
@@ -90,6 +91,22 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
         rewardReceivers.removeAll(prePaidRewards.keySet());
         // Pay rewards to all possible reward receivers, returns all rewards paid
         final var recordBuilder = context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class);
+        // Child dispatches (e.g. the inner CryptoDelete/ContractDelete/self-destruct of an atomic batch)
+        // record their deleted-account beneficiaries on their own dispatch builder, not the root builder
+        // consulted below. Fold those into the root builder so a reward owed to an account deleted inside a
+        // child dispatch is redirected to its beneficiary, instead of tripping the redirect loop. This map
+        // is transient staking scratch (it is not serialized into the record); any future record
+        // serialization must exclude these folded child-dispatch entries.
+        context.forEachChildRecord(DeleteCapableTransactionStreamBuilder.class, child -> {
+            // Only fold committed child dispatches. forEachChildRecord also hands back reverted
+            // REVERSIBLE children (rollback keeps them in the list and does not clear their
+            // beneficiary map); a reverted delete leaves the account non-deleted, so its stale entry
+            // would never be consulted, but skipping it keeps the redirect's bound exact and rules out
+            // any fold-order ambiguity if the same account were deleted more than once in one txn.
+            if (child.status() != REVERTED_SUCCESS) {
+                child.forEachDeletedAccountBeneficiary(recordBuilder::addBeneficiaryForDeletedAccount);
+            }
+        });
         final var rewardsPaid = rewardsPayer.payRewardsIfPending(
                 rewardReceivers,
                 stakingRewardAccountId,

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
@@ -8,7 +8,10 @@ import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.AC
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
 import com.hedera.hapi.node.base.AccountID;
@@ -40,7 +43,10 @@ import java.time.LocalDate;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -914,6 +920,98 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
         assertThat(rewards).hasSize(1);
         // because the transferId is owner for the deleted payer account
         assertThat(rewards).containsEntry(ownerId, 178900L);
+    }
+
+    @Test
+    void redirectsRewardForAccountDeletedInChildDispatch() {
+        // Same reward situation as rewardsUltimateBeneficiaryInsteadOfDeletedAccount, except the
+        // deleted -> beneficiary mapping is recorded on a CHILD dispatch builder (as happens for the
+        // inner CryptoDelete of an atomic batch), not on the root builder consulted by the redirect.
+        // The handler must fold the child mapping into the root builder, otherwise the redirect loop
+        // throws IllegalStateException and the batch is rolled back to a zero-fee FAIL_INVALID record.
+        final var accountBalance = 555L * HBARS_TO_TINYBARS;
+        final var ownerBalance = 111L * HBARS_TO_TINYBARS;
+        final var payerAccountBefore = new AccountCustomizer()
+                .withAccount(account)
+                .withBalance(accountBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(true)
+                .build();
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(ownerBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .build();
+        addToState(Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore));
+
+        writableAccountStore.put(payerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(0)
+                .stakedNodeId(0L)
+                .build());
+        writableAccountStore.put(ownerAccountBefore
+                .copyBuilder()
+                .tinybarBalance(ownerBalance + accountBalance)
+                .stakedNodeId(0L)
+                .build());
+        writableAccountStore.put(Account.newBuilder()
+                .accountId(AccountID.newBuilder().accountNum(800).build())
+                .tinybarBalance(123L * HBARS_TO_TINYBARS)
+                .build());
+
+        given(context.consensusTime())
+                .willReturn(LocalDate.ofEpochDay(stakePeriodStart + 2)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
+                .willReturn(recordBuilder);
+
+        // The root builder starts with an EMPTY deleted-account map; the mapping only exists on the
+        // child dispatch builder. Back the root builder mock with a real map so the fold is observable.
+        final Map<AccountID, AccountID> rootBeneficiaries = new HashMap<>();
+        given(recordBuilder.getNumberOfDeletedAccounts()).willAnswer(inv -> rootBeneficiaries.size());
+        given(recordBuilder.getDeletedAccountBeneficiaryFor(any()))
+                .willAnswer(inv -> rootBeneficiaries.get(inv.<AccountID>getArgument(0)));
+        doAnswer(inv -> {
+                    rootBeneficiaries.put(inv.getArgument(0), inv.getArgument(1));
+                    return null;
+                })
+                .when(recordBuilder)
+                .addBeneficiaryForDeletedAccount(any(), any());
+
+        // A child dispatch recorded (payer -> owner) on its own builder; expose it via forEachChildRecord.
+        final DeleteCapableTransactionStreamBuilder childBuilder = mock(DeleteCapableTransactionStreamBuilder.class);
+        doAnswer(inv -> {
+                    final BiConsumer<AccountID, AccountID> action = inv.getArgument(0);
+                    action.accept(payerId, ownerId);
+                    return null;
+                })
+                .when(childBuilder)
+                .forEachDeletedAccountBeneficiary(any());
+        doAnswer(inv -> {
+                    final Consumer<DeleteCapableTransactionStreamBuilder> consumer = inv.getArgument(1);
+                    consumer.accept(childBuilder);
+                    return null;
+                })
+                .when(context)
+                .forEachChildRecord(eq(DeleteCapableTransactionStreamBuilder.class), any());
+
+        stakePeriodManager.setCurrentStakePeriodFor(context.consensusTime());
+        mockEntityIdFactory();
+
+        final var rewards = subject.applyStakingRewards(context, Collections.emptySet(), emptyMap());
+
+        // The reward is redirected to the (non-deleted) beneficiary, exactly as in the non-batch case.
+        assertThat(rewards).hasSize(1);
+        assertThat(rewards).containsEntry(ownerId, 178900L);
+        // And the child dispatch's mapping was folded into the root builder.
+        assertThat(rootBeneficiaries).containsEntry(payerId, ownerId);
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
@@ -8,9 +8,11 @@ import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.AC
 import static java.util.Collections.emptyMap;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willAnswer;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
@@ -1193,6 +1195,124 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
         final var node0InfoAfter = writableStakingInfoStore.get(node0Id.number());
         assertThat(node0InfoAfter.stakeToReward()).isEqualTo(node0InfoBefore.stakeToReward() - HBARS_TO_TINYBARS);
         assertThat(node0InfoAfter.unclaimedStakeRewardStart()).isZero();
+    }
+
+    @Test
+    void redirectsRewardOfStakeeDeletedInInnerBatchTransactionToBeneficiary() {
+        // Atomic-batch case of the deleted-stakee freeze, exercising the child-dispatch beneficiary fold. In an
+        // atomic batch the stakee is deleted by an inner (BATCH_INNER) transaction, which does not pay staking
+        // rewards and records its delete->beneficiary mapping only on its own child record builder. Reward
+        // finalization runs once, on the parent batch, where the stakee's start-of-batch (original) value is
+        // still non-deleted -- so it is (correctly) rediscovered as a reward receiver whose reward must be
+        // redirected to the beneficiary. Without folding the child builder's mapping onto the parent (root)
+        // builder, payRewardsIfPending throws IllegalStateException (parent has no beneficiary,
+        // getNumberOfDeletedAccounts() == 0) and the batch is rolled back to a zero-fee FAIL_INVALID record.
+        // Complements redirectsRewardForAccountDeletedInChildDispatch (a node staker deleted in a PRIOR txn):
+        // here the deleted account is a node stakee with an indirect staker, deleted in the CURRENT txn, so it
+        // also exercises the node-stake settlement path (its stake is withdrawn exactly once).
+        final var accountBalance = 55L * HBARS_TO_TINYBARS;
+        // The indirect staker (payer) stakes to the stakee (owner) and is touched in the batch.
+        final var payerAccountBefore = new AccountCustomizer()
+                .withAccount(account)
+                .withBalance(accountBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedToMe(0L)
+                .withStakedAccountId(ownerId)
+                .build();
+        // The rewardable stakee is NOT deleted at the start of the batch; unlike the prior-transaction case, it
+        // is deleted only by an inner transaction within this batch, so its original value is still non-deleted.
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(0L)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedNodeId(node0Id.number())
+                .withStakedToMe(accountBalance)
+                .build();
+        // transferAccount is the beneficiary the inner CryptoDelete redirected the stakee's balance to.
+        addToState(
+                Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore, transferAccountId, transferAccount));
+
+        mockEntityIdFactory();
+
+        final var node0InfoBefore = writableStakingInfoState.get(node0Id);
+
+        // The staker sends 1 hbar, which rediscovers the (still non-deleted at start-of-batch) stakee.
+        writableAccountStore.put(account.copyBuilder()
+                .tinybarBalance(accountBalance - HBARS_TO_TINYBARS)
+                .stakedAccountId(ownerId)
+                .build());
+        // The inner transaction marked the stakee deleted (its remaining balance moved to the beneficiary).
+        writableAccountStore.put(ownerAccountBefore
+                .copyBuilder()
+                .deleted(true)
+                .tinybarBalance(0L)
+                .build());
+
+        given(context.consensusTime())
+                .willReturn(LocalDate.ofEpochDay(stakePeriodStart + 2)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        stakePeriodManager.setCurrentStakePeriodFor(context.consensusTime());
+
+        // The parent (root) builder starts WITHOUT any deleted-account beneficiary (the mapping is on the inner
+        // delete's child builder). Back it with a real map so the fold -> redirect chain is exercised for real.
+        final Map<AccountID, AccountID> rootBeneficiaries = new HashMap<>();
+        given(context.userTransactionRecordBuilder(DeleteCapableTransactionStreamBuilder.class))
+                .willReturn(recordBuilder);
+        willAnswer(inv -> {
+                    rootBeneficiaries.put(inv.getArgument(0), inv.getArgument(1));
+                    return null;
+                })
+                .given(recordBuilder)
+                .addBeneficiaryForDeletedAccount(any(AccountID.class), any(AccountID.class));
+        given(recordBuilder.getNumberOfDeletedAccounts()).willAnswer(inv -> rootBeneficiaries.size());
+        given(recordBuilder.getDeletedAccountBeneficiaryFor(any(AccountID.class)))
+                .willAnswer(inv -> rootBeneficiaries.get(inv.<AccountID>getArgument(0)));
+
+        // The inner (child) dispatch builder carries the delete->beneficiary mapping, exposed the same way the
+        // production fold reads it -- via forEachDeletedAccountBeneficiary, as CryptoDelete records it.
+        final var childRecordBuilder = mock(DeleteCapableTransactionStreamBuilder.class);
+        willAnswer(inv -> {
+                    final BiConsumer<AccountID, AccountID> action = inv.getArgument(0);
+                    action.accept(ownerId, transferAccountId);
+                    return null;
+                })
+                .given(childRecordBuilder)
+                .forEachDeletedAccountBeneficiary(any());
+        willAnswer(inv -> {
+                    final Consumer<DeleteCapableTransactionStreamBuilder> consumer = inv.getArgument(1);
+                    consumer.accept(childRecordBuilder);
+                    return null;
+                })
+                .given(context)
+                .forEachChildRecord(eq(DeleteCapableTransactionStreamBuilder.class), any());
+
+        // Finalization must not throw (it used to fail with IllegalStateException), and the reward must be
+        // redirected to the beneficiary exactly once -- never to the deleted stakee.
+        final var rewards =
+                assertDoesNotThrow(() -> subject.applyStakingRewards(context, Collections.emptySet(), emptyMap()));
+        assertThat(rewards).hasSize(1).containsKey(transferAccountId).doesNotContainKey(ownerId);
+        assertThat(rewards.get(transferAccountId)).isPositive();
+
+        // The child dispatch's mapping was folded into the parent (root) builder.
+        assertThat(rootBeneficiaries).containsEntry(ownerId, transferAccountId);
+
+        // A batch has a single finalization, so the delete settles the stakee's node stake exactly once --
+        // withdrawn, and not re-awarded because the account is deleted -- exactly as a standalone CryptoDelete
+        // does; the indirect-staker touch adds no further change. So stakeToReward drops by precisely the
+        // stakee's totalStake: neither left stale (no withdrawal) nor drained twice. That a LATER transaction
+        // touching the orphaned staker must not re-withdraw is covered by
+        // doesNotWithdrawNodeStakeForStakeeDeletedInPriorTransaction.
+        final var node0InfoAfter = writableStakingInfoStore.get(node0Id.number());
+        assertThat(node0InfoAfter.stakeToReward())
+                .isEqualTo(node0InfoBefore.stakeToReward() - roundedToHbar(totalStake(ownerAccountBefore)));
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/AtomicBatchStakedDeleteRewardRedirectionTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/AtomicBatchStakedDeleteRewardRedirectionTest.java
@@ -1,0 +1,504 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.staking;
+
+import static com.hedera.node.app.service.token.impl.schemas.V0490TokenSchema.STAKING_NETWORK_REWARDS_STATE_ID;
+import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_STATE_ACCESS;
+import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION;
+import static com.hedera.services.bdd.junit.TestTags.INTEGRATION;
+import static com.hedera.services.bdd.junit.hedera.embedded.EmbeddedMode.REPEATABLE;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountInfo;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCall;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.contractDelete;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.uploadInitCode;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.EmbeddedVerbs.viewSingleton;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertionsHold;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingAllOf;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilStartOfNextStakingPeriod;
+import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.STAKING_REWARD;
+import static com.hedera.services.bdd.suites.HapiSuite.flattened;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
+import com.hedera.hapi.node.state.token.NetworkStakingRewards;
+import com.hedera.node.app.service.token.TokenService;
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.LeakyRepeatableHapiTest;
+import com.hedera.services.bdd.junit.TargetEmbeddedMode;
+import com.hedera.services.bdd.spec.transactions.HapiTxnOp;
+import com.hederahashgraph.api.proto.java.CryptoGetInfoResponse.AccountInfo;
+import com.hederahashgraph.api.proto.java.TransactionRecord;
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DynamicTest;
+import org.junit.jupiter.api.Tag;
+
+/**
+ * Regression test for the atomic-batch staked-delete finalization bug. A reported proof-of-concept
+ * showed that an atomic batch whose final inner transaction deletes a staked account with a positive
+ * pending staking reward threw {@code IllegalStateException} from root staking-reward finalization,
+ * which escaped every fee-charging boundary and replaced the whole batch with a zero-fee {@code
+ * FAIL_INVALID} record (rolling back all inner work and all fees, for free, repeatably).
+ *
+ * <p>This is the inverted proof-of-concept: the same fifteen fee-bearing storage-writing contract
+ * calls followed by a valid staked delete, asserting the FIXED behavior — the batch succeeds, the
+ * deleted account's reward is redirected to its beneficiary, every inner record persists, and fees
+ * are charged.
+ */
+@Tag(INTEGRATION)
+@HapiTestLifecycle
+@TargetEmbeddedMode(REPEATABLE)
+class AtomicBatchStakedDeleteRewardRedirectionTest {
+    private static final String SLOT_USER = "SlotUser";
+    // A contract with a payable constructor, so the staked contract can be created holding an HBAR balance.
+    private static final String PAYABLE_CONTRACT = "PayableConstructor";
+    private static final String BATCH_KEY = "rewardRedirectBatchKey";
+    private static final String WORK_PAYER = "rewardRedirectWorkPayer";
+    private static final String OUTER_PAYER = "rewardRedirectOuterPayer";
+    private static final String STAKED_ATTACKER = "rewardRedirectStakedAttacker";
+    private static final String DELETE_BENEFICIARY = "rewardRedirectBeneficiary";
+    private static final String WORK_PREFIX = "rewardRedirectWork";
+    private static final String DELETE_INNER = "rewardRedirectDeleteInner";
+    private static final String EXPLOIT_BATCH = "rewardRedirectBatch";
+    private static final String ATTACKER_BEFORE = "rewardRedirectAttackerBefore";
+
+    private static final String CONTRACT_ADMIN_KEY = "rewardRedirectContractAdminKey";
+    private static final String STAKED_CONTRACT = "rewardRedirectStakedContract";
+    private static final String CONTRACT_DELETE_BENEFICIARY = "rewardRedirectContractBeneficiary";
+    private static final String CONTRACT_DELETE_PAYER = "rewardRedirectContractDeletePayer";
+    private static final String CONTRACT_OUTER_PAYER = "rewardRedirectContractOuterPayer";
+    private static final String CONTRACT_DELETE_INNER = "rewardRedirectContractDeleteInner";
+    private static final String CONTRACT_BATCH = "rewardRedirectContractBatch";
+
+    // A payable contract that self-destructs (EVM SELFDESTRUCT) to msg.sender via its {@code destroy()} method.
+    private static final String SELF_DESTRUCT_CONTRACT = "SelfDestructCallable";
+    private static final String SD_WORK_PAYER = "rewardRedirectSdWorkPayer";
+    private static final String SD_CALL_PAYER = "rewardRedirectSdCallPayer";
+    private static final String SD_OUTER_PAYER = "rewardRedirectSdOuterPayer";
+    private static final String SD_INNER = "rewardRedirectSdInner";
+    private static final String SD_BATCH = "rewardRedirectSdBatch";
+
+    private static final int WORK_INNER_COUNT = 15;
+    private static final long GAS_LIMIT = 500_000L;
+    private static final long CONTRACT_CREATE_GAS = 1_000_000L;
+
+    @LeakyRepeatableHapiTest(
+            value = {NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION, NEEDS_STATE_ACCESS},
+            overrides = {
+                "staking.startThreshold",
+                "staking.perHbarRewardRate",
+                "staking.rewardBalanceThreshold",
+                "staking.requireMinStakeToReward"
+            })
+    final Stream<DynamicTest> stakedDeleteInAtomicBatchRedirectsRewardAndChargesFees() {
+        final var attackerPendingReward = new AtomicLong();
+        final var beneficiaryBefore = new AtomicLong();
+        final var beneficiaryAfter = new AtomicLong();
+        final var workPayerBefore = new AtomicLong();
+        final var workPayerAfter = new AtomicLong();
+        final var outerPayerBefore = new AtomicLong();
+        final var outerPayerAfter = new AtomicLong();
+        final var networkPendingBefore = new AtomicLong();
+        final var networkPendingAfter = new AtomicLong();
+        final var batchRecord = new AtomicReference<TransactionRecord>();
+        final var deleteRecord = new AtomicReference<TransactionRecord>();
+
+        final var deleteInner = cryptoDelete(STAKED_ATTACKER)
+                .transfer(DELETE_BENEFICIARY)
+                .payingWith(STAKED_ATTACKER)
+                .signedBy(STAKED_ATTACKER)
+                .memo("t")
+                .batchKey(BATCH_KEY)
+                .via(DELETE_INNER);
+        final var batch = atomicBatch(workThen(WORK_PAYER, deleteInner))
+                .payingWith(OUTER_PAYER)
+                .signedBy(OUTER_PAYER, BATCH_KEY)
+                .memo("b")
+                .via(EXPLOIT_BATCH)
+                .hasKnownStatus(SUCCESS);
+
+        return hapiTest(flattened(
+                // Activate staking rewards with a payable reward fund.
+                overridingAllOf(java.util.Map.of(
+                        "staking.startThreshold", "" + 10 * ONE_HBAR,
+                        "staking.perHbarRewardRate", "6849",
+                        "staking.rewardBalanceThreshold", "0",
+                        "staking.requireMinStakeToReward", "false")),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, STAKING_REWARD, ONE_MILLION_HBARS)),
+                newKeyNamed(BATCH_KEY),
+                uploadInitCode(SLOT_USER),
+                contractCreate(SLOT_USER).gas(CONTRACT_CREATE_GAS),
+                cryptoCreate(WORK_PAYER).balance(ONE_MILLION_HBARS),
+                cryptoCreate(OUTER_PAYER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(STAKED_ATTACKER).balance(ONE_HUNDRED_HBARS).stakedNodeId(0),
+                cryptoCreate(DELETE_BENEFICIARY).balance(0L).receiverSigRequired(false),
+
+                // Accrue a positive, payable pending reward for the staked account.
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                getAccountInfo(STAKED_ATTACKER).savingSnapshot(ATTACKER_BEFORE),
+                assertionsHold((spec, log) -> {
+                    final AccountInfo attacker = spec.registry().getAccountInfo(ATTACKER_BEFORE);
+                    attackerPendingReward.set(pendingOf(attacker));
+                    Assertions.assertThat(attackerPendingReward.get())
+                            .as("precondition: staked account must have a positive pending reward")
+                            .isPositive();
+                }),
+
+                // Snapshot everything the fixed path should change.
+                getAccountBalance(WORK_PAYER).exposingBalanceTo(workPayerBefore::set),
+                getAccountBalance(OUTER_PAYER).exposingBalanceTo(outerPayerBefore::set),
+                getAccountBalance(DELETE_BENEFICIARY).exposingBalanceTo(beneficiaryBefore::set),
+                viewSingleton(
+                        TokenService.NAME,
+                        STAKING_NETWORK_REWARDS_STATE_ID,
+                        (NetworkStakingRewards rewards) -> networkPendingBefore.set(rewards.pendingRewards())),
+
+                // Fifteen fee-bearing storage-writing calls, then the valid staked delete.
+                batch,
+
+                // The batch now SUCCEEDS instead of being replaced by a zero-fee FAIL_INVALID record.
+                // Staking rewards are finalized at the root, so the redirected reward is externalized on
+                // the outer batch record (exactly one), not on the inner delete record.
+                getTxnRecord(EXPLOIT_BATCH)
+                        .hasPriority(recordWith().status(SUCCESS))
+                        .hasPaidStakingRewardsCount(1)
+                        .exposingTo(batchRecord::set),
+                getTxnRecord(DELETE_INNER)
+                        .hasPriority(recordWith().status(SUCCESS))
+                        .hasPaidStakingRewardsCount(0)
+                        .exposingTo(deleteRecord::set),
+                getAccountBalance(WORK_PAYER).exposingBalanceTo(workPayerAfter::set),
+                getAccountBalance(OUTER_PAYER).exposingBalanceTo(outerPayerAfter::set),
+                getAccountBalance(DELETE_BENEFICIARY).exposingBalanceTo(beneficiaryAfter::set),
+                viewSingleton(
+                        TokenService.NAME,
+                        STAKING_NETWORK_REWARDS_STATE_ID,
+                        (NetworkStakingRewards rewards) -> networkPendingAfter.set(rewards.pendingRewards())),
+                workRecordsPresent(),
+                assertionsHold((spec, log) -> {
+                    // Fees are charged for the inner work and the outer batch (the work is not free).
+                    Assertions.assertThat(workPayerBefore.get() - workPayerAfter.get())
+                            .as("the fifteen fee-bearing storage calls must charge the work payer")
+                            .isPositive();
+                    Assertions.assertThat(outerPayerBefore.get() - outerPayerAfter.get())
+                            .as("the outer batch fee must be charged")
+                            .isPositive();
+                    Assertions.assertThat(batchRecord.get().getTransactionFee()).isPositive();
+
+                    // The pending reward was redirected to the (non-deleted) beneficiary: it receives the
+                    // deleted account's principal plus the reward, and the network pending reward drops.
+                    final long beneficiaryGain = beneficiaryAfter.get() - beneficiaryBefore.get();
+                    Assertions.assertThat(beneficiaryGain)
+                            .as("beneficiary receives the deleted account's principal plus its redirected reward")
+                            .isGreaterThan(attackerPendingReward.get());
+                    Assertions.assertThat(networkPendingBefore.get() - networkPendingAfter.get())
+                            .as("the network pending reward must decrease by the reward actually paid out")
+                            .isPositive();
+
+                    // Record-level proof of the redirect: the batch record externalizes exactly one paid
+                    // staking reward, to the delete beneficiary, for the deleted account's pending amount.
+                    final var paidRewards = batchRecord.get().getPaidStakingRewardsList();
+                    Assertions.assertThat(paidRewards)
+                            .as("the batch record externalizes exactly one paid staking reward")
+                            .hasSize(1);
+                    Assertions.assertThat(paidRewards.get(0).getAccountID())
+                            .as("the paid staking reward is attributed to the delete beneficiary")
+                            .isEqualTo(spec.registry().getAccountID(DELETE_BENEFICIARY));
+                    Assertions.assertThat(paidRewards.get(0).getAmount())
+                            .as("the paid reward equals the deleted account's pending reward")
+                            .isEqualTo(attackerPendingReward.get());
+                    log.info(
+                            "PASS: batch SUCCESS, reward {} redirected to beneficiary, fees charged",
+                            attackerPendingReward.get());
+                })));
+    }
+
+    /**
+     * Same fixed behavior as {@link #stakedDeleteInAtomicBatchRedirectsRewardAndChargesFees()} but via an inner
+     * {@code ContractDelete} of a staked contract, exercising the {@code ContractDelete} path of the fix (which
+     * records its beneficiary on its own dispatch builder exactly like {@code CryptoDelete}).
+     */
+    @LeakyRepeatableHapiTest(
+            value = {NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION, NEEDS_STATE_ACCESS},
+            overrides = {
+                "staking.startThreshold",
+                "staking.perHbarRewardRate",
+                "staking.rewardBalanceThreshold",
+                "staking.requireMinStakeToReward"
+            })
+    final Stream<DynamicTest> stakedContractDeleteInAtomicBatchRedirectsRewardAndChargesFees() {
+        final var beneficiaryBefore = new AtomicLong();
+        final var beneficiaryAfter = new AtomicLong();
+        final var outerPayerBefore = new AtomicLong();
+        final var outerPayerAfter = new AtomicLong();
+        final var networkPendingBefore = new AtomicLong();
+        final var networkPendingAfter = new AtomicLong();
+        final var batchRecord = new AtomicReference<TransactionRecord>();
+
+        final var contractDeleteInner = contractDelete(STAKED_CONTRACT)
+                .transferAccount(CONTRACT_DELETE_BENEFICIARY)
+                .payingWith(CONTRACT_DELETE_PAYER)
+                .signedBy(CONTRACT_DELETE_PAYER, CONTRACT_ADMIN_KEY)
+                .memo("t")
+                .batchKey(BATCH_KEY)
+                .via(CONTRACT_DELETE_INNER);
+        final var batch = atomicBatch(workThen(CONTRACT_DELETE_PAYER, contractDeleteInner))
+                .payingWith(CONTRACT_OUTER_PAYER)
+                .signedBy(CONTRACT_OUTER_PAYER, BATCH_KEY)
+                .memo("b")
+                .via(CONTRACT_BATCH)
+                .hasKnownStatus(SUCCESS);
+
+        return hapiTest(flattened(
+                overridingAllOf(java.util.Map.of(
+                        "staking.startThreshold", "" + 10 * ONE_HBAR,
+                        "staking.perHbarRewardRate", "6849",
+                        "staking.rewardBalanceThreshold", "0",
+                        "staking.requireMinStakeToReward", "false")),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, STAKING_REWARD, ONE_MILLION_HBARS)),
+                newKeyNamed(BATCH_KEY),
+                newKeyNamed(CONTRACT_ADMIN_KEY),
+                uploadInitCode(SLOT_USER),
+                contractCreate(SLOT_USER).gas(CONTRACT_CREATE_GAS),
+                uploadInitCode(PAYABLE_CONTRACT),
+                contractCreate(STAKED_CONTRACT)
+                        .bytecode(PAYABLE_CONTRACT)
+                        .adminKey(CONTRACT_ADMIN_KEY)
+                        .stakedNodeId(0)
+                        .balance(ONE_HUNDRED_HBARS)
+                        .gas(CONTRACT_CREATE_GAS),
+                cryptoCreate(CONTRACT_DELETE_PAYER).balance(ONE_MILLION_HBARS),
+                cryptoCreate(CONTRACT_OUTER_PAYER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(CONTRACT_DELETE_BENEFICIARY).balance(0L).receiverSigRequired(false),
+
+                // Accrue a positive, payable pending reward for the staked contract.
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                getAccountBalance(CONTRACT_OUTER_PAYER).exposingBalanceTo(outerPayerBefore::set),
+                getAccountBalance(CONTRACT_DELETE_BENEFICIARY).exposingBalanceTo(beneficiaryBefore::set),
+                viewSingleton(
+                        TokenService.NAME,
+                        STAKING_NETWORK_REWARDS_STATE_ID,
+                        (NetworkStakingRewards rewards) -> networkPendingBefore.set(rewards.pendingRewards())),
+                batch,
+                getTxnRecord(CONTRACT_BATCH)
+                        .hasPriority(recordWith().status(SUCCESS))
+                        .hasPaidStakingRewardsCount(1)
+                        .exposingTo(batchRecord::set),
+                getTxnRecord(CONTRACT_DELETE_INNER)
+                        .hasPriority(recordWith().status(SUCCESS))
+                        .hasPaidStakingRewardsCount(0),
+                getAccountBalance(CONTRACT_OUTER_PAYER).exposingBalanceTo(outerPayerAfter::set),
+                getAccountBalance(CONTRACT_DELETE_BENEFICIARY).exposingBalanceTo(beneficiaryAfter::set),
+                viewSingleton(
+                        TokenService.NAME,
+                        STAKING_NETWORK_REWARDS_STATE_ID,
+                        (NetworkStakingRewards rewards) -> networkPendingAfter.set(rewards.pendingRewards())),
+                assertionsHold((spec, log) -> {
+                    // The outer batch fee is charged (the contract-delete batch is not free).
+                    Assertions.assertThat(outerPayerBefore.get() - outerPayerAfter.get())
+                            .as("the outer batch fee must be charged")
+                            .isPositive();
+                    Assertions.assertThat(batchRecord.get().getTransactionFee()).isPositive();
+
+                    // Record-level proof: the staked contract's pending reward is redirected to the beneficiary.
+                    final var paidRewards = batchRecord.get().getPaidStakingRewardsList();
+                    Assertions.assertThat(paidRewards)
+                            .as("the batch record externalizes exactly one paid staking reward")
+                            .hasSize(1);
+                    Assertions.assertThat(paidRewards.get(0).getAccountID())
+                            .as("the paid staking reward is attributed to the contract-delete beneficiary")
+                            .isEqualTo(spec.registry().getAccountID(CONTRACT_DELETE_BENEFICIARY));
+                    Assertions.assertThat(paidRewards.get(0).getAmount())
+                            .as("the redirected reward is positive")
+                            .isPositive();
+                    Assertions.assertThat(beneficiaryAfter.get() - beneficiaryBefore.get())
+                            .as("beneficiary receives the deleted contract's principal plus its redirected reward")
+                            .isGreaterThan(paidRewards.get(0).getAmount());
+                    Assertions.assertThat(networkPendingBefore.get() - networkPendingAfter.get())
+                            .as("the network pending reward must decrease by the reward actually paid out")
+                            .isPositive();
+                    log.info(
+                            "PASS: contract-delete batch SUCCESS, reward {} redirected to beneficiary, fees charged",
+                            paidRewards.get(0).getAmount());
+                })));
+    }
+
+    /**
+     * Same fixed behavior as {@link #stakedDeleteInAtomicBatchRedirectsRewardAndChargesFees()} but via an inner
+     * contract call that EVM {@code SELFDESTRUCT}s a staked contract to a beneficiary, exercising the third delete
+     * path of the fix. Like {@code CryptoDelete}/{@code ContractDelete}, the self-destruct records its
+     * deleted-contract to beneficiary mapping on its own inner dispatch builder, which the fix folds into the root
+     * builder consulted by staking finalization. The beneficiary here is {@code msg.sender} (the inner call's
+     * pre-existing payer), so this locks in the self-destruct path without depending on the separate fresh-beneficiary
+     * NPE fix.
+     *
+     * <p>This runs under pre-EIP-6780 EVM semantics ({@code v0.46}) because only there does {@code SELFDESTRUCT}
+     * delete a pre-existing contract; under the default {@code v0.70} it would merely sweep the balance and leave the
+     * staked contract (and its reward) in place, so the redirect could not occur.
+     */
+    @LeakyRepeatableHapiTest(
+            value = {NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION, NEEDS_STATE_ACCESS},
+            overrides = {
+                "staking.startThreshold",
+                "staking.perHbarRewardRate",
+                "staking.rewardBalanceThreshold",
+                "staking.requireMinStakeToReward",
+                "contracts.evm.version"
+            })
+    final Stream<DynamicTest> stakedContractSelfDestructInAtomicBatchRedirectsRewardAndChargesFees() {
+        final var outerPayerBefore = new AtomicLong();
+        final var outerPayerAfter = new AtomicLong();
+        final var networkPendingBefore = new AtomicLong();
+        final var networkPendingAfter = new AtomicLong();
+        final var batchRecord = new AtomicReference<TransactionRecord>();
+
+        // The staked contract self-destructs to msg.sender — the inner call's payer, a pre-existing account —
+        // recording the deleted-contract -> beneficiary mapping on its own inner dispatch builder.
+        final var selfDestructInner = contractCall(SELF_DESTRUCT_CONTRACT, "destroy")
+                .payingWith(SD_CALL_PAYER)
+                .signedBy(SD_CALL_PAYER)
+                .memo("t")
+                .gas(GAS_LIMIT)
+                .batchKey(BATCH_KEY)
+                .via(SD_INNER);
+        final var batch = atomicBatch(workThen(SD_WORK_PAYER, selfDestructInner))
+                .payingWith(SD_OUTER_PAYER)
+                .signedBy(SD_OUTER_PAYER, BATCH_KEY)
+                .memo("b")
+                .via(SD_BATCH)
+                .hasKnownStatus(SUCCESS);
+
+        return hapiTest(flattened(
+                // Pre-EIP-6780 EVM semantics (v0.46): SELFDESTRUCT fully deletes a pre-existing contract,
+                // which is required for a staked contract with an accrued reward to be deleted and its reward
+                // redirected. Under the default v0.70 (EIP-6780) SELFDESTRUCT only deletes same-transaction
+                // contracts, which can never have an accrued staking reward, so this path is unreachable there.
+                overridingAllOf(java.util.Map.of(
+                        "staking.startThreshold", "" + 10 * ONE_HBAR,
+                        "staking.perHbarRewardRate", "6849",
+                        "staking.rewardBalanceThreshold", "0",
+                        "staking.requireMinStakeToReward", "false",
+                        "contracts.evm.version", "v0.46")),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, STAKING_REWARD, ONE_MILLION_HBARS)),
+                newKeyNamed(BATCH_KEY),
+                uploadInitCode(SLOT_USER),
+                contractCreate(SLOT_USER).gas(CONTRACT_CREATE_GAS),
+                uploadInitCode(SELF_DESTRUCT_CONTRACT),
+                contractCreate(SELF_DESTRUCT_CONTRACT)
+                        .stakedNodeId(0)
+                        .balance(ONE_HUNDRED_HBARS)
+                        .gas(CONTRACT_CREATE_GAS),
+                cryptoCreate(SD_WORK_PAYER).balance(ONE_MILLION_HBARS),
+                cryptoCreate(SD_OUTER_PAYER).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate(SD_CALL_PAYER).balance(ONE_HUNDRED_HBARS).receiverSigRequired(false),
+
+                // Accrue a positive, payable pending reward for the staked contract.
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                getAccountBalance(SD_OUTER_PAYER).exposingBalanceTo(outerPayerBefore::set),
+                viewSingleton(
+                        TokenService.NAME,
+                        STAKING_NETWORK_REWARDS_STATE_ID,
+                        (NetworkStakingRewards rewards) -> networkPendingBefore.set(rewards.pendingRewards())),
+                batch,
+                getTxnRecord(SD_BATCH)
+                        .hasPriority(recordWith().status(SUCCESS))
+                        .hasPaidStakingRewardsCount(1)
+                        .exposingTo(batchRecord::set),
+                getTxnRecord(SD_INNER).hasPriority(recordWith().status(SUCCESS)),
+                getAccountBalance(SD_OUTER_PAYER).exposingBalanceTo(outerPayerAfter::set),
+                viewSingleton(
+                        TokenService.NAME,
+                        STAKING_NETWORK_REWARDS_STATE_ID,
+                        (NetworkStakingRewards rewards) -> networkPendingAfter.set(rewards.pendingRewards())),
+                assertionsHold((spec, log) -> {
+                    // The outer batch fee is charged (the self-destruct batch is not free).
+                    Assertions.assertThat(outerPayerBefore.get() - outerPayerAfter.get())
+                            .as("the outer batch fee must be charged")
+                            .isPositive();
+                    Assertions.assertThat(batchRecord.get().getTransactionFee()).isPositive();
+
+                    // Record-level proof: the self-destructed staked contract's pending reward is redirected to the
+                    // SELFDESTRUCT beneficiary (msg.sender), not dropped or thrown out of finalization.
+                    final var paidRewards = batchRecord.get().getPaidStakingRewardsList();
+                    Assertions.assertThat(paidRewards)
+                            .as("the batch record externalizes exactly one paid staking reward")
+                            .hasSize(1);
+                    Assertions.assertThat(paidRewards.get(0).getAccountID())
+                            .as("the paid staking reward is attributed to the self-destruct beneficiary")
+                            .isEqualTo(spec.registry().getAccountID(SD_CALL_PAYER));
+                    Assertions.assertThat(paidRewards.get(0).getAmount())
+                            .as("the redirected reward is positive")
+                            .isPositive();
+                    Assertions.assertThat(networkPendingBefore.get() - networkPendingAfter.get())
+                            .as("the network pending reward must decrease by the reward actually paid out")
+                            .isPositive();
+                    log.info(
+                            "PASS: self-destruct batch SUCCESS, reward {} redirected to beneficiary, fees charged",
+                            paidRewards.get(0).getAmount());
+                })));
+    }
+
+    private static HapiTxnOp<?>[] workThen(final String payer, final HapiTxnOp<?> terminalOperation) {
+        final var operations = new HapiTxnOp<?>[WORK_INNER_COUNT + 1];
+        for (int i = 0; i < WORK_INNER_COUNT; i++) {
+            final var value = BigInteger.valueOf(i + 1L);
+            operations[i] = contractCall(SLOT_USER, "consumeA", value, value)
+                    .payingWith(payer)
+                    .signedBy(payer)
+                    .memo("w")
+                    .gas(GAS_LIMIT)
+                    .batchKey(BATCH_KEY)
+                    .via(workName(i));
+        }
+        operations[WORK_INNER_COUNT] = terminalOperation;
+        return operations;
+    }
+
+    private static com.hedera.services.bdd.spec.SpecOperation[] workRecordsPresent() {
+        final var queries = new com.hedera.services.bdd.spec.SpecOperation[WORK_INNER_COUNT];
+        for (int i = 0; i < WORK_INNER_COUNT; i++) {
+            queries[i] = getTxnRecord(workName(i)).hasPriority(recordWith().status(SUCCESS));
+        }
+        return queries;
+    }
+
+    private static String workName(final int index) {
+        return WORK_PREFIX + "%02d".formatted(index);
+    }
+
+    private static long pendingOf(final AccountInfo info) {
+        return info.getStakingInfo().getPendingReward();
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/RepeatableDeletedStakeeIndirectStakerBatchTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/RepeatableDeletedStakeeIndirectStakerBatchTest.java
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.staking;
+
+import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.newKeyNamed;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingAllOf;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilStartOfNextStakingPeriod;
+import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.STAKING_REWARD;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.RepeatableHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
+
+/**
+ * Atomic-batch companion to {@code RepeatableDeletedStakeeIndirectStakerTest}: deleting a rewardable
+ * stakee in one inner transaction and touching its indirect (HIP-406 {@code stakedAccountId}) staker in
+ * another must let the batch succeed, with the deleted stakee's reward redirected to its beneficiary
+ * exactly once. This exercises the child-dispatch beneficiary fold; without it the batch was rolled back
+ * to a zero-fee {@code FAIL_INVALID} record.
+ */
+@HapiTestLifecycle
+public class RepeatableDeletedStakeeIndirectStakerBatchTest {
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
+        lifecycle.doAdhoc(
+                // These overrides only accelerate reward accrual so the scenario plays out in a few
+                // virtual "days"; they are not required for the behavior under test.
+                overridingAllOf(Map.of(
+                        "staking.startThreshold", "" + 10 * ONE_HBAR,
+                        "staking.perHbarRewardRate", "1",
+                        "staking.rewardBalanceThreshold", "0")),
+                // Fund 0.0.800 (STAKING_REWARD) so there is a pool to pay rewards from.
+                cryptoTransfer(tinyBarsFromTo(GENESIS, STAKING_REWARD, ONE_MILLION_HBARS)));
+    }
+
+    @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
+    Stream<DynamicTest> atomicBatchDeletingRewardableStakeeAndTouchingItsIndirectStakerSucceeds() {
+        // Atomic-batch variant of the freeze. Deleting the rewardable stakee in one
+        // inner (BATCH_INNER) transaction and touching its indirect staker in another used to fail the whole
+        // batch: inner transactions do not pay staking rewards, so the batch's single parent finalization
+        // rediscovered the deleted stakee as a reward receiver but could not redirect its reward — the
+        // delete->beneficiary mapping lived only on the inner delete's child record builder, so
+        // StakingRewardsDistributor#payRewardsIfPending threw. Because that throw happens in the parent batch
+        // finalization (not an inner handler), the whole batch was externalized as FAIL_INVALID. The fix copies
+        // the child builders' deleted-account beneficiaries onto the parent record builder before paying, so the
+        // batch succeeds and the reward is redirected exactly once.
+        return hapiTest(
+                newKeyNamed("batchKey"),
+                cryptoCreate("batchOperator").key("batchKey").balance(ONE_HUNDRED_HBARS),
+
+                // "batchDeletedStakee" stakes directly to node 0 and is deleted inside the batch;
+                // "batchDeletedStaker" stakes INDIRECTLY through it and is touched inside the batch.
+                cryptoCreate("batchDeletedStakee").stakedNodeId(0).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate("batchDeletedStaker")
+                        .stakedAccountId("batchDeletedStakee")
+                        .balance(ONE_HUNDRED_HBARS),
+                cryptoCreate("batchStakeeBeneficiary").balance(0L),
+                cryptoCreate("batchStakerReceiver").balance(0L),
+
+                // Roll forward two staking periods so the intermediate stakee becomes rewardable.
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                // One more period so the deleted stakee would be "rewardable" from the batch's perspective.
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+
+                // Inner-1 deletes the rewardable stakee; inner-2 transfers out of its indirect staker.
+                atomicBatch(
+                                cryptoDelete("batchDeletedStakee")
+                                        .transfer("batchStakeeBeneficiary")
+                                        .payingWith("batchDeletedStakee")
+                                        .signedBy("batchDeletedStakee")
+                                        .batchKey("batchKey"),
+                                cryptoTransfer(tinyBarsFromTo("batchDeletedStaker", "batchStakerReceiver", 1L))
+                                        .payingWith("batchDeletedStaker")
+                                        .signedBy("batchDeletedStaker")
+                                        .batchKey("batchKey"))
+                        .payingWith("batchOperator")
+                        .signedBy("batchKey")
+                        .via("deletedStakeeBatch")
+                        .hasKnownStatus(SUCCESS),
+
+                // Reward finalization runs once on the parent batch and redirects the deleted stakee's accrued
+                // reward to the beneficiary. The paid staking reward is recorded on the parent batch record and
+                // names the beneficiary (not the deleted stakee) as the sole recipient, for its full accrued
+                // amount. Before the fix this path threw and failed the batch.
+                getTxnRecord("deletedStakeeBatch")
+                        .hasPaidStakingRewardsCount(1)
+                        .hasPaidStakingRewards(List.of(Pair.of("batchStakeeBeneficiary", 400L))),
+                // The indirect staker's transfer went through and the receiver was credited — no freeze.
+                getAccountBalance("batchStakerReceiver").hasTinyBars(1L));
+    }
+}


### PR DESCRIPTION
Forward-port of #27097 (`release/0.76`) to `release/0.78`.
