### PR TITLE
chore: Include other source sets in KB freshness analysis

### DIFF
--- a/platform-sdk/consensus-kb-freshness/CLAUDE.md
+++ b/platform-sdk/consensus-kb-freshness/CLAUDE.md
@@ -28,8 +28,9 @@ with `java -jar`.
   commented-out text is not a claim.
 - `resolve/` — parse-only source index (`JavaParsing` via the JDK Compiler Tree API; also reads
   `@ConfigData` prefixes and `@ConfigProperty` record components, plus the as-written expression of a
-  non-literal `defaultValue`; the index additionally records every `src/main/java` package for the
-  prose package/FQN checks), the generated/external `Allowlist`, `AnchorResolver` (Tier 0/1/2
+  non-literal `defaultValue`; the file index spans every `src/<sourceSet>/java` tree so a cited
+  regression test resolves, while only `src/main/java` contributes the packages behind the prose
+  package/FQN checks), the generated/external `Allowlist`, `AnchorResolver` (Tier 0/1/2
   per-anchor checks), and `ConfigRecords` (the shared scan of every indexed `@ConfigData` record —
   `src/main/java` trees only, so a test-resource fixture copy never masquerades as a real record).
 - `findings/` — collapse to stable-id findings, `InterfaceDiffAssembler` (Tier 2 method-set diff),

--- a/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/resolve/ConfigRecords.java
+++ b/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/resolve/ConfigRecords.java
@@ -96,10 +96,11 @@ public final class ConfigRecords {
     }
 
     /**
-     * Whether a path lies directly under its module's {@code src/main/java} tree. The index only walks
-     * {@code src/main/java} trees, but a test-resource fixture can embed one (e.g.
-     * {@code <module>/src/test/resources/…/src/main/java/…}) — the first {@code src} segment after the
-     * module must already be the {@code src/main/java} one.
+     * Whether a path lies directly under its module's {@code src/main/java} tree. This is the only
+     * guard keeping non-production records out of the catalog: the index walks every
+     * {@code src/<sourceSet>/java} tree, and a test-resource fixture can embed one of its own (e.g.
+     * {@code <module>/src/test/resources/…/src/main/java/…}) — so the first {@code src} segment after
+     * the module must already be the {@code src/main/java} one.
      *
      * @param repoRelPath the repo-relative source path.
      * @return {@code true} when the module's own source set is {@code src/main/java}.

--- a/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/resolve/SourceIndex.java
+++ b/platform-sdk/consensus-kb-freshness/src/main/java/org/hiero/consensus/kbfreshness/resolve/SourceIndex.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.TreeSet;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import org.hiero.consensus.kbfreshness.resolve.JavaParsing.ParsedFile;
 
@@ -22,11 +23,23 @@ import org.hiero.consensus.kbfreshness.resolve.JavaParsing.ParsedFile;
  * paths declaring it — enough to tell "gone" from "moved to another module" — records every package
  * holding an indexed source (for the prose package/FQN checks), and offers filesystem existence
  * checks plus a cached parse-only view of any file. No compilation, no network.
+ *
+ * <p>The basename map spans every {@code src/<sourceSet>/java} tree, not just {@code src/main/java}:
+ * the KB legitimately cites regression tests as the verification for an invariant or scenario, and a
+ * main-only index reported every such citation as GONE — a false assert that no correct citation
+ * could avoid. The package set stays main-only, so widening the file lookup cannot widen the prose
+ * package/FQN assert surface (see {@link #packageExists}).
  */
 public final class SourceIndex {
 
     /** The path segment separating a module root from the package tree of its main sources. */
     private static final String MAIN_SOURCE_TREE = "/src/main/java/";
+
+    /**
+     * A Gradle source-set tree: {@code /src/<sourceSet>/java/}. Matching the convention rather than a
+     * fixed list keeps a newly added source set (as {@code testOtter} once was) indexed on sight.
+     */
+    private static final Pattern SOURCE_TREE = Pattern.compile("/src/[^/]+/java/");
 
     /** Absolute, normalized repository root. */
     private final Path repoRoot;
@@ -53,7 +66,8 @@ public final class SourceIndex {
 
     /**
      * Builds the index by walking the given repo-relative module roots for {@code *.java} files under
-     * a {@code src/main/java} tree.
+     * any {@code src/<sourceSet>/java} tree. Only main sources contribute packages, so a test class
+     * can be located by basename without making its package assert-worthy in prose.
      *
      * @param repoRoot    the repository root; resolved to an absolute, normalized path.
      * @param moduleRoots the repo-relative module roots to scan.
@@ -72,7 +86,9 @@ public final class SourceIndex {
             try (Stream<Path> walk = Files.walk(start)) {
                 walk.filter(Files::isRegularFile)
                         .filter(p -> p.getFileName().toString().endsWith(".java"))
-                        .filter(p -> p.toString().replace('\\', '/').contains(MAIN_SOURCE_TREE))
+                        .filter(p -> SOURCE_TREE
+                                .matcher(p.toString().replace('\\', '/'))
+                                .find())
                         .forEach(p -> {
                             final String basename = p.getFileName().toString();
                             final String rel = root.relativize(p).toString().replace('\\', '/');

--- a/platform-sdk/consensus-kb-freshness/src/test/java/org/hiero/consensus/kbfreshness/EngineFixtureTest.java
+++ b/platform-sdk/consensus-kb-freshness/src/test/java/org/hiero/consensus/kbfreshness/EngineFixtureTest.java
@@ -720,6 +720,22 @@ class EngineFixtureTest {
         assertThat(report).contains("A target cited by N entries counts as N checks");
     }
 
+    @Test
+    void citedTestSourceResolvesInsteadOfReadingAsGone() {
+        // The KB cites regression tests as an invariant's verification; a main-only file index made
+        // every such citation a false GONE, which no correct citation could avoid.
+        assertThat(byKind(AnchorKind.SOURCE_PATH, t -> t.contains("RegressionFixtureTest.java")))
+                .isEmpty();
+    }
+
+    @Test
+    void configRecordOutsideMainSourcesStaysOutOfTheCatalogScan() {
+        // The file index spans every source set, so `isMainSource` is the only thing keeping a
+        // test-tree record out of the tunables lane.
+        final String coverage = CoverageRenderer.render(result);
+        assertThat(coverage).doesNotContain("TestOnlyConfig");
+    }
+
     // ---- helpers ----
 
     private static List<Finding> byKind(final AnchorKind kind, final Predicate<String> target) {

--- a/platform-sdk/consensus-kb-freshness/src/test/resources/fixtures/repo/platform-sdk/docs/consensus-layer/invariants/INV-003-fixture.md
+++ b/platform-sdk/consensus-kb-freshness/src/test/resources/fixtures/repo/platform-sdk/docs/consensus-layer/invariants/INV-003-fixture.md
@@ -1,0 +1,13 @@
+---
+type: invariant
+id: INV-003
+title: Fixture invariant verified by a regression test
+verification: module-a/src/test/java/com/x/RegressionFixtureTest.java — `guardsTheInvariant`
+---
+
+# INV-003 — Fixture invariant verified by a regression test
+
+The KB cites regression tests as verification, so a test source must resolve like any other
+citation rather than reading as a gone file. Cited in the abbreviated form
+`module-a/.../x/RegressionFixtureTest.java`, which resolves through the basename index rather
+than a filesystem check.

--- a/platform-sdk/consensus-kb-freshness/src/test/resources/fixtures/repo/platform-sdk/module-a/src/test/java/com/x/RegressionFixtureTest.java
+++ b/platform-sdk/consensus-kb-freshness/src/test/resources/fixtures/repo/platform-sdk/module-a/src/test/java/com/x/RegressionFixtureTest.java
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.x;
+
+/** Fixture: a regression test cited by the KB as an invariant's verification. */
+public class RegressionFixtureTest {
+    public void guardsTheInvariant() {}
+}

--- a/platform-sdk/consensus-kb-freshness/src/test/resources/fixtures/repo/platform-sdk/module-a/src/test/java/com/x/TestOnlyConfig.java
+++ b/platform-sdk/consensus-kb-freshness/src/test/resources/fixtures/repo/platform-sdk/module-a/src/test/java/com/x/TestOnlyConfig.java
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.x;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+
+/** Fixture: a config record outside src/main/java — must never reach the tunables catalog scan. */
+@ConfigData("fix.testonly")
+public record TestOnlyConfig(@ConfigProperty(defaultValue = "1") int neverDocumented) {}


### PR DESCRIPTION
**Description**:

It turned out that the deterministic reference checker during the KB freshness analysis uses only the `main` source set. This PR fixes it so that all source sets are included. This avoids false postives in cases where we reference test sources.
