### PR TITLE
fix: Fixes History proof recovery stall issue at genesis when its timeout clock stops advancing

### DIFF
--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/HandleWorkflow.java
@@ -1246,7 +1246,7 @@ public class HandleWorkflow {
                                     activeRosters,
                                     vk,
                                     historyStore,
-                                    blockStreamManager.lastUsedConsensusTime(),
+                                    workTime,
                                     tssConfig,
                                     isActive,
                                     hintsService.activeConstruction()));

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/history/impl/WrapsHistoryProverTest.java
@@ -191,6 +191,48 @@ class WrapsHistoryProverTest {
     }
 
     @Test
+    void genesisMissingSelectedR2IsRecoverableOnlyAfterGracePeriod() {
+        final var lastMessageTime = EPOCH.plusSeconds(2);
+        given(historyLibrary.computeWrapsMessage(any(), any())).willReturn("MSG".getBytes(UTF_8));
+        given(historyLibrary.hashAddressBook(any())).willReturn("HASH".getBytes(UTF_8));
+
+        assertTrue(subject.addWrapsSigningMessage(
+                CONSTRUCTION_ID, new WrapsMessagePublication(SELF_ID, R1_MESSAGE, R1, EPOCH), writableHistoryStore));
+        assertTrue(subject.addWrapsSigningMessage(
+                CONSTRUCTION_ID,
+                new WrapsMessagePublication(OTHER_NODE_ID, R1_MESSAGE, R1, EPOCH.plusSeconds(1)),
+                writableHistoryStore));
+        final var graceEndCaptor = ArgumentCaptor.forClass(Instant.class);
+        verify(writableHistoryStore).advanceWrapsSigningPhase(eq(CONSTRUCTION_ID), eq(R2), graceEndCaptor.capture());
+        final var graceEnd = graceEndCaptor.getValue();
+        assertEquals(EPOCH.plusSeconds(1).plus(GRACE_PERIOD), graceEnd);
+        final var construction = constructionWithPhase(R2, graceEnd);
+
+        // Both R1 participants are required in R2; the other participant's R2 never arrives.
+        assertTrue(subject.addWrapsSigningMessage(
+                CONSTRUCTION_ID,
+                new WrapsMessagePublication(SELF_ID, R2_MESSAGE, R2, lastMessageTime),
+                writableHistoryStore));
+        assertSame(
+                HistoryProver.Outcome.InProgress.INSTANCE,
+                subject.advance(
+                        lastMessageTime, construction, TARGET_METADATA, targetProofKeys, tssConfig, null, true));
+        assertSame(
+                HistoryProver.Outcome.InProgress.INSTANCE,
+                subject.advance(graceEnd, construction, TARGET_METADATA, targetProofKeys, tssConfig, null, true));
+
+        final var outcome = subject.advance(
+                graceEnd.plusNanos(1), construction, TARGET_METADATA, targetProofKeys, tssConfig, null, true);
+
+        final var failure = assertInstanceOf(HistoryProver.Outcome.Failed.class, outcome);
+        assertEquals(
+                "Still missing messages from R1 nodes [2] after end of grace period for phase R2", failure.reason());
+        assertTrue(WrapsHistoryProver.isRecoverableFailure(failure.reason()));
+        verify(writableHistoryStore, never()).advanceWrapsSigningPhase(eq(CONSTRUCTION_ID), eq(R3), any());
+        verifyNoInteractions(submissions);
+    }
+
+    @Test
     void advanceInitializesWrapsMessageAndPublishesR1() {
         subject = new WrapsHistoryProver(
                 SELF_ID,

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/HandleWorkflowTest.java
@@ -2,6 +2,8 @@
 package com.hedera.node.app.workflows.handle;
 
 import static com.hedera.node.app.blocks.BlockStreamManager.PendingWork.POST_UPGRADE_WORK;
+import static com.hedera.node.app.hints.schemas.V059HintsSchema.ACTIVE_HINTS_CONSTRUCTION_STATE_ID;
+import static com.hedera.node.app.history.schemas.V071HistorySchema.LEDGER_ID_STATE_ID;
 import static com.hedera.node.app.records.schemas.V0490BlockRecordSchema.BLOCKS_STATE_ID;
 import static com.hedera.node.app.service.addressbook.impl.schemas.V053AddressBookSchema.NODES_STATE_ID;
 import static com.hedera.node.app.service.entityid.impl.schemas.V0490EntityIdSchema.ENTITY_ID_STATE_ID;
@@ -16,6 +18,7 @@ import static com.hedera.node.config.types.StreamMode.RECORDS;
 import static java.util.Collections.emptyIterator;
 import static java.util.Collections.emptyList;
 import static org.hiero.consensus.platformstate.PlatformStateService.NAME;
+import static org.hiero.consensus.roster.RosterStateId.ROSTER_STATE_STATE_ID;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -32,6 +35,7 @@ import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.withSettings;
 
@@ -50,9 +54,13 @@ import com.hedera.hapi.node.state.blockrecords.BlockInfo;
 import com.hedera.hapi.node.state.common.EntityNumber;
 import com.hedera.hapi.node.state.entity.EntityCounts;
 import com.hedera.hapi.node.state.file.File;
+import com.hedera.hapi.node.state.hints.HintsConstruction;
 import com.hedera.hapi.node.state.history.History;
 import com.hedera.hapi.node.state.history.HistoryProof;
 import com.hedera.hapi.node.state.history.HistoryProofConstruction;
+import com.hedera.hapi.node.state.primitives.ProtoBytes;
+import com.hedera.hapi.node.state.roster.RosterState;
+import com.hedera.hapi.node.state.roster.RoundRosterPair;
 import com.hedera.hapi.node.state.token.NetworkStakingRewards;
 import com.hedera.hapi.platform.event.EventCore;
 import com.hedera.hapi.platform.event.EventDescriptor;
@@ -788,6 +796,81 @@ class HandleWorkflowTest {
         subject.handleRound(state, round, txn -> {});
 
         verify(blockBufferService).ensureNewBlocksPermitted();
+    }
+
+    @Test
+    void historyRecoveryClockAdvancesOnEmptyRoundsUntilSignerIsReady() {
+        givenTssEnabledEmptyRounds();
+        given(blockHashSigner.isReady()).willReturn(false);
+        given(blockStreamManager.lastUsedConsensusTime()).willReturn(NOW);
+
+        // A missing genesis WRAPS message must not freeze recovery time before its 10-second deadline.
+        final var firstRoundTime = NOW.plusSeconds(1);
+        final var afterGracePeriod = NOW.plusSeconds(11);
+        given(round.getConsensusTimestamp()).willReturn(firstRoundTime);
+        subject.handleRound(state, round, txn -> {});
+        given(round.getConsensusTimestamp()).willReturn(afterGracePeriod);
+        subject.handleRound(state, round, txn -> {});
+
+        // After readiness, history must retain the block-based clock even when subsequent rounds are empty.
+        final var readyBlockTime = NOW.plusSeconds(12);
+        given(blockHashSigner.isReady()).willReturn(true);
+        given(blockStreamManager.lastUsedConsensusTime()).willReturn(readyBlockTime);
+        given(round.getConsensusTimestamp()).willReturn(NOW.plusSeconds(13));
+        subject.handleRound(state, round, txn -> {});
+        given(round.getConsensusTimestamp()).willReturn(NOW.plusSeconds(23));
+        subject.handleRound(state, round, txn -> {});
+
+        final var reconciliationTimes = ArgumentCaptor.forClass(Instant.class);
+        verify(historyService, times(4))
+                .reconcile(any(), any(), any(), reconciliationTimes.capture(), any(), eq(true), any());
+        assertEquals(
+                List.of(firstRoundTime, afterGracePeriod, readyBlockTime, readyBlockTime),
+                reconciliationTimes.getAllValues());
+    }
+
+    private void givenTssEnabledEmptyRounds() {
+        final var rosterStates = mock(ReadableStates.class);
+        final ReadableSingletonState<RosterState> rosterState = mock(ReadableSingletonState.class);
+        given(state.getReadableStates(RosterService.NAME)).willReturn(rosterStates);
+        given(rosterStates.<RosterState>getSingleton(ROSTER_STATE_STATE_ID)).willReturn(rosterState);
+        given(rosterState.get())
+                .willReturn(RosterState.newBuilder()
+                        .roundRosterPairs(new RoundRosterPair(0, Bytes.wrap("genesis-roster")))
+                        .build());
+
+        final var entityStates =
+                mock(WritableStates.class, withSettings().extraInterfaces(CommittableWritableStates.class));
+        given(state.getWritableStates(EntityIdService.NAME)).willReturn(entityStates);
+        final var hintsStates = mock(WritableStates.class);
+        final WritableSingletonState<HintsConstruction> hintsConstruction = mock(WritableSingletonState.class);
+        given(state.getWritableStates(HintsService.NAME)).willReturn(hintsStates);
+        lenient()
+                .when(hintsStates.<HintsConstruction>getSingleton(ACTIVE_HINTS_CONSTRUCTION_STATE_ID))
+                .thenReturn(hintsConstruction);
+        given(hintsConstruction.get()).willReturn(HintsConstruction.DEFAULT);
+        final var historyStates = mock(WritableStates.class);
+        given(state.getWritableStates(HistoryService.NAME)).willReturn(historyStates);
+        lenient()
+                .when(historyStates.<ProtoBytes>getSingleton(LEDGER_ID_STATE_ID))
+                .thenReturn(mock(WritableSingletonState.class));
+
+        given(event.getHash()).willReturn(CryptoRandomUtils.randomHash());
+        given(event.getCreatorId()).willReturn(NodeId.of(0));
+        given(event.getEventCore()).willReturn(EventCore.DEFAULT);
+        given(event.allParentsIterator()).willAnswer(ignore -> emptyIterator());
+        given(event.consensusTransactionIterator()).willAnswer(ignore -> emptyIterator());
+        given(round.iterator()).willAnswer(ignore -> List.of(event).iterator());
+        given(networkInfo.nodeInfo(0)).willReturn(mock(NodeInfo.class));
+        given(blockStreamManager.lastIntervalProcessTime()).willReturn(NOW);
+        given(scheduleService.executableTxns(any(), any(), any())).willReturn(mock(ExecutableTxnIterator.class));
+        given(state.getWritableStates(ScheduleService.NAME)).willReturn(mock(WritableStates.class));
+
+        givenSubjectWith(
+                BLOCKS,
+                BlockStreamWriterMode.FILE,
+                emptyList(),
+                Map.of("tss.hintsEnabled", "true", "tss.historyEnabled", "true"));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/27232

During genesis, a missing WRAPS message can leave the network stuck in WAITING_FOR_LEDGER_ID. History reconciliation uses lastUsedConsensusTime(), which can stop advancing before signer readiness even while consensus rounds continue. This prevents the message grace period from expiring and blocks recovery retries.
Use the existing workTime for history reconciliation so recovery follows round timestamps until the signer is ready, preserving the existing block-based clock afterward.
Adds regression coverage for:
- Advancing recovery time across empty rounds while the transaction timestamp is frozen.
- Preserving block-based timing after signer readiness.
- Producing a recoverable failure for a missing genesis R2 message after the grace period.