### PR TITLE
chore: Cleanup non-working code in uncaught exception handler

### DIFF
--- a/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/context/internal/PlatformUncaughtExceptionHandler.java
+++ b/platform-sdk/swirlds-platform-core/src/main/java/com/swirlds/platform/context/internal/PlatformUncaughtExceptionHandler.java
@@ -1,19 +1,19 @@
 // SPDX-License-Identifier: Apache-2.0
 package com.swirlds.platform.context.internal;
 
+import edu.umd.cs.findbugs.annotations.NonNull;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 /**
- * Simple uncaught exception handler that logs the exception and rethrows it.
+ * Simple uncaught exception handler that logs the exception.
  */
 public class PlatformUncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
 
     private static final Logger logger = LogManager.getLogger(PlatformUncaughtExceptionHandler.class);
 
     @Override
-    public void uncaughtException(Thread t, Throwable e) {
-        logger.error("Uncaught exception in thread: " + t.getName(), e);
-        throw new RuntimeException("Uncaught exception", e);
+    public void uncaughtException(final @NonNull Thread t, final @NonNull Throwable e) {
+        logger.error("Uncaught exception in thread: {}", t.getName(), e);
     }
 }


### PR DESCRIPTION
**Description**:
Remove rethrow from the uncaught exception handler, as exception thrown from it are ignored anyway.

**Related issue(s)**:

Fixes #27089 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
