### PR TITLE
fix: Modify the language around folding beneficiary mappings into the root builder at staking finalization

### DIFF
--- a/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
+++ b/hedera-node/hedera-token-service-impl/src/test/java/com/hedera/node/app/service/token/impl/test/handlers/staking/StakingRewardsHandlerImplTest.java
@@ -930,7 +930,7 @@ class StakingRewardsHandlerImplTest extends CryptoTokenHandlerTestBase {
         // deleted -> beneficiary mapping is recorded on a CHILD dispatch builder (as happens for the
         // inner CryptoDelete of an atomic batch), not on the root builder consulted by the redirect.
         // The handler must fold the child mapping into the root builder, otherwise the redirect loop
-        // throws IllegalStateException and the batch is rolled back to a zero-fee FAIL_INVALID record.
+        // cannot resolve the beneficiary and staking finalization fails.
         final var accountBalance = 555L * HBARS_TO_TINYBARS;
         final var ownerBalance = 111L * HBARS_TO_TINYBARS;
         final var payerAccountBefore = new AccountCustomizer()

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/AtomicBatchStakedDeleteRewardRedirectionTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/staking/AtomicBatchStakedDeleteRewardRedirectionTest.java
@@ -51,16 +51,14 @@ import org.junit.jupiter.api.DynamicTest;
 import org.junit.jupiter.api.Tag;
 
 /**
- * Regression test for the atomic-batch staked-delete finalization bug. A reported proof-of-concept
- * showed that an atomic batch whose final inner transaction deletes a staked account with a positive
- * pending staking reward threw {@code IllegalStateException} from root staking-reward finalization,
- * which escaped every fee-charging boundary and replaced the whole batch with a zero-fee {@code
- * FAIL_INVALID} record (rolling back all inner work and all fees, for free, repeatably).
+ * Regression test for staking-reward finalization when a staked account is deleted inside an atomic
+ * batch (HIP-551). For an inner-batch delete, the deleted-account to beneficiary mapping is recorded
+ * on the child dispatch builder rather than the root builder that staking finalization consults, so
+ * without the read-side fold the redirect loop cannot resolve the beneficiary and finalization fails.
  *
- * <p>This is the inverted proof-of-concept: the same fifteen fee-bearing storage-writing contract
- * calls followed by a valid staked delete, asserting the FIXED behavior — the batch succeeds, the
- * deleted account's reward is redirected to its beneficiary, every inner record persists, and fees
- * are charged.
+ * <p>The batch runs fifteen fee-bearing storage-writing contract calls followed by a valid staked
+ * delete, and asserts the correct behavior: the batch succeeds, the deleted account's pending reward
+ * is redirected to its beneficiary, every inner record persists, and fees are charged.
  */
 @Tag(INTEGRATION)
 @HapiTestLifecycle
@@ -72,12 +70,12 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
     private static final String BATCH_KEY = "rewardRedirectBatchKey";
     private static final String WORK_PAYER = "rewardRedirectWorkPayer";
     private static final String OUTER_PAYER = "rewardRedirectOuterPayer";
-    private static final String STAKED_ATTACKER = "rewardRedirectStakedAttacker";
+    private static final String STAKED_ACCOUNT = "rewardRedirectStakedAccount";
     private static final String DELETE_BENEFICIARY = "rewardRedirectBeneficiary";
     private static final String WORK_PREFIX = "rewardRedirectWork";
     private static final String DELETE_INNER = "rewardRedirectDeleteInner";
-    private static final String EXPLOIT_BATCH = "rewardRedirectBatch";
-    private static final String ATTACKER_BEFORE = "rewardRedirectAttackerBefore";
+    private static final String DELETE_BATCH = "rewardRedirectBatch";
+    private static final String STAKED_BEFORE = "rewardRedirectStakedBefore";
 
     private static final String CONTRACT_ADMIN_KEY = "rewardRedirectContractAdminKey";
     private static final String STAKED_CONTRACT = "rewardRedirectStakedContract";
@@ -108,7 +106,8 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                 "staking.requireMinStakeToReward"
             })
     final Stream<DynamicTest> stakedDeleteInAtomicBatchRedirectsRewardAndChargesFees() {
-        final var attackerPendingReward = new AtomicLong();
+        final var stakedPendingReward = new AtomicLong();
+        final var stakedBalanceBefore = new AtomicLong();
         final var beneficiaryBefore = new AtomicLong();
         final var beneficiaryAfter = new AtomicLong();
         final var workPayerBefore = new AtomicLong();
@@ -120,10 +119,10 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
         final var batchRecord = new AtomicReference<TransactionRecord>();
         final var deleteRecord = new AtomicReference<TransactionRecord>();
 
-        final var deleteInner = cryptoDelete(STAKED_ATTACKER)
+        final var deleteInner = cryptoDelete(STAKED_ACCOUNT)
                 .transfer(DELETE_BENEFICIARY)
-                .payingWith(STAKED_ATTACKER)
-                .signedBy(STAKED_ATTACKER)
+                .payingWith(STAKED_ACCOUNT)
+                .signedBy(STAKED_ACCOUNT)
                 .memo("t")
                 .batchKey(BATCH_KEY)
                 .via(DELETE_INNER);
@@ -131,7 +130,7 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                 .payingWith(OUTER_PAYER)
                 .signedBy(OUTER_PAYER, BATCH_KEY)
                 .memo("b")
-                .via(EXPLOIT_BATCH)
+                .via(DELETE_BATCH)
                 .hasKnownStatus(SUCCESS);
 
         return hapiTest(flattened(
@@ -147,7 +146,7 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                 contractCreate(SLOT_USER).gas(CONTRACT_CREATE_GAS),
                 cryptoCreate(WORK_PAYER).balance(ONE_MILLION_HBARS),
                 cryptoCreate(OUTER_PAYER).balance(ONE_HUNDRED_HBARS),
-                cryptoCreate(STAKED_ATTACKER).balance(ONE_HUNDRED_HBARS).stakedNodeId(0),
+                cryptoCreate(STAKED_ACCOUNT).balance(ONE_HUNDRED_HBARS).stakedNodeId(0),
                 cryptoCreate(DELETE_BENEFICIARY).balance(0L).receiverSigRequired(false),
 
                 // Accrue a positive, payable pending reward for the staked account.
@@ -157,11 +156,11 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                 cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
                 waitUntilStartOfNextStakingPeriod(1),
                 cryptoTransfer(tinyBarsFromTo(GENESIS, FUNDING, 1L)),
-                getAccountInfo(STAKED_ATTACKER).savingSnapshot(ATTACKER_BEFORE),
+                getAccountInfo(STAKED_ACCOUNT).savingSnapshot(STAKED_BEFORE),
                 assertionsHold((spec, log) -> {
-                    final AccountInfo attacker = spec.registry().getAccountInfo(ATTACKER_BEFORE);
-                    attackerPendingReward.set(pendingOf(attacker));
-                    Assertions.assertThat(attackerPendingReward.get())
+                    final AccountInfo stakedAccount = spec.registry().getAccountInfo(STAKED_BEFORE);
+                    stakedPendingReward.set(pendingOf(stakedAccount));
+                    Assertions.assertThat(stakedPendingReward.get())
                             .as("precondition: staked account must have a positive pending reward")
                             .isPositive();
                 }),
@@ -169,6 +168,7 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                 // Snapshot everything the fixed path should change.
                 getAccountBalance(WORK_PAYER).exposingBalanceTo(workPayerBefore::set),
                 getAccountBalance(OUTER_PAYER).exposingBalanceTo(outerPayerBefore::set),
+                getAccountBalance(STAKED_ACCOUNT).exposingBalanceTo(stakedBalanceBefore::set),
                 getAccountBalance(DELETE_BENEFICIARY).exposingBalanceTo(beneficiaryBefore::set),
                 viewSingleton(
                         TokenService.NAME,
@@ -178,10 +178,9 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                 // Fifteen fee-bearing storage-writing calls, then the valid staked delete.
                 batch,
 
-                // The batch now SUCCEEDS instead of being replaced by a zero-fee FAIL_INVALID record.
-                // Staking rewards are finalized at the root, so the redirected reward is externalized on
-                // the outer batch record (exactly one), not on the inner delete record.
-                getTxnRecord(EXPLOIT_BATCH)
+                // The batch succeeds. Staking rewards are finalized at the root, so the redirected reward
+                // is externalized on the outer batch record (exactly one), not on the inner delete record.
+                getTxnRecord(DELETE_BATCH)
                         .hasPriority(recordWith().status(SUCCESS))
                         .hasPaidStakingRewardsCount(1)
                         .exposingTo(batchRecord::set),
@@ -198,7 +197,7 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                         (NetworkStakingRewards rewards) -> networkPendingAfter.set(rewards.pendingRewards())),
                 workRecordsPresent(),
                 assertionsHold((spec, log) -> {
-                    // Fees are charged for the inner work and the outer batch (the work is not free).
+                    // Fees are charged for the inner work and the outer batch.
                     Assertions.assertThat(workPayerBefore.get() - workPayerAfter.get())
                             .as("the fifteen fee-bearing storage calls must charge the work payer")
                             .isPositive();
@@ -208,11 +207,14 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                     Assertions.assertThat(batchRecord.get().getTransactionFee()).isPositive();
 
                     // The pending reward was redirected to the (non-deleted) beneficiary: it receives the
-                    // deleted account's principal plus the reward, and the network pending reward drops.
+                    // deleted account's remaining principal (its pre-delete balance minus the delete fee it
+                    // paid as the inner payer) plus the redirected reward, and the network pending reward drops.
                     final long beneficiaryGain = beneficiaryAfter.get() - beneficiaryBefore.get();
+                    final long deleteFee = deleteRecord.get().getTransactionFee();
                     Assertions.assertThat(beneficiaryGain)
-                            .as("beneficiary receives the deleted account's principal plus its redirected reward")
-                            .isGreaterThan(attackerPendingReward.get());
+                            .as("beneficiary receives the deleted account's principal (pre-delete balance minus "
+                                    + "its own delete fee) plus its redirected reward")
+                            .isEqualTo(stakedBalanceBefore.get() - deleteFee + stakedPendingReward.get());
                     Assertions.assertThat(networkPendingBefore.get() - networkPendingAfter.get())
                             .as("the network pending reward must decrease by the reward actually paid out")
                             .isPositive();
@@ -228,10 +230,10 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                             .isEqualTo(spec.registry().getAccountID(DELETE_BENEFICIARY));
                     Assertions.assertThat(paidRewards.get(0).getAmount())
                             .as("the paid reward equals the deleted account's pending reward")
-                            .isEqualTo(attackerPendingReward.get());
+                            .isEqualTo(stakedPendingReward.get());
                     log.info(
                             "PASS: batch SUCCESS, reward {} redirected to beneficiary, fees charged",
-                            attackerPendingReward.get());
+                            stakedPendingReward.get());
                 })));
     }
 
@@ -321,7 +323,7 @@ class AtomicBatchStakedDeleteRewardRedirectionTest {
                         STAKING_NETWORK_REWARDS_STATE_ID,
                         (NetworkStakingRewards rewards) -> networkPendingAfter.set(rewards.pendingRewards())),
                 assertionsHold((spec, log) -> {
-                    // The outer batch fee is charged (the contract-delete batch is not free).
+                    // The outer batch fee is charged.
                     Assertions.assertThat(outerPayerBefore.get() - outerPayerAfter.get())
                             .as("the outer batch fee must be charged")
                             .isPositive();


### PR DESCRIPTION
Forward-port of #27147 (`release/0.76`) to `release/0.77`.