### PR TITLE
feat: Add monitoring for large delays in closing blocks and appending items to blocks

### DIFF
--- a/hapi/hapi/src/main/proto/blocks/block_buffer.proto
+++ b/hapi/hapi/src/main/proto/blocks/block_buffer.proto
@@ -16,6 +16,7 @@ package com.hedera.hapi.block.internal;
 
 // SPDX-License-Identifier: Apache-2.0
 import "services/timestamp.proto";
+import "google/protobuf/wrappers.proto";
 
 option java_package = "com.hedera.hapi.block.internal.protoc";
 // <<<pbj.java_package = "com.hedera.hapi.block.internal">>> This comment is special code for setting PBJ Compiler java package
@@ -87,4 +88,9 @@ message BufferedBlock {
    * The timestamp this block's header was added to the Block.
    */
   proto.Timestamp opened_timestamp = 6;
+
+  /**
+   * The block period (in milliseconds) for this block.
+   */
+  google.protobuf.Int64Value block_period_millis = 7;
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferIO.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferIO.java
@@ -258,6 +258,7 @@ public class BlockBufferIO {
                     .build();
             final BufferedBlock bufferedBlock = BufferedBlock.newBuilder()
                     .blockNumber(block.blockNumber())
+                    .blockPeriodMillis(block.blockPeriodMillis())
                     .openedTimestamp(openedTimestamp)
                     .closedTimestamp(closedTimestamp)
                     .isAcknowledged(block.blockNumber() <= latestAcknowledgedBlockNumber)

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferService.java
@@ -364,7 +364,8 @@ public class BlockBufferService {
         }
 
         // Create a new block state
-        final BlockState blockState = new BlockState(blockNumber);
+        final long blockPeriodMillis = bsConfig().blockPeriod().toMillis();
+        final BlockState blockState = new BlockState(blockNumber, blockPeriodMillis);
         streamingObs.onBlockOpen(blockNumber);
         blockBuffer.put(blockNumber, blockState);
         // update the earliest block number if this is the first block or lower than current earliest
@@ -618,7 +619,9 @@ public class BlockBufferService {
         int numBlocksLoaded = 0;
 
         for (final BufferedBlock bufferedBlock : blocks) {
-            final BlockState block = new BlockState(bufferedBlock.blockNumber());
+            final long blockNumber = bufferedBlock.blockNumber();
+            final long blockPeriodMillis = bufferedBlock.blockPeriodMillisOrElse(-1L);
+            final BlockState block = new BlockState(blockNumber, blockPeriodMillis);
             long blockItemTotalSize = 0L;
             for (final Bytes itemBytes : bufferedBlock.block().items()) {
                 block.addSerializedItem(itemBytes);
@@ -630,19 +633,18 @@ public class BlockBufferService {
             final Instant closedInstant = Instant.ofEpochSecond(closedTimestamp.seconds(), closedTimestamp.nanos());
             final Timestamp openedTimestamp = bufferedBlock.openedTimestamp();
             final Instant openedInstant = Instant.ofEpochSecond(openedTimestamp.seconds(), openedTimestamp.nanos());
-            logger.debug(
-                    "Reconstructed block {} from disk and closed at {}", bufferedBlock.blockNumber(), closedInstant);
+            logger.debug("Reconstructed block {} from disk and closed at {}", blockNumber, closedInstant);
             block.closeBlock(closedInstant);
             block.setOpenedTimestamp(openedInstant);
 
             if (bufferedBlock.isAcknowledged()) {
-                setLatestAcknowledgedBlock(bufferedBlock.blockNumber());
+                setLatestAcknowledgedBlock(blockNumber);
             }
 
-            if (blockBuffer.putIfAbsent(bufferedBlock.blockNumber(), block) != null) {
+            if (blockBuffer.putIfAbsent(blockNumber, block) != null) {
                 logger.debug(
                         "Block {} was read from disk but it was already in the buffer; ignoring block from disk",
-                        bufferedBlock.blockNumber());
+                        blockNumber);
             } else {
                 ++numBlocksLoaded;
                 bufferSizeInBytes.add(blockItemTotalSize);
@@ -1115,6 +1117,21 @@ public class BlockBufferService {
     }
 
     /**
+     * For each block in the buffer, check if there are any delays in closing the block or appending items.
+     */
+    private void checkBlockDelays() {
+        final List<Long> orderedBlocks = new ArrayList<>(blockBuffer.keySet());
+        Collections.sort(orderedBlocks);
+
+        for (final long blockNumber : orderedBlocks) {
+            final BlockState block = blockBuffer.get(blockNumber);
+            if (block != null) {
+                block.checkForDelays();
+            }
+        }
+    }
+
+    /**
      * Task that performs regular operations on the buffer (e.g. pruning and persisting to disk).
      */
     private class BufferWorkerTask implements Runnable {
@@ -1128,6 +1145,7 @@ public class BlockBufferService {
 
             try {
                 checkBuffer();
+                checkBlockDelays();
             } catch (final RuntimeException e) {
                 logger.warn("Periodic buffer worker task failed", e);
             } finally {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnection.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnection.java
@@ -663,7 +663,12 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
                 logger.warn("{} Sending of end stream request failed (reason: {})", this, result.status);
             }
         } catch (final RuntimeException e) {
-            logger.warn("{} Error sending EndStream request", this, e);
+            final FailureType failureType = FailureType.findFailureType(e);
+            if (failureType.isCommonFailure()) {
+                logger.warn("{} Error sending EndStream request (error: {})", this, failureType);
+            } else {
+                logger.warn("{} Error sending EndStream request", this, e);
+            }
         }
     }
 
@@ -978,18 +983,20 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
         if (!isActive()) {
             // the connection is no longer active... no need to process any further
             logger.info(
-                    "{} Timed out sending request to block node (timeout: {}ms, duration: {}μs) - suppressing because connection is no longer active",
+                    "{} Timed out sending request to block node (timeout: {}ms, duration: {}μs, requestSize: {}B) - suppressing because connection is no longer active",
                     connectionContext(correlationId),
                     request.timeoutMillis(),
-                    durationMicros);
+                    durationMicros,
+                    request.streamRequest().protobufSize());
             return new SendRequestResult(SendRequestStatus.CONNECTION_CLOSED, reqStartNanos, reqEndNanos);
         }
 
         logger.warn(
-                "{} Timed out sending request to block node (timeout: {}ms, duration: {}μs)",
+                "{} Timed out sending request to block node (timeout: {}ms, duration: {}μs, requestSize: {}B)",
                 connectionContext(correlationId),
                 request.timeoutMillis(),
-                durationMicros);
+                durationMicros,
+                request.streamRequest().protobufSize());
 
         blockStreamMetrics.recordPipelineOperationTimeout();
 
@@ -1409,7 +1416,8 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
             BufferedItem item;
 
             while ((item = block.bufferedItem(itemIndex)) != null) {
-                connStats.recordHeartbeat(System.currentTimeMillis());
+                final long millisTimestamp = System.currentTimeMillis();
+                connStats.recordHeartbeat(millisTimestamp);
 
                 if (itemIndex == 0) {
                     logger.trace(
@@ -1420,7 +1428,7 @@ public class BlockNodeStreamingConnection extends AbstractBlockNodeConnection
                     if (lastSendTimeMillis == -1) {
                         // if we've never sent a request and this is the first time we are processing a block, update
                         // the last send time to the current time. this will avoid prematurely sending a request
-                        lastSendTimeMillis = System.currentTimeMillis();
+                        lastSendTimeMillis = millisTimestamp;
                     }
                 }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/streaming/BlockState.java
@@ -8,17 +8,22 @@ import com.hedera.pbj.runtime.ParseException;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAdder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * A "block state" is the collection of items contained with a single block and can be streamed to a block node.
  */
 public class BlockState {
+
+    private static final Logger logger = LogManager.getLogger(BlockState.class);
 
     /** Number of low-order bits in a protobuf tag occupied by the wire type (the remaining bits are the field number). */
     private static final int PROTOBUF_TAG_TYPE_BITS = 3;
@@ -27,6 +32,10 @@ public class BlockState {
      * The block number associated with this instance.
      */
     private final long blockNumber;
+    /**
+     * The block period, as milliseconds.
+     */
+    private final long blockPeriodMillis;
     /**
      * Counter used to assign an index to a block item. Items are assigned a monotonically increasing integer value
      * that is used to look up the item and to get the items ordered.
@@ -66,14 +75,67 @@ public class BlockState {
      * Monotonic nanoTime when the block end was sent. Used for latency computation.
      */
     private volatile long blockEndSentNanos = -1;
+    /**
+     * Timestamp (milliseconds) of when the most recent block item was added, or -1 if no items have been added yet.
+     */
+    private volatile long latestItemAddTimestamp = -1;
+    /**
+     * Flag indicating whether a delay was detected in closing the block.
+     */
+    private volatile boolean isWarnedForCloseDelay = false;
+    /**
+     * Flag indicating whether a delay was detected between items being added to the block.
+     */
+    private volatile boolean isWarnedForAppendDelay = false;
 
     /**
      * Create a new block state object.
      *
      * @param blockNumber the block number associated with this block
      */
-    public BlockState(final long blockNumber) {
+    public BlockState(final long blockNumber, final long blockPeriodMillis) {
         this.blockNumber = blockNumber;
+        this.blockPeriodMillis = blockPeriodMillis;
+    }
+
+    /**
+     * Check for whether there is a delay in closing this block or if there is a delay in appending items to this block.
+     * If there are any delays, a WARN log is written with details about the delay. If this block is closed, not opened
+     * (i.e. the header hasn't been added yet), or this block does not have a block period, then this check will not be
+     * performed.
+     */
+    void checkForDelays() {
+        if (isClosed() || openedTimestamp == null || blockPeriodMillis == -1) {
+            return;
+        }
+
+        final long currentTimeMillis = System.currentTimeMillis();
+
+        if (!isWarnedForAppendDelay) {
+            final long appendDelayDurationMillis = currentTimeMillis - latestItemAddTimestamp;
+            if (appendDelayDurationMillis > blockPeriodMillis) {
+                logger.warn(
+                        "Block is slow appending items (block: {}, timeSinceLastAppend: {}ms, lastItemIndex: {})",
+                        blockNumber,
+                        appendDelayDurationMillis,
+                        itemIndex.get());
+                isWarnedForAppendDelay = true;
+            }
+        }
+
+        if (!isWarnedForCloseDelay) {
+            final long openDurationMillis = currentTimeMillis - openedTimestamp.toEpochMilli();
+            final long openThresholdMillis = blockPeriodMillis * 2;
+            if (openDurationMillis > openThresholdMillis) {
+                logger.warn(
+                        "Block has been opened for an extended period of time (block: {}, openDuration: {}ms, blockPeriod: {}ms, lastItemIndex: {})",
+                        blockNumber,
+                        openDurationMillis,
+                        blockPeriodMillis,
+                        itemIndex.get());
+                isWarnedForCloseDelay = true;
+            }
+        }
     }
 
     /**
@@ -97,9 +159,24 @@ public class BlockState {
 
         final int index = itemIndex.incrementAndGet();
         bufferedItems.put(index, new BufferedItem(serializedItem, itemType, index));
+        final long timestampMillis = System.currentTimeMillis();
+
+        if (isWarnedForAppendDelay) {
+            final long diffMillis = timestampMillis - latestItemAddTimestamp;
+            logger.info(
+                    "Block ({}) took {}ms to append the next item (itemIndex: {}->{})",
+                    blockNumber,
+                    diffMillis,
+                    index - 1,
+                    index);
+            isWarnedForAppendDelay = false;
+        }
+
+        latestItemAddTimestamp = timestampMillis;
+
         if (itemType == BlockItem.ItemOneOfType.BLOCK_HEADER) {
             openedNanos = System.nanoTime();
-            openedTimestamp = Instant.now();
+            openedTimestamp = Instant.ofEpochMilli(timestampMillis);
         }
         sizeBytes.add(serializedItem.length());
 
@@ -166,6 +243,13 @@ public class BlockState {
     }
 
     /**
+     * @return the block period (in milliseconds) for this block
+     */
+    public long blockPeriodMillis() {
+        return blockPeriodMillis;
+    }
+
+    /**
      * @return true if the block is closed, else false
      */
     public boolean isClosed() {
@@ -198,6 +282,12 @@ public class BlockState {
             closedNanos = System.nanoTime();
         }
         closedTimestamp = requireNonNull(timestamp, "timestamp must not be null");
+
+        if (isWarnedForCloseDelay) {
+            final long durationMillis =
+                    Duration.between(openedTimestamp, timestamp).toMillis();
+            logger.info("Block ({}) was open for {}ms before being closed", blockNumber, durationMillis);
+        }
     }
 
     /**
@@ -258,19 +348,21 @@ public class BlockState {
         }
         final BlockState that = (BlockState) o;
         return blockNumber == that.blockNumber
+                && blockPeriodMillis == that.blockPeriodMillis
                 && Objects.equals(bufferedItems, that.bufferedItems)
                 && Objects.equals(closedTimestamp, that.closedTimestamp);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(blockNumber, bufferedItems, closedTimestamp);
+        return Objects.hash(blockNumber, blockPeriodMillis, bufferedItems, closedTimestamp);
     }
 
     @Override
     public String toString() {
         return "BlockState{" + "blockNumber="
-                + blockNumber + ", closedTimestamp="
+                + blockNumber + ", blockPeriodMillis="
+                + blockPeriodMillis + ", closedTimestamp="
                 + closedTimestamp + ", blockItemCount="
                 + bufferedItems.size() + '}';
     }

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferIOTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockBufferIOTest.java
@@ -168,7 +168,7 @@ class BlockBufferIOTest {
     @Test
     void readWritePreservesSerializedItemBytesAndDerivesTypes() throws Exception {
         // Build a block by adding items in their serialized form (the production path), capturing the exact bytes.
-        final BlockState block = new BlockState(42L);
+        final BlockState block = new BlockState(42L, 2_000L);
         final List<BlockItem> sourceItems =
                 List.of(newBlockHeader(42L), newEventTransaction(), newStateChanges(), newBlockProof(42L));
         final List<Bytes> expectedBytes = new ArrayList<>();

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionComponentTest.java
@@ -299,7 +299,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         // Feed one item just over configuredMax to force fatal branch if limit not respected
         final AtomicLong streamingBlockNumber = streamingBlockNumber();
         streamingBlockNumber.set(5);
-        final BlockState block = new BlockState(5);
+        final BlockState block = new BlockState(5, 2_000L);
         final BlockItem header = newBlockHeaderItem(5);
         block.addItem(header);
         // Slightly over configuredMax to ensure split/end if not honored
@@ -362,7 +362,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
         assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         doReturn(block).when(bufferService).getBlockState(10);
         /*
         Items 1, 2, and 3 are sized such that, given a request padding of 0 and an item padding of 0, during the pending
@@ -465,7 +465,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
         assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         doReturn(block).when(bufferService).getBlockState(10);
         /*
         The item is sized such that, given a request padding of 0 and an item padding of 0, during the pending request
@@ -568,7 +568,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         final StringBuilder blockSummary =
                 new StringBuilder("\n=== Blocks (seed=").append(seed).append(") ===\n");
         for (int i = 1; i <= numBlocks; i++) {
-            final BlockState block = new BlockState(i);
+            final BlockState block = new BlockState(i, 2_000L);
             doReturn(block).when(bufferService).getBlockState(i);
 
             // Add header
@@ -727,7 +727,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
         assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         doReturn(block).when(bufferService).getBlockState(10);
 
         final Map<Integer, BlockItem> items = new TreeMap<>();
@@ -860,7 +860,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
         assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         doReturn(block).when(bufferService).getBlockState(10);
 
         final Map<Integer, BlockItem> items = new TreeMap<>();
@@ -974,7 +974,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         final AtomicLong streamingBlockNumber = streamingBlockNumber();
         streamingBlockNumber.set(10);
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         final BlockItem header = newBlockHeaderItem(10);
         block.addItem(header);
         block.closeBlock(); // Close the block to force sending
@@ -1082,7 +1082,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
     void testCloseAtBlockBoundary_activeBlock() throws Exception {
         // re-create the connection so we get the worker thread to run
         final long blockNumber = 10;
-        final BlockState block = new BlockState(blockNumber);
+        final BlockState block = new BlockState(blockNumber, 2_000L);
         lenient().when(bufferService.getBlockState(blockNumber)).thenReturn(block);
 
         connection = new BlockNodeStreamingConnection(
@@ -1324,7 +1324,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
 
         streamingBlockNumber.set(10);
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
 
         doReturn(block).when(bufferService).getBlockState(10);
 
@@ -1474,7 +1474,7 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
         assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         doReturn(block).when(bufferService).getBlockState(10);
 
         connection.updateConnectionState(ConnectionState.ACTIVE);
@@ -1570,9 +1570,9 @@ class BlockNodeStreamingConnectionComponentTest extends BlockNodeCommunicationTe
         final AtomicLong streamingBlockNumber = streamingBlockNumber();
         streamingBlockNumber.set(10);
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         doReturn(block).when(bufferService).getBlockState(10);
-        doReturn(new BlockState(11)).when(bufferService).getBlockState(11);
+        doReturn(new BlockState(11, 2_000L)).when(bufferService).getBlockState(11);
 
         connection.updateConnectionState(ConnectionState.ACTIVE);
         // sleep to let the worker detect the state change and start doing work

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockNodeStreamingConnectionTest.java
@@ -623,7 +623,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         // We are ahead of the block node, streaming a block beyond the one it last verified (10).
         streamingBlockNumber.set(15L);
         final PublishStreamResponse response = createBlockNodeBehindResponse(10L);
-        when(bufferService.getBlockState(11L)).thenReturn(new BlockState(11L));
+        when(bufferService.getBlockState(11L)).thenReturn(new BlockState(11L, 2_000L));
         when(stats.shouldIgnoreBehindPublisher(any(Instant.class), any(Duration.class), any(Duration.class)))
                 .thenReturn(false);
         when(stats.addBehindPublisherAndCheckLimit(any(Instant.class), anyInt(), any(Duration.class)))
@@ -772,7 +772,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         final AtomicLong streamingBlockNumber = streamingBlockNumber();
         streamingBlockNumber.set(11); // pretend we are currently streaming block 11
         final PublishStreamResponse response = createResendBlock(10L);
-        when(bufferService.getBlockState(10L)).thenReturn(new BlockState(10L));
+        when(bufferService.getBlockState(10L)).thenReturn(new BlockState(10L, 2_000L));
 
         connection.onNext(response);
 
@@ -1271,7 +1271,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         final AtomicLong streamingBlockNumber = streamingBlockNumber();
 
         doReturn(101L).when(bufferService).getLastBlockNumberProduced();
-        doReturn(new BlockState(101)).when(bufferService).getBlockState(101);
+        doReturn(new BlockState(101, 2_000L)).when(bufferService).getBlockState(101);
 
         assertThat(streamingBlockNumber).hasValue(-1);
 
@@ -1316,7 +1316,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         final AtomicLong streamingBlockNumber = streamingBlockNumber();
 
         streamingBlockNumber.set(10);
-        doReturn(new BlockState(10)).when(bufferService).getBlockState(10);
+        doReturn(new BlockState(10, 2_000L)).when(bufferService).getBlockState(10);
 
         // Call doWork directly - with no items in the block, nothing should be sent
         final Object worker = createWorker();
@@ -1372,11 +1372,11 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
 
         streamingBlockNumber.set(10);
 
-        final BlockState block10 = new BlockState(10);
+        final BlockState block10 = new BlockState(10, 2_000L);
         final BlockItem block10Header = newBlockHeaderItem(10);
         block10.addItem(block10Header);
 
-        final BlockState block11 = new BlockState(11);
+        final BlockState block11 = new BlockState(11, 2_000L);
         final BlockItem block11Header = newBlockHeaderItem(11);
         block11.addItem(block11Header);
 
@@ -1444,7 +1444,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
         assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         final BlockItem header = newBlockHeaderItem(10);
         final BlockItem item = newBlockTxItem(2097120);
         final BlockItem proof = newBlockProofItem(10, 2_000);
@@ -1502,7 +1502,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
         assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         // Each item is 20 MB: above the 2 MB soft limit but well below the 36 MB hard limit.
         // Individually valid, but 20 MB + 20 MB = 40 MB exceeds the hard limit.
         final BlockItem item1 = newBlockTxItem(20_000_000);
@@ -1549,7 +1549,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
         assertThat(config.messageSizeSoftLimitBytes()).isEqualTo(2_097_152L); // soft limit = 2 MB
         assertThat(config.messageSizeHardLimitBytes()).isEqualTo(37_748_736L); // hard limit = 36 MB
 
-        final BlockState block = new BlockState(10);
+        final BlockState block = new BlockState(10, 2_000L);
         final BlockItem item1 = newBlockHeaderItem(10);
         final BlockItem item2 = newBlockTxItem(5_000);
         final BlockItem item3 = newBlockTxItem(5_000);
@@ -1740,7 +1740,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
     void testOnNext_blockNodeBehind_maxValueBlockNumber() {
         activateConnection();
         final PublishStreamResponse response = createBlockNodeBehindResponse(Long.MAX_VALUE);
-        when(bufferService.getBlockState(0L)).thenReturn(new BlockState(0L));
+        when(bufferService.getBlockState(0L)).thenReturn(new BlockState(0L, 2_000L));
         when(stats.shouldIgnoreBehindPublisher(any(Instant.class), any(Duration.class), any(Duration.class)))
                 .thenReturn(false);
         when(stats.addBehindPublisherAndCheckLimit(any(Instant.class), anyInt(), any(Duration.class)))
@@ -1800,7 +1800,7 @@ class BlockNodeStreamingConnectionTest extends BlockNodeCommunicationTestBase {
     void testOnNext_blockNodeBehind_ignorePeriod_firstMessageInWindow() {
         activateConnection();
         final PublishStreamResponse response = createBlockNodeBehindResponse(10L);
-        when(bufferService.getBlockState(11L)).thenReturn(new BlockState(11L));
+        when(bufferService.getBlockState(11L)).thenReturn(new BlockState(11L, 2_000L));
 
         // First message should NOT be ignored (new window, queue is empty)
         when(stats.shouldIgnoreBehindPublisher(any(Instant.class), any(Duration.class), any(Duration.class)))

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockStateTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockStateTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.blocks.impl.streaming;
 
+import static com.hedera.node.app.blocks.impl.streaming.BlockNodeCommunicationTestBase.newBlockFooter;
 import static com.hedera.node.app.blocks.impl.streaming.BlockNodeCommunicationTestBase.newBlockHeaderItem;
 import static com.hedera.node.app.blocks.impl.streaming.BlockNodeCommunicationTestBase.newBlockProofItem;
 import static com.hedera.node.app.blocks.impl.streaming.BlockNodeCommunicationTestBase.newBlockTxItem;
@@ -9,11 +10,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.hedera.hapi.block.stream.BlockItem;
 import com.hedera.hapi.block.stream.BlockItem.ItemOneOfType;
+import com.hedera.node.app.blocks.impl.streaming.BlockState.BufferedItem;
+import com.hedera.node.app.spi.fixtures.util.LogCaptor;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodHandles.Lookup;
 import java.lang.invoke.VarHandle;
 import java.time.Instant;
+import java.util.List;
 import java.util.concurrent.ConcurrentMap;
+import org.apache.logging.log4j.LogManager;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -35,10 +42,17 @@ class BlockStateTest {
     }
 
     private BlockState block;
+    private LogCaptor logCaptor;
 
     @BeforeEach
     void beforeEach() {
-        block = new BlockState(1);
+        block = new BlockState(1, 2_000L);
+        logCaptor = new LogCaptor(LogManager.getLogger(BlockState.class));
+    }
+
+    @AfterEach
+    void afterEach() {
+        logCaptor.stopCapture();
     }
 
     @Test
@@ -48,6 +62,7 @@ class BlockStateTest {
         assertThat(block.blockNumber()).isEqualTo(1);
         assertThat(block.itemCount()).isZero();
         assertThat(block.blockItem(0)).isNull();
+        assertThat(block.blockPeriodMillis()).isEqualTo(2_000L);
     }
 
     @Test
@@ -176,6 +191,254 @@ class BlockStateTest {
 
         assertThat(block.isClosed()).isFalse();
         assertThat(block.closedTimestamp()).isNull();
+    }
+
+    @Test
+    void testCheckForDelays_blockClosed() {
+        block = new BlockState(1, 250L);
+
+        block.closeBlock();
+        block.checkForDelays();
+
+        assertThat(logCaptor.warnLogs()).isEmpty();
+        assertThat(logCaptor.infoLogs()).isEmpty();
+    }
+
+    @Test
+    void testCheckForDelays_blockNotOpened() throws Exception {
+        block = new BlockState(1, 250L);
+
+        Thread.sleep(1_000L);
+
+        block.closeBlock();
+        block.checkForDelays();
+
+        // since the block was never opened - i.e. the header was never added - there is no delay
+        assertThat(logCaptor.warnLogs()).isEmpty();
+        assertThat(logCaptor.infoLogs()).isEmpty();
+    }
+
+    @Test
+    void testCheckForDelays_noBlockPeriod() throws Exception {
+        block = new BlockState(1, -1L);
+        Thread.sleep(200L);
+
+        // add the header to "open" the block
+        final BlockItem header = newBlockHeaderItem(1);
+        block.addSerializedItem(
+                BlockItem.PROTOBUF.toBytes(header), header.item().kind());
+
+        block.checkForDelays();
+        block.closeBlock();
+
+        // since the block period is missing (-1), the close delay check will not proceed
+        assertThat(logCaptor.warnLogs()).isEmpty();
+        assertThat(logCaptor.infoLogs()).isEmpty();
+    }
+
+    @Test
+    void testCheckForDelays_closeDelay_withinThreshold() throws Exception {
+        block = new BlockState(1, 500);
+        Thread.sleep(550L);
+
+        // add the header to "open" the block
+        final BlockItem header = newBlockHeaderItem(1);
+        block.addSerializedItem(
+                BlockItem.PROTOBUF.toBytes(header), header.item().kind());
+
+        block.checkForDelays();
+        block.closeBlock();
+
+        // since the block was closed within the block period, the close delay warning will not be triggered
+        assertThat(logCaptor.warnLogs()).isEmpty();
+        assertThat(logCaptor.infoLogs()).isEmpty();
+    }
+
+    @Test
+    void testCheckForDelays_closeDelay_exceededThreshold() throws Exception {
+        block = new BlockState(1, 500);
+        // add the header to "open" the block
+        final BlockItem header = newBlockHeaderItem(1);
+        block.addSerializedItem(
+                BlockItem.PROTOBUF.toBytes(header), header.item().kind());
+
+        Thread.sleep(1250L);
+
+        // add another item so the check doesn't trigger on the slow append path too
+        final BlockItem item = newBlockTxItem(100);
+        block.addSerializedItem(BlockItem.PROTOBUF.toBytes(item), item.item().kind());
+
+        block.checkForDelays();
+
+        final List<String> warnLogs = logCaptor.warnLogs();
+        assertThat(warnLogs).hasSize(1);
+        assertThat(warnLogs.getFirst()).startsWith("Block has been opened for an extended period of time");
+        assertThat(logCaptor.infoLogs()).isEmpty();
+
+        // check for delays again - there should NOT be additional warnings
+        Thread.sleep(25L);
+        block.checkForDelays();
+        Thread.sleep(25L);
+        block.checkForDelays();
+
+        assertThat(logCaptor.warnLogs()).hasSize(1);
+        assertThat(logCaptor.infoLogs()).isEmpty();
+
+        // now close the block - an INFO log should be included now
+        block.closeBlock();
+
+        final List<String> infoLogs = logCaptor.infoLogs();
+        assertThat(logCaptor.warnLogs()).hasSize(1);
+        assertThat(infoLogs).hasSize(1);
+        assertThat(infoLogs.getFirst()).startsWith("Block (1) was open for ");
+    }
+
+    @Test
+    void testCheckForDelays_appendDelay_withinThreshold() throws Exception {
+        block = new BlockState(1, 250);
+        // add the header to "open" the block
+        final BlockItem header = newBlockHeaderItem(1);
+        block.addSerializedItem(
+                BlockItem.PROTOBUF.toBytes(header), header.item().kind());
+
+        Thread.sleep(50);
+
+        block.checkForDelays();
+
+        assertThat(logCaptor.warnLogs()).isEmpty();
+        assertThat(logCaptor.infoLogs()).isEmpty();
+    }
+
+    @Test
+    void testCheckForDelays_appendDelay_exceededThreshold() throws Exception {
+        block = new BlockState(1, 250);
+        // add the header to "open" the block
+        final BlockItem header = newBlockHeaderItem(1);
+        block.addSerializedItem(
+                BlockItem.PROTOBUF.toBytes(header), header.item().kind());
+
+        // sleep for a little over the block period, but don't sleep for too long else we will trigger the close delay
+        Thread.sleep(400);
+
+        block.checkForDelays();
+
+        final List<String> warnLogs1 = logCaptor.warnLogs();
+        assertThat(warnLogs1).hasSize(1);
+        assertThat(warnLogs1.getFirst()).contains("Block is slow appending items", "lastItemIndex: 0");
+        assertThat(logCaptor.infoLogs()).isEmpty();
+
+        // append another item - this should generate an INFO log about the next item taking X amount of time to append
+        final BlockItem item = newBlockTxItem(100);
+        block.addSerializedItem(BlockItem.PROTOBUF.toBytes(item), item.item().kind());
+
+        final List<String> infoLogs1 = logCaptor.infoLogs();
+        assertThat(logCaptor.warnLogs()).hasSize(1);
+        assertThat(infoLogs1).hasSize(1);
+        assertThat(infoLogs1.getFirst()).contains("Block (1) took", "to append the next item (itemIndex: 0->1)");
+
+        // add another slow item - it should retrigger and a new WARN log will be generated
+        // this will also trigger the block close delay too as a side effect of sleeping more than 2x the block period
+        Thread.sleep(400);
+
+        block.checkForDelays();
+
+        final List<String> warnLogs2 = logCaptor.warnLogs();
+        warnLogs2.forEach(System.out::println);
+        assertThat(warnLogs2).hasSize(3);
+        assertThat(warnLogs2.get(0)).contains("Block is slow appending items", "lastItemIndex: 0");
+        assertThat(warnLogs2.get(1)).contains("Block is slow appending items", "lastItemIndex: 1");
+        assertThat(warnLogs2.get(2)).contains("Block has been opened for an extended period of time (block: 1,");
+
+        // close the block and check the INFO logs
+        block.closeBlock();
+
+        // there should be 2 INFO logs: one for the second item delay and one for the block close delay
+        // there will not be a "recovery" INFO log for the second item
+        final List<String> infoLogs2 = logCaptor.infoLogs();
+        assertThat(infoLogs2).hasSize(2);
+        assertThat(infoLogs2.get(0)).contains("Block (1) took", "to append the next item (itemIndex: 0->1)");
+        assertThat(infoLogs2.get(1)).contains("Block (1) was open for", "before being closed");
+    }
+
+    @Test
+    void testAddSerializedItem_nullItem() {
+        assertThat(block.itemCount()).isZero();
+
+        block.addSerializedItem(null);
+
+        assertThat(block.itemCount()).isZero();
+    }
+
+    @Test
+    void testAddSerializedItem_realItem() {
+        assertThat(block.itemCount()).isZero();
+
+        final BlockItem header = newBlockHeaderItem(1);
+        block.addSerializedItem(BlockItem.PROTOBUF.toBytes(header));
+
+        assertThat(block.itemCount()).isOne();
+
+        final BlockItem item = block.blockItem(0);
+        assertThat(item).isEqualTo(header);
+    }
+
+    @Test
+    void testItemOfType_null() {
+        assertThatThrownBy(() -> BlockState.itemTypeOf(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("serializedItem must not be null");
+    }
+
+    @Test
+    void testItemOfType_zeroLength() {
+        final BlockItem.ItemOneOfType type = BlockState.itemTypeOf(Bytes.EMPTY);
+        assertThat(type).isEqualTo(BlockItem.ItemOneOfType.UNSET);
+    }
+
+    @Test
+    void testItemOfType() {
+        final Bytes header = BlockItem.PROTOBUF.toBytes(newBlockHeaderItem(10));
+        final Bytes signedTransaction = BlockItem.PROTOBUF.toBytes(newBlockTxItem(100));
+        final Bytes footer = BlockItem.PROTOBUF.toBytes(newBlockFooter());
+        final Bytes proof = BlockItem.PROTOBUF.toBytes(newBlockProofItem(10, 1_000));
+
+        assertThat(BlockState.itemTypeOf(header)).isEqualTo(BlockItem.ItemOneOfType.BLOCK_HEADER);
+        assertThat(BlockState.itemTypeOf(signedTransaction)).isEqualTo(BlockItem.ItemOneOfType.SIGNED_TRANSACTION);
+        assertThat(BlockState.itemTypeOf(footer)).isEqualTo(BlockItem.ItemOneOfType.BLOCK_FOOTER);
+        assertThat(BlockState.itemTypeOf(proof)).isEqualTo(BlockItem.ItemOneOfType.BLOCK_PROOF);
+    }
+
+    @Test
+    void testSizeBytes() {
+        assertThat(block.sizeBytes()).isZero();
+
+        final BlockItem item = newBlockTxItem(1_000);
+        block.addSerializedItem(BlockItem.PROTOBUF.toBytes(item), BlockItem.ItemOneOfType.SIGNED_TRANSACTION);
+
+        assertThat(block.sizeBytes()).isGreaterThan(1_000);
+    }
+
+    @Test
+    void testGetBufferedItem() {
+        assertThat(block.bufferedItem(0)).isNull();
+
+        final Bytes item1 = BlockItem.PROTOBUF.toBytes(newBlockHeaderItem(1));
+        final Bytes item2 = BlockItem.PROTOBUF.toBytes(newBlockTxItem(1_000));
+        final Bytes item3 = BlockItem.PROTOBUF.toBytes(newBlockProofItem(1, 500));
+        block.addSerializedItem(item1, BlockItem.ItemOneOfType.BLOCK_HEADER);
+        block.addSerializedItem(item2, BlockItem.ItemOneOfType.SIGNED_TRANSACTION);
+        block.addSerializedItem(item3, BlockItem.ItemOneOfType.BLOCK_PROOF);
+
+        final BufferedItem bufferedItem1 = block.bufferedItem(0);
+        final BufferedItem bufferedItem2 = block.bufferedItem(1);
+        final BufferedItem bufferedItem3 = block.bufferedItem(2);
+        assertThat(bufferedItem1).isNotNull();
+        assertThat(bufferedItem2).isNotNull();
+        assertThat(bufferedItem3).isNotNull();
+
+        assertThat(bufferedItem1.serializedItem()).isEqualTo(item1);
+        assertThat(bufferedItem2.serializedItem()).isEqualTo(item2);
+        assertThat(bufferedItem3.serializedItem()).isEqualTo(item3);
     }
 
     // Utilities

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockTestUtils.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/BlockTestUtils.java
@@ -82,7 +82,8 @@ public class BlockTestUtils {
     }
 
     public static BlockState toBlockState(final BufferedBlock bufferedBlock) {
-        final BlockState block = new BlockState(bufferedBlock.blockNumber());
+        final BlockState block =
+                new BlockState(bufferedBlock.blockNumber(), bufferedBlock.blockPeriodMillisOrElse(-1L));
 
         bufferedBlock.block().items().forEach(block::addSerializedItem);
 
@@ -111,7 +112,7 @@ public class BlockTestUtils {
 
     public static BlockState generateRandomBlock(final long blockNumber) {
         final int numItems = ThreadLocalRandom.current().nextInt(25, 250);
-        final BlockState block = new BlockState(blockNumber);
+        final BlockState block = new BlockState(blockNumber, 2_000L);
         block.addItem(newBlockHeader(blockNumber));
         for (int i = 0; i < numItems; ++i) {
             block.addItem(newRandomItem());

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/GrpcBlockItemWriterTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/blocks/impl/streaming/GrpcBlockItemWriterTest.java
@@ -137,7 +137,7 @@ class GrpcBlockItemWriterTest {
     @Test
     void testFlushPendingBlockWritesPendingArtifacts() throws Exception {
         final var blockNumber = 7L;
-        final var blockState = new BlockState(blockNumber);
+        final var blockState = new BlockState(blockNumber, 2_000L);
         blockState.addItem(BlockItem.newBuilder()
                 .blockHeader(BlockHeader.newBuilder().number(blockNumber).build())
                 .build());
@@ -181,7 +181,7 @@ class GrpcBlockItemWriterTest {
     @Test
     void testFlushIncompleteBlockWritesIssArtifactWithoutClosingBuffer() throws Exception {
         final var blockNumber = 7L;
-        final var blockState = new BlockState(blockNumber);
+        final var blockState = new BlockState(blockNumber, 2_000L);
         blockState.addItem(BlockItem.newBuilder()
                 .blockHeader(BlockHeader.newBuilder().number(blockNumber).build())
                 .build());
@@ -237,7 +237,7 @@ class GrpcBlockItemWriterTest {
     @Test
     void flushIncompleteBlockIsNoOpWhenNoItems() {
         final var blockNumber = 7L;
-        when(blockBufferService.getBlockState(blockNumber)).thenReturn(new BlockState(blockNumber));
+        when(blockBufferService.getBlockState(blockNumber)).thenReturn(new BlockState(blockNumber, 2_000L));
         final var writer =
                 new GrpcBlockItemWriter(configProvider, selfNodeAccountIdManager, fileSystem, blockBufferService);
         writer.openBlock(blockNumber);


### PR DESCRIPTION
**Description**:
These changes add monitoring for detecting when a block is not being closed in a timely manner and when there is a significant delay between appending new items to a block. The checking is triggered by the block buffer worker task and happens after the buffer pruning is complete. Each block in the buffer will be checked and if a delay is detected, a WARN log is emitted with information about the delay. If the delay is recovered (e.g. the block is eventually closed or another item is eventually added to the block), an additional INFO log is emitted that captures the full duration of the delay. Block item delays can be re-triggered if there are delays between multiple items. Each delay, whether the block close or item append, will be logged at most once.

This PR also includes a few other changes:
- Add additional testing for `BlockState` to improve test coverage
- Check for common failures to reduce logging when an error is received over the gRPC connection between the CN and BN
- Include the request size when a timeout sending a request is detected

**Related issue(s)**:

Fixes #27021 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
