### PR TITLE
fix: Cherry-pick stale createdContractIds, atomic batch rollback fixes

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/blocks/impl/BlockStreamBuilder.java
@@ -1556,6 +1556,10 @@ public class BlockStreamBuilder
         if (traceDataSizeLimiter.hasExceededTraceDataSizeLimit()) {
             clearContractTraceData();
         }
+        if (evmTransactionResult != null) {
+            logs = null;
+            createdContractIds = null;
+        }
     }
 
     @NonNull


### PR DESCRIPTION
Forward-port of #27101 (`release/0.76`) to `release/0.78`.