### PR TITLE
test: Delete old BlockNode files (#27200)

### DIFF
--- a/.github/workflows/support/citr/cronClean.sh
+++ b/.github/workflows/support/citr/cronClean.sh
@@ -11,6 +11,15 @@ done
 
 wait
 
+NofBNNodes=`kubectl -n ${NAMESPACE} get pods | grep 'block-node' | wc -l`
+
+for i in `seq 1 1 ${NofBNNodes}`
+do
+  kubectl -n ${NAMESPACE} exec block-node-${i}-0 -- bash -c "find /opt/hiero/block-node/data/ -type f -mmin +59 -exec rm -f {} \;" >/dev/null 2>&1 &
+done
+
+wait
+
 minioIP=`kubectl -n ${NAMESPACE} describe pod minio-pool-1-0 | grep -E '^IP[\:]' | awk '{print $NF}'`
 nlgpod=`kubectl -n ${NAMESPACE} get pods | grep nlg-network-load-generator | awk '{print $1}'`
 


### PR DESCRIPTION
**Description**:
Deletes archived blocknode files on given namespace. It's a part of cronClean workflow https://github.com/hiero-ledger/hiero-consensus-node/actions/workflows/903-cron-clean.yaml
 
**Related issue(s)**:

Fixes #27200

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
Tested: https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/34266840639