### PR TITLE
docs: Fix ADR-003 recovery recipe

### DIFF
--- a/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
@@ -92,6 +92,7 @@ easiest path — using artifacts from one node sidesteps any cross-node-consiste
    and not as a getter. It is not carried on `ConsensusLayerBuildingBlocks`, so a driver written against the public
    building blocks cannot reach it. The driver must therefore be written from inside the consensus-layer packages, or
    the modules must first expose an accessor. See **Recipe reachability** below.
+
 4. **Mark and dump.** On the underlying `SignedState`, call `markAsStateToSave(StateToDiskReason.PCES_RECOVERY_COMPLETE)`
    (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/snapshot/StateToDiskReason.java#PCES_RECOVERY_COMPLETE`);
    construct a `StateDumpRequest` via `StateDumpRequest.create(...)`
@@ -105,8 +106,10 @@ easiest path — using artifacts from one node sidesteps any cross-node-consiste
    is private, and the wire is built in the constructor
    (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/StateModule.java#StateModule`) only so an
    unsoldered wire exists. Nothing under `src/main/java` injects a `StateDumpRequest`. See **Recipe reachability**.
+
 5. **Close the last record or block file with the execution team.** Coordinate so that the execution-side block stream aligns
    with the dumped state's last consensus round. This is critical because it must be distributed along with the signed state.
+
 6. **Distribute and restart.** Copy the recovered state, block files, and PCES to all nodes; restart the network from it.
 
 ### Implementation notes

--- a/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
+++ b/platform-sdk/docs/consensus-layer/decisions/ADR-003-remove-pces-recovery-method.md
@@ -34,10 +34,10 @@ Historically, `SwirldsPlatform` carried two methods intended to support this flo
 
 Neither method had automated test coverage. The replay entry point was effectively superseded by
 `PcesModule.replayPcesEvents(pcesReplayLowerBound, startingRound)`
-(`platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java:357`), which is exercised
-by every normal startup. The recovery bootstrap was not exercised by anything: it sat in `SwirldsPlatform` as code that
-might or might not still work, and any regression in it would only surface during an emergency, at which point
-operators have no margin to diagnose and fix it.
+(`platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java#start`), which is
+exercised by every normal startup. The recovery bootstrap was not exercised by anything: it sat in `SwirldsPlatform`
+as code that might or might not still work, and any regression in it would only surface during an emergency, at which
+point operators have no margin to diagnose and fix it.
 
 ISS-recovery events are also rare and not on a hot path. The consensus team can write the small amount of glue code
 needed at the moment recovery is invoked, against the platform state of the day, with engineers present. Recovery is
@@ -54,7 +54,8 @@ state (see Step 5 below).
 
 The recipe below records the minimum constraints any such driver must satisfy. It is included in the Decision because
 it *is* the mechanism: the decision to not ship recovery code only holds up if the path that replaces it is documented
-clearly enough that a present engineer can write it correctly under pressure.
+clearly enough that a present engineer can write it correctly under pressure. Two of its steps no longer meet that
+bar against the current API — see **Recipe reachability** below.
 
 ### Prerequisites
 
@@ -69,39 +70,82 @@ easiest path — using artifacts from one node sidesteps any cross-node-consiste
 ### Steps
 
 1. **Bring up the platform without gossip.** Perform the same construction-time work as a normal start, then run only
-   the first three lines of `SwirldsPlatform.start()` (`SwirldsPlatform.java:118-120`: recycle bin, metrics, wiring
-   model). Do **not** start gossip — the `gossipModule().startInputWire().inject(...)` call at line 123.
+   the prelude of `SwirldsPlatform.start()`
+   (`platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/SwirldsPlatform.java#start`) — the four
+   statements that start the recycle bin, the metrics provider, the metrics and the wiring model. Do **not** start
+   gossip: skip the `gossipModule().startInputWire().inject(...)` call, the last statement of `start()`.
 2. **Run replay.** Call `PcesModule.replayPcesEvents(pcesReplayLowerBound, startingRound)`
-   (`SwirldsPlatform.java:122`). The replayer drains the PCES iterator into the intake pipeline; consensus is reached
-   and transactions handle as during normal startup.
-3. **Capture the resulting state.** Acquire the latest immutable state via the `latestImmutableStateNexus`
-   (`SwirldsPlatform.java:114`; interface `SignedStateNexus.getState(reason)` at
-   `platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/nexus/SignedStateNexus.java#getState`). The
-   result is a `ReservedSignedState`
-   (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/signed/ReservedSignedState.java#ReservedSignedState`) that
-   must be closed when done.
+   (`platform-sdk/consensus-pces/src/main/java/org/hiero/consensus/pces/PcesModule.java#replayPcesEvents`) — the
+   statement `start()` runs immediately before it injects gossip. The replayer drains the PCES iterator into the
+   intake pipeline; consensus is reached and transactions handle as during normal startup.
+3. **Capture the resulting state.** What is needed is the latest immutable state as a `ReservedSignedState`
+   (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/signed/ReservedSignedState.java#ReservedSignedState`),
+   which must be closed when done. The natural source is the `latestImmutableStateNexus` — interface
+   `SignedStateNexus.getState(reason)` at
+   `platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/nexus/SignedStateNexus.java#getState`.
+
+   **Not followable from the public building blocks as of 2026-09-08.** The nexus is no longer a field on
+   `SwirldsPlatform`: it is a local built in
+   `platform-sdk/swirlds-platform-core/src/main/java/org/hiero/consensus/ConsensusLayerFactory.java#createLatestImmutableStateNexus`
+   and handed only to `TransactionHandlingModule`, which exposes it as a setter input wire
+   (`platform-sdk/consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/TransactionHandlingModule.java#latestImmutableStateInputWire`)
+   and not as a getter. It is not carried on `ConsensusLayerBuildingBlocks`, so a driver written against the public
+   building blocks cannot reach it. The driver must therefore be written from inside the consensus-layer packages, or
+   the modules must first expose an accessor. See **Recipe reachability** below.
 4. **Mark and dump.** On the underlying `SignedState`, call `markAsStateToSave(StateToDiskReason.PCES_RECOVERY_COMPLETE)`
    (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/snapshot/StateToDiskReason.java#PCES_RECOVERY_COMPLETE`);
    construct a `StateDumpRequest` via `StateDumpRequest.create(...)`
    (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/saved/StateDumpRequest.java#create`);
-   submit it to the state snapshot manager's dump task via the state module's dump input wire
-   (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/StateModule.java:203`), handled by
-   `StateSnapshotManager::dumpStateTask`
-   (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultStateSnapshotManager.java#dumpStateTask`); block
-   on `request.waitForFinished()` so the process does not exit before the on-disk write completes.
+   submit it to the state snapshot manager's dump task, handled by `StateSnapshotManager::dumpStateTask`
+   (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/persistence/DefaultStateSnapshotManager.java#dumpStateTask`);
+   then run `request.waitForFinished()` so the process does not exit before the on-disk write completes — it is a
+   `Runnable` record component, so the blocking call is `request.waitForFinished().run()`, not the accessor alone.
+
+   **Also not followable as of 2026-09-08.** `StateModule` exposes no dump input wire: `stateSnapshotManagerWiring`
+   is private, and the wire is built in the constructor
+   (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/StateModule.java#StateModule`) only so an
+   unsoldered wire exists. Nothing under `src/main/java` injects a `StateDumpRequest`. See **Recipe reachability**.
 5. **Close the last record or block file with the execution team.** Coordinate so that the execution-side block stream aligns
    with the dumped state's last consensus round. This is critical because it must be distributed along with the signed state.
 6. **Distribute and restart.** Copy the recovered state, block files, and PCES to all nodes; restart the network from it.
 
 ### Implementation notes
 
-- `pcesReplayLowerBound` is the initial ancient threshold from the loaded state, or 0 for genesis
-  (`SwirldsPlatform.java:285`).
-- `startingRound` is the last consensus round in the loaded state (`SwirldsPlatform.java:257`).
+- `pcesReplayLowerBound` and `startingRound` are no longer derived inside `SwirldsPlatform`; both are constructor
+  arguments, computed by the caller in
+  `platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/builder/PlatformBuilder.java#build`. A driver
+  that constructs the platform itself must supply them: `pcesReplayLowerBound` is
+  `ancientThresholdOf(initialSignedState.getState())`, or 0 for genesis; `startingRound` is
+  `initialSignedState.getRound()`, or 0 for genesis.
 - After injecting the PCES iterator, the replay code flushes pipeline events to ensure all replayed transactions are
-  processed before signaling that replay is complete.
-- The blocking `StateDumpRequest.waitForFinished()` is essential — without it the JVM may exit before the on-disk
-  write finishes, leaving an incomplete recovery state.
+  processed before signaling that replay is complete
+  (`platform-sdk/consensus-pces-impl/src/main/java/org/hiero/consensus/pces/impl/replayer/PcesReplayer.java#replayPces`).
+- Running `StateDumpRequest.waitForFinished()` is essential — without it the JVM may exit before the on-disk write
+  finishes, leaving an incomplete recovery state. Note the component is a `Runnable`
+  (`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/saved/StateDumpRequest.java#StateDumpRequest`),
+  so `request.waitForFinished()` returns immediately and blocks nothing; the driver must call `.run()` on it. The
+  latch it awaits is released by `dumpStateTask` via `request.finishedCallback()`.
+
+### Recipe reachability
+
+Steps 3 and 4 name the mechanism the recovery driver needs, but neither handle is reachable from
+`ConsensusLayerBuildingBlocks` today: the latest-immutable-state nexus is a private local wired only into
+`TransactionHandlingModule`, and `StateModule` has no public dump input wire. A driver written against the public
+building blocks therefore cannot complete the recipe as written.
+
+Two reachable substitutes exist, and both are weaker than what the steps describe.
+`platform-sdk/consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/TransactionHandlingModule.java#stateOutputWire`
+is an `OutputWire<ReservedSignedState>` a driver can solder a capture onto in place of reading the nexus. And
+`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/StateModule.java#sendState`, called after
+`markAsStateToSave(...)`, reaches disk through the state module's `saveToDiskFilter` and
+`platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/persistence/StateSnapshotManager.java#saveStateTask`
+— but that is the *in-band* save path, which writes to the ordinary saved-state directory rather than a
+reason-named dump directory and returns no completion handle, so it has no equivalent of the `waitForFinished`
+guarantee this ADR calls essential.
+
+Closing this is a decision the deciders have not made. Either the driver is written from inside the consensus-layer
+packages, where the private handles are visible, or the modules expose the two accessors the recipe assumes. Whoever
+drives the next recovery should resolve it before the recipe is relied on under pressure.
 
 ## Temporary Nature
 
@@ -130,7 +174,8 @@ should be revisited and likely retired when block nodes go live.
 - **Tribal knowledge risk.** This ADR is the canonical reference for what a recovery driver must do; if it goes stale
   or is hard to find at 3am, an engineer may miss a step (the record/block-file coordination in particular is easy to
   forget). Mitigation: an operational runbook can be derived from this ADR and kept where on-call engineers look
-  first.
+  first. This risk has already materialized once: startup and state wiring moved out from under steps 3 and 4 without
+  the recipe following — see **Recipe reachability**.
 
 ### Neutral
 
@@ -186,3 +231,16 @@ See **Decision** above.
 - [`../../proposals/consensus-layer/Consensus-Layer.md`](../../proposals/consensus-layer/Consensus-Layer.md) — the
   proposal that moves state-saving and lifecycle to the Execution side; relevant context for any future revision of
   the recovery driver, as noted under **Neutral** consequences.
+
+## Notes
+
+- 2026-09-08 — refreshed the recipe against the current code. Decision unchanged; the mechanism it
+  documents had drifted. Steps 3 and 4 no longer resolve: `latestImmutableStateNexus` left
+  `SwirldsPlatform` in `fd06b80baf` (2026-07-17) and is now a private local in
+  `ConsensusLayerFactory`, and `StateModule` exposes no dump input wire — both recorded under
+  **Recipe reachability**, which also names the weaker reachable substitutes. `start()` runs a
+  four-statement prelude, not three, and `initialAncientThreshold`/`startingRound` are constructor
+  arguments computed in `PlatformBuilder#build`, not values `SwirldsPlatform` derives. Corrected
+  `request.waitForFinished()` to `request.waitForFinished().run()` — the component is a `Runnable`,
+  so the accessor alone blocks nothing. All `SwirldsPlatform.java:NN` citations were past
+  end-of-file and are now `#symbol` anchors — Michael Heinrichs (@netopyr).


### PR DESCRIPTION
**Description**:

The recovery recipe described in ADR-003 has become hard to follow after modularization, because it requires accessing some components which have become private to the owning modules. This PR adds documentation pointing out the challenges. We may want to reconsider the decision in ADR-003 and provide access to these components or even implement the recovery path.