### PR TITLE
fix: purge adopted hinTS construction's preprocessing votes at handoff

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/WritableHintsStoreImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/hints/impl/WritableHintsStoreImpl.java
@@ -178,7 +178,12 @@ public class WritableHintsStoreImpl extends ReadableHintsStoreImpl implements Wr
             }
         }
         log.info("Handing off to upcoming construction #{}", upcomingConstruction.constructionId());
-        // The next construction is becoming the active one; so purge obsolete votes now
+        // The next construction is becoming the active one; so purge obsolete votes now. Its voters
+        // are the outgoing roster (fromRoster is its source roster), and the outgoing active
+        // construction is likewise done with. We key both purges off fromRoster rather than each
+        // construction's own source roster hash, which may already have been pruned from the roster
+        // store (only two rosters are retained).
+        purgeVotes(upcomingConstruction, ignore -> fromRoster);
         purgeVotes(requireNonNull(activeConstruction.get()), ignore -> fromRoster);
         // If the previous scheme's party size was different than the new one, purge the hinTS keys;
         // this is likely optional, but seems like a better default behavior than leaving them in state

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/WritableHintsStoreImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/hints/impl/WritableHintsStoreImplTest.java
@@ -358,6 +358,33 @@ class WritableHintsStoreImplTest {
     }
 
     @Test
+    void handoffPurgesUpcomingConstructionVotes() {
+        // The upcoming construction's voters are the outgoing roster (its source roster == the
+        // fromRoster passed to handoff); its votes must be purged so they are not orphaned once it
+        // becomes active. The outgoing active construction here has no votes, so a purge to empty
+        // can only come from the upcoming construction being purged.
+        final var activeConstruction = HintsConstruction.newBuilder()
+                .constructionId(123L)
+                .sourceRosterHash(A_ROSTER_HASH)
+                .targetRosterHash(A_ROSTER_HASH)
+                .build();
+        final var nextConstruction = HintsConstruction.newBuilder()
+                .constructionId(456L)
+                .sourceRosterHash(C_ROSTER_HASH)
+                .targetRosterHash(C_ROSTER_HASH)
+                .hintsScheme(HintsScheme.DEFAULT)
+                .build();
+        setConstructions(activeConstruction, nextConstruction);
+        addSomeVotesFor(456L, C_ROSTER);
+        assertEquals(3, subject.getVotes(456L, Set.of(1L, 2L, 3L)).size());
+
+        subject.handoff(C_ROSTER, C_ROSTER, C_ROSTER_HASH, false);
+
+        assertSame(nextConstruction, constructionNow(ACTIVE_HINTS_CONSTRUCTION_STATE_ID));
+        assertEquals(0L, votesNow().size());
+    }
+
+    @Test
     void setCrsState() {
         final var crsState = setInitialCrsState();
 


### PR DESCRIPTION
Description:
At a roster handoff, WritableHintsStoreImpl.handoff now also purges the preprocessing votes of the construction being adopted, not just the outgoing active one. Both purges are keyed off fromRoster. Added a test covering the new purge.
Why:
The upcoming construction’s votes were cast by the outgoing roster, but nothing cleaned them up when it became active. They only got a purge at the next handoff, keyed by the wrong roster, so votes from nodes that had since left the roster were never removed. Those stale entries sat in the PREPROCESSING_VOTES map forever and grew a little with every roster change that dropped a node.
Purging the adopted construction’s votes right away, using fromRoster (which is exactly its source roster), clears them cleanly. I keyed off fromRoster on purpose rather than resolving each construction’s own source roster hash, because only the two most recent rosters are kept, so an older source roster may already be gone and resolving it could NPE the handoff.
The leak was small, bounded, and only writable by consensus nodes, so this is housekeeping, not a security fix. The purged votes are never read after a construction is adopted, so nothing else is affected.