### PR TITLE
fix: unblock CI checks failing on main (FrontendThrottleReclaimTest, Snyk zstd-jni)

### DIFF
--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/FrontendThrottleReclaimTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/throttling/FrontendThrottleReclaimTest.java
@@ -39,6 +39,11 @@ import org.junit.jupiter.api.Tag;
  * bucket that was actually charged. They run in embedded mode so there is a single frontend throttle to observe,
  * and the throttled transactions are paid by {@link com.hedera.services.bdd.suites.HapiSuite#CIVILIAN_PAYER}
  * because system accounts are exempt from throttling.
+ *
+ * <p>The same definitions also drive the consensus throttle, where an auto-creation claims {@code CRYPTO_CREATE}
+ * capacity for the transfer's implicit creation and again for the child {@code CRYPTO_CREATE} dispatch. The 4s
+ * burst period on the one-op buckets leaves the consensus throttle room for both claims, while the frontend, which
+ * splits capacity across nodes, still fits exactly one operation.
  */
 @Tag(TOKEN)
 public class FrontendThrottleReclaimTest {

--- a/hedera-node/test-clients/src/main/resources/testSystemFiles/frontend-reclaim-assoc-throttles.json
+++ b/hedera-node/test-clients/src/main/resources/testSystemFiles/frontend-reclaim-assoc-throttles.json
@@ -2,7 +2,7 @@
   "buckets": [
     {
       "name": "ReclaimAssociateLimit",
-      "burstPeriod": 1,
+      "burstPeriod": 4,
       "throttleGroups": [
         {
           "opsPerSec": 1,
@@ -12,7 +12,7 @@
     },
     {
       "name": "ReclaimCreateLimit",
-      "burstPeriod": 1,
+      "burstPeriod": 4,
       "throttleGroups": [
         {
           "opsPerSec": 1,

--- a/hedera-node/test-clients/src/main/resources/testSystemFiles/frontend-reclaim-hv-create-throttles.json
+++ b/hedera-node/test-clients/src/main/resources/testSystemFiles/frontend-reclaim-hv-create-throttles.json
@@ -2,7 +2,7 @@
   "buckets": [
     {
       "name": "ReclaimNormalCreateLimit",
-      "burstPeriod": 1,
+      "burstPeriod": 4,
       "throttleGroups": [
         {
           "opsPerSec": 1,
@@ -14,7 +14,7 @@
     },
     {
       "name": "ReclaimHighVolumeCreateLimit",
-      "burstPeriod": 1,
+      "burstPeriod": 4,
       "highVolume": true,
       "throttleGroups": [
         {

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies.constraints {
     }
     api("com.github.ben-manes.caffeine:caffeine:3.2.4") { because("com.github.benmanes.caffeine") }
     api("com.github.docker-java:docker-java-api:3.7.1") { because("com.github.dockerjava.api") }
+    api("com.github.luben:zstd-jni:1.5.7-16") { because("com.github.luben.zstd_jni") }
     api("com.github.spotbugs:spotbugs-annotations:4.9.8") {
         because("com.github.spotbugs.annotations")
     }


### PR DESCRIPTION
Fixes the two checks that are currently red on every PR.

**`HAPI Tests (Misc)`** — `FrontendThrottleReclaimTest` (#27122) fails deterministically under `hapiTestMiscEmbedded` with `THROTTLED_AT_CONSENSUS`. The fixtures pin the `CryptoCreate` bucket to one op for the frontend, but the same definitions drive the consensus throttle, where an auto-creation claims `CryptoCreate` capacity for the transfer's implicit creation and again for the child `CryptoCreate` dispatch. Raising `burstPeriod` to 4s on the one-op buckets gives the consensus throttle room for both claims; the frontend already auto-scaled these buckets to a 4s burst to fit one op after splitting capacity across nodes, so the frontend scenario is unchanged. Verified with `./gradlew :test-clients:testEmbedded --tests '*FrontendThrottleReclaimTest'`.

**`Snyk Scan`** — five high-severity findings in `com.github.luben:zstd-jni@1.5.7-11`, pulled in transitively by `pbj-grpc-common@0.15.10` and fixed in `1.5.7-14`. Adds an explicit constraint on `zstd-jni:1.5.7-16` (same approach as the vertx pin in #27025); the `aggregation` runtime classpath Snyk scans now resolves `1.5.7-11 -> 1.5.7-16`.
