### PR TITLE
fix: deleting a rewardable stakee no longer freezes its indirect stakers

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHandlerImpl.java
@@ -269,7 +269,13 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
         final var stakedAccountId = account.stakedAccountId();
         final var stakedAccount = accountStore.getOriginalValue(stakedAccountId);
         // if the special reward receiver account is not staked to a node, it will not need to receive reward
-        if (stakedAccount != null && stakedAccount.hasStakedNodeId()) {
+        //
+        // A stakee deleted in a prior transaction still carries its stakedNodeId and stakedToMe, so it
+        // would otherwise be rediscovered here whenever one of its indirect stakers is touched. We must
+        // not treat it as a reward receiver: its reward can no longer be redirected to a beneficiary
+        // (the delete->beneficiary mapping lives only on the deleting transaction's record builder), so
+        // StakingRewardsDistributor#payRewardsIfPending would throw and fail the unrelated transaction.
+        if (stakedAccount != null && stakedAccount.hasStakedNodeId() && !stakedAccount.deleted()) {
             updatedSpecialRewardReceivers.add(stakedAccountId);
         }
         return updatedSpecialRewardReceivers;
@@ -306,8 +312,16 @@ public class StakingRewardsHandlerImpl implements StakingRewardsHandler {
             final var scenario = StakeIdChangeType.forCase(originalAccount, modifiedAccount);
             final var containStakeMetaChanges = hasStakeMetaChanges(originalAccount, modifiedAccount);
 
+            // A stakee deleted in a PRIOR transaction already had its node stake settled at delete time,
+            // but it can be pulled back into the modification set here when an orphaned indirect staker's
+            // balance change updates its stale stakedToMe. Re-running the node-stake adjustment would
+            // withdraw that stale stake again without re-awarding it (the award path is guarded by
+            // !modifiedAccount.deleted()), spuriously draining the node's stakeToReward on every such
+            // transaction. An account deleted in the CURRENT transaction is unaffected (its original
+            // value is not yet deleted), so its delete-time withdrawal still happens.
+            final var deletedBeforeThisTxn = originalAccount != null && originalAccount.deleted();
             // If this scenario is changing StakedId from a node or to a node, change stake of those nodes
-            if ((scenario.withdrawsFromNode() || scenario.awardsToNode())) {
+            if (!deletedBeforeThisTxn && (scenario.withdrawsFromNode() || scenario.awardsToNode())) {
                 adjustNodeStakes(
                         scenario,
                         originalAccount,

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHelper.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/staking/StakingRewardsHelper.java
@@ -97,7 +97,12 @@ public class StakingRewardsHelper {
                     possibleRewardReceivers.add(id);
                 }
             } else {
-                if (isCurrentlyStakedToNode(writableAccountStore.get(id))) {
+                // Skip a stakee deleted in a prior transaction (its reward can no longer be redirected);
+                // one deleted in the current transaction is kept, mirroring the stake-to-me guard in
+                // StakingRewardsHandlerImpl#updateSpecialRewardReceivers.
+                final var originalAcct = writableAccountStore.getOriginalValue(id);
+                if ((originalAcct == null || !originalAcct.deleted())
+                        && isCurrentlyStakedToNode(writableAccountStore.get(id))) {
                     possibleRewardReceivers.add(id);
                 }
             }

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
@@ -47,6 +47,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
@@ -1313,6 +1314,171 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
         final var node0InfoAfter = writableStakingInfoStore.get(node0Id.number());
         assertThat(node0InfoAfter.stakeToReward())
                 .isEqualTo(node0InfoBefore.stakeToReward() - roundedToHbar(totalStake(ownerAccountBefore)));
+    }
+
+    @Test
+    void doesNotRewardStakeeDeletedInPriorTransaction() {
+        // Regression for the deleted-stakee freeze. The staker (payer) stakes to an account (owner)
+        // that was deleted in a PRIOR transaction but still carries its stakedNodeId/stakedToMe.
+        // Touching the staker must not rediscover the deleted stakee as a reward receiver; doing so
+        // used to throw IllegalStateException (its reward could not be redirected to a beneficiary,
+        // since that mapping only exists on the deleting transaction's record builder).
+        final var accountBalance = 55L * HBARS_TO_TINYBARS;
+        final var payerAccountBefore = new AccountCustomizer()
+                .withAccount(account)
+                .withBalance(accountBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart - 2)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedToMe(0L)
+                .withStakedAccountId(ownerId)
+                .build();
+        // The stakee is already deleted (deleted in an earlier transaction), but its staking fields
+        // were left intact by CryptoDelete, so without the guard it would be rediscovered here.
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(0L)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart - 2)
+                .withDeclineReward(false)
+                .withDeleted(true)
+                .withStakedNodeId(node0Id.number())
+                .withStakedToMe(accountBalance)
+                .build();
+        addToState(Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore));
+
+        mockEntityIdFactory();
+
+        // The staker's balance changes (it sends 1 hbar), which previously triggered rediscovery of
+        // the deleted stakee.
+        writableAccountStore.put(account.copyBuilder()
+                .tinybarBalance(accountBalance - HBARS_TO_TINYBARS)
+                .stakedAccountId(ownerId)
+                .build());
+
+        given(context.consensusTime())
+                .willReturn(LocalDate.ofEpochDay(stakePeriodStart)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        stakePeriodManager.setCurrentStakePeriodFor(context.consensusTime());
+
+        // Finalization must not throw (it used to fail with IllegalStateException because the reward
+        // could not be redirected), and the deleted stakee must not be rewarded.
+        final var rewards =
+                assertDoesNotThrow(() -> subject.applyStakingRewards(context, Collections.emptySet(), emptyMap()));
+        assertThat(rewards).doesNotContainKey(ownerId);
+    }
+
+    @Test
+    void doesNotRewardDeletedExplicitRewardReceiver() {
+        // Defense-in-depth companion to the guard above. A stakee deleted in a prior transaction that is
+        // surfaced through the explicit reward-receiver path (StakingRewardsHelper#isCurrentlyStakedToNode,
+        // which the contract service can feed) must also be skipped, so finalization neither throws nor
+        // rewards it.
+        final var accountBalance = 55L * HBARS_TO_TINYBARS;
+        final var payerAccountBefore = new AccountCustomizer()
+                .withAccount(account)
+                .withBalance(accountBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart - 2)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedToMe(0L)
+                .withStakedAccountId(ownerId)
+                .build();
+        // The stakee is already deleted (deleted in an earlier transaction) but still staked to a node.
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(0L)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart - 2)
+                .withDeclineReward(false)
+                .withDeleted(true)
+                .withStakedNodeId(node0Id.number())
+                .withStakedToMe(accountBalance)
+                .build();
+        addToState(Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore));
+
+        mockEntityIdFactory();
+
+        writableAccountStore.put(account.copyBuilder()
+                .tinybarBalance(accountBalance - HBARS_TO_TINYBARS)
+                .stakedAccountId(ownerId)
+                .build());
+
+        given(context.consensusTime())
+                .willReturn(LocalDate.ofEpochDay(stakePeriodStart)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        stakePeriodManager.setCurrentStakePeriodFor(context.consensusTime());
+
+        // The deleted stakee is passed explicitly (as the contract service would); it must still be
+        // filtered out before reward distribution.
+        final var rewards = assertDoesNotThrow(() -> subject.applyStakingRewards(context, Set.of(ownerId), emptyMap()));
+        assertThat(rewards).doesNotContainKey(ownerId);
+    }
+
+    @Test
+    void doesNotWithdrawNodeStakeForStakeeDeletedInPriorTransaction() {
+        // Regression for the node-stake drift adjacent to the deleted-stakee freeze fix. The staker
+        // (payer) stakes to an account (owner) that was deleted in a PRIOR transaction. The owner's
+        // node stake was already settled when it was deleted, but its stale stakedToMe is still updated
+        // when the staker's balance changes, pulling the deleted owner back into the modification set.
+        // adjustStakeMetadata then withdrew the owner's entire (stale) stakedToMe from the node WITHOUT
+        // re-awarding (the award path is guarded by !modifiedAccount.deleted()), spuriously reducing the
+        // node's stakeToReward on every transaction the orphaned staker makes and masking the rewardable
+        // stake of the node's other stakers. The node's stake must be left untouched.
+        final var accountBalance = 55L * HBARS_TO_TINYBARS;
+        final var payerAccountBefore = new AccountCustomizer()
+                .withAccount(account)
+                .withBalance(accountBalance)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart - 2)
+                .withDeclineReward(false)
+                .withDeleted(false)
+                .withStakedToMe(0L)
+                .withStakedAccountId(ownerId)
+                .build();
+        // The stakee was deleted in an earlier transaction; CryptoDelete left its staking fields intact.
+        final var ownerAccountBefore = new AccountCustomizer()
+                .withAccount(ownerAccount)
+                .withBalance(0L)
+                .withStakeAtStartOfLastRewardPeriod(-1L)
+                .withStakePeriodStart(stakePeriodStart - 2)
+                .withDeclineReward(false)
+                .withDeleted(true)
+                .withStakedNodeId(node0Id.number())
+                .withStakedToMe(accountBalance)
+                .build();
+        addToState(Map.of(payerId, payerAccountBefore, ownerId, ownerAccountBefore));
+
+        mockEntityIdFactory();
+
+        final var node0InfoBefore = writableStakingInfoState.get(node0Id);
+
+        // The staker sends 1 hbar, which updates the deleted stakee's stale stakedToMe.
+        writableAccountStore.put(account.copyBuilder()
+                .tinybarBalance(accountBalance - HBARS_TO_TINYBARS)
+                .stakedAccountId(ownerId)
+                .build());
+
+        given(context.consensusTime())
+                .willReturn(LocalDate.ofEpochDay(stakePeriodStart)
+                        .atStartOfDay(ZoneOffset.UTC)
+                        .toInstant());
+        given(context.writableStore(WritableAccountStore.class)).willReturn(writableAccountStore);
+        stakePeriodManager.setCurrentStakePeriodFor(context.consensusTime());
+
+        subject.applyStakingRewards(context, Collections.emptySet(), emptyMap());
+
+        // The deleted stakee's node stake was already withdrawn at delete time; the later transaction
+        // must not withdraw it again. Before the fix, node0's stakeToReward dropped by the stale
+        // stakedToMe (accountBalance), i.e. 666 hbar -> 611 hbar.
+        final var node0InfoAfter = writableStakingInfoStore.get(node0Id.number());
+        assertThat(node0InfoAfter.stakeToReward()).isEqualTo(node0InfoBefore.stakeToReward());
     }
 
     @Test

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/RepeatableDeletedStakeeIndirectStakerTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/RepeatableDeletedStakeeIndirectStakerTest.java
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.services.bdd.suites.staking;
+
+import static com.hedera.services.bdd.junit.RepeatableReason.NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION;
+import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
+import static com.hedera.services.bdd.spec.queries.QueryVerbs.getTxnRecord;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoCreate;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoDelete;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoTransfer;
+import static com.hedera.services.bdd.spec.transactions.TxnVerbs.cryptoUpdate;
+import static com.hedera.services.bdd.spec.transactions.crypto.HapiCryptoTransfer.tinyBarsFromTo;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.overridingAllOf;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitUntilStartOfNextStakingPeriod;
+import static com.hedera.services.bdd.suites.HapiSuite.FUNDING;
+import static com.hedera.services.bdd.suites.HapiSuite.GENESIS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HBAR;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_HUNDRED_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.ONE_MILLION_HBARS;
+import static com.hedera.services.bdd.suites.HapiSuite.STAKING_REWARD;
+import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.SUCCESS;
+
+import com.hedera.services.bdd.junit.HapiTestLifecycle;
+import com.hedera.services.bdd.junit.RepeatableHapiTest;
+import com.hedera.services.bdd.junit.support.TestLifecycle;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DynamicTest;
+
+/**
+ * Regression tests for the deleted-stakee freeze: deleting an account that an indirect staker
+ * (HIP-406 {@code stakedAccountId}) points at must not permanently break that staker.
+ *
+ * <p>Before the fix, deleting a rewardable intermediate stakee left its {@code stakedNodeId} and
+ * {@code stakedToMe} populated, so reward finalization in a <em>later</em> transaction rediscovered
+ * the deleted stakee as a reward receiver, computed a positive reward for it, and then could not
+ * redirect that reward (the delete-&gt;beneficiary mapping lives only on the deleting transaction's
+ * record builder). {@code StakingRewardsDistributor#payRewardsIfPending} threw
+ * {@code IllegalStateException}, the handle workflow rolled the savepoint back, and the transaction
+ * was externalized as {@code FAIL_INVALID} — so any balance-changing transaction touching the staker
+ * (outbound transfer, inbound transfer, or even clearing its staking election) failed the same way.
+ *
+ * <p>The fix ({@code StakingRewardsHandlerImpl#updateSpecialRewardReceivers}) skips a stakee that was
+ * already deleted at the start of the transaction, so it is never rediscovered as a reward receiver.
+ * These tests assert that the previously-frozen operations now succeed.
+ */
+@HapiTestLifecycle
+public class RepeatableDeletedStakeeIndirectStakerTest {
+
+    @BeforeAll
+    static void beforeAll(@NonNull final TestLifecycle lifecycle) {
+        lifecycle.doAdhoc(
+                // These overrides only accelerate reward accrual so the scenario plays out in a few
+                // virtual "days"; they are not required for the behavior under test.
+                overridingAllOf(Map.of(
+                        "staking.startThreshold", "" + 10 * ONE_HBAR,
+                        "staking.perHbarRewardRate", "1",
+                        "staking.rewardBalanceThreshold", "0")),
+                // Fund 0.0.800 (STAKING_REWARD) so there is a pool to pay rewards from.
+                cryptoTransfer(tinyBarsFromTo(GENESIS, STAKING_REWARD, ONE_MILLION_HBARS)));
+    }
+
+    @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
+    Stream<DynamicTest> indirectStakerCanTransactAfterItsRewardableStakeeIsDeleted() {
+        return hapiTest(
+                // "deletedStakee" stakes directly to node 0 and will be deleted;
+                // "deletedStaker" stakes INDIRECTLY through it and used to get frozen.
+                cryptoCreate("deletedStakee").stakedNodeId(0).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate("deletedStaker").stakedAccountId("deletedStakee").balance(ONE_HUNDRED_HBARS),
+                // CryptoDelete requires a transfer target for the deleted account's remaining balance.
+                cryptoCreate("deletedStakeeBeneficiary").balance(0L),
+                cryptoCreate("deletedStakerReceiver").balance(0L),
+
+                // Roll forward two staking periods so the indirect staker becomes rewardable.
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+
+                // Delete the rewardable intermediate stakee (deletedStaker still points at it).
+                cryptoDelete("deletedStakee")
+                        .transfer("deletedStakeeBeneficiary")
+                        .payingWith("deletedStakee")
+                        .via("deleteStakee")
+                        .hasKnownStatus(SUCCESS),
+                // The stakee really was rewardable: its accrued reward is redirected to the beneficiary on
+                // delete. This guards against a future setup drift that would turn the scenario into a no-op,
+                // and confirms the same-transaction redirect (which the fix preserves) still works.
+                getTxnRecord("deleteStakee").hasPaidStakingRewardsCount(1),
+
+                // Advance one more period so the deleted stakee would be "rewardable" again from the
+                // perspective of a later transaction touching its indirect staker.
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+
+                // The staker's outbound transfer now SUCCEEDS and the receiver is credited.
+                cryptoTransfer(tinyBarsFromTo("deletedStaker", "deletedStakerReceiver", 1L))
+                        .payingWith("deletedStaker")
+                        .hasKnownStatus(SUCCESS),
+                getAccountBalance("deletedStakerReceiver").hasTinyBars(1L),
+
+                // The staker can also clear its staking election (newStakedNodeId(-1)) -> SUCCESS.
+                cryptoUpdate("deletedStaker")
+                        .newStakedNodeId(-1L)
+                        .payingWith("deletedStaker")
+                        .hasKnownStatus(SUCCESS));
+    }
+
+    @RepeatableHapiTest(NEEDS_VIRTUAL_TIME_FOR_FAST_EXECUTION)
+    Stream<DynamicTest> thirdPartyCanTransferIntoIndirectStakerAfterItsRewardableStakeeIsDeleted() {
+        // Proves a THIRD PARTY can also pay INTO the affected staker: crediting the receiver no longer
+        // rediscovers the deleted stakee.
+        return hapiTest(
+                cryptoCreate("inboundDeletedStakee").stakedNodeId(0).balance(ONE_HUNDRED_HBARS),
+                cryptoCreate("inboundDeletedStaker")
+                        .stakedAccountId("inboundDeletedStakee")
+                        .balance(ONE_HUNDRED_HBARS),
+                cryptoCreate("inboundDeletedStakeeBeneficiary").balance(0L),
+                // A separate, unrelated sender (the "third party").
+                cryptoCreate("inboundDeletedSender").balance(ONE_HUNDRED_HBARS),
+
+                // Roll forward two periods so the indirect staker becomes rewardable.
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+
+                // Delete the rewardable intermediate stakee.
+                cryptoDelete("inboundDeletedStakee")
+                        .transfer("inboundDeletedStakeeBeneficiary")
+                        .payingWith("inboundDeletedStakee")
+                        .via("inboundDeleteStakee")
+                        .hasKnownStatus(SUCCESS),
+                // The stakee really was rewardable: its accrued reward is redirected to the beneficiary on
+                // delete (guards against the scenario silently becoming a no-op).
+                getTxnRecord("inboundDeleteStakee").hasPaidStakingRewardsCount(1),
+                waitUntilStartOfNextStakingPeriod(1),
+                cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
+
+                // Third party pays INTO the affected staker -> SUCCESS, recipient is credited.
+                cryptoTransfer(tinyBarsFromTo("inboundDeletedSender", "inboundDeletedStaker", 1L))
+                        .payingWith("inboundDeletedSender")
+                        .hasKnownStatus(SUCCESS),
+                getAccountBalance("inboundDeletedStaker").hasTinyBars(ONE_HUNDRED_HBARS + 1L));
+    }
+}


### PR DESCRIPTION
Forward-port of #27112 (`release/0.76`) to `release/0.77`.