### PR TITLE
ci(fix): broken TCK & JS SDK XTS tests

### DIFF
--- a/.github/workflows/819-call-tck-regression.yaml
+++ b/.github/workflows/819-call-tck-regression.yaml
@@ -172,7 +172,7 @@ jobs:
           echo "Using proto version: ${PROTO_VERSION}"
 
           # Install with the extracted versions
-          pnpm add @hiero-ledger/sdk@^${SDK_VERSION} long@${LONG_VERSION} @hiero-ledger/proto@${PROTO_VERSION}
+          pnpm add @hiero-ledger/sdk@${SDK_VERSION} long@${LONG_VERSION} @hiero-ledger/proto@${PROTO_VERSION}
           pnpm install
           nohup pnpm start &
           server_pid=$!

--- a/.github/workflows/821-call-block-node-regression.yaml
+++ b/.github/workflows/821-call-block-node-regression.yaml
@@ -235,7 +235,7 @@ jobs:
           # (e.g. protobufjs 8.0.1 in lockfile vs 8.2.0 in manifest, caused by
           # pnpm.overrides being silently ignored in pnpm v11+).
           # --ignore-scripts skips unapproved build scripts (ERR_PNPM_IGNORED_BUILDS).
-          pnpm add "@hiero-ledger/sdk@^${SDK_VERSION}" "long@${LONG_VERSION}" "@hiero-ledger/proto@${PROTO_VERSION}"
+          pnpm add "@hiero-ledger/sdk@${SDK_VERSION}" "long@${LONG_VERSION}" "@hiero-ledger/proto@${PROTO_VERSION}"
           pnpm install --no-frozen-lockfile --ignore-scripts
           nohup pnpm start &
           server_pid=$!


### PR DESCRIPTION
Forward-port of #27059 (`release/0.76`) to `release/0.78`.