### PR TITLE
feat: Traffic throttling for gossip (disabled by default)

### DIFF
--- a/platform-sdk/base-utility/src/main/java/org/hiero/base/io/streams/SerializableDataInputStream.java
+++ b/platform-sdk/base-utility/src/main/java/org/hiero/base/io/streams/SerializableDataInputStream.java
@@ -594,12 +594,35 @@ public class SerializableDataInputStream extends AugmentedDataInputStream {
      */
     @NonNull
     public <T> T readPbjRecord(@NonNull final Codec<T> codec) throws IOException {
+        return readPbjRecord(codec, MAX_PBJ_RECORD_SIZE);
+    }
+
+    /**
+     * Reads a PBJ record from the stream, rejecting anything whose declared encoded size falls outside
+     * {@code [0, maxSize]}.
+     *
+     * <p>The declared size is peer controlled, so it is validated before it is used to set the read limit. This
+     * check does not rely on the codec's own {@code maxSize} enforcement.
+     *
+     * @param codec   the codec to use to parse the record
+     * @param maxSize the maximum permitted encoded size of the record, in bytes
+     * @param <T>     the type of the record
+     * @return the parsed record
+     * @throws IOException if an IO error occurs, or the declared size is out of range
+     */
+    @NonNull
+    public <T> T readPbjRecord(@NonNull final Codec<T> codec, final int maxSize) throws IOException {
         final int size = readInt();
+        if (size < 0 || size > maxSize) {
+            throw new IOException(
+                    "PBJ record declared size " + size + " is outside the permitted range [0, " + maxSize + "]");
+        }
         readableSequentialData.limit(readableSequentialData.position() + size);
+
         try {
             // parse strictly with a default depth and max record size to prevent very large messages.
             // We can't use `parseStrict` as it doesn't support record size validation.
-            final T parsed = codec.parse(readableSequentialData, true, false, DEFAULT_MAX_DEPTH, MAX_PBJ_RECORD_SIZE);
+            final T parsed = codec.parse(readableSequentialData, true, false, DEFAULT_MAX_DEPTH, maxSize);
             if (readableSequentialData.position() != readableSequentialData.limit()) {
                 throw new EOFException("PBJ record was not fully read");
             }

--- a/platform-sdk/consensus-gossip-impl/build.gradle.kts
+++ b/platform-sdk/consensus-gossip-impl/build.gradle.kts
@@ -21,6 +21,7 @@ testModuleInfo {
     requires("org.hiero.consensus.utility.test.fixtures")
     requires("awaitility")
     requires("java.management")
+    requires("org.assertj.core")
     requires("org.junit.jupiter.api")
     requires("org.junit.jupiter.params")
     requires("org.mockito")

--- a/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/gossip/sync/SyncMetrics.java
+++ b/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/gossip/sync/SyncMetrics.java
@@ -184,6 +184,12 @@ public class SyncMetrics {
 
     private final IntegerGauge broadcastDisabledDueToOverload;
 
+    private static final CountPerSecond.Config RPC_READ_THROTTLED_CONFIG = new CountPerSecond.Config(
+                    PLATFORM_CATEGORY, "rpcReadThrottled")
+            .withUnit("hz")
+            .withDescription("Number of times per second reading from a peer was paused by the byte shaper");
+    private final CountPerSecond rpcReadThrottled;
+
     private final AverageStat syncIndicatorDiff;
     private final AverageStat eventRecRate;
     private final AverageStat knownSetSize;
@@ -194,6 +200,8 @@ public class SyncMetrics {
     private final ConcurrentHashMap<NodeId, PhaseTimer<SyncPhase>> syncPhasePerNode = new ConcurrentHashMap<>();
     private final Metrics metrics;
     private final AverageAndMax outputQueuePollTime;
+    private final AverageAndMax shaperOccupancy;
+    private final AverageAndMax readThrottleTime;
     private final Time time;
     private final IntegerGauge rpcReadThreadRunning;
     private final IntegerGauge rpcWriteThreadRunning;
@@ -286,6 +294,23 @@ public class SyncMetrics {
                 "rpc_output_queue_poll_time",
                 "amount of us spent sleeping waiting for poll to happen or timeout on rpc output queue",
                 FORMAT_10_0);
+        rpcReadThrottled = new CountPerSecond(metrics, RPC_READ_THROTTLED_CONFIG);
+
+        shaperOccupancy = new AverageAndMax(
+                metrics,
+                PLATFORM_CATEGORY,
+                "rpc_shaper_occupancy",
+                "per-mille of the per-peer inbound byte budget consumed, sampled once per incoming message",
+                FORMAT_10_0);
+
+        readThrottleTime = new AverageAndMax(
+                metrics,
+                PLATFORM_CATEGORY,
+                "rpc_read_throttle_time",
+                "amount of us the rpc read thread was paused by the per-peer byte shaper",
+                FORMAT_10_0);
+
+        precreateDynamicMetrics(peers);
 
         precreateDynamicMetrics(peers);
     }
@@ -602,5 +627,26 @@ public class SyncMetrics {
      */
     public void disabledBroadcastDueToOverload(final boolean disabled) {
         broadcastDisabledDueToOverload.add(disabled ? 1 : -1);
+    }
+
+    /**
+     * Report how much of a peer's inbound byte budget is currently consumed. The max across peers is what the
+     * shadow-mode rollout gate is read from.
+     *
+     * @param occupancy fraction of the burst budget consumed, from 0.0 to 1.0
+     */
+    public void reportShaperOccupancy(final double occupancy) {
+        shaperOccupancy.update(Math.round(occupancy * 1000));
+    }
+
+    /**
+     * Reading from a peer was paused because the peer was over its byte budget. Note that nanos are passed in but
+     * microseconds are reported.
+     *
+     * @param nanos length of the pause in nanoseconds
+     */
+    public void rpcReadThrottled(final long nanos) {
+        rpcReadThrottled.count();
+        readThrottleTime.update(nanos / 1000);
     }
 }

--- a/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/PeerByteShaper.java
+++ b/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/PeerByteShaper.java
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.gossip.impl.network.protocol.rpc;
+
+import com.swirlds.base.time.Time;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+import org.hiero.consensus.gossip.config.TrafficShapingConfig;
+
+/**
+ * Per-peer inbound byte budget. Bytes read from a peer are charged against a token bucket; when the peer is over
+ * budget, {@link #charge(long)} returns how long the reader should pause.
+ *
+ * <p>Implemented as a GCRA, which is equivalent to a token bucket but holds a single long of state and needs no
+ * refill timer. {@code tatNanos} is a virtual clock running ahead of real time in proportion to the bytes charged;
+ * how far ahead it is allowed to run is the burst allowance.
+ *
+ * <p>This class is not thread safe. One instance is owned by the rpc read thread for a single peer.
+ */
+public class PeerByteShaper {
+
+    private static final long NANOS_PER_SECOND = 1_000_000_000L;
+
+    private final Time time;
+    private final long bytesPerSecond;
+    private final long burstNanos;
+    private final long ceilingNanos;
+
+    /** Virtual clock; ahead of now by the amount of budget currently consumed. */
+    private long tatNanos;
+
+    /** Budget consumed as observed by the most recent {@link #charge(long)}, from 0.0 to 1.0. */
+    private double lastOccupancy;
+
+    /**
+     * @param time   platform time source; must be monotonic, and injectable for tests
+     * @param config traffic shaping configuration
+     */
+    public PeerByteShaper(@NonNull final Time time, @NonNull final TrafficShapingConfig config) {
+        this.time = Objects.requireNonNull(time);
+        this.bytesPerSecond = config.peerBytesPerSecond();
+        // multiplyExact so a misconfigured burst fails at startup rather than silently wrapping
+        this.burstNanos = Math.multiplyExact(config.peerBurstBytes(), NANOS_PER_SECOND) / bytesPerSecond;
+        this.ceilingNanos = burstNanos + config.maxReadDelay().toNanos();
+        this.tatNanos = time.nanoTime();
+    }
+
+    /**
+     * Charge the bytes read from this peer since the previous call.
+     *
+     * @param bytes bytes read since the last call; bounded in practice by one message plus one socket buffer, so the
+     *              multiplication below cannot overflow for any sane {@code maxMessageBytes}
+     * @return nanoseconds the reader should pause before reading again, or 0 if the peer is within budget
+     */
+    public long charge(final long bytes) {
+        final long now = time.nanoTime();
+
+        // an idle peer accrues the full burst allowance, but no more
+        if (tatNanos < now) {
+            tatNanos = now;
+        }
+
+        tatNanos += bytes * NANOS_PER_SECOND / bytesPerSecond;
+
+        // cap the debt so one large message cannot produce an unbounded stall
+        final long ceiling = now + ceilingNanos;
+        if (tatNanos > ceiling) {
+            tatNanos = ceiling;
+        }
+
+        final long used = tatNanos - now;
+        lastOccupancy = used <= 0 ? 0.0 : Math.min(1.0, (double) used / burstNanos);
+
+        return Math.max(0L, used - burstNanos);
+    }
+
+    /**
+     * Budget consumed as of the last {@link #charge(long)} call: 0.0 idle, 1.0 burst exhausted. Reported rather than
+     * recomputed so that only one clock read happens per message.
+     *
+     * @return the last observed occupancy
+     */
+    public double lastOccupancy() {
+        return lastOccupancy;
+    }
+}

--- a/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/PeerTrafficReporter.java
+++ b/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/PeerTrafficReporter.java
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.gossip.impl.network.protocol.rpc;
+
+import static com.swirlds.logging.legacy.LogMarker.SOCKET_EXCEPTIONS;
+
+import com.swirlds.base.time.Time;
+import com.swirlds.logging.legacy.payload.PeerTrafficShapingPayload;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.util.Objects;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.hiero.base.concurrent.throttle.RateLimiter;
+import org.hiero.consensus.gossip.config.TrafficShapingConfig;
+import org.hiero.consensus.model.node.NodeId;
+
+/**
+ * Reports how much of its inbound byte budget a peer is using. Two thresholds: above the low watermark a warning is
+ * logged, above the high watermark an evidence record is produced. Neither disconnects the peer, and neither affects
+ * how hard the peer is shaped, which follows continuously from the budget itself.
+ *
+ * <p>Repeat suppression is delegated to {@link RateLimiter}. Occupancy is sampled
+ * per message, so a peer sitting near a threshold would otherwise generate a log line per message.
+ *
+ * <p>This class is not thread safe. One instance is owned by the rpc read thread for a single peer.
+ */
+public class PeerTrafficReporter {
+
+    private static final Logger logger = LogManager.getLogger(PeerTrafficReporter.class);
+
+    private final TrafficShapingConfig config;
+    private final NodeId peerId;
+    private final Time time;
+    private final RateLimiter warningLimiter;
+
+    public PeerTrafficReporter(
+            @NonNull final Time time, @NonNull final TrafficShapingConfig config, @NonNull final NodeId peerId) {
+        this.time = Objects.requireNonNull(time);
+        this.config = Objects.requireNonNull(config);
+        this.peerId = Objects.requireNonNull(peerId);
+        this.warningLimiter = new RateLimiter(time, config.reportInterval());
+    }
+
+    /**
+     * Report the current budget occupancy for this peer.
+     *
+     * @param occupancy  fraction of the burst budget consumed, from 0.0 to 1.0
+     * @param delayNanos the pause that was applied, or 0 if the peer is within budget
+     */
+    public void report(final double occupancy, final long delayNanos) {
+
+        if (occupancy >= config.highWatermark()) {
+            // here, possible integration with Sheriff module should be added to report breaches
+            // disconnect and possibly shun offending node
+            // for now, reporting it as an error, as it indicates either broken code or misconfigured limits
+            // which would lead to broken production environment
+            logger.warn(
+                    SOCKET_EXCEPTIONS.getMarker(),
+                    new PeerTrafficShapingPayload(
+                            "Peer inbound traffic budget high watermark breached, misconfigured settings",
+                            peerId.id(),
+                            Math.round(occupancy * 1000),
+                            Math.round(config.highWatermark() * 1000),
+                            delayNanos,
+                            config.enforce()));
+        }
+
+        if (occupancy >= config.lowWatermark() && warningLimiter.requestAndTrigger()) {
+            logger.warn(
+                    SOCKET_EXCEPTIONS.getMarker(),
+                    new PeerTrafficShapingPayload(
+                            "Peer inbound traffic budget watermark breached",
+                            peerId.id(),
+                            Math.round(occupancy * 1000),
+                            Math.round(config.lowWatermark() * 1000),
+                            delayNanos,
+                            config.enforce()));
+        }
+    }
+}

--- a/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/RpcPeerProtocol.java
+++ b/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/RpcPeerProtocol.java
@@ -33,6 +33,7 @@ import org.hiero.base.concurrent.pool.ParallelExecutor;
 import org.hiero.base.concurrent.throttle.RateLimiter;
 import org.hiero.consensus.gossip.config.BroadcastConfig;
 import org.hiero.consensus.gossip.config.SyncConfig;
+import org.hiero.consensus.gossip.config.TrafficShapingConfig;
 import org.hiero.consensus.gossip.impl.gossip.permits.SyncPermitProvider;
 import org.hiero.consensus.gossip.impl.gossip.rpc.GossipRpcReceiver;
 import org.hiero.consensus.gossip.impl.gossip.rpc.GossipRpcReceiverHandler;
@@ -48,6 +49,7 @@ import org.hiero.consensus.gossip.impl.network.Connection;
 import org.hiero.consensus.gossip.impl.network.NetworkMetrics;
 import org.hiero.consensus.gossip.impl.network.NetworkProtocolException;
 import org.hiero.consensus.gossip.impl.network.protocol.PeerProtocol;
+import org.hiero.consensus.io.counting.ByteCounter;
 import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.status.PlatformStatus;
 
@@ -177,6 +179,21 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
     private final RpcOverloadMonitor overloadMonitor;
 
     /**
+     * Configuration for per-peer inbound traffic shaping
+     */
+    private final TrafficShapingConfig trafficConfig;
+
+    /**
+     * Per-peer inbound byte budget; charged on every incoming message
+     */
+    private final PeerByteShaper shaper;
+
+    /**
+     * Threshold reporting for {@link #shaper}
+     */
+    private final PeerTrafficReporter trafficReporter;
+
+    /**
      * Constructs a new rpc protocol
      *
      * @param peerId           the id of the peer being synced with in this protocol
@@ -188,6 +205,7 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
      * @param time             the {@link Time} instance for the platformeturns the {@link Time} instance for the
      *                         platform
      * @param syncMetrics      metrics tracking syncing
+     * @param trafficConfig    configuration for traffic shaper
      * @param syncConfig       sync configuration
      * @param broadcastConfig  broadcast configuration
      * @param exceptionHandler handler for errors which happens when managing the connection/dispatch loop
@@ -202,6 +220,7 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
             @NonNull final Time time,
             @NonNull final SyncMetrics syncMetrics,
             @NonNull final SyncConfig syncConfig,
+            @NonNull final TrafficShapingConfig trafficConfig,
             @NonNull final BroadcastConfig broadcastConfig,
             @NonNull final RpcInternalExceptionHandler exceptionHandler) {
         this.executor = Objects.requireNonNull(executor);
@@ -212,13 +231,17 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
         this.time = Objects.requireNonNull(time);
         this.syncMetrics = Objects.requireNonNull(syncMetrics);
         this.syncConfig = syncConfig;
+        this.trafficConfig = Objects.requireNonNull(trafficConfig);
+        this.shaper = new PeerByteShaper(time, trafficConfig);
+        this.trafficReporter = new PeerTrafficReporter(time, trafficConfig, remotePeerId);
+
         this.pingHandler = new RpcPingHandler(time, networkMetrics, remotePeerId, this, syncConfig.pingPeriod());
 
         this.exceptionRateLimiter = new RateLimiter(time, SOCKET_EXCEPTION_DURATION);
         this.exceptionHandler = exceptionHandler;
 
-        this.inputQueue =
-                syncMetrics.createMeasuredQueue("rpc_input_%02d".formatted(peerId.id()), new LinkedBlockingQueue<>());
+        this.inputQueue = syncMetrics.createMeasuredQueue(
+                "rpc_input_%02d".formatted(peerId.id()), new LinkedBlockingQueue<>(syncConfig.rpcInputQueueCapacity()));
         this.outputQueue =
                 syncMetrics.createMeasuredQueue("rpc_output_%02d".formatted(peerId.id()), new LinkedBlockingQueue<>());
         this.overloadMonitor = new RpcOverloadMonitor(
@@ -425,9 +448,12 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
      * @throws IOException          on any kind of I/O error
      * @throws SyncTimeoutException if conversation finish has not happened in the allotted time
      */
-    private void readMessages(@NonNull final Connection connection) throws IOException, SyncTimeoutException {
+    private void readMessages(@NonNull final Connection connection)
+            throws IOException, InterruptedException, SyncTimeoutException, NetworkProtocolException {
 
         final SyncInputStream input = connection.getDis();
+        final ByteCounter byteCounter = input.byteCounter();
+        long lastByteCount = byteCounter.getTotalCount();
         syncMetrics.rpcReadThreadRunning(+1);
         try {
             while (true) {
@@ -449,30 +475,38 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
                 if (incomingBatchSize == END_OF_CONVERSATION) {
                     break;
                 }
+                // we never send more than EVENT_BATCH_SIZE in one batch, so anything larger is a protocol violation
+                if (incomingBatchSize > EVENT_BATCH_SIZE) {
+                    // possibly Sheriff report?
+                    throw new NetworkProtocolException("Peer " + remotePeerId + " declared a batch of "
+                            + incomingBatchSize + " messages, maximum is " + EVENT_BATCH_SIZE);
+                }
 
                 for (int i = 0; i < incomingBatchSize; i++) {
+
+                    lastByteCount = throttleReads(byteCounter, lastByteCount);
 
                     final int messageType = input.read();
                     switch (messageType) {
                         case SYNC_DATA:
                             final GossipSyncData gossipSyncData = input.readPbjRecord(GossipSyncData.PROTOBUF);
-                            inputQueue.add(() -> receiver.receiveSyncData(SyncData.fromProtobuf(gossipSyncData)));
+                            enqueueInput(() -> receiver.receiveSyncData(SyncData.fromProtobuf(gossipSyncData)));
                             break;
                         case KNOWN_TIPS:
                             final GossipKnownTips knownTips = input.readPbjRecord(GossipKnownTips.PROTOBUF);
-                            inputQueue.add(() -> receiver.receiveTips(knownTips.knownTips()));
+                            enqueueInput(() -> receiver.receiveTips(knownTips.knownTips()));
                             break;
                         case EVENT:
                             final List<GossipEvent> events =
                                     Collections.singletonList(input.readPbjRecord(GossipEvent.PROTOBUF));
-                            inputQueue.add(() -> receiver.receiveEvents(events));
+                            enqueueInput(() -> receiver.receiveEvents(events));
                             break;
                         case BROADCAST_EVENT:
                             final GossipEvent event = input.readPbjRecord(GossipEvent.PROTOBUF);
-                            inputQueue.add(() -> receiver.receiveBroadcastEvent(event));
+                            enqueueInput(() -> receiver.receiveBroadcastEvent(event));
                             break;
                         case EVENTS_FINISHED:
-                            inputQueue.add(receiver::receiveEventsFinished);
+                            enqueueInput(receiver::receiveEventsFinished);
                             break;
                         case PING:
                             pingHandler.handleIncomingPing(input.readLong());
@@ -484,15 +518,81 @@ public class RpcPeerProtocol implements PeerProtocol, GossipRpcSender {
                             // we are still reporting delay to receive, not to handle
                             // we want to measure the network ping, rather than dispatch thread ping
                             // it is still handled over there, to make overloadMonitor managed from same thread
-                            inputQueue.add(() -> overloadMonitor.reportPing(pingMillis));
+                            enqueueInput(() -> overloadMonitor.reportPing(pingMillis));
                             break;
                     }
                 }
             }
         } finally {
-            inputQueue.add(POISON_PILL);
+            enqueuePoisonPill();
             processMessages = false;
             syncMetrics.rpcReadThreadRunning(-1);
+        }
+    }
+
+    /**
+     * Charge the bytes read from the peer since the previous call against the peer's byte budget, and pause reading if
+     * the peer is over budget. Called between messages, never in the middle of one, so a pause never leaves a partially
+     * read message on the stream.
+     *
+     * <p>The pause is bounded by {@link TrafficShapingConfig#maxReadDelay()} because pausing also stops us
+     * answering the peer's pings.
+     *
+     * @param byteCounter   counts bytes read from the socket for the current connection
+     * @param lastByteCount value the counter held on the previous call
+     * @return the counter value to compare against on the next call
+     */
+    private long throttleReads(@NonNull final ByteCounter byteCounter, final long lastByteCount)
+            throws InterruptedException {
+
+        if (!trafficConfig.enabled()) {
+            return lastByteCount;
+        }
+
+        final long byteCount = byteCounter.getTotalCount();
+        final long delayNanos = shaper.charge(byteCount - lastByteCount);
+
+        syncMetrics.reportShaperOccupancy(shaper.lastOccupancy());
+        trafficReporter.report(shaper.lastOccupancy(), trafficConfig.enforce() ? delayNanos : 0L);
+
+        if (delayNanos > 0) {
+            syncMetrics.rpcReadThrottled(delayNanos);
+            if (trafficConfig.enforce()) {
+                TimeUnit.NANOSECONDS.sleep(delayNanos);
+            }
+        }
+        return byteCount;
+    }
+
+    /**
+     * Hand a parsed message to the dispatch thread, waiting if the dispatch queue is full. Waiting here is the intended
+     * backpressure: it stops us reading the socket, which closes the TCP receive window and slows the peer at the
+     * source.
+     *
+     * @param message the action to be run by the dispatch thread
+     * @throws SyncTimeoutException if the dispatch thread has not drained the queue within
+     *                              {@link SyncConfig#maxSyncTime()}, which means it is wedged rather than merely busy
+     */
+    private void enqueueInput(@NonNull final Runnable message) throws SyncTimeoutException, InterruptedException {
+        final long deadline =
+                time.currentTimeMillis() + syncConfig.maxSyncTime().toMillis();
+
+        while (!inputQueue.offer(
+                message, syncConfig.rpcIdleDispatchPollTimeout().toMillis(), TimeUnit.MILLISECONDS)) {
+            if (time.currentTimeMillis() > deadline) {
+                throw new SyncTimeoutException(
+                        syncConfig.maxSyncTime(), Duration.ofMillis(deadline - time.currentTimeMillis()));
+            }
+        }
+    }
+
+    /**
+     * The dispatch thread only exits when it sees {@link #POISON_PILL}, so it has to be delivered even when the queue
+     * is full.
+     */
+    private void enqueuePoisonPill() {
+        while (!inputQueue.offer(POISON_PILL)) {
+            Thread.yield();
         }
     }
 

--- a/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/RpcProtocol.java
+++ b/platform-sdk/consensus-gossip-impl/src/main/java/org/hiero/consensus/gossip/impl/network/protocol/rpc/RpcProtocol.java
@@ -21,6 +21,7 @@ import org.hiero.base.concurrent.pool.CachedPoolParallelExecutor;
 import org.hiero.consensus.event.IntakeEventCounter;
 import org.hiero.consensus.gossip.config.BroadcastConfig;
 import org.hiero.consensus.gossip.config.SyncConfig;
+import org.hiero.consensus.gossip.config.TrafficShapingConfig;
 import org.hiero.consensus.gossip.impl.gossip.GossipController;
 import org.hiero.consensus.gossip.impl.gossip.permits.SyncGuard;
 import org.hiero.consensus.gossip.impl.gossip.permits.SyncGuardFactory;
@@ -51,6 +52,7 @@ public class RpcProtocol implements Protocol, GossipController {
     private final SyncMetrics syncMetrics;
     private final SyncConfig syncConfig;
     private final BroadcastConfig broadcastConfig;
+    private final TrafficShapingConfig trafficConfig;
     private final ShadowgraphSynchronizer synchronizer;
     private final SyncPermitProvider permitProvider;
     private final AtomicBoolean gossipHalted = new AtomicBoolean(false);
@@ -112,6 +114,9 @@ public class RpcProtocol implements Protocol, GossipController {
 
         this.syncConfig = configuration.getConfigData(SyncConfig.class);
         this.broadcastConfig = configuration.getConfigData(BroadcastConfig.class);
+        this.trafficConfig = configuration.getConfigData(TrafficShapingConfig.class);
+        validateTrafficShapingConfig(trafficConfig, broadcastConfig);
+
         final int permitCount;
         if (syncConfig.onePermitPerPeer()) {
             permitCount = rosterSize - 1;
@@ -147,6 +152,7 @@ public class RpcProtocol implements Protocol, GossipController {
                 time,
                 syncMetrics,
                 syncConfig,
+                trafficConfig,
                 broadcastConfig,
                 NetworkUtils::handleNetworkException);
 
@@ -272,5 +278,33 @@ public class RpcProtocol implements Protocol, GossipController {
      */
     public void clear() {
         synchronizer.clear();
+    }
+
+    /**
+     * Fail fast on configurations that would be actively harmful rather than merely badly tuned.
+     */
+    private static void validateTrafficShapingConfig(
+            @NonNull final TrafficShapingConfig traffic, @NonNull final BroadcastConfig broadcast) {
+
+        if (traffic.peerBytesPerSecond() <= 0) {
+            throw new IllegalArgumentException("trafficShaping.peerBytesPerSecond must be positive");
+        }
+        if (traffic.peerBurstBytes() <= 0) {
+            throw new IllegalArgumentException("trafficShaping.peerBurstBytes must be positive");
+        }
+        if (traffic.maxMessageBytes() <= 0) {
+            throw new IllegalArgumentException("trafficShaping.maxMessageBytes must be positive");
+        }
+        if (traffic.lowWatermark() >= traffic.highWatermark()) {
+            throw new IllegalArgumentException("trafficShaping.lowWatermark must be below highWatermark");
+        }
+        // pausing reads also stops us answering pings; if we pause for long enough the peer decides we are
+        // unhealthy and disables broadcast towards us, which is worse than the traffic we are limiting
+        final Duration pauseCeiling = broadcast.disablePingThreshold().dividedBy(2);
+        if (traffic.maxReadDelay().compareTo(pauseCeiling) >= 0) {
+            throw new IllegalArgumentException("trafficShaping.maxReadDelay (" + traffic.maxReadDelay()
+                    + ") must be well below half of broadcast.disablePingThreshold ("
+                    + broadcast.disablePingThreshold() + ")");
+        }
     }
 }

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/PeerByteShaperTest.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/gossip/PeerByteShaperTest.java
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.gossip.impl.gossip;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.withinPercentage;
+
+import com.swirlds.base.test.fixtures.time.FakeTime;
+import com.swirlds.config.api.ConfigurationBuilder;
+import java.time.Duration;
+import org.hiero.consensus.gossip.config.TrafficShapingConfig;
+import org.hiero.consensus.gossip.config.TrafficShapingConfig_;
+import org.hiero.consensus.gossip.impl.network.protocol.rpc.PeerByteShaper;
+import org.junit.jupiter.api.Test;
+
+class PeerByteShaperTest {
+
+    private static final long NANOS_PER_SECOND = 1_000_000_000L;
+    private static final long RATE = 1_000_000L; // 1 MB/s
+    private static final long BURST = 4_000_000L; // 4 s of burst
+    private static final Duration MAX_DELAY = Duration.ofMillis(200);
+
+    /** One chunk costs 100ms of budget at {@link #RATE}, comfortably under {@link #MAX_DELAY}. */
+    private static final long CHUNK = 100_000L;
+
+    @Test
+    void withinBurstNothingIsDelayed() {
+        final FakeTime time = new FakeTime();
+        final PeerByteShaper shaper = new PeerByteShaper(time, config());
+
+        assertThat(shaper.charge(BURST)).isZero();
+        assertThat(shaper.lastOccupancy()).isEqualTo(1.0);
+    }
+
+    @Test
+    void exceedingBurstDelaysProportionally() {
+        final FakeTime time = new FakeTime();
+        final PeerByteShaper shaper = new PeerByteShaper(time, config());
+
+        shaper.charge(BURST);
+        // CHUNK at 1 MB/s is 100ms of debt beyond the exhausted burst
+        assertThat(shaper.charge(CHUNK)).isEqualTo(Duration.ofMillis(100).toNanos());
+    }
+
+    @Test
+    void delayNeverExceedsMaxReadDelay() {
+        final FakeTime time = new FakeTime();
+        final PeerByteShaper shaper = new PeerByteShaper(time, config());
+
+        // 100 MB at 1 MB/s would be 100 seconds of debt
+        assertThat(shaper.charge(100_000_000L)).isEqualTo(MAX_DELAY.toNanos());
+    }
+
+    @Test
+    void idlePeerAccruesBurstButNoMore() {
+        final FakeTime time = new FakeTime();
+        final PeerByteShaper shaper = new PeerByteShaper(time, config());
+
+        shaper.charge(BURST);
+        time.tick(Duration.ofHours(1));
+
+        assertThat(shaper.charge(BURST)).isZero();
+        assertThat(shaper.charge(1)).isPositive();
+    }
+
+    @Test
+    void occupancyIsZeroWhenIdle() {
+        final FakeTime time = new FakeTime();
+        final PeerByteShaper shaper = new PeerByteShaper(time, config());
+
+        assertThat(shaper.charge(0)).isZero();
+        assertThat(shaper.lastOccupancy()).isZero();
+    }
+
+    @Test
+    void sustainedThroughputConvergesToConfiguredRate() {
+        final FakeTime time = new FakeTime();
+        final PeerByteShaper shaper = new PeerByteShaper(time, config());
+
+        final long startNanos = time.nanoTime();
+        final long runForNanos = Duration.ofSeconds(120).toNanos();
+        final long readerLoopFloorNanos = Duration.ofMillis(10).toNanos();
+
+        long delivered = 0;
+        while (time.nanoTime() - startNanos < runForNanos) {
+            final long delayNanos = shaper.charge(CHUNK);
+            delivered += CHUNK;
+            // a reader that honours the pause, but never spins faster than its own loop floor. Offering a chunk
+            // every 10ms is 10 MB/s, ten times the configured rate, so the shaper has to do the work.
+            time.tick(Duration.ofNanos(Math.max(delayNanos, readerLoopFloorNanos)));
+        }
+
+        final long elapsedNanos = time.nanoTime() - startNanos;
+        final double elapsedSeconds = elapsedNanos / (double) NANOS_PER_SECOND;
+
+        // The shaper never rejects bytes, so the property under test is not "fewer bytes arrived" but "virtual time
+        // cannot run further ahead of real time than burst + maxReadDelay". That caps the total at
+        // rate * (elapsed + burst + maxReadDelay).
+        final long ceiling = Math.round(RATE * elapsedSeconds)
+                + BURST
+                + Math.round(RATE * (MAX_DELAY.toNanos() / (double) NANOS_PER_SECOND));
+        assertThat(delivered).isLessThanOrEqualTo(ceiling);
+
+        // It must also not over-throttle: a reader willing to go faster should achieve at least the configured rate.
+        assertThat(delivered).isGreaterThanOrEqualTo(Math.round(RATE * elapsedSeconds));
+
+        // Over a window much longer than the burst, average bandwidth is close to the configured rate. The residual
+        // overshoot is the initial burst amortised over the window, so it shrinks as the window grows.
+        assertThat(delivered / elapsedSeconds).isCloseTo(RATE, withinPercentage(10));
+    }
+
+    private static TrafficShapingConfig config() {
+        return ConfigurationBuilder.create()
+                .autoDiscoverExtensions()
+                .withValue(TrafficShapingConfig_.PEER_BYTES_PER_SECOND, String.valueOf(RATE))
+                .withValue(TrafficShapingConfig_.PEER_BURST_BYTES, String.valueOf(BURST))
+                .withValue(TrafficShapingConfig_.MAX_READ_DELAY, String.valueOf(MAX_DELAY))
+                .build()
+                .getConfigData(TrafficShapingConfig.class);
+    }
+}

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/sync/RpcPeerProtocolTests.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/sync/RpcPeerProtocolTests.java
@@ -3,10 +3,6 @@ package org.hiero.consensus.gossip.impl.sync;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.base.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
-import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.Mockito.atLeastOnce;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
@@ -15,6 +11,7 @@ import com.swirlds.base.time.Time;
 import com.swirlds.base.utility.Pair;
 import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
+import com.swirlds.metrics.api.Metrics;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
 import java.time.Duration;
@@ -82,8 +79,26 @@ public class RpcPeerProtocolTests {
     /** Batch size larger than {@code RpcPeerProtocol.EVENT_BATCH_SIZE} (512), which is package private. */
     private static final short OVERSIZED_BATCH = Short.MAX_VALUE;
 
+    /** Sustained budget for the throttling test; orders of magnitude below what the exchange achieves. */
+    private static final long THROTTLE_BYTES_PER_SECOND = 100L;
+
+    /**
+     * Burst for the throttling test. At {@link #THROTTLE_BYTES_PER_SECOND} this is 100 ms of budget, so throttling
+     * begins after a couple of messages regardless of how fast the machine is.
+     */
+    private static final long THROTTLE_BURST_BYTES = 10L;
+
+    private static final Duration THROTTLE_WAIT = Duration.ofSeconds(60);
+
+    /** Short poll interval so a wait returns close to when its condition is actually met. */
+    private static final Duration POLL_INTERVAL = Duration.ofMillis(20);
+
     private final AtomicReference<Throwable> failure = new AtomicReference<>();
     private final List<Thread> startedThreads = new CopyOnWriteArrayList<>();
+
+    /** The per-node protocol loop threads, a subset of {@link #startedThreads}. */
+    private final List<Thread> nodeThreads = new CopyOnWriteArrayList<>();
+
     private final AtomicBoolean running = new AtomicBoolean(true);
 
     private CachedPoolParallelExecutor executor;
@@ -164,10 +179,17 @@ public class RpcPeerProtocolTests {
         final List<PeerInfo> peers = Utilities.createPeerInfoList(roster, selfId);
         final NodeId otherPeer = peers.get(0).nodeId();
 
-        final SyncPermitProvider permits =
-                new SyncPermitProvider(configuration, metrics, Time.getCurrent(), ROSTER_SIZE);
-        final RpcPeerProtocol protocol =
-                newProtocol(configuration, metrics, Time.getCurrent(), peers, selfId, otherPeer, permits, null);
+        final Time time = Time.getCurrent();
+        final SyncPermitProvider permits = new SyncPermitProvider(configuration, metrics, time, ROSTER_SIZE);
+        final RpcPeerProtocol protocol = newProtocol(
+                configuration,
+                metrics,
+                time,
+                peers,
+                selfId,
+                otherPeer,
+                permits,
+                new CountingSyncMetrics(metrics, time, peers));
         protocol.setRpcPeerHandler(new NoOpHandler());
 
         final Pair<Connection, Connection> connections = ConnectionFactory.createLocalConnections(selfId, otherPeer);
@@ -210,38 +232,56 @@ public class RpcPeerProtocolTests {
     /**
      * With enforcement on and a byte budget far below what the exchange needs, reads are paused, but the two nodes
      * still make progress. This is the guard against the shaper wedging an otherwise healthy exchange.
+     *
+     * <p>Both waits below are on the conditions actually being asserted, rather than on a proxy for them. Waiting on
+     * a sync count instead would be a different quantity from the one that triggers throttling: three sync
+     * conversations move only ~150 bytes, which is below the trigger threshold, so whether throttling had occurred
+     * by the time the wait returned would depend on how far the exchange happened to overshoot before the first
+     * poll. That is satisfied reliably on a warm machine and intermittently on CI.
+     *
+     * <p>{@link #THROTTLE_BURST_BYTES} is also deliberately tiny: at {@link #THROTTLE_BYTES_PER_SECOND} it is 100 ms
+     * of budget, so a couple of messages arriving within 100 ms is enough. Engagement therefore does not depend on
+     * machine speed.
      */
     @Test
     @Timeout(120)
     void enforcingShaperThrottlesReadsButKeepsSyncing() throws Throwable {
         final Configuration configuration = new TestConfigBuilder()
                 .withValue(TrafficShapingConfig_.ENFORCE, "true")
-                .withValue(TrafficShapingConfig_.PEER_BYTES_PER_SECOND, "100")
-                .withValue(TrafficShapingConfig_.PEER_BURST_BYTES, "200")
+                .withValue(TrafficShapingConfig_.PEER_BYTES_PER_SECOND, String.valueOf(THROTTLE_BYTES_PER_SECOND))
+                .withValue(TrafficShapingConfig_.PEER_BURST_BYTES, String.valueOf(THROTTLE_BURST_BYTES))
                 .withValue(TrafficShapingConfig_.MAX_READ_DELAY, "20ms")
                 .getOrCreateConfig();
 
         final Harness harness = start(configuration, Duration.ZERO);
 
-        // let a few syncs happen under throttling without any forced disconnections
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(60))
-                .until(() -> harness.syncsInitiated() >= 3 || failure.get() != null);
+        // wait for the property under test, not for something correlated with it
+        Awaitility.await("a read thread is throttled")
+                .atMost(THROTTLE_WAIT)
+                .pollDelay(Duration.ZERO)
+                .pollInterval(POLL_INTERVAL)
+                .until(() -> harness.totalThrottles() > 0 || failure.get() != null);
         rethrowIfFailed();
+
+        // throttling must slow the exchange down, not stop it
+        final long syncsWhenThrottled = harness.syncsInitiated();
+        Awaitility.await("syncing continues while throttled")
+                .atMost(THROTTLE_WAIT)
+                .pollDelay(Duration.ZERO)
+                .pollInterval(POLL_INTERVAL)
+                .until(() -> harness.syncsInitiated() > syncsWhenThrottled || failure.get() != null);
 
         running.set(false);
         disconnectBoth();
+        joinNodeThreads();
 
-        for (final SyncMetrics metrics : harness.syncMetrics()) {
-            // at least one node must have paused its read thread
-            try {
-                verify(metrics, atLeastOnce()).rpcReadThrottled(anyLong());
-                return;
-            } catch (final AssertionError ignored) {
-                // try the other node
-            }
-        }
-        throw new AssertionError("expected at least one node to throttle its read thread");
+        rethrowIfFailed();
+        assertThat(harness.totalThrottles())
+                .as("expected at least one node to throttle its read thread")
+                .isPositive();
+        assertThat(harness.syncsInitiated())
+                .as("expected syncing to continue while throttled")
+                .isGreaterThan(syncsWhenThrottled);
     }
 
     // -----------------------------------------------------------------------------------------------------------
@@ -252,9 +292,19 @@ public class RpcPeerProtocolTests {
      * Two {@link RpcPeerProtocol} instances, each looping over connections to the other, driven by
      * {@link StateMachineHandler}.
      */
-    private record Harness(List<SyncMetrics> syncMetrics, AtomicLong lastSyncMillis, AtomicLong syncCount) {
+    private record Harness(List<CountingSyncMetrics> syncMetrics, AtomicLong lastSyncMillis, AtomicLong syncCount) {
+
         long syncsInitiated() {
             return syncCount.get();
+        }
+
+        /**
+         * @return how many times either node paused its read thread
+         */
+        long totalThrottles() {
+            return syncMetrics.stream()
+                    .mapToLong(CountingSyncMetrics::throttleCount)
+                    .sum();
         }
     }
 
@@ -268,7 +318,7 @@ public class RpcPeerProtocolTests {
         final NoOpMetrics metrics = new NoOpMetrics();
         final Time time = Time.getCurrent();
 
-        final List<SyncMetrics> allSyncMetrics = new ArrayList<>();
+        final List<CountingSyncMetrics> allSyncMetrics = new ArrayList<>();
         final AtomicLong lastSyncMillis = new AtomicLong(time.currentTimeMillis());
         final AtomicLong syncCount = new AtomicLong();
 
@@ -278,7 +328,7 @@ public class RpcPeerProtocolTests {
             final NodeId otherPeer = peers.get(0).nodeId();
 
             final SyncPermitProvider permits = new SyncPermitProvider(configuration, metrics, time, ROSTER_SIZE);
-            final SyncMetrics syncMetrics = spy(new SyncMetrics(metrics, time, peers));
+            final CountingSyncMetrics syncMetrics = new CountingSyncMetrics(metrics, time, peers);
             allSyncMetrics.add(syncMetrics);
 
             final RpcPeerProtocol protocol =
@@ -286,7 +336,7 @@ public class RpcPeerProtocolTests {
             protocol.setRpcPeerHandler(
                     new StateMachineHandler(protocol, time, handlerDelay, lastSyncMillis, syncCount, failure));
 
-            startDaemon("rpc-" + selfId.id(), () -> {
+            nodeThreads.add(startDaemon("rpc-" + selfId.id(), () -> {
                 while (running.get()) {
                     try {
                         if (permits.acquire()) {
@@ -296,10 +346,20 @@ public class RpcPeerProtocolTests {
                         failure.compareAndSet(null, e);
                     }
                 }
-            });
+            }));
         }
 
         return new Harness(allSyncMetrics, lastSyncMillis, syncCount);
+    }
+
+    /**
+     * Waits for the node loop threads to exit. Assertions on counters updated by those threads must not run while
+     * they are still live, since {@code running.set(false)} only stops the loop at its next iteration.
+     */
+    private void joinNodeThreads() throws InterruptedException {
+        for (final Thread thread : nodeThreads) {
+            thread.join(TimeUnit.SECONDS.toMillis(10));
+        }
     }
 
     private RpcPeerProtocol newProtocol(
@@ -310,10 +370,7 @@ public class RpcPeerProtocolTests {
             @NonNull final NodeId selfId,
             @NonNull final NodeId otherPeer,
             @NonNull final SyncPermitProvider permits,
-            final SyncMetrics providedSyncMetrics) {
-
-        final SyncMetrics syncMetrics =
-                providedSyncMetrics != null ? providedSyncMetrics : new SyncMetrics(metrics, time, peers);
+            @NonNull final SyncMetrics syncMetrics) {
 
         return new RpcPeerProtocol(
                 otherPeer,
@@ -446,6 +503,34 @@ public class RpcPeerProtocolTests {
     // -----------------------------------------------------------------------------------------------------------
     // fakes
     // -----------------------------------------------------------------------------------------------------------
+
+    /**
+     * Counts read-thread pauses in a way that is safe to observe while the protocol is still running.
+     *
+     * <p>A Mockito spy is not usable here. {@code SyncMetrics} is called concurrently from the read, write and
+     * dispatch threads of both nodes, and Mockito does not support {@code verify} running concurrently with
+     * invocation. A plain counter also lets a test wait for throttling to occur rather than waiting on something
+     * correlated with it and hoping.
+     */
+    private static final class CountingSyncMetrics extends SyncMetrics {
+
+        private final AtomicLong throttleCount = new AtomicLong();
+
+        CountingSyncMetrics(
+                @NonNull final Metrics metrics, @NonNull final Time time, @NonNull final List<PeerInfo> peers) {
+            super(metrics, time, peers);
+        }
+
+        @Override
+        public void rpcReadThrottled(final long nanos) {
+            throttleCount.incrementAndGet();
+            super.rpcReadThrottled(nanos);
+        }
+
+        long throttleCount() {
+            return throttleCount.get();
+        }
+    }
 
     /**
      * Emulates the state machine of the real rpc handler closely enough to drive a full sync round trip, and fails

--- a/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/sync/RpcPeerProtocolTests.java
+++ b/platform-sdk/consensus-gossip-impl/src/test/java/org/hiero/consensus/gossip/impl/sync/RpcPeerProtocolTests.java
@@ -1,8 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 package org.hiero.consensus.gossip.impl.sync;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hiero.base.concurrent.manager.AdHocThreadManager.getStaticThreadManager;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import com.hedera.hapi.node.state.roster.Roster;
 import com.hedera.hapi.node.state.roster.RosterEntry;
@@ -13,14 +17,23 @@ import com.swirlds.config.api.Configuration;
 import com.swirlds.config.extensions.test.fixtures.TestConfigBuilder;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import org.awaitility.Awaitility;
 import org.hiero.base.concurrent.pool.CachedPoolParallelExecutor;
-import org.hiero.base.concurrent.pool.ParallelExecutor;
 import org.hiero.base.concurrent.throttle.RateLimiter;
 import org.hiero.consensus.fakes.noop.NoOpMetrics;
 import org.hiero.consensus.gossip.config.BroadcastConfig;
 import org.hiero.consensus.gossip.config.SyncConfig;
+import org.hiero.consensus.gossip.config.SyncConfig_;
+import org.hiero.consensus.gossip.config.TrafficShapingConfig;
+import org.hiero.consensus.gossip.config.TrafficShapingConfig_;
 import org.hiero.consensus.gossip.impl.gossip.Utilities;
 import org.hiero.consensus.gossip.impl.gossip.permits.SyncPermitProvider;
 import org.hiero.consensus.gossip.impl.gossip.rpc.GossipRpcReceiverHandler;
@@ -28,6 +41,7 @@ import org.hiero.consensus.gossip.impl.gossip.rpc.SyncData;
 import org.hiero.consensus.gossip.impl.gossip.sync.SyncMetrics;
 import org.hiero.consensus.gossip.impl.network.Connection;
 import org.hiero.consensus.gossip.impl.network.NetworkMetrics;
+import org.hiero.consensus.gossip.impl.network.NetworkProtocolException;
 import org.hiero.consensus.gossip.impl.network.PeerInfo;
 import org.hiero.consensus.gossip.impl.network.protocol.rpc.RpcPeerProtocol;
 import org.hiero.consensus.gossip.impl.test.fixtures.sync.ConnectionFactory;
@@ -36,222 +50,339 @@ import org.hiero.consensus.model.node.NodeId;
 import org.hiero.consensus.model.status.PlatformStatus;
 import org.hiero.consensus.roster.test.fixtures.RosterFactory;
 import org.hiero.consensus.test.fixtures.Randotron;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
+/**
+ * Tests for {@link RpcPeerProtocol}, driving two instances against each other over a local piped connection.
+ *
+ * <p>Covers the original frequent-disconnection scenario plus the per-peer traffic shaping behaviour: a bounded
+ * dispatch queue, rejection of oversized message batches, and read throttling when a peer exceeds its byte budget.
+ */
 public class RpcPeerProtocolTests {
 
-    private long lastSentSync;
-    private Throwable foundException;
+    /** How many forced disconnect cycles to run. */
+    private static final int DISCONNECT_CYCLES = 50;
+
+    /**
+     * Time between forced disconnections. Must be several times the sum of the artificial delays in
+     * {@link StateMachineHandler}, so that a few complete syncs fit between disconnections.
+     */
+    private static final Duration CYCLE_PERIOD = Duration.ofMillis(100);
+
+    /**
+     * If no sync has been initiated for this long at the end of the run, the protocol is wedged. One failure mode is
+     * the state "I believe a sync was sent, but cleanup happened and I did not notice".
+     */
+    private static final Duration NO_SYNC_TOLERANCE = Duration.ofSeconds(1);
+
+    private static final int ROSTER_SIZE = 2;
+
+    /** Batch size larger than {@code RpcPeerProtocol.EVENT_BATCH_SIZE} (512), which is package private. */
+    private static final short OVERSIZED_BATCH = Short.MAX_VALUE;
+
+    private final AtomicReference<Throwable> failure = new AtomicReference<>();
+    private final List<Thread> startedThreads = new CopyOnWriteArrayList<>();
+    private final AtomicBoolean running = new AtomicBoolean(true);
+
+    private CachedPoolParallelExecutor executor;
+
+    // pairing state for handing out the two ends of a local connection
     private NodeId alreadyAsked = null;
     private volatile Connection otherConnection = null;
     private volatile Connection lastConnection = null;
 
-    @Test
-    public void testPeerProtocolFrequentDisconnections() throws Throwable {
-
-        final Randotron randotron = Randotron.create();
-
-        final AtomicBoolean running = new AtomicBoolean(true);
-
-        final ParallelExecutor executor = new CachedPoolParallelExecutor(getStaticThreadManager(), "a name");
-        executor.start();
-
-        final Roster roster = RosterFactory.randomRoster(randotron, 2);
-
-        final NoOpMetrics metrics = new NoOpMetrics();
-
-        final Configuration configuration = new TestConfigBuilder().getOrCreateConfig();
-
-        final SyncConfig syncConfig = configuration.getConfigData(SyncConfig.class);
-        final BroadcastConfig broadcastConfig = configuration.getConfigData(BroadcastConfig.class);
-
-        final Time time = Time.getCurrent();
-        final SyncPermitProvider permitProvider = new SyncPermitProvider(
-                metrics, time, syncConfig, roster.rosterEntries().size());
-
-        for (int i = 0; i < 2; i++) {
-
-            final RosterEntry selfEntry = roster.rosterEntries().get(i);
-            final NodeId selfId = NodeId.of(selfEntry.nodeId());
-
-            final List<PeerInfo> peers = Utilities.createPeerInfoList(roster, selfId);
-            // other peer will be the only one in list of other peers
-            final NodeId otherPeer = peers.get(0).nodeId();
-
-            final RpcPeerProtocol peerProtocol = new RpcPeerProtocol(
-                    selfId,
-                    executor,
-                    () -> false,
-                    () -> PlatformStatus.ACTIVE,
-                    permitProvider,
-                    new NetworkMetrics(metrics, selfId, peers),
-                    Time.getCurrent(),
-                    new SyncMetrics(metrics, Time.getCurrent(), peers),
-                    syncConfig,
-                    broadcastConfig,
-                    this::handleException);
-
-            peerProtocol.setRpcPeerHandler(new GossipRpcReceiverHandler() {
-
-                // we need to emulate the state machine of actual rpc handler
-
-                private boolean receivedEvents;
-                private boolean receivedTips;
-                private boolean receivedSyncData;
-                private boolean sentTips;
-                private boolean sentSyncData = false;
-
-                @Override
-                public boolean checkForPeriodicActions(final boolean wantToExit, final boolean ignoreIncomingEvents) {
-                    maybeSendSync();
-                    return true;
-                }
-
-                private void maybeSendSync() {
-                    if (!sentSyncData) {
-                        // we don't care what contents we are sending, remote side is also a test implementation
-                        peerProtocol.sendSyncData(new SyncData(EventWindow.getGenesisEventWindow(), List.of(), false));
-                        lastSentSync = time.currentTimeMillis();
-                        sentSyncData = true;
-                    }
-                }
-
-                @Override
-                public void cleanup() {
-                    sentSyncData = false;
-                    sentTips = false;
-                    receivedSyncData = false;
-                    receivedTips = false;
-                    receivedEvents = false;
-                }
-
-                @Override
-                public void setCommunicationOverloaded(final boolean overloaded) {
-                    // no-op
-                }
-
-                @Override
-                public void receiveSyncData(@NonNull final SyncData syncMessage) {
-                    maybeSendSync();
-                    receivedSyncData = true;
-                    peerProtocol.sendTips(List.of());
-                    sentTips = true;
-                }
-
-                @Override
-                public void receiveTips(@NonNull final List<Boolean> tips) {
-                    if (!receivedSyncData) {
-                        throw new IllegalStateException("ERROR: Received tips before sync data");
-                    }
-                    receivedTips = true;
-                    try {
-                        // pretend we are doing some processing which takes time (filtering events, serializing them and
-                        // sending them over network etc)
-                        Thread.sleep(5);
-                    } catch (final InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    peerProtocol.sendEvents(List.of());
-                    peerProtocol.sendEndOfEvents();
-                }
-
-                @Override
-                public void receiveEvents(@NonNull final List<GossipEvent> gossipEvents) {
-                    if (!receivedTips) {
-                        throw new IllegalStateException("ERROR: Received events before tips");
-                    }
-                    receivedEvents = true;
-                    try {
-                        // pretend we are doing some processing which takes time (deserializing events, receiving them
-                        // over network etc)
-                        Thread.sleep(6);
-                    } catch (final InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                }
-
-                @Override
-                public void receiveEventsFinished() {
-                    try {
-                        // again, wait for emulating internal processing and network delays
-                        Thread.sleep(7);
-                    } catch (final InterruptedException e) {
-                        throw new RuntimeException(e);
-                    }
-                    cleanup();
-                }
-
-                @Override
-                public void receiveBroadcastEvent(@NonNull final GossipEvent gossipEvent) {
-                    // no-op
-                }
-            });
-
-            new Thread(() -> {
-                        while (running.get()) {
-                            try {
-                                if (permitProvider.acquire()) {
-                                    final Connection connection = connect(selfId, otherPeer);
-                                    peerProtocol.runProtocol(connection);
-                                }
-                            } catch (final Exception exc) {
-                                foundException = exc;
-                            }
-                        }
-                    })
-                    .start();
-        }
-
-        for (int i = 0; i < 100; i++) {
-            // force disconnections multiple times per second;
-            // this time should be few times bigger than sum of all the delays in the methods above, to allow few syncs
-            // to happen between disconnections
-            Thread.sleep(100);
-            synchronized (this) {
-                if (lastConnection != null) {
-                    lastConnection.disconnect();
-                    otherConnection.disconnect();
-                }
-            }
-            if (foundException != null) {
-                throw foundException;
-            }
-        }
-
+    @AfterEach
+    void tearDown() throws InterruptedException {
         running.set(false);
-        if (lastConnection != null) {
-            synchronized (this) {
-                lastConnection.disconnect();
-                otherConnection.disconnect();
-            }
+        disconnectBoth();
+        for (final Thread thread : startedThreads) {
+            thread.join(TimeUnit.SECONDS.toMillis(5));
         }
-        Thread.sleep(100);
-        final long noSyncTime = time.currentTimeMillis() - lastSentSync;
-        if (noSyncTime > 1000) {
-            // one of the possible failure scenarios is that we are stuck in illegal state of
-            // "I think sync was sent to other party, but cleanup has happened and I didn't notice"
-            // we want to fail the test in such case
-            fail("Has not synced in " + noSyncTime + " ms");
+        if (executor != null) {
+            executor.stop();
         }
     }
 
-    private void handleException(
-            @NonNull final Exception e, @NonNull final Connection connection, @NonNull final RateLimiter rateLimiter) {
-        if (e.getCause().toString().contains("ERROR")) {
-            foundException = e.getCause();
+    // -----------------------------------------------------------------------------------------------------------
+    // tests
+    // -----------------------------------------------------------------------------------------------------------
+
+    @Test
+    @Timeout(120)
+    void frequentDisconnectionsKeepSyncing() throws Throwable {
+        final Harness harness = start(defaultConfig(), Duration.ofMillis(5));
+
+        for (int i = 0; i < DISCONNECT_CYCLES; i++) {
+            Thread.sleep(CYCLE_PERIOD.toMillis());
+            disconnectBoth();
+            rethrowIfFailed();
         }
+
+        stopAndAssertStillSyncing(harness);
     }
 
     /**
-     * Create the pair of local connections between the nodes and returns them depending on who is asking. Valid only
-     * for two nodes.
-     *
-     * @param selfId    who is asking for connection
-     * @param otherPeer to whom connection should be made
-     * @return connection for given node
-     * @throws IOException should never happen
+     * With a dispatch queue of one and a deliberately slow handler, the read thread has to block on the queue rather
+     * than throw. This is the regression test for switching the read loop from {@code add} to a blocking offer.
      */
-    private synchronized Connection connect(final NodeId selfId, final NodeId otherPeer) throws IOException {
+    @Test
+    @Timeout(120)
+    void tinyInputQueueWithSlowDispatchStillSyncs() throws Throwable {
+        final Configuration configuration = new TestConfigBuilder()
+                .withValue(SyncConfig_.RPC_INPUT_QUEUE_CAPACITY, "1")
+                .getOrCreateConfig();
+
+        final Harness harness = start(configuration, Duration.ofMillis(20));
+
+        for (int i = 0; i < DISCONNECT_CYCLES / 2; i++) {
+            Thread.sleep(CYCLE_PERIOD.toMillis());
+            disconnectBoth();
+            rethrowIfFailed();
+        }
+
+        stopAndAssertStillSyncing(harness);
+    }
+
+    /**
+     * A peer declaring a batch larger than we would ever send is a protocol violation: the connection is dropped and
+     * an evidence record is produced.
+     */
+    @Test
+    @Timeout(60)
+    void oversizedBatchIsRejectedAsMalformed() throws Exception {
+        startExecutor();
+
+        final Randotron randotron = Randotron.create();
+        final Roster roster = RosterFactory.randomRoster(randotron, ROSTER_SIZE);
+        final Configuration configuration = defaultConfig();
+        final NoOpMetrics metrics = new NoOpMetrics();
+
+        final RosterEntry selfEntry = roster.rosterEntries().get(0);
+        final NodeId selfId = NodeId.of(selfEntry.nodeId());
+        final List<PeerInfo> peers = Utilities.createPeerInfoList(roster, selfId);
+        final NodeId otherPeer = peers.get(0).nodeId();
+
+        final SyncPermitProvider permits =
+                new SyncPermitProvider(configuration, metrics, Time.getCurrent(), ROSTER_SIZE);
+        final RpcPeerProtocol protocol =
+                newProtocol(configuration, metrics, Time.getCurrent(), peers, selfId, otherPeer, permits, null);
+        protocol.setRpcPeerHandler(new NoOpHandler());
+
+        final Pair<Connection, Connection> connections = ConnectionFactory.createLocalConnections(selfId, otherPeer);
+        final Connection victim = connections.left();
+        final Connection attacker = connections.right();
+
+        // the attacker has to keep draining, otherwise the victim's write thread fills the pipe buffer and blocks
+        final Thread drainer = startDaemon("attacker-drain", () -> {
+            try {
+                while (running.get() && attacker.getDis().read() >= 0) {
+                    // discard
+                }
+            } catch (final IOException ignored) {
+                // expected once the connection is closed
+            }
+        });
+
+        assertThat(permits.acquire()).isTrue();
+        final Thread victimThread = startDaemon("victim", () -> {
+            try {
+                protocol.runProtocol(victim);
+            } catch (final Exception e) {
+                failure.set(e);
+            }
+        });
+
+        attacker.getDos().writeShort(OVERSIZED_BATCH);
+        attacker.getDos().flush();
+
+        // the violation must take the connection down rather than being logged and ignored
+        Awaitility.await().atMost(Duration.ofSeconds(20)).until(() -> !victimThread.isAlive());
+        assertThat(handledExceptions).anyMatch(RpcPeerProtocolTests::causedByProtocolViolation);
+
+        running.set(false);
+        victim.disconnect();
+        attacker.disconnect();
+        drainer.join(TimeUnit.SECONDS.toMillis(5));
+    }
+
+    /**
+     * With enforcement on and a byte budget far below what the exchange needs, reads are paused, but the two nodes
+     * still make progress. This is the guard against the shaper wedging an otherwise healthy exchange.
+     */
+    @Test
+    @Timeout(120)
+    void enforcingShaperThrottlesReadsButKeepsSyncing() throws Throwable {
+        final Configuration configuration = new TestConfigBuilder()
+                .withValue(TrafficShapingConfig_.ENFORCE, "true")
+                .withValue(TrafficShapingConfig_.PEER_BYTES_PER_SECOND, "100")
+                .withValue(TrafficShapingConfig_.PEER_BURST_BYTES, "200")
+                .withValue(TrafficShapingConfig_.MAX_READ_DELAY, "20ms")
+                .getOrCreateConfig();
+
+        final Harness harness = start(configuration, Duration.ZERO);
+
+        // let a few syncs happen under throttling without any forced disconnections
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(60))
+                .until(() -> harness.syncsInitiated() >= 3 || failure.get() != null);
+        rethrowIfFailed();
+
+        running.set(false);
+        disconnectBoth();
+
+        for (final SyncMetrics metrics : harness.syncMetrics()) {
+            // at least one node must have paused its read thread
+            try {
+                verify(metrics, atLeastOnce()).rpcReadThrottled(anyLong());
+                return;
+            } catch (final AssertionError ignored) {
+                // try the other node
+            }
+        }
+        throw new AssertionError("expected at least one node to throttle its read thread");
+    }
+
+    // -----------------------------------------------------------------------------------------------------------
+    // harness
+    // -----------------------------------------------------------------------------------------------------------
+
+    /**
+     * Two {@link RpcPeerProtocol} instances, each looping over connections to the other, driven by
+     * {@link StateMachineHandler}.
+     */
+    private record Harness(List<SyncMetrics> syncMetrics, AtomicLong lastSyncMillis, AtomicLong syncCount) {
+        long syncsInitiated() {
+            return syncCount.get();
+        }
+    }
+
+    private Harness start(@NonNull final Configuration configuration, @NonNull final Duration handlerDelay)
+            throws IOException {
+
+        startExecutor();
+
+        final Randotron randotron = Randotron.create();
+        final Roster roster = RosterFactory.randomRoster(randotron, ROSTER_SIZE);
+        final NoOpMetrics metrics = new NoOpMetrics();
+        final Time time = Time.getCurrent();
+
+        final List<SyncMetrics> allSyncMetrics = new ArrayList<>();
+        final AtomicLong lastSyncMillis = new AtomicLong(time.currentTimeMillis());
+        final AtomicLong syncCount = new AtomicLong();
+
+        for (int i = 0; i < ROSTER_SIZE; i++) {
+            final NodeId selfId = NodeId.of(roster.rosterEntries().get(i).nodeId());
+            final List<PeerInfo> peers = Utilities.createPeerInfoList(roster, selfId);
+            final NodeId otherPeer = peers.get(0).nodeId();
+
+            final SyncPermitProvider permits = new SyncPermitProvider(configuration, metrics, time, ROSTER_SIZE);
+            final SyncMetrics syncMetrics = spy(new SyncMetrics(metrics, time, peers));
+            allSyncMetrics.add(syncMetrics);
+
+            final RpcPeerProtocol protocol =
+                    newProtocol(configuration, metrics, time, peers, selfId, otherPeer, permits, syncMetrics);
+            protocol.setRpcPeerHandler(
+                    new StateMachineHandler(protocol, time, handlerDelay, lastSyncMillis, syncCount, failure));
+
+            startDaemon("rpc-" + selfId.id(), () -> {
+                while (running.get()) {
+                    try {
+                        if (permits.acquire()) {
+                            protocol.runProtocol(connect(selfId, otherPeer));
+                        }
+                    } catch (final Exception e) {
+                        failure.compareAndSet(null, e);
+                    }
+                }
+            });
+        }
+
+        return new Harness(allSyncMetrics, lastSyncMillis, syncCount);
+    }
+
+    private RpcPeerProtocol newProtocol(
+            @NonNull final Configuration configuration,
+            @NonNull final NoOpMetrics metrics,
+            @NonNull final Time time,
+            @NonNull final List<PeerInfo> peers,
+            @NonNull final NodeId selfId,
+            @NonNull final NodeId otherPeer,
+            @NonNull final SyncPermitProvider permits,
+            final SyncMetrics providedSyncMetrics) {
+
+        final SyncMetrics syncMetrics =
+                providedSyncMetrics != null ? providedSyncMetrics : new SyncMetrics(metrics, time, peers);
+
+        return new RpcPeerProtocol(
+                otherPeer,
+                executor,
+                () -> false,
+                () -> PlatformStatus.ACTIVE,
+                permits,
+                new NetworkMetrics(metrics, selfId, peers),
+                time,
+                syncMetrics,
+                configuration.getConfigData(SyncConfig.class),
+                configuration.getConfigData(TrafficShapingConfig.class),
+                configuration.getConfigData(BroadcastConfig.class),
+                this::handleException);
+    }
+
+    private void startExecutor() {
+        executor = new CachedPoolParallelExecutor(getStaticThreadManager(), "rpc-peer-protocol-tests");
+        executor.start();
+    }
+
+    private static Configuration defaultConfig() {
+        return new TestConfigBuilder().getOrCreateConfig();
+    }
+
+    private void stopAndAssertStillSyncing(@NonNull final Harness harness) throws Throwable {
+        running.set(false);
+        disconnectBoth();
+        Thread.sleep(CYCLE_PERIOD.toMillis());
+        rethrowIfFailed();
+
+        final long sinceLastSync =
+                Time.getCurrent().currentTimeMillis() - harness.lastSyncMillis().get();
+        assertThat(sinceLastSync)
+                .as("protocol appears wedged: no sync initiated for %d ms", sinceLastSync)
+                .isLessThan(NO_SYNC_TOLERANCE.toMillis());
+        assertThat(harness.syncsInitiated()).isPositive();
+    }
+
+    private void rethrowIfFailed() throws Throwable {
+        final Throwable throwable = failure.get();
+        if (throwable != null) {
+            throw throwable;
+        }
+    }
+
+    private synchronized void disconnectBoth() {
+        if (lastConnection != null) {
+            lastConnection.disconnect();
+        }
+        if (otherConnection != null) {
+            otherConnection.disconnect();
+        }
+    }
+
+    private Thread startDaemon(@NonNull final String name, @NonNull final Runnable body) {
+        final Thread thread = new Thread(body, name);
+        thread.setDaemon(true);
+        startedThreads.add(thread);
+        thread.start();
+        return thread;
+    }
+
+    /**
+     * Hands out the two ends of a local connection pair. Valid only for two nodes: the first caller creates the pair
+     * and takes one end, the second caller takes the other.
+     */
+    private synchronized Connection connect(@NonNull final NodeId selfId, @NonNull final NodeId otherPeer)
+            throws IOException {
 
         if (alreadyAsked == null) {
             final Pair<Connection, Connection> connections =
@@ -263,11 +394,219 @@ public class RpcPeerProtocolTests {
         }
 
         if (selfId.equals(alreadyAsked)) {
-            throw new IllegalArgumentException(
-                    "Node " + selfId + "asked about connection twice before other one tried to do so");
+            throw new IllegalStateException(
+                    "Node " + selfId + " asked for a connection twice before the other node did");
         }
         final Connection connection = otherConnection;
         alreadyAsked = null;
         return connection;
+    }
+
+    // -----------------------------------------------------------------------------------------------------------
+    // exception capture
+    // -----------------------------------------------------------------------------------------------------------
+
+    private final List<Exception> handledExceptions = new CopyOnWriteArrayList<>();
+
+    private void handleException(
+            @NonNull final Exception e, @NonNull final Connection connection, @NonNull final RateLimiter rateLimiter) {
+        handledExceptions.add(e);
+        // the handler in production swallows expected network churn; only surface state machine violations
+        if (containsStateMachineViolation(e)) {
+            failure.compareAndSet(null, e);
+        }
+    }
+
+    private static boolean containsStateMachineViolation(final Throwable throwable) {
+        for (Throwable t = throwable; t != null; t = t.getCause()) {
+            if (t instanceof IllegalStateException
+                    && t.getMessage() != null
+                    && t.getMessage().contains("ERROR")) {
+                return true;
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return false;
+    }
+
+    private static boolean causedByProtocolViolation(final Throwable throwable) {
+        for (Throwable t = throwable; t != null; t = t.getCause()) {
+            if (t instanceof NetworkProtocolException) {
+                return true;
+            }
+            if (t.getCause() == t) {
+                break;
+            }
+        }
+        return false;
+    }
+
+    // -----------------------------------------------------------------------------------------------------------
+    // fakes
+    // -----------------------------------------------------------------------------------------------------------
+
+    /**
+     * Emulates the state machine of the real rpc handler closely enough to drive a full sync round trip, and fails
+     * the test if messages arrive out of order. Artificial delays stand in for filtering, serialisation and network
+     * time, and are what makes the dispatch thread slower than the read thread.
+     */
+    private static final class StateMachineHandler implements GossipRpcReceiverHandler {
+
+        private final RpcPeerProtocol protocol;
+        private final Time time;
+        private final Duration delay;
+        private final AtomicLong lastSyncMillis;
+        private final AtomicLong syncCount;
+        private final AtomicReference<Throwable> failure;
+
+        private boolean receivedTips;
+        private boolean receivedSyncData;
+        private boolean sentSyncData;
+
+        private StateMachineHandler(
+                @NonNull final RpcPeerProtocol protocol,
+                @NonNull final Time time,
+                @NonNull final Duration delay,
+                @NonNull final AtomicLong lastSyncMillis,
+                @NonNull final AtomicLong syncCount,
+                @NonNull final AtomicReference<Throwable> failure) {
+            this.protocol = protocol;
+            this.time = time;
+            this.delay = delay;
+            this.lastSyncMillis = lastSyncMillis;
+            this.syncCount = syncCount;
+            this.failure = failure;
+        }
+
+        @Override
+        public boolean checkForPeriodicActions(final boolean wantToExit, final boolean ignoreIncomingEvents) {
+            maybeSendSync();
+            return true;
+        }
+
+        private void maybeSendSync() {
+            if (!sentSyncData) {
+                // contents do not matter, the remote side is also a test implementation
+                protocol.sendSyncData(new SyncData(EventWindow.getGenesisEventWindow(), List.of(), false));
+                lastSyncMillis.set(time.currentTimeMillis());
+                syncCount.incrementAndGet();
+                sentSyncData = true;
+            }
+        }
+
+        @Override
+        public void cleanup() {
+            sentSyncData = false;
+            receivedSyncData = false;
+            receivedTips = false;
+        }
+
+        @Override
+        public void setCommunicationOverloaded(final boolean overloaded) {
+            // no-op
+        }
+
+        @Override
+        public void receiveSyncData(@NonNull final SyncData syncMessage) {
+            maybeSendSync();
+            receivedSyncData = true;
+            protocol.sendTips(List.of());
+        }
+
+        @Override
+        public void receiveTips(@NonNull final List<Boolean> tips) {
+            if (!receivedSyncData) {
+                fail("ERROR: received tips before sync data");
+                return;
+            }
+            receivedTips = true;
+            pause();
+            protocol.sendEvents(List.of());
+            protocol.sendEndOfEvents();
+        }
+
+        @Override
+        public void receiveEvents(@NonNull final List<GossipEvent> gossipEvents) {
+            if (!receivedTips) {
+                fail("ERROR: received events before tips");
+                return;
+            }
+            pause();
+        }
+
+        @Override
+        public void receiveEventsFinished() {
+            pause();
+            cleanup();
+        }
+
+        @Override
+        public void receiveBroadcastEvent(@NonNull final GossipEvent gossipEvent) {
+            // no-op
+        }
+
+        private void fail(@NonNull final String message) {
+            final IllegalStateException e = new IllegalStateException(message);
+            failure.compareAndSet(null, e);
+            throw e;
+        }
+
+        private void pause() {
+            if (delay.isZero()) {
+                return;
+            }
+            try {
+                Thread.sleep(delay.toMillis());
+            } catch (final InterruptedException e) {
+                Thread.currentThread().interrupt();
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    /** Handler that does nothing; used where no exchange is expected. */
+    private static final class NoOpHandler implements GossipRpcReceiverHandler {
+
+        @Override
+        public boolean checkForPeriodicActions(final boolean wantToExit, final boolean ignoreIncomingEvents) {
+            return true;
+        }
+
+        @Override
+        public void cleanup() {
+            // no-op
+        }
+
+        @Override
+        public void setCommunicationOverloaded(final boolean overloaded) {
+            // no-op
+        }
+
+        @Override
+        public void receiveSyncData(@NonNull final SyncData syncMessage) {
+            // no-op
+        }
+
+        @Override
+        public void receiveTips(@NonNull final List<Boolean> tips) {
+            // no-op
+        }
+
+        @Override
+        public void receiveEvents(@NonNull final List<GossipEvent> gossipEvents) {
+            // no-op
+        }
+
+        @Override
+        public void receiveEventsFinished() {
+            // no-op
+        }
+
+        @Override
+        public void receiveBroadcastEvent(@NonNull final GossipEvent gossipEvent) {
+            // no-op
+        }
     }
 }

--- a/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/GossipConfigurationExtension.java
+++ b/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/GossipConfigurationExtension.java
@@ -23,7 +23,8 @@ public class GossipConfigurationExtension implements ConfigurationExtension {
                 ProtocolConfig.class,
                 SocketConfig.class,
                 SyncConfig.class,
-                BroadcastConfig.class);
+                BroadcastConfig.class,
+                TrafficShapingConfig.class);
     }
 
     /**

--- a/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/SyncConfig.java
+++ b/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/SyncConfig.java
@@ -74,6 +74,9 @@ import java.time.Duration;
  * @param keepSendingEventsWhenUnhealthy     when enabled, instead of completely reducing number of syncs when system is
  *                                           unhealthy, we will just stop receiving and processing remote events, while
  *                                           we still continue sending our own events
+ * @param rpcInputQueueCapacity              maximum number of parsed messages which can be waiting for the rpc
+ *                                           dispatch thread; when full, the read thread stops reading from the
+ *                                           socket, which applies TCP backpressure to the peer
  * @param pingPeriod                         period at which ping messages are sent to peers during syncs
  */
 @ConfigData("sync")
@@ -100,4 +103,5 @@ public record SyncConfig(
         @ConfigProperty(defaultValue = "-1") double fairMaxConcurrentSyncs,
         @ConfigProperty(defaultValue = "0.3") double fairMinimalRoundRobinSize,
         @ConfigProperty(defaultValue = "true") boolean keepSendingEventsWhenUnhealthy,
+        @ConfigProperty(defaultValue = "1000") int rpcInputQueueCapacity,
         @ConfigProperty(defaultValue = "1s") Duration pingPeriod) {}

--- a/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/TrafficShapingConfig.java
+++ b/platform-sdk/consensus-gossip/src/main/java/org/hiero/consensus/gossip/config/TrafficShapingConfig.java
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.consensus.gossip.config;
+
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+import java.time.Duration;
+
+/**
+ * Configuration of per-peer inbound traffic shaping for the rpc gossip protocol.
+ *
+ * @param enabled            compute and report the per-peer byte budget; when false the shaper is entirely inert
+ * @param enforce            additionally pause reading from a peer which is over budget. When false the shaper runs
+ *                           in shadow mode: everything is measured and reported, nothing is slowed down
+ * @param peerBytesPerSecond sustained inbound rate permitted per peer, in bytes per second. Uniform across all
+ *                           peers; not weighted by stake or role
+ * @param peerBurstBytes     inbound bytes a peer may consume instantaneously before the sustained rate applies. Also
+ *                           acts as the connection grace period, since a fresh shaper starts with the full burst
+ *                           available
+ * @param maxReadDelay       maximum time reading from a peer may be paused in one step. This is a liveness bound
+ *                           rather than a tuning knob: while reads are paused we do not answer the peer's pings, so
+ *                           this must stay well below {@link BroadcastConfig#disablePingThreshold()} or the peer
+ *                           will treat us as unhealthy
+ * @param maxMessageBytes    maximum permitted encoded size of a single gossip message, in bytes
+ * @param lowWatermark       fraction of the burst budget above which a rate limited warning is logged
+ * @param highWatermark      fraction of the burst budget above which an serious error is reported (and in future, peer disconnected)
+ * @param reportInterval     minimum interval between repeated warnings or evidence records for the same peer
+ */
+@ConfigData("trafficShaping")
+public record TrafficShapingConfig(
+        @ConfigProperty(defaultValue = "true") boolean enabled,
+        @ConfigProperty(defaultValue = "false") boolean enforce,
+        @ConfigProperty(defaultValue = "20000000") long peerBytesPerSecond,
+        @ConfigProperty(defaultValue = "200000000") long peerBurstBytes,
+        @ConfigProperty(defaultValue = "200ms") Duration maxReadDelay,
+        @ConfigProperty(defaultValue = "45000000") int maxMessageBytes,
+        @ConfigProperty(defaultValue = "0.6") double lowWatermark,
+        @ConfigProperty(defaultValue = "0.9") double highWatermark,
+        @ConfigProperty(defaultValue = "1m") Duration reportInterval) {}

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodeLogResultsAssert.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/MultipleNodeLogResultsAssert.java
@@ -2,6 +2,7 @@
 package org.hiero.otter.fixtures.assertions;
 
 import com.swirlds.logging.legacy.LogMarker;
+import com.swirlds.logging.legacy.payload.AbstractLogPayload;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.logging.log4j.Level;
@@ -115,6 +116,38 @@ public class MultipleNodeLogResultsAssert extends AbstractAssert<MultipleNodeLog
             OtterAssertions.assertThat(result).hasMessageContaining(searchString);
         }
 
+        return this;
+    }
+
+    /**
+     * Verifies that every node in these results has at least one message carrying a payload of the specified type.
+     *
+     * @param payloadType the payload class to look for
+     * @return this assertion object for method chaining
+     */
+    @NonNull
+    public MultipleNodeLogResultsAssert allNodesHaveMessageWithPayload(
+            @NonNull final Class<? extends AbstractLogPayload> payloadType) {
+        isNotNull();
+        for (final SingleNodeLogResult result : actual.results()) {
+            OtterAssertions.assertThat(result).hasMessageWithPayload(payloadType);
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that no node in these results has a message carrying a payload of the specified type.
+     *
+     * @param payloadType the payload class that must be absent
+     * @return this assertion object for method chaining
+     */
+    @NonNull
+    public MultipleNodeLogResultsAssert haveNoMessagesWithPayload(
+            @NonNull final Class<? extends AbstractLogPayload> payloadType) {
+        isNotNull();
+        for (final SingleNodeLogResult result : actual.results()) {
+            OtterAssertions.assertThat(result).hasNoMessageWithPayload(payloadType);
+        }
         return this;
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/SingleNodeLogResultAssert.java
+++ b/platform-sdk/consensus-otter-tests/src/testFixtures/java/org/hiero/otter/fixtures/assertions/SingleNodeLogResultAssert.java
@@ -4,6 +4,7 @@ package org.hiero.otter.fixtures.assertions;
 import static org.hiero.otter.fixtures.internal.helpers.Utils.collectMarkers;
 
 import com.swirlds.logging.legacy.LogMarker;
+import com.swirlds.logging.legacy.payload.AbstractLogPayload;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.List;
@@ -175,5 +176,44 @@ public class SingleNodeLogResultAssert extends AbstractAssert<SingleNodeLogResul
         logStatements.append("****************\n");
 
         failWithMessage(logStatements.toString());
+    }
+
+    /**
+     * Verifies that at least one log message carries a payload of the specified type.
+     *
+     * @param payloadType the payload class to look for
+     * @return this assertion object for method chaining
+     */
+    @NonNull
+    public SingleNodeLogResultAssert hasMessageWithPayload(
+            @NonNull final Class<? extends AbstractLogPayload> payloadType) {
+        isNotNull();
+        final String identifier = payloadType.getName();
+        final boolean found = actual.logs().stream()
+                .anyMatch(log -> identifier.equals(AbstractLogPayload.extractPayloadType(log.message())));
+        if (!found) {
+            failWithMessage("Expected to find a message with payload '%s', but did not", identifier);
+        }
+        return this;
+    }
+
+    /**
+     * Verifies that no log message carries a payload of the specified type.
+     *
+     * @param payloadType the payload class that must be absent
+     * @return this assertion object for method chaining
+     */
+    @NonNull
+    public SingleNodeLogResultAssert hasNoMessageWithPayload(
+            @NonNull final Class<? extends AbstractLogPayload> payloadType) {
+        isNotNull();
+        final String identifier = payloadType.getName();
+        final List<StructuredLog> logs = actual.logs().stream()
+                .filter(log -> identifier.equals(AbstractLogPayload.extractPayloadType(log.message())))
+                .toList();
+        if (!logs.isEmpty()) {
+            failWithMessage(String.format("Expected to find no message with payload '%s'", identifier), logs);
+        }
+        return this;
     }
 }

--- a/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/TrafficShapingTest.java
+++ b/platform-sdk/consensus-otter-tests/src/testOtter/java/org/hiero/otter/test/TrafficShapingTest.java
@@ -1,0 +1,293 @@
+// SPDX-License-Identifier: Apache-2.0
+package org.hiero.otter.test;
+
+import static org.hiero.consensus.model.status.PlatformStatus.ACTIVE;
+import static org.hiero.consensus.model.status.PlatformStatus.BEHIND;
+import static org.hiero.consensus.model.status.PlatformStatus.CHECKING;
+import static org.hiero.consensus.model.status.PlatformStatus.OBSERVING;
+import static org.hiero.consensus.model.status.PlatformStatus.REPLAYING_EVENTS;
+import static org.hiero.otter.fixtures.Capability.USES_REAL_NETWORK;
+import static org.hiero.otter.fixtures.OtterAssertions.assertContinuouslyThat;
+import static org.hiero.otter.fixtures.OtterAssertions.assertThat;
+import static org.hiero.otter.fixtures.assertions.StatusProgressionStep.target;
+
+import com.swirlds.logging.legacy.payload.AbstractLogPayload;
+import com.swirlds.logging.legacy.payload.PeerTrafficShapingPayload;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import java.time.Duration;
+import org.hiero.consensus.gossip.config.TrafficShapingConfig_;
+import org.hiero.otter.fixtures.Network;
+import org.hiero.otter.fixtures.Node;
+import org.hiero.otter.fixtures.OtterTest;
+import org.hiero.otter.fixtures.TestEnvironment;
+import org.hiero.otter.fixtures.TimeManager;
+import org.hiero.otter.fixtures.logging.StructuredLog;
+import org.hiero.otter.fixtures.result.SingleNodeLogResult;
+
+/**
+ * Tests the per-peer inbound traffic shaper in the rpc gossip protocol.
+ *
+ * <h2>Why this is container only</h2>
+ *
+ * The Turtle environment substitutes {@code TurtleGossipModule} / {@code SimulatedGossip} for the real gossip stack,
+ * so {@code RpcPeerProtocol} — and therefore the shaper — never executes there. These tests require
+ * {@link org.hiero.otter.fixtures.Capability#USES_REAL_NETWORK} so they only run against the Container environment,
+ * where nodes gossip over real sockets.
+ *
+ * <h2>How heavy traffic is produced</h2>
+ *
+ * Rather than adding a malicious flooding node, these tests shrink the byte budget until ordinary gossip traffic
+ * exceeds it. That exercises exactly the same code path with far less machinery, and it lets the budget be the one
+ * variable under test.
+ *
+ * <h2>Why the network survives an absurdly small budget</h2>
+ *
+ * The shaper caps any single pause at {@code maxReadDelay}, which puts a floor on throughput regardless of how low
+ * the configured rate is. Charges are taken per message from a byte counter sitting under an 8 KiB buffered stream,
+ * so a charge is at most about one socket buffer. The resulting floor is roughly:
+ *
+ * <pre>
+ *     floor ~= socketBufferBytes / maxReadDelay
+ *            = 8192 B / 100 ms
+ *            ~= 80 KiB/s per peer
+ * </pre>
+ *
+ * With {@link #TIGHT_BYTES_PER_SECOND} set to 8 KiB/s, the shaper is therefore continuously engaged while the peer
+ * still receives roughly ten times its configured rate. That gap is expected and is the reason these tests are
+ * stable, but it is also a real limitation of the design: the configured sustained rate is not achievable for
+ * message sizes whose cost exceeds {@code maxReadDelay}. If that behaviour is changed, the throughput floor
+ * disappears and {@link #TIGHT_BYTES_PER_SECOND} will need raising to keep the network alive here.
+ */
+public class TrafficShapingTest {
+
+    /** Nodes in each test network. Four is enough for consensus with headroom. */
+    private static final int NETWORK_SIZE = 4;
+
+    /**
+     * A sustained budget far below real gossip traffic, so the shaper is guaranteed to engage. Not so low that the
+     * network starves, for the reason described in the class javadoc.
+     */
+    private static final long TIGHT_BYTES_PER_SECOND = 8192L;
+
+    /** Roughly 8 seconds of burst at {@link #TIGHT_BYTES_PER_SECOND}; enough to cover the startup handshake. */
+    private static final long TIGHT_BURST_BYTES = 65536L;
+
+    /**
+     * Maximum pause applied to a read thread. Must stay well below {@code broadcast.disablePingThreshold} (900 ms
+     * by default), because a paused read thread does not answer the peer's pings and a peer that stops receiving
+     * ping replies will conclude we are unhealthy.
+     */
+    private static final Duration MAX_READ_DELAY = Duration.ofMillis(100);
+
+    /** Short reporting interval so watermark breaches surface quickly instead of once a minute. */
+    private static final Duration REPORT_INTERVAL = Duration.ofSeconds(1);
+
+    private static final Duration REPORT_TIMEOUT = Duration.ofSeconds(90);
+    private static final Duration OBSERVATION_TIME = Duration.ofSeconds(30);
+
+    private static final String PAYLOAD_TYPE = PeerTrafficShapingPayload.class.getName();
+
+    /**
+     * A budget generous enough that healthy traffic never approaches it must produce no reports at all. This is the
+     * false positive guard: if the shaper complains here, its defaults are miscalibrated and enabling enforcement
+     * in production would throttle honest peers.
+     *
+     * @param env the test environment
+     */
+    @OtterTest(requires = USES_REAL_NETWORK)
+    void healthyTrafficIsNeverReported(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        network.addNodes(NETWORK_SIZE);
+
+        // defaults for the budget, but report aggressively so that any breach would be visible
+        network.withConfigValue(TrafficShapingConfig_.ENABLED, true)
+                .withConfigValue(TrafficShapingConfig_.ENFORCE, true)
+                .withConfigValue(TrafficShapingConfig_.REPORT_INTERVAL, REPORT_INTERVAL);
+
+        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+        assertContinuouslyThat(network.newReconnectResults()).doNotAttemptToReconnect();
+        assertContinuouslyThat(network.newConsensusResults())
+                .haveEqualCommonRounds()
+                .haveConsistentRounds();
+        assertContinuouslyThat(network.newPlatformStatusResults()).doNotEnterAnyStatusesOf(BEHIND);
+
+        network.start();
+
+        timeManager.waitFor(OBSERVATION_TIME);
+
+        // the whole point of the test: nothing was reported
+        for (final Node node : network.nodes()) {
+            assertThat(node.newLogResult()).hasNoMessageWithPayload(PeerTrafficShapingPayload.class);
+        }
+
+        assertThat(network.newPlatformStatusResults())
+                .haveSteps(target(ACTIVE).requiringInterim(REPLAYING_EVENTS, OBSERVING, CHECKING));
+    }
+
+    /**
+     * In shadow mode the shaper measures and reports but never pauses a read thread, so a budget far below real
+     * traffic must produce reports on every node while leaving the network completely unaffected.
+     *
+     * <p>This is the configuration the design proposes shipping as the default, and the property under test is that
+     * turning it on is free.
+     *
+     * @param env the test environment
+     */
+    @OtterTest(requires = USES_REAL_NETWORK)
+    void shadowModeReportsHeavyPeersWithoutAffectingTraffic(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        network.addNodes(NETWORK_SIZE);
+        applyTightBudget(network, false);
+
+        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+        assertContinuouslyThat(network.newReconnectResults()).doNotAttemptToReconnect();
+        assertContinuouslyThat(network.newConsensusResults())
+                .haveEqualCommonRounds()
+                .haveConsistentRounds();
+        // shadow mode must not perturb the network at all, so BEHIND is a failure
+        assertContinuouslyThat(network.newPlatformStatusResults()).doNotEnterAnyStatusesOf(BEHIND);
+
+        network.start();
+
+        timeManager.waitForCondition(
+                () -> allNodesReportedShaping(network),
+                REPORT_TIMEOUT,
+                "Shaper did not report a watermark breach on every node despite a budget of " + TIGHT_BYTES_PER_SECOND
+                        + " bytes/s");
+
+        timeManager.waitFor(OBSERVATION_TIME);
+
+        assertThat(network.newLogResults()).allNodesHaveMessageWithPayload(PeerTrafficShapingPayload.class);
+        assertThat(network.newPlatformStatusResults())
+                .haveSteps(target(ACTIVE).requiringInterim(REPLAYING_EVENTS, OBSERVING, CHECKING));
+        assertThat(network.newConsensusResults()).haveAdvancedSinceRound(2);
+
+        // nothing should have been paused, since enforcement is off
+        for (final Node node : network.nodes()) {
+            assertThat(enforcedPauseCount(node.newLogResult()))
+                    .as("shadow mode must not pause any read thread")
+                    .isZero();
+        }
+    }
+
+    /**
+     * With enforcement on and the same tight budget, read threads are actually paused. The network must still come
+     * up, reach {@link org.hiero.consensus.model.status.PlatformStatus#ACTIVE}, and keep making consensus progress.
+     *
+     * <p>This is the liveness regression test for the shaper's most dangerous failure mode: throttling a peer so
+     * hard that it treats us as dead. Note that {@code network.start()} itself waits for every node to become
+     * {@code ACTIVE}, so a shaper that wedges gossip fails the test before any assertion runs.
+     *
+     * @param env the test environment
+     */
+    @OtterTest(requires = USES_REAL_NETWORK)
+    void enforcedShapingThrottlesReadsWithoutBreakingConsensus(@NonNull final TestEnvironment env) {
+        final Network network = env.network();
+        final TimeManager timeManager = env.timeManager();
+
+        network.addNodes(NETWORK_SIZE);
+        applyTightBudget(network, true);
+
+        assertContinuouslyThat(network.newLogResults()).haveNoErrorLevelMessages();
+        assertContinuouslyThat(network.newConsensusResults())
+                .haveEqualCommonRounds()
+                .haveConsistentRounds();
+
+        // If throttling starves a node it will fall behind and reconnect. That is the failure this test exists to
+        // catch, so it is asserted continuously rather than only at the end.
+        assertContinuouslyThat(network.newReconnectResults()).doNotAttemptToReconnect();
+        assertContinuouslyThat(network.newPlatformStatusResults()).doNotEnterAnyStatusesOf(BEHIND);
+
+        network.start();
+
+        timeManager.waitForCondition(
+                () -> allNodesReportedShaping(network),
+                REPORT_TIMEOUT,
+                "Shaper did not report a watermark breach on every node despite a budget of " + TIGHT_BYTES_PER_SECOND
+                        + " bytes/s");
+
+        // At least one node must have actually paused a read thread, otherwise enforcement is not being applied and
+        // this test would be silently identical to the shadow mode one.
+        timeManager.waitForCondition(
+                () -> network.nodes().stream().anyMatch(node -> enforcedPauseCount(node.newLogResult()) > 0),
+                REPORT_TIMEOUT,
+                "No node paused a read thread, so enforcement was not applied");
+
+        timeManager.waitFor(OBSERVATION_TIME);
+
+        assertThat(network.newLogResults()).allNodesHaveMessageWithPayload(PeerTrafficShapingPayload.class);
+        assertThat(network.newPlatformStatusResults())
+                .haveSteps(target(ACTIVE).requiringInterim(REPLAYING_EVENTS, OBSERVING, CHECKING));
+
+        // the network was slowed, but it kept working
+        assertThat(network.newConsensusResults()).haveAdvancedSinceRound(2).haveEqualCommonRounds();
+        assertThat(network.newLogResults()).haveNoErrorLevelMessages();
+    }
+
+    // -----------------------------------------------------------------------------------------------------------
+    // helpers
+    // -----------------------------------------------------------------------------------------------------------
+
+    /**
+     * Applies a byte budget far below real gossip traffic to every node in the network.
+     *
+     * @param network the network to configure
+     * @param enforce {@code true} to actually pause read threads, {@code false} for shadow mode
+     */
+    private static void applyTightBudget(@NonNull final Network network, final boolean enforce) {
+        network.withConfigValue(TrafficShapingConfig_.ENABLED, true)
+                .withConfigValue(TrafficShapingConfig_.ENFORCE, enforce)
+                .withConfigValue(TrafficShapingConfig_.PEER_BYTES_PER_SECOND, TIGHT_BYTES_PER_SECOND)
+                .withConfigValue(TrafficShapingConfig_.PEER_BURST_BYTES, TIGHT_BURST_BYTES)
+                .withConfigValue(TrafficShapingConfig_.MAX_READ_DELAY, MAX_READ_DELAY)
+                .withConfigValue(TrafficShapingConfig_.REPORT_INTERVAL, REPORT_INTERVAL);
+    }
+
+    /**
+     * @param network the network to inspect
+     * @return {@code true} if every node has logged at least one traffic shaping report
+     */
+    private static boolean allNodesReportedShaping(@NonNull final Network network) {
+        return network.nodes().stream().allMatch(node -> reportCount(node.newLogResult()) > 0);
+    }
+
+    /**
+     * @param result the log result to inspect
+     * @return the number of traffic shaping reports in the result
+     */
+    private static long reportCount(@NonNull final SingleNodeLogResult result) {
+        return result.logs().stream()
+                .filter(TrafficShapingTest::isShapingReport)
+                .count();
+    }
+
+    /**
+     * Counts reports where a pause was actually applied. Distinguishes enforcement from shadow mode without needing
+     * access to node metrics, which the Otter framework does not currently expose.
+     *
+     * @param result the log result to inspect
+     * @return the number of reports carrying a non-zero pause
+     */
+    private static long enforcedPauseCount(@NonNull final SingleNodeLogResult result) {
+        return result.logs().stream()
+                .filter(TrafficShapingTest::isShapingReport)
+                .map(log -> AbstractLogPayload.parsePayload(PeerTrafficShapingPayload.class, log.message()))
+                .filter(payload -> payload.isEnforced() && payload.getDelayNanos() > 0)
+                .count();
+    }
+
+    /**
+     * Matches on the payload type rather than the message text, so the log wording can change without breaking
+     * these tests.
+     *
+     * @param log the log entry to test
+     * @return {@code true} if the entry carries a {@link PeerTrafficShapingPayload}
+     */
+    private static boolean isShapingReport(@NonNull final StructuredLog log) {
+        return PAYLOAD_TYPE.equals(AbstractLogPayload.extractPayloadType(log.message()));
+    }
+}

--- a/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/PeerTrafficShapingPayload.java
+++ b/platform-sdk/swirlds-logging/src/main/java/com/swirlds/logging/legacy/payload/PeerTrafficShapingPayload.java
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.swirlds.logging.legacy.payload;
+
+/**
+ * This payload is logged when a peer's inbound byte budget crosses a reporting watermark.
+ *
+ * <p>Emitted by the gossip per-peer traffic shaper. Tests match on the payload type rather than on message text,
+ * so the human readable message can change freely without breaking them.
+ */
+public class PeerTrafficShapingPayload extends AbstractLogPayload {
+
+    private long peerId;
+    private long occupancyPerMille;
+    private long thresholdPerMille;
+    private long delayNanos;
+    private boolean enforced;
+
+    public PeerTrafficShapingPayload() {}
+
+    /**
+     * @param message           a human readable message, must not contain '{'
+     * @param peerId            the peer whose budget was breached
+     * @param occupancyPerMille the fraction of the burst budget consumed, in per-mille
+     * @param thresholdPerMille the watermark that was breached, in per-mille
+     * @param delayNanos        the pause applied to the read thread, or 0 if none was applied
+     * @param enforced          {@code true} if the pause was actually applied, {@code false} in shadow mode
+     */
+    public PeerTrafficShapingPayload(
+            final String message,
+            final long peerId,
+            final long occupancyPerMille,
+            final long thresholdPerMille,
+            final long delayNanos,
+            final boolean enforced) {
+        super(message);
+        this.peerId = peerId;
+        this.occupancyPerMille = occupancyPerMille;
+        this.thresholdPerMille = thresholdPerMille;
+        this.delayNanos = delayNanos;
+        this.enforced = enforced;
+    }
+
+    public long getPeerId() {
+        return peerId;
+    }
+
+    public void setPeerId(final long peerId) {
+        this.peerId = peerId;
+    }
+
+    public long getOccupancyPerMille() {
+        return occupancyPerMille;
+    }
+
+    public void setOccupancyPerMille(final long occupancyPerMille) {
+        this.occupancyPerMille = occupancyPerMille;
+    }
+
+    public long getThresholdPerMille() {
+        return thresholdPerMille;
+    }
+
+    public void setThresholdPerMille(final long thresholdPerMille) {
+        this.thresholdPerMille = thresholdPerMille;
+    }
+
+    public long getDelayNanos() {
+        return delayNanos;
+    }
+
+    public void setDelayNanos(final long delayNanos) {
+        this.delayNanos = delayNanos;
+    }
+
+    public boolean isEnforced() {
+        return enforced;
+    }
+
+    public void setEnforced(final boolean enforced) {
+        this.enforced = enforced;
+    }
+}


### PR DESCRIPTION
**Description**:

Traffic shaping for the gossip. Idea is to limit the traffic to specific average rate, while allowing sporadic peaks. Please check the class javadocs for more explanation.

In current form, actual limitation is disabled, only reporting is enabled, so we can get information if proposed limits are ok for all the environments. After getting info about that and projected max traffic in future, final numbers can be tweaked.

Code also indicates the point for future integration with Sheriff module, which could make decisions about disconnection/shunning node for breaching the contract, but actual code is included. Traffic shaping by itself can slow down consumption, but never disconnects.



**Related issue(s)**:

Fixes #26931

**Notes for reviewer**:

SerializableDataInputStream change is needed, because PBJ is broken regarding message size detection (which was reported multiple times, and nobody is willing to fix it). It can be rolled back after PBJ releases proper version and it gets included in the main branch.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
