### PR TITLE
fix: replay processed inner fees when a later inner exceeds the record limit

### DIFF
--- a/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/AtomicBatchHandler.java
+++ b/hedera-node/hedera-util-service-impl/src/main/java/com/hedera/node/app/service/util/impl/handlers/AtomicBatchHandler.java
@@ -196,7 +196,21 @@ public class AtomicBatchHandler implements TransactionHandler {
                         });
             }
 
-            final var streamBuilder = context.dispatch(dispatchOptions);
+            final ReplayableFeeStreamBuilder streamBuilder;
+            try {
+                streamBuilder = context.dispatch(dispatchOptions);
+            } catch (final HandleException e) {
+                /* A HandleException can escape context.dispatch() itself (instead of being reported as a
+                non-SUCCESS stream-builder status) when it is thrown eagerly during inner-dispatch setup -
+                most notably MAX_CHILD_RECORDS_EXCEEDED, thrown while allocating this inner's base record
+                builder before the inner is ever handled. The inner that threw was never charged, but the
+                batch is about to be rolled back, so we must still replay the recorded side effects (fees
+                and Ethereum-specific effects) of all previously processed inners. We rethrow with the
+                original status (so the batch's reported result is unchanged) but now carrying an onRollback
+                that replays the accumulated rollback queue. HandleException must not chain a cause, so we
+                construct a fresh exception copying the status. */
+                throw new HandleException(e.getStatus(), replaying(rollbackQueue));
+            }
 
             /* Let's collect the recorded fees and add a replay action to the rollback queue. */
             final var recordedCharges = List.copyOf(recordedFeeCharging.charges());
@@ -211,12 +225,21 @@ public class AtomicBatchHandler implements TransactionHandler {
                 /* Finally, if any transaction within the batch fails: throw HandleException and,
                 within its onRollback handler, iterate the rollback queue and replay all collected side effects
                 of previously executed transactions (and the one that has just failed). */
-                throw new HandleException(
-                        INNER_TRANSACTION_FAILED,
-                        (feeChargingContext, dispatch) ->
-                                rollbackQueue.forEach(onRollback -> onRollback.replay(feeChargingContext, dispatch)));
+                throw new HandleException(INNER_TRANSACTION_FAILED, replaying(rollbackQueue));
             }
         }
+    }
+
+    /**
+     * Builds an {@link HandleException.OnRollback} that replays every side effect accumulated in the given
+     * rollback queue (the recorded fees and Ethereum-specific effects of all previously processed inners).
+     *
+     * @param rollbackQueue the accumulated rollback actions to replay
+     * @return an {@link HandleException.OnRollback} that replays the entire queue
+     */
+    private static HandleException.OnRollback replaying(@NonNull final List<HandleException.OnRollback> rollbackQueue) {
+        return (feeChargingContext, dispatch) ->
+                rollbackQueue.forEach(onRollback -> onRollback.replay(feeChargingContext, dispatch));
     }
 
     /**

--- a/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/AtomicBatchHandlerTest.java
+++ b/hedera-node/hedera-util-service-impl/src/test/java/com/hedera/node/app/service/util/impl/test/handlers/AtomicBatchHandlerTest.java
@@ -7,6 +7,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_TRANSACTION_IN_BL
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_BATCH_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT_ID;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.MAX_CHILD_RECORDS_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MISSING_BATCH_KEY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.SUCCESS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.UNKNOWN;
@@ -60,6 +61,7 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -391,6 +393,58 @@ class AtomicBatchHandlerTest {
         // Make sure that when the side effects are replayed they include EthereumTransaction's callback
         handleException.maybeReplay(mock(FeeCharging.Context.class), handleContext);
         assertTrue(rollbackCallbackCalledFlag.get());
+    }
+
+    @Test
+    void priorInnerFeesAreReplayedWhenNextInnerDispatchThrowsEagerly() throws PreCheckException {
+        // inner[0] is an EthereumTransaction that succeeds and registers a rollback side effect;
+        // inner[1]'s dispatch throws MAX_CHILD_RECORDS_EXCEEDED eagerly (as it does when the next
+        // inner's base record slot cannot be allocated against an already-full following sink),
+        // escaping context.dispatch() before inner[1]'s fee replay could be registered.
+        final var innerTxn1 = innerTxnFrom("123");
+        final var innerTxn2 = innerTxnFrom("456");
+        final var innerTxnBody1 = newTxnBodyBuilder(payerId2, consensusTimestamp, SIMPLE_KEY_A)
+                .ethereumTransaction(EthereumTransactionBody.newBuilder().build())
+                .build();
+        final var innerTxnBody2 = newTxnBodyBuilder(payerId2, consensusTimestamp, SIMPLE_KEY_A)
+                .consensusCreateTopic(ConsensusCreateTopicTransactionBody.DEFAULT)
+                .build();
+        final var bytes = transactionsToBytes(innerTxn1, innerTxn2);
+        final var txnBody = newAtomicBatch(payerId1, consensusTimestamp, bytes);
+        final var storeFactoryMock = mock(StoreFactory.class);
+        given(handleContext.body()).willReturn(txnBody);
+        given(handleContext.storeFactory()).willReturn(storeFactoryMock);
+        given(handleContext.consensusNow()).willReturn(Instant.ofEpochSecond(1_234_567L));
+        given(transactionParser.parse(eq(bytes.getFirst()), any())).willReturn(innerTxnBody1);
+        given(transactionParser.parse(eq(bytes.getLast()), any())).willReturn(innerTxnBody2);
+
+        final var rollbackCallbackCalledFlag = new AtomicBoolean(false);
+        final var dispatchCount = new AtomicInteger(0);
+        given(handleContext.dispatch(any())).willAnswer(answer -> {
+            if (dispatchCount.getAndIncrement() == 0) {
+                // inner[0]: register the EthereumTransaction rollback side effect and succeed
+                final var options = (DispatchOptions<StreamBuilder>) answer.getArgument(0);
+                options.dispatchMetadata()
+                        .getMetadata(BATCH_ROLLBACK_CALLBACK_CONSUMER, Consumer.class)
+                        .ifPresent(consumer -> ((Consumer<HandleException.OnRollback>) consumer)
+                                .accept((_, _) -> rollbackCallbackCalledFlag.set(true)));
+                return recordBuilder;
+            }
+            // inner[1]: a HandleException escapes from within dispatch itself
+            throw new HandleException(MAX_CHILD_RECORDS_EXCEEDED);
+        });
+        given(recordBuilder.status()).willReturn(SUCCESS);
+
+        final var handleException = assertThrows(HandleException.class, () -> subject.handle(handleContext));
+        // The batch surfaces the original status of the escaping exception, not INNER_TRANSACTION_FAILED
+        assertEquals(MAX_CHILD_RECORDS_EXCEEDED, handleException.getStatus());
+
+        // The rethrown exception carries the rollback queue accumulated so far, so replaying it
+        // re-applies the already-processed inner's side effects: its EthereumTransaction callback and
+        // its fee replay.
+        handleException.maybeReplay(mock(FeeCharging.Context.class), handleContext);
+        assertTrue(rollbackCallbackCalledFlag.get());
+        verify(recordBuilder).setReplayedFees(any());
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip551/AtomicBatchNegativeTest.java
@@ -89,6 +89,7 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.REVERTED_SUCCE
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TRANSACTION_OVERSIZE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.esaulpaugh.headlong.abi.Address;
 import com.google.protobuf.ByteString;
@@ -106,6 +107,7 @@ import com.hederahashgraph.api.proto.java.TransactionRecord;
 import java.math.BigInteger;
 import java.time.Instant;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
@@ -733,6 +735,108 @@ public class AtomicBatchNegativeTest {
                     getAccountBalance("collector").hasTokenBalance("ftB", 0),
                     getAccountBalance("receiver").hasTokenBalance("ftA", 0),
                     getAccountBalance("receiver").hasTokenBalance("ftC", 0));
+        }
+
+        @LeakyHapiTest(overrides = {"consensus.handle.maxFollowingRecords"})
+        @DisplayName("Processed inners are still charged when a later inner overflows the record limit")
+        // BATCH_65
+        public Stream<DynamicTest> processedInnersChargedWhenLaterInnerOverflowsRecordLimit() {
+            final var batchKey = "batchKey";
+            final var workPayer = "workPayer";
+            final var outerPayer = "outerPayer";
+            final var workPayerBefore = new AtomicLong();
+            final var workPayerAfter = new AtomicLong();
+            // With maxFollowingRecords=3 the batch's following-record sink holds 4 builders (the batch
+            // base plus 3 inners). The first three cryptoCreate inners fill the sink; the fourth inner's
+            // base record slot cannot be allocated, so MAX_CHILD_RECORDS_EXCEEDED is thrown eagerly while
+            // dispatching it - after the first three inners were processed and charged. Those charges must
+            // survive the batch rollback (HIP-551), so the inner payer's balance must strictly decrease.
+            return hapiTest(
+                    overriding("consensus.handle.maxFollowingRecords", "3"),
+                    newKeyNamed(batchKey),
+                    cryptoCreate(workPayer).key(batchKey).balance(ONE_HUNDRED_HBARS),
+                    cryptoCreate(outerPayer).balance(ONE_HUNDRED_HBARS),
+                    getAccountBalance(workPayer).exposingBalanceTo(workPayerBefore::set),
+                    atomicBatch(
+                                    cryptoCreate("a0")
+                                            .payingWith(workPayer)
+                                            .signedBy(batchKey)
+                                            .batchKey(batchKey),
+                                    cryptoCreate("a1")
+                                            .payingWith(workPayer)
+                                            .signedBy(batchKey)
+                                            .batchKey(batchKey),
+                                    cryptoCreate("a2")
+                                            .payingWith(workPayer)
+                                            .signedBy(batchKey)
+                                            .batchKey(batchKey),
+                                    cryptoCreate("a3")
+                                            .payingWith(workPayer)
+                                            .signedBy(batchKey)
+                                            .batchKey(batchKey))
+                            .payingWith(outerPayer)
+                            .signedBy(outerPayer, batchKey)
+                            .hasKnownStatus(MAX_CHILD_RECORDS_EXCEEDED),
+                    getAccountBalance(workPayer).exposingBalanceTo(workPayerAfter::set),
+                    withOpContext(
+                            (spec, opLog) -> assertTrue(
+                                    workPayerBefore.get() > workPayerAfter.get(),
+                                    "processed inner payers must be charged despite the capacity-triggered rollback (HIP-551)")));
+        }
+
+        @LeakyHapiTest(overrides = {"consensus.handle.maxFollowingRecords"})
+        @DisplayName("Processed ContractCall inner is still charged when a later inner overflows the record limit")
+        // BATCH_66
+        public Stream<DynamicTest> processedContractCallInnerChargedWhenLaterInnerOverflowsRecordLimit() {
+            final var manyChildren = "ManyChildren";
+            final var batchKey = "batchKey";
+            final var workPayer = "workPayer";
+            final var outerPayer = "outerPayer";
+            final var innerTxn = "heavyContractCallInner";
+            // maxFollowingRecords=5 -> following-record sink capacity 6 = batch base + inner base + 4 children.
+            final var childCreates = 4;
+            final var workPayerBefore = new AtomicLong();
+            final var workPayerAfter = new AtomicLong();
+            // A single ContractCall inner creates enough internal contracts (each a removable child record)
+            // to fill the following-record sink exactly, so the second inner's base record slot cannot be
+            // allocated and MAX_CHILD_RECORDS_EXCEEDED is thrown while dispatching it. The processed
+            // ContractCall's gas+service fee must still be charged after the batch rollback.
+            return hapiTest(
+                    overriding("consensus.handle.maxFollowingRecords", "5"),
+                    newKeyNamed(batchKey),
+                    uploadInitCode(manyChildren),
+                    contractCreate(manyChildren).gas(2_000_000),
+                    cryptoCreate(workPayer).key(batchKey).balance(ONE_HUNDRED_HBARS),
+                    cryptoCreate(outerPayer).balance(ONE_HUNDRED_HBARS),
+                    getAccountBalance(workPayer).exposingBalanceTo(workPayerBefore::set),
+                    atomicBatch(
+                                    contractCall(
+                                                    manyChildren,
+                                                    "createThingsRepeatedly",
+                                                    BigInteger.valueOf(childCreates))
+                                            .payingWith(workPayer)
+                                            .signedBy(batchKey)
+                                            .gas(4_000_000)
+                                            .batchKey(batchKey)
+                                            .via(innerTxn),
+                                    cryptoCreate("tail")
+                                            .payingWith(workPayer)
+                                            .signedBy(batchKey)
+                                            .batchKey(batchKey))
+                            .payingWith(outerPayer)
+                            .signedBy(outerPayer, batchKey)
+                            .hasKnownStatus(MAX_CHILD_RECORDS_EXCEEDED),
+                    getAccountBalance(workPayer).exposingBalanceTo(workPayerAfter::set),
+                    // The processed inner's own record survives as REVERTED_SUCCESS with its removable child
+                    // records dropped by the rollback.
+                    getTxnRecord(innerTxn)
+                            .andAllChildRecords()
+                            .hasNonStakingChildRecordCount(0)
+                            .hasPriority(recordWith().status(REVERTED_SUCCESS)),
+                    withOpContext(
+                            (spec, opLog) -> assertTrue(
+                                    workPayerBefore.get() > workPayerAfter.get(),
+                                    "processed ContractCall inner payer must be charged (incl. gas) despite the capacity-triggered rollback (HIP-551)")));
         }
 
         @HapiTest


### PR DESCRIPTION
Forward-port of #27066 (`release/0.76`) to `release/0.78`.
