### PR TITLE
fix: fix flaky BN backpressure test

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
@@ -8,6 +8,7 @@ import static com.hedera.services.bdd.spec.HapiSpec.hapiTest;
 import static com.hedera.services.bdd.spec.utilops.BlockNodeVerbs.blockNode;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertBlockNodeCommsLogContainsTimeframe;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.assertBlockNodeCommsLogDoesNotContainText;
+import static com.hedera.services.bdd.spec.utilops.UtilVerbs.awaitBlockNodeCommsLogContainsText;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.doingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.sourcingContextual;
 import static com.hedera.services.bdd.spec.utilops.UtilVerbs.waitForActive;
@@ -234,11 +235,14 @@ public class BlockNodeBackPressureSuite {
     final Stream<DynamicTest> backPressureAllNodesCheckingScenario() {
         final AtomicReference<Instant> time = new AtomicReference<>();
         return hapiTest(
-                // Let the 4-node network stabilize before shutting down the block node
-                doingContextual(
-                        spec -> LockSupport.parkNanos(Duration.ofSeconds(30).toNanos())),
-                // Capture the time before shutting down: the buffer can saturate and log backpressure
-                // during the container's shutdown/drain phase, before shutDownImmediately() returns.
+                // Anchor on a condition, not a clock. A fixed park cannot guarantee the buffer is
+                // healthy at t0: with maxBlocks=5 and four real block-node containers, node0 can
+                // saturate while the network is still settling. The timeframe op below only matches
+                // lines in [t0, t0+timeframe], so a saturation logged before t0 is invisible no
+                // matter how long it polls. An acknowledgement proves the connection is up and the
+                // buffer is draining, so the saturation asserted below is caused by the shutdown.
+                awaitBlockNodeCommsLogContainsText(
+                        byNodeId(0), "BlockAcknowledgement received for block", Duration.ofMinutes(2)),
                 doingContextual(spec -> time.set(Instant.now())),
                 blockNode(0).shutDownImmediately(),
                 // With REAL block nodes (Docker containers), shutdown takes ~15s before the
@@ -267,7 +271,10 @@ public class BlockNodeBackPressureSuite {
                         spec -> LockSupport.parkNanos(Duration.ofSeconds(30).toNanos())),
                 blockNode(0).shutDownImmediately(),
                 blockNode(1).shutDownImmediately(),
-                waitForAny(allNodes(), Duration.ofSeconds(120), PlatformStatus.CHECKING),
+                // With both block nodes down, backpressure blocks the handler thread, so a node
+                // can fall BEHIND consensus rather than pass through CHECKING; either status shows
+                // it has stopped being ACTIVE, which is what this step is waiting for.
+                waitForAny(allNodes(), Duration.ofSeconds(120), PlatformStatus.CHECKING, PlatformStatus.BEHIND),
                 doingContextual(
                         spec -> LockSupport.parkNanos(Duration.ofSeconds(30).toNanos())),
                 blockNode(0).startImmediately(),
@@ -277,7 +284,7 @@ public class BlockNodeBackPressureSuite {
 
     /**
      * Smoke test: a healthy block node combined with a low
-     * {@code blockStream.buffer.ackedBlocksToRetain} value should never engage backpressure and
+     * {@code blockStream.buffer.minAckedBlocksToBuffer} value should never engage backpressure and
      * the node should remain ACTIVE throughout. Verifies the new property wires through end-to-end
      * without regressing the happy path. The unit tests in {@code BlockBufferServiceTest} verify the
      * pruning algorithm itself.

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/blocknode/BlockNodeBackPressureSuite.java
@@ -284,7 +284,7 @@ public class BlockNodeBackPressureSuite {
 
     /**
      * Smoke test: a healthy block node combined with a low
-     * {@code blockStream.buffer.minAckedBlocksToBuffer} value should never engage backpressure and
+     * {@code blockStream.buffer.ackedBlocksToRetain} value should never engage backpressure and
      * the node should remain ACTIVE throughout. Verifies the new property wires through end-to-end
      * without regressing the happy path. The unit tests in {@code BlockBufferServiceTest} verify the
      * pruning algorithm itself.


### PR DESCRIPTION
**Description**:
Hardens `backPressureAllNodesCheckingScenario` in `BlockNodeBackPressureSuite`:

- Replace the fixed 30s park before the shutdown with `awaitBlockNodeCommsLogContainsText`
  on a block acknowledgement, so t0 is anchored on a healthy, draining buffer rather than a
  clock — otherwise a saturation logged before t0 is invisible to the timeframe assertion.
- Accept `BEHIND` as well as `CHECKING` in `waitForAny`, since backpressure can block the
  handler thread and push a node behind consensus instead of through CHECKING.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
