### PR TITLE
fix: Block royalty payments even when receiver is exempt from in-scope fallback fee

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
@@ -11,6 +11,7 @@ import static com.hedera.node.app.hapi.utils.CommonPbjConverters.fromPbj;
 import static com.hedera.node.app.service.token.impl.handlers.transfer.AssociateTokenRecipientsStep.PLACEHOLDER_SYNTHETIC_ASSOCIATION;
 import static com.hedera.node.app.service.token.impl.handlers.transfer.AssociateTokenRecipientsStep.PLACEHOLDER_SYNTHETIC_ASSOCIATION_HV;
 import static com.hedera.node.app.service.token.impl.handlers.transfer.AssociateTokenRecipientsStep.associationFeeFor;
+import static com.hedera.node.app.service.token.impl.handlers.transfer.EnsureAliasesStep.isAlias;
 import static com.hedera.node.app.service.token.impl.util.AirdropHandlerHelper.createAccountPendingAirdrop;
 import static com.hedera.node.app.service.token.impl.util.AirdropHandlerHelper.createFirstAccountPendingAirdrop;
 import static com.hedera.node.app.service.token.impl.util.AirdropHandlerHelper.createFungibleTokenPendingAirdropId;
@@ -131,18 +132,32 @@ public class TokenAirdropHandler extends TransferExecutor implements Transaction
         var tokensConfig = context.configuration().getConfigData(TokensConfig.class);
         List<TokenTransferList> tokenTransferList = new ArrayList<>();
 
-        // validate the transaction body token transfers and NFT transfers
-        validator.validateSemantics(context, op, accountStore, tokenStore, tokenRelStore, nftStore);
-
-        // If the transaction is valid, charge custom fees in advance
         var convertedOp = CryptoTransferTransactionBody.newBuilder()
                 .tokenTransfers(op.tokenTransfers())
                 .build();
+        final var isHighVolume = context.body().highVolume();
+        final var transferContext = new TransferContextImpl(context, convertedOp, true, isHighVolume);
+
+        // Custom-fee validation and assessment compare account IDs directly, so use canonical account IDs in all
+        // subsequent steps. The shared context also retains the alias resolutions needed by custom-fee assessment.
+        if (containsAliases(convertedOp)) {
+            final var syntheticCryptoTransferTxn = TransactionBody.newBuilder()
+                    .highVolume(isHighVolume)
+                    .cryptoTransfer(convertedOp)
+                    .build();
+            convertedOp = ensureAndReplaceAliasesInOp(syntheticCryptoTransferTxn, transferContext);
+        }
+        final var resolvedAirdropOp =
+                op.copyBuilder().tokenTransfers(convertedOp.tokenTransfers()).build();
+
+        // validate the transaction body token transfers and NFT transfers
+        validator.validateSemantics(context, resolvedAirdropOp, accountStore, tokenStore, tokenRelStore, nftStore);
 
         // after charging custom fees, the original transfer may be reduced (in case of fractional fee with
         // netOfTransfers = false)
         // so we should use the new transfer value instead of the original one
-        var opBodyAfterCustomFeesAssessment = assessAndChargeCustomFee(context, convertedOp);
+        var opBodyAfterCustomFeesAssessment = assessAndChargeCustomFee(context, convertedOp, transferContext);
+        validator.validatePostCustomFeeAssessment(opBodyAfterCustomFeesAssessment);
         for (final var xfers : opBodyAfterCustomFeesAssessment.tokenTransfers()) {
             throwIfReceiverCannotClaimAirdrop(xfers, accountStore);
 
@@ -190,6 +205,7 @@ public class TokenAirdropHandler extends TransferExecutor implements Transaction
                     shouldExecuteCryptoTransfer = true;
                     addTransfersToTransferList(
                             fungibleLists.transferFungibleAmounts(),
+                            tokenId,
                             senderId,
                             senderAccountAmount.get().isApproval(),
                             transferListBuilder);
@@ -231,7 +247,10 @@ public class TokenAirdropHandler extends TransferExecutor implements Transaction
 
         // transfer tokens, that are not in pending state, if any...
         if (!tokenTransferList.isEmpty()) {
-            executeAirdropCryptoTransfer(context, tokenTransferList, recordBuilder);
+            executeAirdropCryptoTransfer(context, tokenTransferList, transferContext, recordBuilder);
+        } else {
+            // With no executable transfers, the normal transfer path cannot externalize the custom fees charged above.
+            externalizeTransferContext(transferContext, recordBuilder);
         }
     }
 
@@ -393,21 +412,33 @@ public class TokenAirdropHandler extends TransferExecutor implements Transaction
      * the credits for the receivers.
      *
      * @param fungibleAmounts the fungible airdrop amounts
+     * @param tokenId the token being transferred
      * @param sender the sender account id
      * @param isApproval is approval
      * @param transferListBuilder the transfer list builder
      */
     private void addTransfersToTransferList(
             @NonNull final List<AccountAmount> fungibleAmounts,
+            @NonNull final TokenID tokenId,
             @NonNull final AccountID sender,
             final boolean isApproval,
             @NonNull final TokenTransferList.Builder transferListBuilder) {
         List<AccountAmount> amounts = new LinkedList<>();
         final var receiversAmountList =
                 fungibleAmounts.stream().filter(item -> item.amount() > 0).toList();
-        var senderAmount =
-                receiversAmountList.stream().mapToLong(AccountAmount::amount).sum();
-        var newSenderAccountAmount = createAccountAmount(sender, -senderAmount, isApproval);
+        final long senderDebit;
+        try {
+            final var senderAmount = receiversAmountList.stream()
+                    .mapToLong(AccountAmount::amount)
+                    .reduce(0L, Math::addExact);
+            senderDebit = Math.negateExact(senderAmount);
+        } catch (final ArithmeticException e) {
+            throw new IllegalStateException(
+                    "Executable fungible airdrop credits for token " + tokenId
+                            + " cannot be represented as a sender debit for " + sender,
+                    e);
+        }
+        var newSenderAccountAmount = createAccountAmount(sender, senderDebit, isApproval);
         amounts.add(newSenderAccountAmount);
         amounts.addAll(receiversAmountList);
         transferListBuilder.transfers(amounts);
@@ -461,14 +492,29 @@ public class TokenAirdropHandler extends TransferExecutor implements Transaction
      * </p>
      */
     private CryptoTransferTransactionBody assessAndChargeCustomFee(
-            @NonNull final HandleContext context, @NonNull final CryptoTransferTransactionBody body) {
+            @NonNull final HandleContext context,
+            @NonNull final CryptoTransferTransactionBody body,
+            @NonNull final TransferContextImpl transferContext) {
         final var isHighVolume = context.body().highVolume();
         final var syntheticCryptoTransferTxn = TransactionBody.newBuilder()
                 .highVolume(isHighVolume)
                 .cryptoTransfer(body)
                 .build();
-        final var transferContext = new TransferContextImpl(context, body, true, isHighVolume);
         return chargeCustomFeeForAirdrops(syntheticCryptoTransferTxn, transferContext);
+    }
+
+    private static boolean containsAliases(@NonNull final CryptoTransferTransactionBody body) {
+        for (final var tokenTransfers : body.tokenTransfers()) {
+            if (tokenTransfers.transfers().stream().anyMatch(adjustment -> isAlias(adjustment.accountIDOrThrow()))) {
+                return true;
+            }
+            if (tokenTransfers.nftTransfers().stream()
+                    .anyMatch(transfer -> isAlias(transfer.senderAccountIDOrThrow())
+                            || isAlias(transfer.receiverAccountIDOrThrow()))) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CustomFeeAssessmentStep.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/CustomFeeAssessmentStep.java
@@ -123,7 +123,7 @@ public class CustomFeeAssessmentStep {
         final var config = handleContext.configuration();
         final Predicate<AccountID> autoCreationTest;
         if (transferContext.isEnforceMonoServiceRestrictionsOnAutoCreationCustomFeePayments()) {
-            autoCreationTest = transferContext.resolutions().values()::contains;
+            autoCreationTest = transferContext::isAutoCreated;
         } else {
             autoCreationTest = accountId -> false;
         }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContext.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContext.java
@@ -56,6 +56,14 @@ public interface TransferContext {
     Map<Bytes, AccountID> resolutions();
 
     /**
+     * Returns whether the account was created from an alias in this transfer.
+     *
+     * @param accountId the account to check
+     * @return true if the account was created in this transfer, false otherwise
+     */
+    boolean isAutoCreated(AccountID accountId);
+
+    /**
      * Charges extra fee to the HAPI payer account in the current transfer context with the given amount.
      * @param amount the amount to charge
      */

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContextImpl.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferContextImpl.java
@@ -23,8 +23,10 @@ import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * The context of a token transfer. This is used to pass information between the steps of the transfer.
@@ -36,6 +38,7 @@ public class TransferContextImpl implements TransferContext {
     private int numAutoCreations;
     private int numLazyCreations;
     private final Map<Bytes, AccountID> resolutions = new LinkedHashMap<>();
+    private final Set<AccountID> autoCreatedAccountIds = new LinkedHashSet<>();
     private final List<TokenAssociation> automaticAssociations = new ArrayList<>();
     private final List<ItemizedAssessedFee> itemizedAssessedFees = new ArrayList<>();
     private CryptoTransferTransactionBody syntheticBody = null;
@@ -121,6 +124,7 @@ public class TransferContextImpl implements TransferContext {
         // Keep the created account in the resolutions map
         final var createdAccount = autoAccountCreator.create(alias, reqMaxAutoAssociations, highVolume);
         resolutions.put(alias, createdAccount);
+        autoCreatedAccountIds.add(createdAccount);
     }
 
     @Override
@@ -140,6 +144,11 @@ public class TransferContextImpl implements TransferContext {
 
     public Map<Bytes, AccountID> resolutions() {
         return resolutions;
+    }
+
+    @Override
+    public boolean isAutoCreated(final AccountID accountId) {
+        return autoCreatedAccountIds.contains(accountId);
     }
 
     @Override

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferExecutor.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/transfer/TransferExecutor.java
@@ -176,7 +176,7 @@ public class TransferExecutor extends BaseTokenHandler {
         final var topLevelPayer = context.payer();
         transferContext.validateHbarAllowances();
         // Replace all aliases in the transaction body with its account ids; use in all further steps
-        final var replacedOp = ensureAndReplaceAliasesInOp(txn, transferContext, validator);
+        final var replacedOp = ensureAndReplaceAliasesInOp(txn, transferContext);
         List<CryptoTransferTransactionBody> txns = List.of(replacedOp);
         if (!skipCustomFee) {
             txns = new CustomFeeAssessmentStep(replacedOp).assessCustomFees(transferContext);
@@ -257,6 +257,18 @@ public class TransferExecutor extends BaseTokenHandler {
             }
         }
 
+        externalizeTransferContext(transferContext, recordBuilder);
+    }
+
+    /**
+     * Externalizes the record data accumulated while processing a transfer.
+     *
+     * @param transferContext the transfer context containing accumulated record data
+     * @param recordBuilder the record builder to update
+     */
+    protected void externalizeTransferContext(
+            @NonNull final TransferContextImpl transferContext,
+            @NonNull final CryptoTransferStreamBuilder recordBuilder) {
         if (!transferContext.getAutomaticAssociations().isEmpty()) {
             transferContext.getAutomaticAssociations().forEach(recordBuilder::addAutomaticTokenAssociation);
         }
@@ -352,6 +364,7 @@ public class TransferExecutor extends BaseTokenHandler {
     protected void executeAirdropCryptoTransfer(
             @NonNull final HandleContext context,
             @NonNull final List<TokenTransferList> tokenTransferList,
+            @NonNull final TransferContextImpl transferContext,
             @NonNull final CryptoTransferStreamBuilder recordBuilder) {
         final var isHighVolume = context.body().highVolume();
         var cryptoTransferBody = CryptoTransferTransactionBody.newBuilder()
@@ -362,8 +375,6 @@ public class TransferExecutor extends BaseTokenHandler {
                 .cryptoTransfer(cryptoTransferBody)
                 .highVolume(isHighVolume)
                 .build();
-
-        final var transferContext = new TransferContextImpl(context, cryptoTransferBody, true, isHighVolume);
 
         // We should skip custom fee steps here, because they must be already prepaid
         executeCryptoTransferWithoutCustomFee(syntheticCryptoTransferTxn, transferContext, context, recordBuilder);
@@ -429,14 +440,11 @@ public class TransferExecutor extends BaseTokenHandler {
      *
      * @param txn the given transaction body
      * @param transferContext the given transfer context
-     * @param validator crypto transfer validator
      * @return the replaced transaction body with all aliases replaced with its account ids
      * @throws HandleException if any error occurs during the process
      */
-    private CryptoTransferTransactionBody ensureAndReplaceAliasesInOp(
-            @NonNull final TransactionBody txn,
-            @NonNull final TransferContextImpl transferContext,
-            @NonNull final CryptoTransferValidator validator)
+    protected CryptoTransferTransactionBody ensureAndReplaceAliasesInOp(
+            @NonNull final TransactionBody txn, @NonNull final TransferContextImpl transferContext)
             throws HandleException {
         final var op = txn.cryptoTransferOrThrow();
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoTransferValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/CryptoTransferValidator.java
@@ -74,7 +74,7 @@ public class CryptoTransferValidator {
      */
     public void pureChecks(@NonNull final CryptoTransferTransactionBody op) throws PreCheckException {
         final var acctAmounts = op.transfersOrElse(TransferList.DEFAULT).accountAmounts();
-        validateTruePreCheck(isNetZeroAdjustment(acctAmounts), INVALID_ACCOUNT_AMOUNTS);
+        validateTruePreCheck(netAdjustmentOf(acctAmounts).equals(ZERO), INVALID_ACCOUNT_AMOUNTS);
 
         final var uniqueAcctIds = new HashSet<AccountID>();
         // Validate hbar transfers
@@ -292,7 +292,7 @@ public class CryptoTransferValidator {
             final Set<AccountID> uniqueTokenAcctIds,
             final AllowanceStrategy allowanceStrategy)
             throws PreCheckException {
-        validateTruePreCheck(isNetZeroAdjustment(fungibleTransfers), TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN);
+        validateTruePreCheck(netAdjustmentOf(fungibleTransfers).equals(ZERO), TRANSFERS_NOT_ZERO_SUM_FOR_TOKEN);
         boolean nonZeroFungibleValueFound = false;
         for (final AccountAmount acctAmount : fungibleTransfers) {
             if (allowanceStrategy.equals(AllowanceStrategy.ALLOWANCES_REJECTED)) {
@@ -339,12 +339,12 @@ public class CryptoTransferValidator {
         }
     }
 
-    private static boolean isNetZeroAdjustment(@NonNull final List<AccountAmount> adjusts) {
+    static BigInteger netAdjustmentOf(@NonNull final List<AccountAmount> adjusts) {
         var net = ZERO;
         for (var adjust : adjusts) {
             net = net.add(BigInteger.valueOf(adjust.amount()));
         }
-        return net.equals(ZERO);
+        return net;
     }
 
     /**

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
@@ -16,6 +16,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_AIRDROP_WITH_FALL
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_TRANSFER_LIST_SIZE_LIMIT_EXCEEDED;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsable;
 import static com.hedera.node.app.service.token.impl.util.TokenHandlerHelper.getIfUsableForAliasedId;
+import static com.hedera.node.app.service.token.impl.validators.CryptoTransferValidator.netAdjustmentOf;
 import static com.hedera.node.app.service.token.impl.validators.CryptoTransferValidator.validateTokenTransfers;
 import static com.hedera.node.app.spi.workflows.HandleException.validateFalse;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
@@ -28,8 +29,10 @@ import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.NftTransfer;
 import com.hedera.hapi.node.base.TokenID;
 import com.hedera.hapi.node.base.TokenType;
+import com.hedera.hapi.node.base.TransferList;
 import com.hedera.hapi.node.state.token.Account;
 import com.hedera.hapi.node.state.token.Token;
+import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
 import com.hedera.hapi.node.token.TokenAirdropTransactionBody;
 import com.hedera.hapi.node.transaction.CustomFee;
 import com.hedera.node.app.service.token.ReadableNftStore;
@@ -100,6 +103,45 @@ public class TokenAirdropValidator {
         validateTokenTransfers(op.tokenTransfers(), CryptoTransferValidator.AllowanceStrategy.ALLOWANCES_REJECTED);
     }
 
+    /**
+     * Validates the fungible balance changes produced by custom-fee assessment before they are split into executable
+     * transfers and pending airdrops. The split reconstructs each executable debit from its credits, so it relies on
+     * the assessed changes remaining zero-sum and having exactly one sender per fungible token.
+     *
+     * @param op the crypto transfer body produced by custom-fee assessment
+     */
+    public void validatePostCustomFeeAssessment(@NonNull final CryptoTransferTransactionBody op) {
+        requireNonNull(op);
+        final var hbarNetAdjustment =
+                netAdjustmentOf(op.transfersOrElse(TransferList.DEFAULT).accountAmounts());
+        if (hbarNetAdjustment.signum() != 0) {
+            throw new IllegalStateException(
+                    "Custom fee assessment returned non-zero-sum HBAR adjustments with net " + hbarNetAdjustment);
+        }
+        for (final var tokenTransfers : op.tokenTransfers()) {
+            final var fungibleTransfers = tokenTransfers.transfers();
+            if (!fungibleTransfers.isEmpty()) {
+                final var tokenId = tokenTransfers.token();
+                final var tokenNetAdjustment = netAdjustmentOf(fungibleTransfers);
+                if (tokenNetAdjustment.signum() != 0) {
+                    throw new IllegalStateException("Custom fee assessment returned non-zero-sum adjustments for token "
+                            + tokenId + " with net " + tokenNetAdjustment);
+                }
+                final var debits = fungibleTransfers.stream()
+                        .filter(adjustment -> adjustment.amount() < 0)
+                        .toList();
+                if (debits.size() != 1) {
+                    throw new IllegalStateException("Custom fee assessment returned " + debits.size()
+                            + " debits for token " + tokenId + "; expected exactly one");
+                }
+                if (debits.getFirst().amount() == Long.MIN_VALUE) {
+                    throw new IllegalStateException("Custom fee assessment returned a Long.MIN_VALUE debit for token "
+                            + tokenId + ", which cannot be safely reconstructed from its credits");
+                }
+            }
+        }
+    }
+
     public void validateSemantics(
             @NonNull final HandleContext context,
             @NonNull final TokenAirdropTransactionBody op,
@@ -147,16 +189,15 @@ public class TokenAirdropValidator {
                                 validateTrue(
                                         isExemptFromCustomFees(token, receiver, fee),
                                         TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY);
-                            } else {
-                                // And even without a fallback, there must be no implied royalty fee payment (that is,
-                                // the sender must be fee exempt or receive no fungible value in the airdrop)
-                                final var senderId = transfer.senderAccountIDOrThrow();
-                                if (!isExemptFromCustomFees(token, senderId, fee)) {
-                                    // (FUTURE) Use a different response code for this failure mode
-                                    validateFalse(
-                                            senderIsCreditedFungibleValue(op, senderId),
-                                            TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY);
-                                }
+                            }
+                            // And even without a fallback, there must be no implied royalty fee payment (that is,
+                            // the sender must be fee exempt or receive no fungible value in the airdrop)
+                            final var senderId = transfer.senderAccountIDOrThrow();
+                            if (!isExemptFromCustomFees(token, senderId, fee)) {
+                                // (FUTURE) Use a different response code for this failure mode
+                                validateFalse(
+                                        senderIsCreditedFungibleValue(op, senderId),
+                                        TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY);
                             }
                         }
                     }

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/validators/TokenAirdropValidator.java
@@ -268,6 +268,8 @@ public class TokenAirdropValidator {
         final var tokenRel = getIfUsable(senderAccount.accountIdOrThrow(), tokenId, tokenRelStore);
         // Add rather than Math.abs: Math.abs(Long.MIN_VALUE) wraps negative and passes for any balance.
         validateTrue(tokenRel.balance() + senderAmount.amount() >= 0, INSUFFICIENT_TOKEN_BALANCE);
+        validateTrue(senderAmount.amount() != Long.MIN_VALUE, INSUFFICIENT_TOKEN_BALANCE);
+        validateTrue(tokenRel.balance() >= -senderAmount.amount(), INSUFFICIENT_TOKEN_BALANCE);
     }
 
     private void validateNftTransfers(

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/TokenAirdropHandlerTest.java
@@ -4,6 +4,7 @@ package com.hedera.node.app.service.token.impl.test.handlers;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.BATCH_SIZE_LIMIT_EXCEEDED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_ACCOUNT_AMOUNTS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.EMPTY_TOKEN_TRANSFER_BODY;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TOKEN_BALANCE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ACCOUNT_AMOUNTS;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.OK;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TOKEN_NOT_ASSOCIATED_TO_ACCOUNT;
@@ -21,8 +22,10 @@ import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mock.Strictness.LENIENT;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.hedera.hapi.node.base.AccountAmount;
 import com.hedera.hapi.node.base.AccountID;
 import com.hedera.hapi.node.base.Fraction;
 import com.hedera.hapi.node.base.NftTransfer;
@@ -164,6 +167,35 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
 
         Assertions.assertThatCode(() -> tokenAirdropHandler.pureChecks(pureChecksContext))
                 .doesNotThrowAnyException();
+    }
+
+    @Test
+    void handleRejectsLongMinValueFungibleDebit() {
+        givenStoresAndConfig(handleContext);
+        final var airdrop = TokenAirdropTransactionBody.newBuilder()
+                .tokenTransfers(TokenTransferList.newBuilder()
+                        .token(fungibleTokenId)
+                        .transfers(
+                                AccountAmount.newBuilder()
+                                        .accountID(ownerId)
+                                        .amount(Long.MIN_VALUE)
+                                        .build(),
+                                AccountAmount.newBuilder()
+                                        .accountID(tokenReceiverId)
+                                        .amount(Long.MAX_VALUE)
+                                        .build(),
+                                AccountAmount.newBuilder()
+                                        .accountID(hbarReceiverId)
+                                        .amount(1)
+                                        .build())
+                        .build())
+                .build();
+        givenAirdropTxn(airdrop, payerId);
+        given(expiryValidator.expirationStatus(any(), anyBoolean(), anyLong())).willReturn(OK);
+
+        Assertions.assertThatThrownBy(() -> tokenAirdropHandler.handle(handleContext))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(INSUFFICIENT_TOKEN_BALANCE));
     }
 
     @Test
@@ -339,13 +371,16 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
         given(handleContext.savepointStack()).willReturn(stack);
         given(handleContext.dispatchMetadata()).willReturn(DispatchMetadata.EMPTY_METADATA);
         given(stack.getBaseBuilder(TokenAirdropStreamBuilder.class)).willReturn(tokenAirdropRecordBuilder);
-        var tokenWithNoCustomFees =
-                fungibleToken.copyBuilder().customFees(Collections.emptyList()).build();
+        var tokenWithCustomFees = fungibleToken
+                .copyBuilder()
+                .customFees(
+                        List.of(withFixedFee(FixedFee.newBuilder().amount(66).build())))
+                .build();
         var nftWithNoCustomFees = nonFungibleToken
                 .copyBuilder()
                 .customFees(Collections.emptyList())
                 .build();
-        writableTokenStore.putAndIncrementCount(tokenWithNoCustomFees);
+        writableTokenStore.putAndIncrementCount(tokenWithCustomFees);
         writableTokenStore.putAndIncrementCount(nftWithNoCustomFees);
         given(storeFactory.writableStore(WritableTokenStore.class)).willReturn(writableTokenStore);
         given(storeFactory.readableStore(ReadableTokenStore.class)).willReturn(writableTokenStore);
@@ -387,6 +422,7 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
         assertThat(Objects.requireNonNull(nextAirdrop).hasNextAirdrop()).isFalse();
         assertThat(nextAirdrop.hasPreviousAirdrop()).isTrue();
         assertThat(nextAirdrop.previousAirdrop()).isEqualTo(headPendingAirdropId);
+        verify(tokenAirdropRecordBuilder).assessedCustomFees(argThat(fees -> fees.size() == 1));
     }
 
     @Test
@@ -471,6 +507,8 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
         refreshWritableStores();
         givenStoresAndConfig(handleContext);
         given(handleContext.dispatchMetadata()).willReturn(DispatchMetadata.EMPTY_METADATA);
+        given(handleContext.savepointStack()).willReturn(stack);
+        given(stack.getBaseBuilder(TokenAirdropStreamBuilder.class)).willReturn(tokenAirdropRecordBuilder);
         // mock record builder
         tokenAirdropHandler =
                 new TokenAirdropHandler(tokenAirdropValidator, validator, hookCallsFactory, entityIdFactory);
@@ -519,6 +557,7 @@ class TokenAirdropHandlerTest extends CryptoTransferHandlerTestBase {
         assertThat(writableAccountStore.get(ownerId).tinybarBalance()).isEqualTo(10000 - 66);
         // fractional fee is 1/2, so new fungible balance is 500 instead of 1000
         assertThat(relationToFungible.balance()).isEqualTo(500L);
+        verify(tokenAirdropRecordBuilder).assessedCustomFees(argThat(assessedFees -> assessedFees.size() == 2));
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/CustomFeeAssessmentStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/CustomFeeAssessmentStepTest.java
@@ -202,6 +202,8 @@ class CustomFeeAssessmentStepTest extends StepsBase {
         final var tokensReceiver = asAccount(0L, 0L, tokenReceiver);
 
         givenTxn();
+        // Model the NFT sender having been resolved from an existing alias. It must not be treated as auto-created.
+        transferContext.resolutions().put(ecKeyAlias.value(), ownerId);
 
         final var listOfOps = subject.assessCustomFees(transferContext);
         assertThat(listOfOps).hasSize(2);

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/transfer/EnsureAliasesStepTest.java
@@ -104,6 +104,9 @@ class EnsureAliasesStepTest extends StepsBase {
         assertThat(transferContext.numOfLazyCreations()).isZero();
         assertThat(transferContext.resolutions()).containsKey(edKeyAlias.value());
         assertThat(transferContext.resolutions()).containsKey(ecKeyAlias.value());
+        assertThat(transferContext.isAutoCreated(hbarReceiverId)).isTrue();
+        assertThat(transferContext.isAutoCreated(tokenReceiverId)).isTrue();
+        assertThat(transferContext.isAutoCreated(ownerId)).isFalse();
     }
 
     @Test
@@ -195,6 +198,12 @@ class EnsureAliasesStepTest extends StepsBase {
         assertThat(transferContext.resolutions()).containsKey(evmAddressAlias1.value());
         assertThat(transferContext.resolutions()).containsKey(evmAddressAlias2.value());
         assertThat(transferContext.resolutions()).containsKey(evmAddressAlias3.value());
+        assertThat(transferContext.isAutoCreated(transferContext.resolutions().get(evmAddressAlias1.value())))
+                .isTrue();
+        assertThat(transferContext.isAutoCreated(transferContext.resolutions().get(evmAddressAlias2.value())))
+                .isTrue();
+        assertThat(transferContext.isAutoCreated(transferContext.resolutions().get(evmAddressAlias3.value())))
+                .isTrue();
     }
 
     @Test
@@ -218,6 +227,8 @@ class EnsureAliasesStepTest extends StepsBase {
         assertThat(transferContext.numOfLazyCreations()).isZero();
         assertThat(transferContext.resolutions()).containsKey(edKeyAlias.value());
         assertThat(transferContext.resolutions()).containsKey(ecKeyAlias.value());
+        assertThat(transferContext.isAutoCreated(hbarReceiverId)).isFalse();
+        assertThat(transferContext.isAutoCreated(tokenReceiverId)).isFalse();
     }
 
     @Test

--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/TokenAirdropValidatorTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/validators/TokenAirdropValidatorTest.java
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.service.token.impl.test.validators;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.hedera.hapi.node.base.AccountAmount;
+import com.hedera.hapi.node.base.AccountID;
+import com.hedera.hapi.node.base.TokenID;
+import com.hedera.hapi.node.base.TokenTransferList;
+import com.hedera.hapi.node.base.TransferList;
+import com.hedera.hapi.node.token.CryptoTransferTransactionBody;
+import com.hedera.node.app.service.token.impl.validators.TokenAirdropValidator;
+import org.junit.jupiter.api.Test;
+
+class TokenAirdropValidatorTest {
+    private static final AccountID ACCOUNT_1 = accountId(1);
+    private static final AccountID ACCOUNT_2 = accountId(2);
+    private static final AccountID ACCOUNT_3 = accountId(3);
+    private static final AccountID ACCOUNT_4 = accountId(4);
+    private static final AccountID ACCOUNT_5 = accountId(5);
+    private static final TokenID TOKEN_1 = TokenID.newBuilder().tokenNum(1).build();
+
+    private final TokenAirdropValidator subject = new TokenAirdropValidator();
+
+    @Test
+    void acceptsZeroSumFungibleChangesWithOneTokenDebit() {
+        final var op = CryptoTransferTransactionBody.newBuilder()
+                .transfers(TransferList.newBuilder()
+                        .accountAmounts(adjustment(ACCOUNT_1, -1), adjustment(ACCOUNT_2, 1))
+                        .build())
+                .tokenTransfers(TokenTransferList.newBuilder()
+                        .token(TOKEN_1)
+                        .transfers(adjustment(ACCOUNT_1, -2), adjustment(ACCOUNT_2, 1), adjustment(ACCOUNT_3, 1))
+                        .build())
+                .build();
+
+        assertThatCode(() -> subject.validatePostCustomFeeAssessment(op)).doesNotThrowAnyException();
+    }
+
+    @Test
+    void rejectsNonZeroSumHbarChanges() {
+        final var op = CryptoTransferTransactionBody.newBuilder()
+                .transfers(TransferList.newBuilder()
+                        .accountAmounts(adjustment(ACCOUNT_1, -1), adjustment(ACCOUNT_2, 2))
+                        .build())
+                .build();
+
+        assertThatThrownBy(() -> subject.validatePostCustomFeeAssessment(op))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Custom fee assessment returned non-zero-sum HBAR adjustments with net 1");
+    }
+
+    @Test
+    void rejectsNonZeroSumTokenChanges() {
+        final var op = CryptoTransferTransactionBody.newBuilder()
+                .tokenTransfers(TokenTransferList.newBuilder()
+                        .token(TOKEN_1)
+                        .transfers(adjustment(ACCOUNT_1, -1), adjustment(ACCOUNT_2, 2))
+                        .build())
+                .build();
+
+        assertThatThrownBy(() -> subject.validatePostCustomFeeAssessment(op))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Custom fee assessment returned non-zero-sum adjustments for token")
+                .hasMessageContaining("with net 1");
+    }
+
+    @Test
+    void rejectsMultipleTokenDebitsEvenWhenChangesAreZeroSum() {
+        final var op = CryptoTransferTransactionBody.newBuilder()
+                .tokenTransfers(TokenTransferList.newBuilder()
+                        .token(TOKEN_1)
+                        .transfers(adjustment(ACCOUNT_1, -1), adjustment(ACCOUNT_2, -1), adjustment(ACCOUNT_3, 2))
+                        .build())
+                .build();
+
+        assertThatThrownBy(() -> subject.validatePostCustomFeeAssessment(op))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Custom fee assessment returned 2 debits for token")
+                .hasMessageContaining("expected exactly one");
+    }
+
+    @Test
+    void rejectsChangesWhoseLongSumWrapsToZero() {
+        final var op = CryptoTransferTransactionBody.newBuilder()
+                .tokenTransfers(TokenTransferList.newBuilder()
+                        .token(TOKEN_1)
+                        .transfers(
+                                adjustment(ACCOUNT_1, Long.MIN_VALUE),
+                                adjustment(ACCOUNT_2, Long.MAX_VALUE),
+                                adjustment(ACCOUNT_3, Long.MAX_VALUE),
+                                adjustment(ACCOUNT_4, Long.MAX_VALUE),
+                                adjustment(ACCOUNT_5, 3))
+                        .build())
+                .build();
+
+        assertThatThrownBy(() -> subject.validatePostCustomFeeAssessment(op))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Custom fee assessment returned non-zero-sum adjustments for token")
+                .hasMessageContaining("with net 18446744073709551616");
+    }
+
+    @Test
+    void rejectsLongMinValueDebitThatCannotBeSafelyReconstructed() {
+        final var op = CryptoTransferTransactionBody.newBuilder()
+                .tokenTransfers(TokenTransferList.newBuilder()
+                        .token(TOKEN_1)
+                        .transfers(
+                                adjustment(ACCOUNT_1, Long.MIN_VALUE),
+                                adjustment(ACCOUNT_2, Long.MAX_VALUE),
+                                adjustment(ACCOUNT_3, 1))
+                        .build())
+                .build();
+
+        assertThatThrownBy(() -> subject.validatePostCustomFeeAssessment(op))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Custom fee assessment returned a Long.MIN_VALUE debit for token")
+                .hasMessageContaining("cannot be safely reconstructed from its credits");
+    }
+
+    private static AccountID accountId(final long accountNum) {
+        return AccountID.newBuilder().accountNum(accountNum).build();
+    }
+
+    private static AccountAmount adjustment(final AccountID accountId, final long amount) {
+        return AccountAmount.newBuilder().accountID(accountId).amount(amount).build();
+    }
+}

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomRoyaltyFees.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/crypto/TransferWithCustomRoyaltyFees.java
@@ -7,6 +7,7 @@ import static com.hedera.services.bdd.junit.TestTags.CRYPTO;
 import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.assertions.AccountDetailsAsserts.accountDetailsWith;
 import static com.hedera.services.bdd.spec.assertions.TransactionRecordAsserts.recordWith;
+import static com.hedera.services.bdd.spec.keys.SigControl.SECP256K1_ON;
 import static com.hedera.services.bdd.spec.keys.TrieSigMapGenerator.uniqueWithFullPrefixesFor;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountBalance;
 import static com.hedera.services.bdd.spec.queries.QueryVerbs.getAccountDetails;
@@ -20,6 +21,7 @@ import static com.hedera.services.bdd.spec.transactions.TxnVerbs.mintToken;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAirdrop;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenAssociate;
 import static com.hedera.services.bdd.spec.transactions.TxnVerbs.tokenCreate;
+import static com.hedera.services.bdd.spec.transactions.contract.HapiParserUtil.evmAddressFromSecp256k1Key;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFee;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHbarFeeInheritingRoyaltyCollector;
 import static com.hedera.services.bdd.spec.transactions.token.CustomFeeSpecs.fixedHtsFee;
@@ -53,9 +55,12 @@ import static com.hederahashgraph.api.proto.java.ResponseCodeEnum.TOKEN_NOT_ASSO
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.esaulpaugh.headlong.abi.Address;
 import com.google.protobuf.ByteString;
 import com.hedera.node.app.hapi.utils.ByteStringUtils;
 import com.hedera.services.bdd.junit.HapiTest;
+import com.hedera.services.bdd.spec.HapiSpec;
+import com.hedera.services.bdd.suites.contract.Utils;
 import com.hederahashgraph.api.proto.java.AccountAmount;
 import com.hederahashgraph.api.proto.java.AccountID;
 import com.hederahashgraph.api.proto.java.NftTransfer;
@@ -63,7 +68,9 @@ import com.hederahashgraph.api.proto.java.TokenSupplyType;
 import com.hederahashgraph.api.proto.java.TokenTransferList;
 import com.hederahashgraph.api.proto.java.TokenType;
 import com.hederahashgraph.api.proto.java.TransferList;
+import edu.umd.cs.findbugs.annotations.NonNull;
 import java.util.List;
+import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
@@ -1632,10 +1639,193 @@ public class TransferWithCustomRoyaltyFees {
                                 movingUnique(nonFungibleToken, 2L).between(tokenTreasury, tokenReceiver),
                                 moving(1000, feeDenom).between(tokenReceiver, tokenTreasury))
                         .signedByPayerAnd(tokenTreasury, tokenReceiver),
-                // And even the non-sender can still airdrop without receiving a bidirectional airdrop
+                // And even the non-exempt sender can still airdrop without receiving a bidirectional airdrop
                 tokenAirdrop(movingUnique(nonFungibleToken, 1L).between(tokenOwner, tokenReceiver))
                         .signedByPayerAnd(tokenOwner),
                 getAccountBalance(htsCollector).hasTokenBalance(feeDenom, 0));
+    }
+
+    /**
+     * Verifies that bidirectional airdrops cannot trigger NFT royalty fee payments <b>even in the presence of
+     * a fallback-fee-exempt receiver</b>.
+     * <p>
+     * That is, checks that if an NFT is airdropped by a sender that also <i>receives</i> a fungible airdrop in
+     * the same transaction, that can only succeed if the sender is exempt from the non-fungible token type's
+     * fees; and it does not matter whether the NFT receiver is exempt from a potentially applicable fallback fee
+     * or not.
+     */
+    @HapiTest
+    final Stream<DynamicTest> biDirectionalAirdropsCannotTriggerRoyaltyPaymentsEvenIfReceiverIsFallbackFeeExempt() {
+        return hapiTest(
+                newKeyNamed(NFT_KEY),
+                cryptoCreate(htsCollector),
+                cryptoCreate(tokenReceiver).balance(ONE_MILLION_HBARS),
+                cryptoCreate(tokenTreasury),
+                cryptoCreate(tokenOwner),
+                tokenCreate(feeDenom).treasury(tokenTreasury).initialSupply(2000),
+                tokenAssociate(tokenOwner, feeDenom),
+                tokenAssociate(tokenReceiver, feeDenom),
+                tokenAssociate(htsCollector, feeDenom),
+                cryptoTransfer(
+                        moving(1000, feeDenom).between(tokenTreasury, tokenReceiver),
+                        moving(1000, feeDenom).between(tokenTreasury, htsCollector)),
+                tokenCreate(nonFungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(NFT_KEY)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .withCustom(royaltyFeeWithFallback(
+                                1, 1, fixedHbarFeeInheritingRoyaltyCollector(ONE_HBAR), htsCollector)),
+                tokenAssociate(tokenReceiver, nonFungibleToken),
+                tokenAssociate(tokenOwner, nonFungibleToken),
+                mintToken(
+                        nonFungibleToken,
+                        List.of(
+                                ByteStringUtils.wrapUnsafely("meta1".getBytes()),
+                                ByteStringUtils.wrapUnsafely("meta2".getBytes()))),
+                cryptoTransfer(movingUnique(nonFungibleToken, 1L).between(tokenTreasury, tokenOwner)),
+
+                // If the sender in a bidirectional airdrop would pay a royalty fee for the NFT it is sending, we fail
+                // even if the receiver is exempt from a potentially applicable fallback fee
+                tokenAirdrop(
+                                movingUnique(nonFungibleToken, 1L).between(tokenOwner, htsCollector),
+                                moving(1000, feeDenom).between(htsCollector, tokenOwner))
+                        .signedByPayerAnd(tokenOwner, htsCollector)
+                        .hasKnownStatus(TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY),
+                // But an exempt sender in the exact situation is fine (no royalty charged)---this debits
+                // the collector's balance of 1000 tokens without diverting any royalty from the exempt sender
+                tokenAirdrop(
+                                movingUnique(nonFungibleToken, 2L).between(tokenTreasury, htsCollector),
+                                moving(1000, feeDenom).between(htsCollector, tokenTreasury))
+                        .signedByPayerAnd(tokenTreasury, htsCollector),
+                // And even a non-exempt sender can airdrop when the receiver is exempt from the fallback fee that
+                // would have otherwise been triggered
+                tokenAirdrop(movingUnique(nonFungibleToken, 1L).between(tokenOwner, htsCollector))
+                        .signedByPayerAnd(tokenOwner, htsCollector),
+                getAccountBalance(htsCollector).hasTokenBalance(feeDenom, 0));
+    }
+
+    /**
+     * Verifies that bidirectional airdrops cannot trigger NFT royalty fee payments <b>even in the presence of
+     * a fallback-fee-exempt receiver</b>, where the sender is an aliased account.
+     * <p>
+     * That is, checks that if an NFT is airdropped by an aliased sender that also <i>receives</i> a fungible airdrop
+     * in the same transaction, that can only succeed if the sender is exempt from the non-fungible token type's fees;
+     * and it does not matter whether the NFT receiver is exempt from a potentially applicable fallback fee or not.
+     */
+    @HapiTest
+    final Stream<DynamicTest>
+            aliasedSenderBiDirectionalAirdropsCannotTriggerRoyaltyPaymentsEvenIfReceiverIsFallbackFeeExempt() {
+        return hapiTest(
+                newKeyNamed("ecKey").shape(SECP256K1_ON),
+                newKeyNamed("treasuryKey").shape(SECP256K1_ON),
+                newKeyNamed(NFT_KEY),
+                cryptoCreate(htsCollector),
+                cryptoCreate(tokenReceiver).balance(ONE_MILLION_HBARS),
+                cryptoCreate(tokenTreasury).key("treasuryKey").withMatchingEvmAddress(),
+                cryptoCreate(tokenOwner).key("ecKey").withMatchingEvmAddress(),
+                tokenCreate(feeDenom).treasury(tokenTreasury).initialSupply(2000),
+                tokenAssociate(tokenOwner, feeDenom),
+                tokenAssociate(tokenReceiver, feeDenom),
+                tokenAssociate(htsCollector, feeDenom),
+                cryptoTransfer(
+                        moving(1000, feeDenom).between(tokenTreasury, tokenReceiver),
+                        moving(1000, feeDenom).between(tokenTreasury, htsCollector)),
+                tokenCreate(nonFungibleToken)
+                        .treasury(tokenTreasury)
+                        .tokenType(TokenType.NON_FUNGIBLE_UNIQUE)
+                        .initialSupply(0)
+                        .supplyKey(NFT_KEY)
+                        .supplyType(TokenSupplyType.INFINITE)
+                        .withCustom(royaltyFeeWithFallback(
+                                1, 1, fixedHbarFeeInheritingRoyaltyCollector(ONE_HBAR), htsCollector)),
+                tokenAssociate(tokenReceiver, nonFungibleToken),
+                tokenAssociate(tokenOwner, nonFungibleToken),
+                mintToken(
+                        nonFungibleToken,
+                        List.of(
+                                ByteStringUtils.wrapUnsafely("meta1".getBytes()),
+                                ByteStringUtils.wrapUnsafely("meta2".getBytes()))),
+                cryptoTransfer(movingUnique(nonFungibleToken, 1L).between(tokenTreasury, tokenOwner)),
+
+                // If the sender in a bidirectional airdrop would pay a royalty fee for the NFT it is sending, we fail
+                // even if the receiver is exempt from a potentially applicable fallback fee
+                tokenAirdrop((spec, b) -> {
+                            final var aliasedSenderId = aliasedEvmAddressAccountId(spec, "ecKey");
+                            final var htsCollectorId = asId(htsCollector, spec);
+                            b.addAllTokenTransfers(List.of(
+                                    ttl(
+                                            spec,
+                                            nonFungibleToken,
+                                            ttlB -> ttlB.addNftTransfers(NftTransfer.newBuilder()
+                                                    .setSenderAccountID(aliasedSenderId)
+                                                    .setReceiverAccountID(htsCollectorId)
+                                                    .setSerialNumber(1))),
+                                    ttl(spec, feeDenom, ttlB -> ttlB.addTransfers(AccountAmount.newBuilder()
+                                                    .setAccountID(htsCollectorId)
+                                                    .setAmount(-1000))
+                                            .addTransfers(AccountAmount.newBuilder()
+                                                    .setAccountID(
+                                                            spec.registry().getAccountID(tokenOwner))
+                                                    .setAmount(+1000)))));
+                        })
+                        .signedByPayerAnd(tokenOwner, htsCollector)
+                        .hasKnownStatus(TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY),
+                // But an exempt sender in the exact situation is fine (no royalty charged)---this debits
+                // the collector's balance of 1000 tokens without diverting any royalty from the exempt sender
+                tokenAirdrop((spec, b) -> {
+                            final var aliasedSenderId = aliasedEvmAddressAccountId(spec, "treasuryKey");
+                            final var htsCollectorId = asId(htsCollector, spec);
+                            b.addAllTokenTransfers(List.of(
+                                    ttl(
+                                            spec,
+                                            nonFungibleToken,
+                                            ttlB -> ttlB.addNftTransfers(NftTransfer.newBuilder()
+                                                    .setSenderAccountID(aliasedSenderId)
+                                                    .setReceiverAccountID(htsCollectorId)
+                                                    .setSerialNumber(2))),
+                                    ttl(spec, feeDenom, ttlB -> ttlB.addTransfers(AccountAmount.newBuilder()
+                                                    .setAccountID(htsCollectorId)
+                                                    .setAmount(-1000))
+                                            .addTransfers(AccountAmount.newBuilder()
+                                                    .setAccountID(
+                                                            spec.registry().getAccountID(tokenTreasury))
+                                                    .setAmount(+1000)))));
+                        })
+                        .signedByPayerAnd(tokenTreasury, htsCollector),
+                // And even a non-exempt sender can airdrop when the receiver is exempt from the fallback fee that
+                // would have otherwise been triggered
+                tokenAirdrop((spec, b) -> {
+                            final var aliasedSenderId = aliasedEvmAddressAccountId(spec, "ecKey");
+                            final var htsCollectorId = asId(htsCollector, spec);
+                            b.addAllTokenTransfers(List.of(ttl(
+                                    spec,
+                                    nonFungibleToken,
+                                    ttlB -> ttlB.addNftTransfers(NftTransfer.newBuilder()
+                                            .setSenderAccountID(aliasedSenderId)
+                                            .setReceiverAccountID(htsCollectorId)
+                                            .setSerialNumber(1)))));
+                        })
+                        .signedByPayerAnd(tokenOwner, htsCollector),
+                getAccountBalance(htsCollector).hasTokenBalance(feeDenom, 0));
+    }
+
+    private static TokenTransferList ttl(
+            @NonNull final HapiSpec spec,
+            @NonNull final String token,
+            @NonNull final Consumer<TokenTransferList.Builder> consumer) {
+        final var builder = TokenTransferList.newBuilder().setToken(asTokenId(token, spec));
+        consumer.accept(builder);
+        return builder.build();
+    }
+
+    private static AccountID aliasedEvmAddressAccountId(@NonNull final HapiSpec spec, @NonNull final String key) {
+        final var senderEvmAddress = evmAddressFromSecp256k1Key(spec.registry().getKey(key));
+        return Utils.accountIdWithHexedEvmAddress(
+                spec.shard(),
+                spec.realm(),
+                Address.toChecksumAddress(senderEvmAddress.value()).substring(2));
     }
 
     /**


### PR DESCRIPTION
Forward-port of #27069 (`release/0.76`) to `release/0.77`.