### PR TITLE
fix: #27206 - improve/fix MerkleDB JMH tests

### DIFF
--- a/platform-sdk/swirlds-benchmarks/settings.txt
+++ b/platform-sdk/swirlds-benchmarks/settings.txt
@@ -7,4 +7,3 @@ benchmark.csvOutputFolder,                     data
 benchmark.csvWriteFrequency,                   1000
 benchmark.csvAppend,                           true
 virtualMap.familyThrottleThreshold,            10000000000
-prometheus.endpointEnabled,                    true

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkMetrics.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkMetrics.java
@@ -166,7 +166,7 @@ public final class BenchmarkMetrics {
 
     private final FunctionGauge.Config<Double> diskReadOpsConfig = new FunctionGauge.Config<>(
                     "ADA",
-                    "diskReadOps/s",
+                    "diskReadOps_per_s",
                     Double.class,
                     () -> 1000. * (curDiskStats[DISK_STAT_ROPS] - prevDiskStats[DISK_STAT_ROPS]) / (curTime - prevTime))
             .withDescription("Disk read operations per sec")
@@ -174,7 +174,7 @@ public final class BenchmarkMetrics {
 
     private final FunctionGauge.Config<Double> diskReadBytesConfig = new FunctionGauge.Config<>(
                     "ADB",
-                    "diskReadBytes/s",
+                    "diskReadBytes_per_s",
                     Double.class,
                     () -> 1000.
                             * sectorSize
@@ -193,7 +193,7 @@ public final class BenchmarkMetrics {
 
     private final FunctionGauge.Config<Double> diskWriteOpsConfig = new FunctionGauge.Config<>(
                     "ADD",
-                    "diskWriteOps/s",
+                    "diskWriteOps_per_s",
                     Double.class,
                     () -> 1000. * (curDiskStats[DISK_STAT_WOPS] - prevDiskStats[DISK_STAT_WOPS]) / (curTime - prevTime))
             .withDescription("Disk write operations per sec")
@@ -201,7 +201,7 @@ public final class BenchmarkMetrics {
 
     private final FunctionGauge.Config<Double> diskWriteBytesConfig = new FunctionGauge.Config<>(
                     "ADE",
-                    "diskWriteBytes/s",
+                    "diskWriteBytes_per_s",
                     Double.class,
                     () -> 1000.
                             * sectorSize

--- a/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkMetrics.java
+++ b/platform-sdk/swirlds-benchmarks/src/jmh/java/com/swirlds/benchmark/BenchmarkMetrics.java
@@ -66,6 +66,7 @@ public final class BenchmarkMetrics {
     private String origMetricString;
     private String curMetricString;
     private Metrics metrics;
+    private DefaultMetricsProvider metricsProvider;
 
     /*
      *    System metrics: time, memory, CPU
@@ -121,7 +122,7 @@ public final class BenchmarkMetrics {
 
     private static final LongGauge.Config TPS_CONFIG = new LongGauge.Config(BENCHMARK_CATEGORY, "tps")
             .withDescription("transactions per second")
-            .withFormat(FORMAT_FLOAT0);
+            .withFormat(FORMAT_INTEGER);
 
     private BenchmarkMetrics() {
         // prevent instantiation
@@ -246,15 +247,20 @@ public final class BenchmarkMetrics {
             logger.error("Can't parse {}: {} ", diskSectorSizeFile, ex);
             return;
         }
+        diskMetricsRegistered = true;
+        updateDiskMetrics(); // first call: only populates curDiskStats, prevDiskStats stays null
+        updateDiskMetrics(); // second call: shifts curDiskStats into prevDiskStats, repopulates curDiskStats
+        if (!diskMetricsRegistered) {
+            // updateDiskMetrics() failed and reset the flag; don't register gauges backed by null stats
+            return;
+        }
+
         metrics.getOrCreate(diskReadOpsConfig);
         metrics.getOrCreate(diskReadBytesConfig);
         metrics.getOrCreate(diskReadTimeConfig);
         metrics.getOrCreate(diskWriteOpsConfig);
         metrics.getOrCreate(diskWriteBytesConfig);
         metrics.getOrCreate(diskWriteTimeConfig);
-        diskMetricsRegistered = true;
-
-        updateDiskMetrics();
     }
 
     /*
@@ -343,7 +349,7 @@ public final class BenchmarkMetrics {
         metricService = Executors.newSingleThreadScheduledExecutor(
                 getStaticThreadManager().createThreadFactory("benchmark", "MetricsWriter"));
 
-        final DefaultMetricsProvider metricsProvider = new DefaultMetricsProvider(configuration);
+        metricsProvider = new DefaultMetricsProvider(configuration);
         metrics = metricsProvider.createPlatformMetrics(NodeId.FIRST_NODE_ID);
 
         final PrometheusConfig prometheusConfig = configuration.getConfigData(PrometheusConfig.class);
@@ -414,5 +420,6 @@ public final class BenchmarkMetrics {
 
     public static void stop() {
         INSTANCE.metricService.shutdownNow();
+        INSTANCE.metricsProvider.stop();
     }
 }


### PR DESCRIPTION
**Description**:
- Fix NPE in disk-I/O JMH benchmark metrics (`prevDiskStats` read before initialization)
- Shut down the metrics provider in `BenchmarkMetrics.stop()`
- Fix TPS gauge display format
- Fix disk metric names to use `_per_s` to avoid exceptions in logs

Fixes #27206
