### PR TITLE
fix: rlp lists parsing fix

### DIFF
--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/ethereum/EthTxData.java
@@ -695,6 +695,11 @@ public record EthTxData(
         if (rlpList.size() != 12) {
             return null;
         }
+        // Per EIP-1559 the access list field must always be an RLP list, even when empty
+        // (canonically encoded as 0xc0); a byte-string in this position is malformed.
+        if (!rlpList.get(8).isList()) {
+            return null;
+        }
 
         return new EthTxData(
                 rawTx,
@@ -709,9 +714,7 @@ public record EthTxData(
                 rlpList.get(6).asBigInt(), // value
                 rlpList.get(7).data(), // callData
                 rlpList.get(8).data(), // accessList
-                rlpList.get(8) != null && rlpList.get(8).isList()
-                        ? encodeRlpList(rlpList.get(8).asRLPList())
-                        : new Object[0], // accessList as RLPList
+                encodeRlpList(rlpList.get(8).asRLPList()), // accessList as RLPList
                 null, // authorizationList
                 null,
                 asByte(rlpList.get(9)), // yParity
@@ -735,6 +738,11 @@ public record EthTxData(
         if (rlpList.size() != 11) {
             return null;
         }
+        // Per EIP-2930 the access list field must always be an RLP list, even when empty
+        // (canonically encoded as 0xc0); a byte-string in this position is malformed.
+        if (!rlpList.get(7).isList()) {
+            return null;
+        }
 
         return new EthTxData(
                 rawTx,
@@ -749,9 +757,7 @@ public record EthTxData(
                 rlpList.get(5).asBigInt(), // value
                 rlpList.get(6).data(), // callData
                 rlpList.get(7).data(), // accessList
-                rlpList.get(7).isList()
-                        ? encodeRlpList(rlpList.get(7).asRLPList())
-                        : new Object[0], // accessList encoded as Object
+                encodeRlpList(rlpList.get(7).asRLPList()), // accessList encoded as Object
                 null, // authorizationList
                 null,
                 asByte(rlpList.get(8)), // yParity
@@ -775,6 +781,11 @@ public record EthTxData(
         if (rlpList.size() != 13) {
             return null;
         }
+        // Per EIP-7702 the access list and authorization list fields must always be RLP lists, even
+        // when empty (canonically encoded as 0xc0); a byte-string in either position is malformed.
+        if (!rlpList.get(8).isList() || !rlpList.get(9).isList()) {
+            return null;
+        }
 
         return new EthTxData(
                 rawTx,
@@ -789,13 +800,9 @@ public record EthTxData(
                 rlpList.get(6).asBigInt(), // value
                 rlpList.get(7).data(), // callData
                 rlpList.get(8).data(), // accessList
-                rlpList.get(8) != null && rlpList.get(8).isList()
-                        ? encodeRlpList(rlpList.get(8).asRLPList())
-                        : new Object[0], // accessList as RLPList
+                encodeRlpList(rlpList.get(8).asRLPList()), // accessList as RLPList
                 rlpList.get(9).data(),
-                rlpList.get(9) != null && rlpList.get(9).isList()
-                        ? encodeRlpList(rlpList.get(9).asRLPList())
-                        : new Object[0], // authorizationList - must preserve full RLP encoding
+                encodeRlpList(rlpList.get(9).asRLPList()), // authorizationList - must preserve full RLP encoding
                 asByte(rlpList.get(10)), // yParity
                 null, // v
                 rlpList.get(11).data(), // r

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataAccessListsTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataAccessListsTest.java
@@ -4,6 +4,7 @@ package com.hedera.node.app.hapi.utils.ethereum;
 import static com.hedera.node.app.hapi.utils.ethereum.CodeDelegationTest.fillBytes;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import com.esaulpaugh.headlong.rlp.RLPEncoder;
@@ -20,7 +21,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class EthTxDataAccessListsTest {
 
     // EIP2930
-    private static byte[] buildDefaultType1RawTransaction(final byte[] accessList) {
+    private static byte[] buildDefaultType1RawTransaction(final Object accessList) {
         return RLPEncoder.sequence(
                 Integers.toBytes(0x01),
                 List.of(
@@ -38,7 +39,7 @@ class EthTxDataAccessListsTest {
     }
 
     // EIP1559
-    private static byte[] buildDefaultType2RawTransaction(final byte[] accessList) {
+    private static byte[] buildDefaultType2RawTransaction(final Object accessList) {
         return RLPEncoder.sequence(
                 Integers.toBytes(0x02),
                 List.of(
@@ -57,7 +58,7 @@ class EthTxDataAccessListsTest {
     }
 
     // EIP7702
-    private static byte[] buildDefaultType4RawTransaction(final byte[] accessList) {
+    private static byte[] buildDefaultType4RawTransaction(final Object accessList) {
         return RLPEncoder.sequence(
                 Integers.toBytes(0x04),
                 List.of(
@@ -70,7 +71,7 @@ class EthTxDataAccessListsTest {
                         Integers.toBytesUnsigned(BigInteger.ZERO),
                         new byte[] {},
                         accessList,
-                        fillBytes(5, 0x40),
+                        new Object[] {}, // authorizationList (empty, canonically encoded as a list)
                         Integers.toBytes(27),
                         fillBytes(32, 0x05),
                         fillBytes(32, 0x06)));
@@ -78,7 +79,7 @@ class EthTxDataAccessListsTest {
 
     private record RawTransactionHolder(EthTxData.EthTransactionType type, byte[] data) {
 
-        public static RawTransactionHolder of(final EthTxData.EthTransactionType type, final byte[] accessList) {
+        public static RawTransactionHolder of(final EthTxData.EthTransactionType type, final Object accessList) {
             return new RawTransactionHolder(
                     type,
                     switch (type) {
@@ -105,11 +106,10 @@ class EthTxDataAccessListsTest {
             new Object[] {addr1, new Object[] {key1, key2}},
             new Object[] {addr2, new Object[] {}}
         };
-        final byte[] accessListBytes = RLPEncoder.sequence(accessList);
         return Stream.of(
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessListBytes));
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessList));
     }
 
     @MethodSource("provideTransactionsWithCorrectAccessList")
@@ -137,7 +137,7 @@ class EthTxDataAccessListsTest {
     }
 
     private static Stream<RawTransactionHolder> provideTransactionsWhereAccessListIsNotList() {
-        final byte[] accessListIsNotAList = {0x01};
+        final Object[] accessListIsNotAList = {new byte[] {0x01}};
         return Stream.of(
                 RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessListIsNotAList),
                 RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessListIsNotAList),
@@ -155,13 +155,31 @@ class EthTxDataAccessListsTest {
         assertEquals("Access list item should be a list", thrown.getMessage());
     }
 
+    private static Stream<RawTransactionHolder> provideTransactionsWhereAccessListIsEmptyButNotList() {
+        // Encodes to the RLP empty byte-string token 0x80, not the canonical empty list token 0xc0.
+        // Same total length, same signature bytes, but a different, non-canonical wire encoding of
+        // "no access list".
+        final byte[] accessListIsEmptyByteString = new byte[0];
+        return Stream.of(
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessListIsEmptyByteString),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessListIsEmptyByteString),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessListIsEmptyByteString));
+    }
+
+    @MethodSource("provideTransactionsWhereAccessListIsEmptyButNotList")
+    @ParameterizedTest(name = "Transaction.AccessListIsEmptyButNotList {0}")
+    void rejectsAccessListThatIsEmptyButNotACanonicalList(final RawTransactionHolder raw) {
+        // the transaction should be rejected at parse time rather than silently accepted with an empty access list.
+        final EthTxData tx = EthTxData.populateEthTxData(raw.data());
+        assertNull(tx);
+    }
+
     private static Stream<RawTransactionHolder> provideTransactionsWhereAccessListHasWrongItems() {
         final Object[] accessList = {new Object[] {new byte[] {0x01}, new byte[] {0x01}, new byte[] {0x01}}};
-        final byte[] accessListBytes = RLPEncoder.sequence(accessList);
         return Stream.of(
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessListBytes));
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessList));
     }
 
     @MethodSource("provideTransactionsWhereAccessListHasWrongItems")
@@ -178,11 +196,10 @@ class EthTxDataAccessListsTest {
     private static Stream<RawTransactionHolder> provideTransactionsWhereAccessListHasWrongAddress() {
         final byte[] addr1 = fillBytes(17, 0x10);
         final Object[] accessList = {new Object[] {addr1, new byte[] {0x01}}};
-        final byte[] accessListBytes = RLPEncoder.sequence(accessList);
         return Stream.of(
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessListBytes));
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessList));
     }
 
     @MethodSource("provideTransactionsWhereAccessListHasWrongAddress")
@@ -199,11 +216,10 @@ class EthTxDataAccessListsTest {
     private static Stream<RawTransactionHolder> provideTransactionsWhereStorageKeyIsNotList() {
         final byte[] addr1 = fillBytes(20, 0x10);
         final Object[] accessList = {new Object[] {addr1, new byte[] {0x01}}};
-        final byte[] accessListBytes = RLPEncoder.sequence(accessList);
         return Stream.of(
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessListBytes));
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessList));
     }
 
     @MethodSource("provideTransactionsWhereStorageKeyIsNotList")
@@ -221,11 +237,10 @@ class EthTxDataAccessListsTest {
         final byte[] addr1 = fillBytes(20, 0x10);
         final byte[] key1 = fillBytes(17, 0x10);
         final Object[] accessList = {new Object[] {addr1, new Object[] {key1}}};
-        final byte[] accessListBytes = RLPEncoder.sequence(accessList);
         return Stream.of(
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessListBytes),
-                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessListBytes));
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP2930, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP1559, accessList),
+                RawTransactionHolder.of(EthTxData.EthTransactionType.EIP7702, accessList));
     }
 
     @MethodSource("provideTransactionsWhereStorageKeyHasWrongKey")

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataTest.java
@@ -445,14 +445,14 @@ class EthTxDataTest {
         assertNull(EthTxData.populateEthTxData(Arrays.copyOf(canonical, canonical.length + 1)));
     }
 
-    byte[][] normalRlpData() {
+    Object[] normalRlpData() {
         final var oneByte = new byte[] {1};
-        final byte[][] rlpArray = new byte[][] {
+        final var emptyObjectArray = new Object[] {};
+        return new Object[] {
             oneByte, oneByte, oneByte, oneByte,
             oneByte, oneByte, oneByte, oneByte,
-            oneByte, oneByte, oneByte, oneByte
+            emptyObjectArray, oneByte, oneByte, oneByte
         };
-        return rlpArray;
     }
 
     @Test

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataType4TransactionTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataType4TransactionTest.java
@@ -356,13 +356,16 @@ class EthTxDataType4TransactionTest {
     /// for the legacy, type-1 and type-2 equivalents.
     @Test
     void populateEip7702EthTxDataReturnsNullWhenTrailingBytesFollowEnvelope() {
-        final byte[] authorizationList = rlpList(
-                rlpBytes(new byte[] {0x01}),
-                rlpBytes(repeat((byte) 0x11, 20)),
-                rlpUInt(5),
-                rlpUInt(1),
-                rlpBytes(repeat((byte) 0x22, 32)),
-                rlpBytes(repeat((byte) 0x33, 32)));
+        final Object[] authorizationList = {
+            new Object[] {
+                new byte[] {0x01},
+                repeat((byte) 0x11, 20),
+                Integers.toBytes(5),
+                Integers.toBytes(1),
+                repeat((byte) 0x22, 32),
+                repeat((byte) 0x33, 32)
+            }
+        };
         final byte[] canonical = buildType4Raw(
                 fillBytes(2, 0x01),
                 1,
@@ -385,81 +388,6 @@ class EthTxDataType4TransactionTest {
             System.arraycopy(suffix, 0, suffixed, canonical.length, suffix.length);
             assertNull(EthTxData.populateEthTxData(suffixed), "trailing byte must be rejected");
         }
-    }
-
-    private static byte[] rlpBytes(byte[] bytes) {
-        if (bytes.length == 1 && (bytes[0] & 0xFF) < 0x80) {
-            return new byte[] {bytes[0]};
-        }
-        if (bytes.length <= 55) {
-            byte[] out = new byte[1 + bytes.length];
-            out[0] = (byte) (0x80 + bytes.length);
-            System.arraycopy(bytes, 0, out, 1, bytes.length);
-            return out;
-        }
-        // length > 55
-        byte[] lenEnc = encodeLen(bytes.length);
-        byte[] out = new byte[1 + lenEnc.length + bytes.length];
-        out[0] = (byte) (0xB7 + lenEnc.length);
-        System.arraycopy(lenEnc, 0, out, 1, lenEnc.length);
-        System.arraycopy(bytes, 0, out, 1 + lenEnc.length, bytes.length);
-        return out;
-    }
-
-    private static byte[] rlpUInt(int value) {
-        if (value == 0) {
-            return new byte[] {(byte) 0x80}; // empty (zero)
-        }
-        // minimal big-endian
-        int v = value;
-        int size = 0;
-        byte[] tmp = new byte[8];
-        while (v != 0) {
-            tmp[7 - size] = (byte) (v & 0xFF);
-            v >>>= 8;
-            size++;
-        }
-        byte[] be = new byte[size];
-        System.arraycopy(tmp, 8 - size, be, 0, size);
-        return rlpBytes(be);
-    }
-
-    private static byte[] rlpList(byte[]... items) {
-        int payloadLen = 0;
-        for (byte[] it : items) payloadLen += it.length;
-        byte[] payload = new byte[payloadLen];
-        int off = 0;
-        for (byte[] it : items) {
-            System.arraycopy(it, 0, payload, off, it.length);
-            off += it.length;
-        }
-        if (payloadLen <= 55) {
-            byte[] out = new byte[1 + payloadLen];
-            out[0] = (byte) (0xC0 + payloadLen);
-            System.arraycopy(payload, 0, out, 1, payloadLen);
-            return out;
-        }
-        byte[] lenEnc = encodeLen(payloadLen);
-        byte[] out = new byte[1 + lenEnc.length + payloadLen];
-        out[0] = (byte) (0xF7 + lenEnc.length);
-        System.arraycopy(lenEnc, 0, out, 1, lenEnc.length);
-        System.arraycopy(payload, 0, out, 1 + lenEnc.length, payloadLen);
-        return out;
-    }
-
-    private static byte[] encodeLen(int len) {
-        // big-endian, minimal
-        int n = len;
-        int size = 0;
-        byte[] tmp = new byte[8];
-        while (n != 0) {
-            tmp[7 - size] = (byte) (n & 0xFF);
-            n >>>= 8;
-            size++;
-        }
-        byte[] out = new byte[size];
-        System.arraycopy(tmp, 8 - size, out, 0, size);
-        return out;
     }
 
     private static byte[] repeat(byte b, int n) {

--- a/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataType4TransactionTest.java
+++ b/hedera-node/hapi-utils/src/test/java/com/hedera/node/app/hapi/utils/ethereum/EthTxDataType4TransactionTest.java
@@ -40,7 +40,18 @@ class EthTxDataType4TransactionTest {
 
         final byte[] expectedAccessListBytes = RLPEncoder.sequence(accessListList);
 
-        final byte[] authorizationList = fillBytes(5, 0x40);
+        final byte[] authChainId = {0x01, 0x2A};
+        final byte[] authAddress = fillBytes(20, 0x99);
+        final int authNonce = 3;
+        final int authYParity = 1;
+        final byte[] authR = fillBytes(32, 0xB0);
+        final byte[] authS = fillBytes(32, 0xC0);
+        final Object[] authorizationEntry = {
+            authChainId, authAddress, Integers.toBytes(authNonce), Integers.toBytes(authYParity), authR, authS
+        };
+        final Object[] authorizationList = {authorizationEntry};
+        final byte[] expectedAuthorizationListBytes = RLPEncoder.sequence(authorizationList);
+
         final int recId = 27;
         final byte[] r = fillBytes(32, 0x90);
         final byte[] s = fillBytes(32, 0xA0);
@@ -55,7 +66,7 @@ class EthTxDataType4TransactionTest {
             Integers.toBytesUnsigned(BigInteger.valueOf(value)), // 6
             callData, // 7
             accessListList, // 8 (list)
-            authorizationList, // 9
+            authorizationList, // 9 (list)
             new byte[] {(byte) recId}, // 10
             r, // 11
             s // 12
@@ -88,14 +99,15 @@ class EthTxDataType4TransactionTest {
         assertArrayEquals(key1, (byte[]) firstKeys[0]);
         assertArrayEquals(key2, (byte[]) firstKeys[1]);
 
-        assertArrayEquals(authorizationList, tx.authorizationList());
+        assertArrayEquals(expectedAuthorizationListBytes, tx.authorizationList());
         assertEquals(recId, tx.recId());
         assertArrayEquals(r, tx.r());
         assertArrayEquals(s, tx.s());
     }
 
     @Test
-    void returnsEmptyWhenAuthorizationTopLevelNotList() {
+    void rejectsAuthorizationListThatIsNotAList() {
+        // Encodes to a plain RLP byte-string, not a list - malformed regardless of content.
         final byte[] auth = {0x01};
 
         final byte[] raw = buildType4Raw(
@@ -113,16 +125,43 @@ class EthTxDataType4TransactionTest {
                 fillBytes(32, 0x05),
                 fillBytes(32, 0x06));
 
+        // The transaction should be rejected at parse time rather than silently accepted with a
+        // malformed authorization list.
         final EthTxData tx = EthTxData.populateEthTxData(raw);
-        assertNotNull(tx);
+        assertNull(tx);
+    }
 
-        final var thrown = assertThrows(IllegalArgumentException.class, tx::extractCodeDelegations);
-        assertEquals("Authorization list item should be a list", thrown.getMessage());
+    @Test
+    void rejectsAuthorizationListThatIsEmptyButNotACanonicalList() {
+        // Encodes to the RLP empty byte-string token 0x80, not the canonical empty list token 0xc0.
+        final byte[] authorizationListIsEmptyByteString = new byte[0];
+
+        final byte[] raw = buildType4Raw(
+                fillBytes(2, 0x01),
+                1,
+                fillBytes(3, 0x02),
+                fillBytes(3, 0x03),
+                100,
+                fillBytes(20, 0x04),
+                0L,
+                new byte[] {},
+                new Object[] {}, // canonical empty access list
+                authorizationListIsEmptyByteString,
+                27,
+                fillBytes(32, 0x05),
+                fillBytes(32, 0x06));
+
+        // The transaction should be rejected at parse time rather than silently accepted with an
+        // empty authorization list.
+        final EthTxData tx = EthTxData.populateEthTxData(raw);
+        assertNull(tx);
     }
 
     @Test
     void extractCodeDelegationsThrowsWhenInnerItemNotList() {
-        final byte[] auth = {(byte) 0xC1, 0x01};
+        // Authorization list has one entry, and that entry is a single-element list (wrong element
+        // count - a genuine authorization entry must have exactly 6 elements).
+        final Object[] authorizationList = {new Object[] {new byte[] {0x01}}};
 
         final byte[] raw = buildType4Raw(
                 fillBytes(2, 0x0A),
@@ -134,7 +173,7 @@ class EthTxDataType4TransactionTest {
                 0L,
                 new byte[] {},
                 new Object[] {},
-                auth,
+                authorizationList,
                 28,
                 fillBytes(32, 0x0E),
                 fillBytes(32, 0x0F));
@@ -148,7 +187,9 @@ class EthTxDataType4TransactionTest {
 
     @Test
     void extractCodeDelegationsThrowsWhenTopLevelListSizeNotSix() {
-        final byte[] auth = {(byte) 0xC1, (byte) 0xC0};
+        // Authorization list has one entry, and that entry is a single-element list (wrong element
+        // count - a genuine authorization entry must have exactly 6 elements).
+        final Object[] authorizationList = {new Object[] {new Object[] {}}};
 
         final byte[] raw = buildType4Raw(
                 fillBytes(2, 0x1A),
@@ -160,7 +201,7 @@ class EthTxDataType4TransactionTest {
                 0L,
                 new byte[] {},
                 new Object[] {},
-                auth,
+                authorizationList,
                 29,
                 fillBytes(32, 0x1E),
                 fillBytes(32, 0x1F));
@@ -182,7 +223,7 @@ class EthTxDataType4TransactionTest {
             final long value,
             final byte[] callData,
             final Object[] accessListList,
-            final byte[] authorizationList,
+            final Object authorizationList,
             final int recId,
             final byte[] r,
             final byte[] s) {
@@ -218,8 +259,9 @@ class EthTxDataType4TransactionTest {
         final byte[] r = repeat((byte) 0x22, 32);
         final byte[] s = repeat((byte) 0x33, 32);
 
-        final byte[] authorizationList = rlpList(
-                rlpBytes(chainId), rlpBytes(address), rlpUInt(nonce), rlpUInt(yParity), rlpBytes(r), rlpBytes(s));
+        final Object[] authorizationList = {
+            new Object[] {chainId, address, Integers.toBytes(nonce), Integers.toBytes(yParity), r, s}
+        };
 
         final byte[] raw = buildType4Raw(
                 fillBytes(2, 0x01),
@@ -252,8 +294,9 @@ class EthTxDataType4TransactionTest {
         final byte[] r = repeat((byte) 0x22, 32);
         final byte[] s = repeat((byte) 0x33, 32);
 
-        final byte[] authorizationList = rlpList(
-                rlpBytes(chainId), rlpBytes(address), rlpUInt(nonce), rlpUInt(yParity), rlpBytes(r), rlpBytes(s));
+        final Object[] authorizationList = {
+            new Object[] {chainId, address, Integers.toBytes(nonce), Integers.toBytes(yParity), r, s}
+        };
 
         final byte[] raw = buildType4Raw(
                 fillBytes(2, 0x01),

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/spec/transactions/contract/HapiEthereumCall.java
@@ -91,6 +91,9 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
     private byte[] signedBytes = null;
     private final List<AuthorizationListItem> authorizationListItems = new ArrayList<>();
     private final List<AccessListItem> accessListItems = new ArrayList<>();
+    private byte[] accessList = null;
+    private Object[] accessListRlp = null;
+    private Function<EthTxData, byte[]> ethTxDataEncodeFunction = EthTxData::encodeTx;
 
     public HapiEthereumCall withExplicitParams(final Supplier<String> supplier) {
         explicitHexedParams = Optional.of(supplier);
@@ -296,12 +299,22 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
     }
 
     public HapiEthereumCall markAsJumboTxn() {
-        isJumboTxn = true;
+        this.isJumboTxn = true;
         return this;
     }
 
     public HapiEthereumCall withAccessList(final List<AccessListItem> items) {
         accessListItems.addAll(items);
+        return this;
+    }
+
+    public HapiEthereumCall withAccessList(final byte[] accessList) {
+        this.accessList = accessList;
+        return this;
+    }
+
+    public HapiEthereumCall withEthTxDataEncodeFunction(final Function<EthTxData, byte[]> ethTxDataEncodeFunction) {
+        this.ethTxDataEncodeFunction = ethTxDataEncodeFunction;
         return this;
     }
 
@@ -377,16 +390,18 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
         }
 
         // encode accessList
-        byte[] accessList = null;
-        Object[] accessListRlp = null;
-        if (type != EthTransactionType.LEGACY_ETHEREUM && !accessListItems.isEmpty()) {
-            accessListRlp = accessListItems.stream()
-                    .map(e -> new Object[] {
-                        e.address().toArray(),
-                        e.storageKeys().stream().map(Bytes::toArray).toArray()
-                    })
-                    .toArray();
-            accessList = RLPEncoder.sequence(accessListRlp);
+        if (type != EthTransactionType.LEGACY_ETHEREUM) {
+            if (!accessListItems.isEmpty()) {
+                accessListRlp = accessListItems.stream()
+                        .map(e -> new Object[] {
+                            e.address().toArray(),
+                            e.storageKeys().stream().map(Bytes::toArray).toArray()
+                        })
+                        .toArray();
+                accessList = RLPEncoder.sequence(accessListRlp);
+            } else if (accessListRlp != null) {
+                accessList = RLPEncoder.sequence(accessListRlp);
+            }
         }
 
         // encode codeDelegation/authorizationList
@@ -447,7 +462,7 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
         final EthereumTransactionBody ethOpBody = spec.txns()
                 .<EthereumTransactionBody, EthereumTransactionBody.Builder>body(
                         EthereumTransactionBody.class, builder -> {
-                            builder.setEthereumData(ByteString.copyFrom(finalEthTxData.encodeTx()));
+                            builder.setEthereumData(ByteString.copyFrom(ethTxDataEncodeFunction.apply(finalEthTxData)));
                             maxGasAllowance.ifPresent(builder::setMaxGasAllowance);
                             ethFileID.ifPresent(builder::setCallData);
                         });
@@ -484,9 +499,7 @@ public class HapiEthereumCall extends HapiBaseCall<HapiEthereumCall> {
             });
         }
         if (rawResultObserver != null) {
-            doObservedLookup(spec, txnSubmitted, rcd -> {
-                rawResultObserver.accept(rcd.getContractCallResult());
-            });
+            doObservedLookup(spec, txnSubmitted, rcd -> rawResultObserver.accept(rcd.getContractCallResult()));
         }
         if (eventDataObserver != null) {
             doObservedLookup(

--- a/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/AccessListTest.java
+++ b/hedera-node/test-clients/src/main/java/com/hedera/services/bdd/suites/contract/ethereum/AccessListTest.java
@@ -19,6 +19,8 @@ import static com.hedera.services.bdd.suites.HapiSuite.flattened;
 import static com.hedera.services.bdd.suites.utils.MiscEETUtils.genRandomBytes;
 
 import com.esaulpaugh.headlong.abi.Address;
+import com.esaulpaugh.headlong.rlp.RLPEncoder;
+import com.esaulpaugh.headlong.util.Integers;
 import com.hedera.node.app.hapi.utils.ethereum.AccessListItem;
 import com.hedera.node.app.hapi.utils.ethereum.EthTxData;
 import com.hedera.services.bdd.junit.HapiTest;
@@ -30,6 +32,7 @@ import com.hedera.services.bdd.spec.dsl.annotations.Contract;
 import com.hedera.services.bdd.spec.dsl.entities.SpecAccount;
 import com.hedera.services.bdd.spec.dsl.entities.SpecContract;
 import com.hedera.services.bdd.spec.transactions.contract.HapiEthereumCall;
+import com.hederahashgraph.api.proto.java.ResponseCodeEnum;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -116,12 +119,44 @@ public class AccessListTest {
                 .signingWith(SECP_256K1_SOURCE_KEY)
                 .type(type)
                 .withAccessList(accessList)
-                .exposingGasTo((status, gas) -> Assertions.assertEquals(
+                .exposingGasTo((_, gas) -> Assertions.assertEquals(
                         expectedGas.getAsLong(),
                         gas,
                         "Wrong gas for type:%s AccessList:%s".formatted(type, accessList)));
     }
+
+    // build type 1, EIP2930 transaction with accessList from byte[]
+    private static byte[] buildType1RawTransaction(final EthTxData data) {
+        return RLPEncoder.sequence(
+                Integers.toBytes(0x01),
+                List.of(
+                        data.chainId(),
+                        Integers.toBytes(data.nonce()),
+                        data.gasPrice(),
+                        Integers.toBytes(data.gasLimit()),
+                        data.to(),
+                        Integers.toBytesUnsigned(data.value()),
+                        data.callData(),
+                        data.accessList(),
+                        Integers.toBytes(data.recId()),
+                        data.r(),
+                        data.s()));
+    }
     // ------------------------------- /Utils -------------------------------
+
+    @HapiTest
+    final Stream<DynamicTest> rejectsAccessListThatIsNotACanonicalListTest() {
+        return hapiTest(
+                // prepare sender
+                newKeyNamed(SECP_256K1_SOURCE_KEY).shape(SECP_256K1_SHAPE),
+                // send transaction with RLP empty byte-string Access List
+                ethereumCall(callerContract.name(), "call", TARGET_CONTRACT_ADDRESS.get())
+                        .signingWith(SECP_256K1_SOURCE_KEY)
+                        .type(EthTxData.EthTransactionType.EIP2930)
+                        .withAccessList(new byte[0])
+                        .withEthTxDataEncodeFunction(AccessListTest::buildType1RawTransaction)
+                        .hasPrecheck(ResponseCodeEnum.INVALID_ETHEREUM_TRANSACTION));
+    }
 
     @HapiTest
     final Stream<DynamicTest> accessListIntrinsicGasTest() {
@@ -134,7 +169,7 @@ public class AccessListTest {
                 ethereumCall(callerContract.name(), "call", TARGET_CONTRACT_ADDRESS.get())
                         .signingWith(SECP_256K1_SOURCE_KEY)
                         .type(EthTxData.EthTransactionType.LEGACY_ETHEREUM)
-                        .exposingGasTo((status, gas) -> legacyGas.set(gas)),
+                        .exposingGasTo((_, gas) -> legacyGas.set(gas)),
                 // EIP2930/EIP1559 calls with random accessList
                 Stream.of(EthTxData.EthTransactionType.EIP2930, EthTxData.EthTransactionType.EIP1559)
                         .flatMap(type -> Stream.of(
@@ -156,7 +191,7 @@ public class AccessListTest {
                 ethereumCall(callerContract.name(), "call", TARGET_CONTRACT_ADDRESS.get())
                         .signingWith(SECP_256K1_SOURCE_KEY)
                         .type(EthTxData.EthTransactionType.LEGACY_ETHEREUM)
-                        .exposingGasTo((status, gas) -> legacyGas.set(gas)),
+                        .exposingGasTo((_, gas) -> legacyGas.set(gas)),
                 // EIP2930/EIP1559 calls to check the discount
                 Stream.of(EthTxData.EthTransactionType.EIP2930, EthTxData.EthTransactionType.EIP1559)
                         .flatMap(type -> Stream.of(
@@ -206,13 +241,13 @@ public class AccessListTest {
                 ethereumCall(callerContract.name(), "callDelegation")
                         .signingWith(SECP_256K1_SOURCE_KEY)
                         .type(EthTxData.EthTransactionType.EIP2930)
-                        .exposingGasTo((status, gas) -> originalGas.set(gas)),
+                        .exposingGasTo((_, gas) -> originalGas.set(gas)),
                 // -100 for CALL
                 ethereumCall(callerContract.name(), "callDelegation")
                         .signingWith(SECP_256K1_SOURCE_KEY)
                         .type(EthTxData.EthTransactionType.EIP2930)
                         .withAccessList(List.of(new AccessListItem(TARGET_CONTRACT_ADDRESS_BYTES.get(), List.of())))
-                        .exposingGasTo((status, gas) -> Assertions.assertEquals(originalGas.get() - 100, gas)),
+                        .exposingGasTo((_, gas) -> Assertions.assertEquals(originalGas.get() - 100, gas)),
                 // -100 for CALL, +2400 for Address. Using sourcing() because of 'signerAddress.get()'
                 sourcing(() -> ethereumCall(callerContract.name(), "callDelegation")
                         .signingWith(SECP_256K1_SOURCE_KEY)
@@ -220,7 +255,7 @@ public class AccessListTest {
                         .withAccessList(List.of(
                                 new AccessListItem(TARGET_CONTRACT_ADDRESS_BYTES.get(), List.of()),
                                 new AccessListItem(signerAddress.get(), List.of())))
-                        .exposingGasTo((status, gas) -> Assertions.assertEquals(originalGas.get() - 100 + 2400, gas))),
+                        .exposingGasTo((_, gas) -> Assertions.assertEquals(originalGas.get() - 100 + 2400, gas))),
                 // -100 for CALL, +2400 for Address, -100 for SLOAD, -100 for SSTORE. Using sourcing() because of
                 // 'signerAddress.get()'
                 sourcing(() -> ethereumCall(callerContract.name(), "callDelegation")
@@ -229,7 +264,7 @@ public class AccessListTest {
                         .withAccessList(List.of(
                                 new AccessListItem(TARGET_CONTRACT_ADDRESS_BYTES.get(), List.of()),
                                 new AccessListItem(signerAddress.get(), List.of(SLOT_3))))
-                        .exposingGasTo((status, gas) ->
+                        .exposingGasTo((_, gas) ->
                                 Assertions.assertEquals(originalGas.get() - 100 + 2400 - 100 - 100, gas)))));
     }
 }


### PR DESCRIPTION
**Description**:
This PR rejects `EIP-1559`, `EIP-2930`, and `EIP-7702` transactions at parse time (`populateEthTxData` returns null) whenever the `access-list` or `authorization-list` field is not a RLP list. Adds regression tests covering all three transaction types for both the non-empty and canonical-empty-but-wrong-type cases.
