### PR TITLE
ci: update colors for slack mats reports

### DIFF
--- a/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
+++ b/.github/workflows/templates/slack-mats-test-failure-detailed.json.tpl
@@ -1,7 +1,10 @@
+{{- $refName := getenv "REF_NAME" | required "REF_NAME must be set" -}}
+{{- $color := "#FF0000" -}}
+{{- if strings.HasPrefix "release/" $refName -}}{{- $color = "#F08080" -}}{{- end -}}
 {
   "attachments": [
     {
-      "color": "#FF0000",
+      "color": {{ $color | data.ToJSON }},
       "blocks": [
         {
           "type": "header",


### PR DESCRIPTION
**Description**:

Update the Slack report for MATS results to be light red for failures on release branches.

**Related Issue(s)**:

Implements #27242
