### PR TITLE
fix: enforce file-update authorization at ingest and charge failed attempts

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/AuthorizationChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/AuthorizationChecker.java
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.workflows;
+
+import static com.hedera.hapi.node.base.HederaFunctionality.FILE_APPEND;
+import static com.hedera.hapi.node.base.HederaFunctionality.FILE_CREATE;
+import static com.hedera.hapi.node.base.HederaFunctionality.FILE_DELETE;
+import static com.hedera.hapi.node.base.HederaFunctionality.FILE_UPDATE;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTHORIZATION_FAILED;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.ENTITY_NOT_ALLOWED_TO_DELETE;
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.spi.authorization.Authorizer;
+import com.hedera.node.app.spi.workflows.PreCheckException;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+/**
+ * Shared privilege check for operations whose authorization is decidable from the payer and transaction body. Both
+ * ingest (fail-fast, throwing) and pre-handle (returning a due-diligence status) use this single class, so the set of
+ * enforced operations and the status mapping live in one place and cannot drift between the two paths.
+ *
+ * <p>Scoped to file operations (create/update/append/delete); {@code FILE_CREATE} never requires a privilege
+ * (pass-through) but is listed for completeness. Every other functionality keeps its consensus-time authorization only.
+ * The privilege decision itself is delegated to {@link Authorizer#hasPrivilegedAuthorization}, the same source of truth
+ * used at consensus.
+ */
+@Singleton
+public class AuthorizationChecker {
+    private final Authorizer authorizer;
+
+    @Inject
+    public AuthorizationChecker(@NonNull final Authorizer authorizer) {
+        this.authorizer = requireNonNull(authorizer, "authorizer must not be null");
+    }
+
+    /**
+     * Returns the response code for a privileged operation whose payer lacks the required privilege, or {@code null}
+     * if the operation is authorized, requires no privilege, or is not one of the enforced operations. This is the
+     * single decision used by both ingest and pre-handle.
+     *
+     * @param payerId the payer account
+     * @param functionality the transaction functionality
+     * @param txBody the transaction body
+     * @return {@code AUTHORIZATION_FAILED}, {@code ENTITY_NOT_ALLOWED_TO_DELETE}, or {@code null} if there is no failure
+     */
+    @Nullable
+    public ResponseCodeEnum failureFor(
+            @NonNull final AccountID payerId,
+            @NonNull final HederaFunctionality functionality,
+            @NonNull final TransactionBody txBody) {
+        if (!isPrivilegedFileOperation(functionality)) {
+            return null;
+        }
+        return switch (authorizer.hasPrivilegedAuthorization(payerId, functionality, txBody)) {
+            case UNAUTHORIZED -> AUTHORIZATION_FAILED;
+            case IMPERMISSIBLE -> ENTITY_NOT_ALLOWED_TO_DELETE;
+            case AUTHORIZED, UNNECESSARY -> null;
+        };
+    }
+
+    /**
+     * Rejects a transaction whose payer lacks the privilege required for an enforced operation (for example, updating
+     * a system file such as the exchange-rate file 0.0.112). A no-op for any other functionality.
+     *
+     * @param payerId the payer account
+     * @param functionality the transaction functionality
+     * @param txBody the transaction body
+     * @throws PreCheckException AUTHORIZATION_FAILED if the payer lacks a required privilege, or
+     *                           ENTITY_NOT_ALLOWED_TO_DELETE if the operation is impermissible
+     */
+    public void enforce(
+            @NonNull final AccountID payerId,
+            @NonNull final HederaFunctionality functionality,
+            @NonNull final TransactionBody txBody)
+            throws PreCheckException {
+        final var failure = failureFor(payerId, functionality, txBody);
+        if (failure != null) {
+            throw new PreCheckException(failure);
+        }
+    }
+
+    private static boolean isPrivilegedFileOperation(@NonNull final HederaFunctionality functionality) {
+        return functionality == FILE_CREATE
+                || functionality == FILE_UPDATE
+                || functionality == FILE_APPEND
+                || functionality == FILE_DELETE;
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -63,6 +63,7 @@ import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.store.ReadableStoreFactoryImpl;
 import com.hedera.node.app.throttle.SynchronizedThrottleAccumulator;
 import com.hedera.node.app.throttle.ThrottleUsage;
+import com.hedera.node.app.workflows.AuthorizationChecker;
 import com.hedera.node.app.workflows.InnerTransaction;
 import com.hedera.node.app.workflows.OpWorkflowMetrics;
 import com.hedera.node.app.workflows.SolvencyPreCheck;
@@ -122,6 +123,7 @@ public final class IngestChecker {
     private final FeeManager feeManager;
     private final NetworkInfo networkInfo;
     private final Authorizer authorizer;
+    private final AuthorizationChecker authorizationChecker;
     private final SynchronizedThrottleAccumulator synchronizedThrottleAccumulator;
     private final InstantSource instantSource;
     private final OpWorkflowMetrics workflowMetrics;
@@ -185,6 +187,7 @@ public final class IngestChecker {
             @NonNull final TransactionDispatcher dispatcher,
             @NonNull final FeeManager feeManager,
             @NonNull final Authorizer authorizer,
+            @NonNull final AuthorizationChecker authorizationChecker,
             @NonNull final SynchronizedThrottleAccumulator synchronizedThrottleAccumulator,
             @NonNull final InstantSource instantSource,
             @NonNull final OpWorkflowMetrics workflowMetrics,
@@ -200,6 +203,7 @@ public final class IngestChecker {
         this.dispatcher = requireNonNull(dispatcher, "dispatcher must not be null");
         this.feeManager = requireNonNull(feeManager, "feeManager must not be null");
         this.authorizer = requireNonNull(authorizer, "authorizer must not be null");
+        this.authorizationChecker = requireNonNull(authorizationChecker, "authorizationChecker must not be null");
         this.synchronizedThrottleAccumulator =
                 requireNonNull(synchronizedThrottleAccumulator, "synchronizedThrottleAccumulator must not be null");
         this.instantSource = requireNonNull(instantSource, "instantSource must not be null");
@@ -327,6 +331,12 @@ public final class IngestChecker {
         // 5a. Check transaction size limits based on the payer account's privileges
         // (governance accounts may submit larger transactions)
         transactionChecker.checkTransactionSizeLimitBasedOnPayer(txInfo, payerAccountId);
+
+        // 5b. Enforce, at ingest, the payer privileges required by operations whose authorization is decidable from
+        //     the payer and body (today, file operations) — failing fast instead of gossiping a transaction we
+        //     already know will fail at consensus. A no-op for every other functionality. Applies to inner batch
+        //     transactions too, like the checks above.
+        authorizationChecker.enforce(payerAccountId, functionality, txBody);
 
         final var payerKey = payer.key();
         // There should, absolutely, be a key for this account. If there isn't, then something is wrong in

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
@@ -31,6 +31,7 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.spi.workflows.TransactionHandler;
 import com.hedera.node.app.state.DeduplicationCache;
+import com.hedera.node.app.workflows.AuthorizationChecker;
 import com.hedera.node.app.workflows.InnerTransaction;
 import com.hedera.node.app.workflows.TransactionChecker;
 import com.hedera.node.app.workflows.TransactionInfo;
@@ -91,6 +92,13 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
     private final DeduplicationCache deduplicationCache;
 
     /**
+     * Shared privilege check (also used at ingest) for a privileged file operation whose payer lacks the required
+     * privilege. Such an operation is decidable from the payer and body, so if it reaches consensus the submitting
+     * node failed its due diligence and is charged accordingly.
+     */
+    private final AuthorizationChecker authorizationChecker;
+
+    /**
      * Creates a new instance of {@code PreHandleWorkflowImpl}.
      *
      * @param dispatcher         the {@link TransactionDispatcher} for invoking the {@link TransactionHandler} for each
@@ -106,13 +114,15 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
             @NonNull final SignatureVerifier signatureVerifier,
             @NonNull final SignatureExpander signatureExpander,
             @NonNull final ConfigProvider configProvider,
-            @NonNull final DeduplicationCache deduplicationCache) {
+            @NonNull final DeduplicationCache deduplicationCache,
+            @NonNull final AuthorizationChecker authorizationChecker) {
         this.dispatcher = requireNonNull(dispatcher);
         this.transactionChecker = requireNonNull(transactionChecker);
         this.signatureVerifier = requireNonNull(signatureVerifier);
         this.signatureExpander = requireNonNull(signatureExpander);
         this.configProvider = requireNonNull(configProvider);
         this.deduplicationCache = requireNonNull(deduplicationCache);
+        this.authorizationChecker = requireNonNull(authorizationChecker);
     }
 
     /**
@@ -324,11 +334,23 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
 
         // 2b. Call Pre-Transaction Handlers
         try {
-            // Check batch key on non-inner transactions,
+            // Pure checks already ran in preHandleTransaction before this method was called. Mirroring the
+            // ingest ordering (pure checks before privilege), reject a privileged file operation whose payer
+            // lacks the required privilege. That is decidable from the payer and body alone, so reaching
+            // consensus means the submitting node failed its due diligence and is charged. This must precede
+            // the batch-key check below, so a stray batch key on an unauthorized privileged file update cannot
+            // mask the authorization failure and shift the charge from the node to the payer.
+            final var fileAuthFailure = authorizationChecker.failureFor(payer, txInfo.functionality(), txInfo.txBody());
+            if (fileAuthFailure != null) {
+                return nodeDueDiligenceFailure(
+                        creatorInfo.accountId(), fileAuthFailure, txInfo, configuration.getVersion());
+            }
+            // A batch key is only valid on an inner transaction; on a top-level transaction it is the payer's
+            // own malformed request.
             if (innerTransaction == InnerTransaction.NO && txInfo.txBody().hasBatchKey()) {
                 throw new PreCheckException(BATCH_KEY_SET_ON_NON_INNER_TRANSACTION);
             }
-            // Gather the signatures from the transaction handler
+            // Then gather the signatures from the transaction handler
             dispatcher.dispatchPreHandle(context);
         } catch (PreCheckException preCheck) {
             // It is quite possible those semantic checks and other tasks will fail and throw a PreCheckException.

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/AuthorizationCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/AuthorizationCheckerTest.java
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.workflows;
+
+import static com.hedera.hapi.node.base.HederaFunctionality.FILE_UPDATE;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTHORIZATION_FAILED;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.ENTITY_NOT_ALLOWED_TO_DELETE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.HederaFunctionality;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.node.app.spi.authorization.Authorizer;
+import com.hedera.node.app.spi.authorization.SystemPrivilege;
+import com.hedera.node.app.spi.workflows.PreCheckException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthorizationCheckerTest {
+    private static final AccountID PAYER_ID =
+            AccountID.newBuilder().accountNum(2).build();
+    private static final TransactionBody TX_BODY = TransactionBody.DEFAULT;
+
+    @Mock
+    private Authorizer authorizer;
+
+    private AuthorizationChecker subject;
+
+    @BeforeEach
+    void setUp() {
+        subject = new AuthorizationChecker(authorizer);
+    }
+
+    // --- enforce(...) : throwing form used at ingest ---
+
+    @ParameterizedTest
+    @EnumSource(
+            value = HederaFunctionality.class,
+            names = {"FILE_CREATE", "FILE_UPDATE", "FILE_APPEND", "FILE_DELETE"})
+    void fileOperationsConsultTheAuthorizerAndRejectUnauthorizedPayers(final HederaFunctionality functionality) {
+        given(authorizer.hasPrivilegedAuthorization(PAYER_ID, functionality, TX_BODY))
+                .willReturn(SystemPrivilege.UNAUTHORIZED);
+
+        assertThatThrownBy(() -> subject.enforce(PAYER_ID, functionality, TX_BODY))
+                .isInstanceOf(PreCheckException.class)
+                .hasFieldOrPropertyWithValue("responseCode", AUTHORIZATION_FAILED);
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = HederaFunctionality.class,
+            mode = EnumSource.Mode.EXCLUDE,
+            names = {"FILE_CREATE", "FILE_UPDATE", "FILE_APPEND", "FILE_DELETE"})
+    void nonFileOperationsAreNotEnforced(final HederaFunctionality functionality) {
+        assertThatCode(() -> subject.enforce(PAYER_ID, functionality, TX_BODY)).doesNotThrowAnyException();
+        verify(authorizer, never()).hasPrivilegedAuthorization(PAYER_ID, functionality, TX_BODY);
+    }
+
+    @Test
+    void authorizedPayerIsAllowed() throws PreCheckException {
+        given(authorizer.hasPrivilegedAuthorization(PAYER_ID, FILE_UPDATE, TX_BODY))
+                .willReturn(SystemPrivilege.AUTHORIZED);
+
+        assertThatCode(() -> subject.enforce(PAYER_ID, FILE_UPDATE, TX_BODY)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void payerNeedingNoPrivilegeIsAllowed() {
+        given(authorizer.hasPrivilegedAuthorization(PAYER_ID, FILE_UPDATE, TX_BODY))
+                .willReturn(SystemPrivilege.UNNECESSARY);
+
+        assertThatCode(() -> subject.enforce(PAYER_ID, FILE_UPDATE, TX_BODY)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void impermissibleOperationIsRejectedAsNotAllowedToDelete() {
+        given(authorizer.hasPrivilegedAuthorization(PAYER_ID, FILE_UPDATE, TX_BODY))
+                .willReturn(SystemPrivilege.IMPERMISSIBLE);
+
+        assertThatThrownBy(() -> subject.enforce(PAYER_ID, FILE_UPDATE, TX_BODY))
+                .isInstanceOf(PreCheckException.class)
+                .hasFieldOrPropertyWithValue("responseCode", ENTITY_NOT_ALLOWED_TO_DELETE);
+    }
+
+    // --- failureFor(...) : status-returning form used at pre-handle ---
+
+    @Test
+    void failureForReturnsAuthorizationFailedForUnauthorizedFileOp() {
+        given(authorizer.hasPrivilegedAuthorization(PAYER_ID, FILE_UPDATE, TX_BODY))
+                .willReturn(SystemPrivilege.UNAUTHORIZED);
+
+        assertThat(subject.failureFor(PAYER_ID, FILE_UPDATE, TX_BODY)).isEqualTo(AUTHORIZATION_FAILED);
+    }
+
+    @Test
+    void failureForReturnsEntityNotAllowedToDeleteForImpermissibleFileOp() {
+        given(authorizer.hasPrivilegedAuthorization(PAYER_ID, FILE_UPDATE, TX_BODY))
+                .willReturn(SystemPrivilege.IMPERMISSIBLE);
+
+        assertThat(subject.failureFor(PAYER_ID, FILE_UPDATE, TX_BODY)).isEqualTo(ENTITY_NOT_ALLOWED_TO_DELETE);
+    }
+
+    @Test
+    void failureForReturnsNullWhenAuthorized() {
+        given(authorizer.hasPrivilegedAuthorization(PAYER_ID, FILE_UPDATE, TX_BODY))
+                .willReturn(SystemPrivilege.AUTHORIZED);
+
+        assertThat(subject.failureFor(PAYER_ID, FILE_UPDATE, TX_BODY)).isNull();
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+            value = HederaFunctionality.class,
+            mode = EnumSource.Mode.EXCLUDE,
+            names = {"FILE_CREATE", "FILE_UPDATE", "FILE_APPEND", "FILE_DELETE"})
+    void failureForReturnsNullAndSkipsTheAuthorizerForNonFileOps(final HederaFunctionality functionality) {
+        assertThat(subject.failureFor(PAYER_ID, functionality, TX_BODY)).isNull();
+        verify(authorizer, never()).hasPrivilegedAuthorization(PAYER_ID, functionality, TX_BODY);
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
@@ -71,6 +71,7 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.state.recordcache.DeduplicationCacheImpl;
 import com.hedera.node.app.throttle.SynchronizedThrottleAccumulator;
+import com.hedera.node.app.workflows.AuthorizationChecker;
 import com.hedera.node.app.workflows.OpWorkflowMetrics;
 import com.hedera.node.app.workflows.SolvencyPreCheck;
 import com.hedera.node.app.workflows.TransactionChecker;
@@ -136,6 +137,9 @@ class IngestCheckerTest extends AppTestBase {
     private Authorizer authorizer;
 
     @Mock(strictness = LENIENT)
+    private AuthorizationChecker authorizationChecker;
+
+    @Mock(strictness = LENIENT)
     private BlockHashSigner blockHashSigner;
 
     @Mock
@@ -199,6 +203,7 @@ class IngestCheckerTest extends AppTestBase {
                 dispatcher,
                 feeManager,
                 authorizer,
+                authorizationChecker,
                 synchronizedThrottleAccumulator,
                 instantSource,
                 opWorkflowMetrics,
@@ -281,6 +286,7 @@ class IngestCheckerTest extends AppTestBase {
                 dispatcher,
                 feeManager,
                 authorizer,
+                authorizationChecker,
                 synchronizedThrottleAccumulator,
                 instantSource,
                 opWorkflowMetrics,

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.hedera.node.app.workflows.prehandle;
 
+import static com.hedera.hapi.node.base.ResponseCodeEnum.AUTHORIZATION_FAILED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_KEY_SET_ON_NON_INNER_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_NODE_ACCOUNT;
@@ -35,7 +36,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.hedera.hapi.node.base.FileID;
+import com.hedera.hapi.node.base.HederaFunctionality;
 import com.hedera.hapi.node.base.ResponseCodeEnum;
+import com.hedera.hapi.node.file.FileUpdateTransactionBody;
 import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.state.entity.EntityCounts;
 import com.hedera.hapi.platform.state.NodeId;
@@ -50,12 +54,15 @@ import com.hedera.node.app.signature.SignatureExpander;
 import com.hedera.node.app.signature.SignatureVerificationFuture;
 import com.hedera.node.app.signature.SignatureVerifier;
 import com.hedera.node.app.signature.impl.SignatureVerificationImpl;
+import com.hedera.node.app.spi.authorization.Authorizer;
+import com.hedera.node.app.spi.authorization.SystemPrivilege;
 import com.hedera.node.app.spi.fixtures.Scenarios;
 import com.hedera.node.app.spi.store.ReadableStoreFactory;
 import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.spi.workflows.PreHandleContext;
 import com.hedera.node.app.state.DeduplicationCache;
 import com.hedera.node.app.store.ReadableStoreFactoryImpl;
+import com.hedera.node.app.workflows.AuthorizationChecker;
 import com.hedera.node.app.workflows.TransactionChecker;
 import com.hedera.node.app.workflows.TransactionScenarioBuilder;
 import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
@@ -122,6 +129,10 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
     @Mock
     private DeduplicationCache deduplicationCache;
 
+    /** A mocked {@link Authorizer} drives the real {@link AuthorizationChecker} used for the privileged-file check. */
+    @Mock(strictness = Strictness.LENIENT)
+    private Authorizer authorizer;
+
     /** We use a real functional store factory with our standard test data set. Needed by the workflow. */
     private ReadableStoreFactory storeFactory;
 
@@ -166,7 +177,8 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
                 signatureVerifier,
                 signatureExpander,
                 configProvider,
-                deduplicationCache);
+                deduplicationCache,
+                new AuthorizationChecker(authorizer));
     }
 
     /**
@@ -677,6 +689,34 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
 
             final PreHandleResult result = platformTx.getMetadata();
             assertThat(result.responseCode()).isEqualTo(BATCH_KEY_SET_ON_NON_INNER_TRANSACTION);
+        }
+
+        @Test
+        @DisplayName("Unauthorized privileged file op with a top-level batch key is charged to the node")
+        void preHandleUnauthorizedFileOpWithBatchKeyChargesNode() throws Exception {
+            // A privileged FILE_UPDATE by an unauthorized payer, carrying a top-level batchKey, reaching
+            // pre-handle without ingest. The authorization failure is decidable from the payer and body, so the
+            // submitting node must be charged (node due diligence); the stray batch key must not mask it and
+            // shift the charge to the payer.
+            final var body = TransactionScenarioBuilder.goodDefaultBody()
+                    .copyBuilder()
+                    .fileUpdate(FileUpdateTransactionBody.newBuilder()
+                            .fileID(FileID.newBuilder().fileNum(121L).build())
+                            .build())
+                    .batchKey(ALICE.keyInfo().publicKey())
+                    .build();
+            final var txInfo = new TransactionScenarioBuilder(body, HederaFunctionality.FILE_UPDATE).txInfo();
+            final Transaction platformTx = createAppPayloadWrapper(asByteArray(txInfo.signedTx()));
+            when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
+                    .thenReturn(txInfo);
+            when(authorizer.hasPrivilegedAuthorization(any(), any(), any())).thenReturn(SystemPrivilege.UNAUTHORIZED);
+
+            workflow.preHandle(storeFactory, NODE_1.asInfo(), Stream.of(platformTx), (txns, bytes) -> {});
+
+            final PreHandleResult result = platformTx.getMetadata();
+            assertThat(result.status()).isEqualTo(NODE_DUE_DILIGENCE_FAILURE);
+            assertThat(result.responseCode()).isEqualTo(AUTHORIZATION_FAILED);
+            assertThat(result.payer()).isEqualTo(NODE_1.nodeAccountID());
         }
     }
 

--- a/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/calculator/FileUpdateFeeCalculator.java
+++ b/hedera-node/hedera-file-service-impl/src/main/java/com/hedera/node/app/service/file/impl/calculator/FileUpdateFeeCalculator.java
@@ -33,9 +33,11 @@ public class FileUpdateFeeCalculator implements ServiceFeeCalculator {
                             HederaFunctionality.FILE_UPDATE,
                             feeContext.body());
 
-            // Even if the privilege is UNAUTHORIZED or IMPERMISSIBLE continue with a free fee
-            // The appropriate error is thrown at a later stage of the workflow
-            if (privilege != SystemPrivilege.UNNECESSARY) {
+            // Waive fees only when the payer actually holds the privilege (AUTHORIZED). An
+            // UNAUTHORIZED (or IMPERMISSIBLE) attempt falls through to the normal fee so the failed
+            // transaction still pays the standard deterrent; its authorization error is thrown at a
+            // later stage of the workflow.
+            if (privilege == SystemPrivilege.AUTHORIZED) {
                 feeResult.clearFees();
                 return;
             }

--- a/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/calculator/FileServiceFeeCalculatorsTest.java
+++ b/hedera-node/hedera-file-service-impl/src/test/java/com/hedera/node/app/service/file/impl/test/calculator/FileServiceFeeCalculatorsTest.java
@@ -251,8 +251,8 @@ class FileServiceFeeCalculatorsTest {
     }
 
     @Test
-    @DisplayName("FileUpdateFeeCalculator with UNAUTHORIZED privilege clears fees")
-    void testFileUpdateWithUnauthorizedPrivilegedAuthorizationClearsFees() throws UnknownHederaFunctionality {
+    @DisplayName("FileUpdateFeeCalculator with UNAUTHORIZED privilege charges the normal fee")
+    void testFileUpdateWithUnauthorizedPrivilegedAuthorizationChargesNormalFee() throws UnknownHederaFunctionality {
         final var transactionID = TransactionID.newBuilder()
                 .accountID(AccountID.newBuilder().accountNum(1001).build())
                 .build();
@@ -273,9 +273,9 @@ class FileServiceFeeCalculatorsTest {
         final var result = feeCalculator.calculateTxFee(fileUpdateBody, new SimpleFeeContextImpl(feeContext, null));
 
         assertThat(result).isNotNull();
-        assertThat(result.getNodeTotalTinycents()).isEqualTo(0L);
-        assertThat(result.getServiceTotalTinycents()).isEqualTo(0L);
-        assertThat(result.getNetworkTotalTinycents()).isEqualTo(0L);
+        assertThat(result.getNodeTotalTinycents()).isEqualTo(100000L);
+        assertThat(result.getServiceTotalTinycents()).isEqualTo(499000000L);
+        assertThat(result.getNetworkTotalTinycents()).isEqualTo(200000L);
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ExchangeRateControlSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/ExchangeRateControlSuite.java
@@ -108,7 +108,7 @@ public class ExchangeRateControlSuite {
                 fileUpdate(EXCHANGE_RATES)
                         .contents("Should be impossible!")
                         .payingWith("randomAccount")
-                        .hasPrecheck(AUTHORIZATION_FAILED));
+                        .hasPrecheckFrom(AUTHORIZATION_FAILED));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/FileDeleteSuite.java
@@ -50,7 +50,15 @@ public class FileDeleteSuite {
 
     @HapiTest
     final Stream<DynamicTest> handleRejectsMissingFile() {
-        return hapiTest(fileDelete("1.2.3").signedBy(GENESIS).hasKnownStatus(ResponseCodeEnum.INVALID_FILE_ID));
+        return hapiTest(fileDelete("1.2.3000").signedBy(GENESIS).hasKnownStatus(ResponseCodeEnum.INVALID_FILE_ID));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> systemRangeFileDeleteRejectedAtIngest() {
+        // A file number inside the system-reserved range that is not a system file cannot be deleted;
+        // the attempt is rejected at ingest.
+        return hapiTest(
+                fileDelete("0.0.3").signedBy(GENESIS).hasPrecheckFrom(ResponseCodeEnum.ENTITY_NOT_ALLOWED_TO_DELETE));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/SystemFileUpdateDueDiligenceTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/SystemFileUpdateDueDiligenceTest.java
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.file;
+
+import static com.hedera.services.bdd.junit.EmbeddedReason.MUST_SKIP_INGEST;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.atomicBatch;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.fileUpdate;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.validateChargedAccount;
+import static com.hedera.services.bdd.suites.HapiSuite.*;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.*;
+
+import com.hedera.services.bdd.junit.EmbeddedHapiTest;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DynamicTest;
+
+/**
+ * Verifies node due-diligence charging when an unauthorized system-file update reaches consensus.
+ *
+ * <p>Whether a payer may update a system file (here the exchange-rate file 0.0.112) is determined from the
+ * payer and the transaction body alone, so a node can decide it during ingest. When such an update is
+ * rejected at ingest it never reaches consensus. If it does reach consensus — for example when it is
+ * submitted directly to a non-default node so ingest is skipped — then the submitting node, rather than the
+ * named payer, is charged: reaching handle means the node did not perform this check itself.
+ *
+ * <p>The test submits to non-default node 0.0.4 under {@code MUST_SKIP_INGEST} so the update lands at
+ * handle, then asserts the submitting node is the charged account. The transaction resolves to
+ * {@code AUTHORIZATION_FAILED}, and the handle-side due-diligence check attributes this to the node that
+ * failed to reject it at ingest, so the submitting node is charged rather than the named payer.
+ *
+ * <p>Also documents the same scenario inside an atomic batch, where the submitting node is currently not
+ * charged: inner-transaction dispatches skip creator charging, so the batch fails with
+ * {@code INNER_TRANSACTION_FAILED} and the batch payer is charged instead.
+ */
+public class SystemFileUpdateDueDiligenceTest {
+    // 0.0.4 is a non-default node; submitting to it bypasses ingest in embedded mode
+    private static final String SUBMITTING_NODE_ACCOUNT_ID = "4";
+
+    @EmbeddedHapiTest(value = MUST_SKIP_INGEST)
+    @DisplayName("an unauthorized system-file update that bypassed ingest is a node due-diligence failure")
+    final Stream<DynamicTest> unauthorizedSystemFileUpdateThatBypassedIngestChargesTheNode() {
+        final var nonPrivilegedPayer = "nonPrivilegedPayer";
+        final var dueDiligenceTxn = "dueDiligenceTxn";
+        return hapiTest(
+                cryptoCreate(nonPrivilegedPayer),
+                // Fund the submitting node so its due-diligence charge can be collected
+                cryptoTransfer(tinyBarsFromTo(GENESIS, SUBMITTING_NODE_ACCOUNT_ID, ONE_HBAR)),
+                // Submit to a non-default node so ingest is skipped and the update reaches handle. Reaching
+                // handle means the node did not reject the update itself, so the node — not the named payer
+                // — is charged.
+                fileUpdate(EXCHANGE_RATES)
+                        .contents("Should be impossible!")
+                        .payingWith(nonPrivilegedPayer)
+                        .via(dueDiligenceTxn)
+                        .setNode(SUBMITTING_NODE_ACCOUNT_ID)
+                        .hasKnownStatus(AUTHORIZATION_FAILED),
+                // The handle-side due-diligence check charges the submitting node 0.0.4, not the payer.
+                validateChargedAccount(dueDiligenceTxn, SUBMITTING_NODE_ACCOUNT_ID));
+    }
+
+    @EmbeddedHapiTest(value = MUST_SKIP_INGEST)
+    @DisplayName("an unauthorized system-file update with a top-level batch key that bypassed ingest charges the node")
+    final Stream<DynamicTest> unauthorizedSystemFileUpdateWithTopLevelBatchKeyChargesTheNode() {
+        final var nonPrivilegedPayer = "nonPrivilegedPayer";
+        final var batchOperator = "batchOperator";
+        final var dueDiligenceTxn = "dueDiligenceTxn";
+        return hapiTest(
+                cryptoCreate(nonPrivilegedPayer),
+                cryptoCreate(batchOperator),
+                // Fund the submitting node so its due-diligence charge can be collected
+                cryptoTransfer(tinyBarsFromTo(GENESIS, SUBMITTING_NODE_ACCOUNT_ID, ONE_HBAR)),
+                // A stray batch key on a top-level (non-inner) transaction is invalid, but the authorization
+                // failure is decidable from the payer and body, so a node that lets this reach consensus is
+                // charged for its due diligence. The batch key must not mask the authorization failure and
+                // shift the charge to the payer.
+                fileUpdate(EXCHANGE_RATES)
+                        .contents("Should be impossible!")
+                        .payingWith(nonPrivilegedPayer)
+                        .batchKey(batchOperator)
+                        .via(dueDiligenceTxn)
+                        .setNode(SUBMITTING_NODE_ACCOUNT_ID)
+                        .hasKnownStatus(AUTHORIZATION_FAILED),
+                validateChargedAccount(dueDiligenceTxn, SUBMITTING_NODE_ACCOUNT_ID));
+    }
+
+    @EmbeddedHapiTest(value = MUST_SKIP_INGEST)
+    @DisplayName(
+            "an unauthorized system-file update inside an atomic batch that bypassed ingest charges the batch payer")
+    final Stream<DynamicTest> unauthorizedSystemFileUpdateInAtomicBatchThatBypassedIngestChargesTheBatchPayer() {
+        final var nonPrivilegedPayer = "nonPrivilegedPayer";
+        final var batchOperator = "batchOperator";
+        final var batchTxn = "batchTxn";
+        return hapiTest(
+                cryptoCreate(nonPrivilegedPayer),
+                cryptoCreate(batchOperator),
+                // Fund the submitting node so a due-diligence charge could be collected from it
+                cryptoTransfer(tinyBarsFromTo(GENESIS, SUBMITTING_NODE_ACCOUNT_ID, ONE_HBAR)),
+                // Ingest privilege-checks batch inner transactions too, so an honest node rejects this batch
+                // outright; submitting to a non-default node bypasses ingest and lets it reach consensus.
+                // This documents the current charging for that case: pre-handle flags the inner update as a
+                // node due-diligence failure, but BATCH_INNER dispatches skip creator charging, so the batch
+                // fails with INNER_TRANSACTION_FAILED and the batch payer — not the submitting node — is
+                // charged. Whether the node should be charged instead is tracked as a follow-up.
+                atomicBatch(fileUpdate(EXCHANGE_RATES)
+                                .contents("Should be impossible!")
+                                .payingWith(nonPrivilegedPayer)
+                                .batchKey(batchOperator)
+                                .hasKnownStatus(AUTHORIZATION_FAILED))
+                        .payingWith(batchOperator)
+                        .via(batchTxn)
+                        .setNode(SUBMITTING_NODE_ACCOUNT_ID)
+                        .hasKnownStatus(INNER_TRANSACTION_FAILED),
+                validateChargedAccount(batchTxn, batchOperator));
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicExchangeRateControlSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicExchangeRateControlSuite.java
@@ -130,13 +130,13 @@ class AtomicExchangeRateControlSuite {
                 cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS),
                 resetRatesOp,
                 cryptoCreate("randomAccount"),
+                // The inner update is unauthorized, so the whole batch is rejected at ingest.
                 atomicBatch(fileUpdate(EXCHANGE_RATES)
                                 .contents("Should be impossible!")
                                 .payingWith("randomAccount")
-                                .hasKnownStatus(AUTHORIZATION_FAILED)
                                 .batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR)
-                        .hasKnownStatus(INNER_TRANSACTION_FAILED));
+                        .hasPrecheckFrom(AUTHORIZATION_FAILED));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileDeleteSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicFileDeleteSuite.java
@@ -62,12 +62,23 @@ class AtomicFileDeleteSuite {
     final Stream<DynamicTest> handleRejectsMissingFile() {
         return hapiTest(
                 cryptoCreate(BATCH_OPERATOR),
-                atomicBatch(fileDelete("1.2.3")
+                atomicBatch(fileDelete("1.2.3000") // 3000 is a non-system, non-existent file id
                                 .signedBy(GENESIS)
                                 .hasKnownStatus(ResponseCodeEnum.INVALID_FILE_ID)
                                 .batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR)
                         .hasKnownStatus(INNER_TRANSACTION_FAILED));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> systemRangeFileDeleteRejectedAtIngest() {
+        // The inner delete targets a system-reserved (non-system-file) number, so the whole batch
+        // is rejected at ingest.
+        return hapiTest(
+                cryptoCreate(BATCH_OPERATOR),
+                atomicBatch(fileDelete("0.0.3").signedBy(GENESIS).batchKey(BATCH_OPERATOR))
+                        .payingWith(BATCH_OPERATOR)
+                        .hasPrecheckFrom(ResponseCodeEnum.ENTITY_NOT_ALLOWED_TO_DELETE));
     }
 
     @HapiTest

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicProtectedFilesUpdateSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicProtectedFilesUpdateSuite.java
@@ -26,7 +26,6 @@ import static com.hedera.services.bdd.suites.HapiSuite.SIMPLE_FEE_SCHEDULE;
 import static com.hedera.services.bdd.suites.HapiSuite.SYSTEM_ADMIN;
 import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.AUTHORIZATION_FAILED;
-import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.INNER_TRANSACTION_FAILED;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -315,13 +314,13 @@ class AtomicProtectedFilesUpdateSuite {
         return hapiTest(
                 cryptoCreate("unauthorizedAccount"),
                 cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS),
+                // The inner update is unauthorized, so the whole batch is rejected at ingest.
                 atomicBatch(fileUpdate(specialFile)
                                 .contents(newContents)
                                 .payingWith("unauthorizedAccount")
-                                .hasKnownStatus(AUTHORIZATION_FAILED)
                                 .batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR)
-                        .hasKnownStatus(INNER_TRANSACTION_FAILED));
+                        .hasPrecheckFrom(AUTHORIZATION_FAILED));
     }
 
     private byte[] extendedBioAddressBook(byte[] contents, String targetMemo, String replaceMemo) {

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicUpdateFailuresSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/batch/AtomicUpdateFailuresSpec.java
@@ -73,53 +73,36 @@ class AtomicUpdateFailuresSpec {
 
     @HapiTest
     final Stream<DynamicTest> precheckRejectsUnauthorized() {
-        // this test is to verify that the system files cannot be updated without privileged account
+        // A civilian cannot update a system file: the unauthorized inner update causes the whole
+        // batch to be rejected at ingest.
         return hapiTest(
                 cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS),
                 cryptoCreate(CIVILIAN),
-                atomicBatch(fileUpdate(ADDRESS_BOOK)
-                                .payingWith(CIVILIAN)
-                                .hasKnownStatus(AUTHORIZATION_FAILED)
-                                .batchKey(BATCH_OPERATOR))
+                atomicBatch(fileUpdate(ADDRESS_BOOK).payingWith(CIVILIAN).batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR)
-                        .hasKnownStatus(INNER_TRANSACTION_FAILED),
-                atomicBatch(fileUpdate(NODE_DETAILS)
-                                .payingWith(CIVILIAN)
-                                .hasKnownStatus(AUTHORIZATION_FAILED)
-                                .batchKey(BATCH_OPERATOR))
+                        .hasPrecheckFrom(AUTHORIZATION_FAILED),
+                atomicBatch(fileUpdate(NODE_DETAILS).payingWith(CIVILIAN).batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR)
-                        .hasKnownStatus(INNER_TRANSACTION_FAILED),
-                atomicBatch(fileUpdate(API_PERMISSIONS)
-                                .payingWith(CIVILIAN)
-                                .hasKnownStatus(AUTHORIZATION_FAILED)
-                                .batchKey(BATCH_OPERATOR))
+                        .hasPrecheckFrom(AUTHORIZATION_FAILED),
+                atomicBatch(fileUpdate(API_PERMISSIONS).payingWith(CIVILIAN).batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR)
-                        .hasKnownStatus(INNER_TRANSACTION_FAILED),
-                atomicBatch(fileUpdate(APP_PROPERTIES)
-                                .payingWith(CIVILIAN)
-                                .hasKnownStatus(AUTHORIZATION_FAILED)
-                                .batchKey(BATCH_OPERATOR))
+                        .hasPrecheckFrom(AUTHORIZATION_FAILED),
+                atomicBatch(fileUpdate(APP_PROPERTIES).payingWith(CIVILIAN).batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR)
-                        .hasKnownStatus(INNER_TRANSACTION_FAILED),
-                atomicBatch(fileUpdate(FEE_SCHEDULE)
-                                .payingWith(CIVILIAN)
-                                .hasKnownStatus(AUTHORIZATION_FAILED)
-                                .batchKey(BATCH_OPERATOR))
+                        .hasPrecheckFrom(AUTHORIZATION_FAILED),
+                atomicBatch(fileUpdate(FEE_SCHEDULE).payingWith(CIVILIAN).batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR)
-                        .hasKnownStatus(INNER_TRANSACTION_FAILED),
-                atomicBatch(fileUpdate(EXCHANGE_RATES)
-                                .payingWith(CIVILIAN)
-                                .hasKnownStatus(AUTHORIZATION_FAILED)
-                                .batchKey(BATCH_OPERATOR))
+                        .hasPrecheckFrom(AUTHORIZATION_FAILED),
+                atomicBatch(fileUpdate(EXCHANGE_RATES).payingWith(CIVILIAN).batchKey(BATCH_OPERATOR))
                         .payingWith(BATCH_OPERATOR)
-                        .hasKnownStatus(INNER_TRANSACTION_FAILED));
+                        .hasPrecheckFrom(AUTHORIZATION_FAILED));
     }
 
     @HapiTest
     final Stream<DynamicTest> precheckAllowsMissing() {
         return hapiTest(
                 cryptoCreate(BATCH_OPERATOR).balance(ONE_MILLION_HBARS),
-                atomicBatch(fileUpdate("1.2.3")
+                atomicBatch(fileUpdate("1.2.3000") // 3000 is a non-system, non-existent file id
                                 .payingWith(GENESIS)
                                 .signedBy(GENESIS)
                                 .fee(1_234_567L)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/UpdateFailuresSpec.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/file/negative/UpdateFailuresSpec.java
@@ -63,17 +63,28 @@ public class UpdateFailuresSpec {
         // this test is to verify that the system files cannot be updated without privileged account
         return hapiTest(
                 cryptoCreate(CIVILIAN),
-                fileUpdate(ADDRESS_BOOK).payingWith(CIVILIAN).hasPrecheck(AUTHORIZATION_FAILED),
-                fileUpdate(NODE_DETAILS).payingWith(CIVILIAN).hasPrecheck(AUTHORIZATION_FAILED),
-                fileUpdate(API_PERMISSIONS).payingWith(CIVILIAN).hasPrecheck(AUTHORIZATION_FAILED),
-                fileUpdate(APP_PROPERTIES).payingWith(CIVILIAN).hasPrecheck(AUTHORIZATION_FAILED),
-                fileUpdate(FEE_SCHEDULE).payingWith(CIVILIAN).hasPrecheck(AUTHORIZATION_FAILED),
-                fileUpdate(EXCHANGE_RATES).payingWith(CIVILIAN).hasPrecheck(AUTHORIZATION_FAILED));
+                fileUpdate(ADDRESS_BOOK).payingWith(CIVILIAN).hasPrecheckFrom(AUTHORIZATION_FAILED),
+                fileUpdate(NODE_DETAILS).payingWith(CIVILIAN).hasPrecheckFrom(AUTHORIZATION_FAILED),
+                fileUpdate(API_PERMISSIONS).payingWith(CIVILIAN).hasPrecheckFrom(AUTHORIZATION_FAILED),
+                fileUpdate(APP_PROPERTIES).payingWith(CIVILIAN).hasPrecheckFrom(AUTHORIZATION_FAILED),
+                fileUpdate(FEE_SCHEDULE).payingWith(CIVILIAN).hasPrecheckFrom(AUTHORIZATION_FAILED),
+                fileUpdate(EXCHANGE_RATES).payingWith(CIVILIAN).hasPrecheckFrom(AUTHORIZATION_FAILED));
+    }
+
+    @HapiTest
+    final Stream<DynamicTest> unrecognizedSystemFileUpdateRejectedAtIngest() {
+        // A file number inside the system-reserved range that is not one of the recognized system
+        // files is still a privileged target: an unprivileged payer is rejected at ingest.
+        return hapiTest(
+                cryptoCreate(CIVILIAN),
+                fileUpdate("0.0.3").payingWith(CIVILIAN).signedBy(CIVILIAN).hasPrecheckFrom(AUTHORIZATION_FAILED));
     }
 
     @HapiTest
     final Stream<DynamicTest> precheckAllowsMissing() {
-        return hapiTest(fileUpdate("1.2.3")
+        // Use a non-system file number (> numReservedSystemEntities) so the update is not a
+        // privileged operation: it passes ingest and fails at consensus with INVALID_FILE_ID.
+        return hapiTest(fileUpdate("1.2.3000")
                 .payingWith(GENESIS)
                 .signedBy(GENESIS)
                 .fee(1_234_567L)

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/FileServiceSimpleFeesTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/hip1261/FileServiceSimpleFeesTest.java
@@ -791,14 +791,19 @@ public class FileServiceSimpleFeesTest {
                 return hapiTest(
                         newKeyNamed(PAYER_KEY),
                         cryptoCreate(PAYER).key(PAYER_KEY).balance(ONE_HUNDRED_HBARS),
-                        fileUpdate("1.2.3")
+                        // Use a non-system file number so the update is not a privileged operation:
+                        // it passes ingest and fails at consensus with INVALID_FILE_ID, still charged
+                        // the base fee.
+                        fileUpdate("1.2.3000")
                                 .contents("abc")
                                 .payingWith(PAYER)
                                 .signedBy(PAYER)
                                 .via("fileUpdateInvalidFileIdTxn")
                                 .hasKnownStatus(INVALID_FILE_ID),
                         validateChargedUsdWithinWithTxnSize(
-                                "fileUpdateInvalidFileIdTxn", ignored -> 0.0, ALLOWED_PERCENT_DIFF));
+                                "fileUpdateInvalidFileIdTxn",
+                                FileServiceSimpleFeesTest::expectedFileUpdateBaseOnlyFeeUsd,
+                                ALLOWED_PERCENT_DIFF));
             }
 
             @HapiTest


### PR DESCRIPTION
Forward-port of #27063 (`release/0.76`) to `release/0.78`.