### PR TITLE
fix: Possible NPE when cleaning up the state in prehandle

### DIFF
--- a/platform-sdk/consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/internal/DefaultTransactionPrehandler.java
+++ b/platform-sdk/consensus-transaction-handling/src/main/java/org/hiero/consensus/transaction/handling/internal/DefaultTransactionPrehandler.java
@@ -101,8 +101,9 @@ public class DefaultTransactionPrehandler implements TransactionPrehandler {
             }
         } finally {
             event.signalPrehandleCompletion();
-            latestImmutableState.close();
-
+            if (latestImmutableState != null) {
+                latestImmutableState.close();
+            }
             preHandleTime.update(startTime, time.nanoTime());
         }
 


### PR DESCRIPTION
**Description**:
In unlikely case state returned would be null (which is allowed) or some exception would be thrown, prehandler would crash with NPE in finally block, which is not a good thing.

**Related issue(s)**:

Fixes #27088


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
