### PR TITLE
fix: release late complete states after freezing

### DIFF
--- a/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/nexus/DefaultLatestCompleteStateNexus.java
+++ b/platform-sdk/consensus-state/src/main/java/org/hiero/consensus/state/nexus/DefaultLatestCompleteStateNexus.java
@@ -25,6 +25,7 @@ public class DefaultLatestCompleteStateNexus implements LatestCompleteStateNexus
 
     private final StateConfig stateConfig;
     private ReservedSignedState currentState;
+    private boolean freezePeriodEntered;
 
     /**
      * Create a new nexus that holds the latest complete signed state.
@@ -44,6 +45,12 @@ public class DefaultLatestCompleteStateNexus implements LatestCompleteStateNexus
      */
     @Override
     public synchronized void setState(@Nullable final ReservedSignedState reservedSignedState) {
+        if (freezePeriodEntered) {
+            if (reservedSignedState != null) {
+                reservedSignedState.close();
+            }
+            return;
+        }
         if (currentState != null) {
             currentState.close();
         }
@@ -70,11 +77,11 @@ public class DefaultLatestCompleteStateNexus implements LatestCompleteStateNexus
     public void updatePlatformStatus(@NonNull final PlatformStatus platformStatus) {
         if (PlatformStatus.FREEZING.equals(platformStatus)) {
             synchronized (this) {
-                if (currentState == null) {
-                    return;
+                freezePeriodEntered = true;
+                if (currentState != null) {
+                    currentState.close();
+                    currentState = null;
                 }
-                currentState.close();
-                currentState = null;
             }
         }
     }


### PR DESCRIPTION
## Description

### Problem

FREEZING clears `DefaultLatestCompleteStateNexus`, but a completed signed state selected for periodic saving can arrive afterward and repopulate it. The retained reservation prevents its virtual-map copy from flushing, leaving the async snapshot pending. The synchronous freeze save then waits behind it on the sequential snapshot-manager scheduler.

The original [HAPI restart failure](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/33910545925/job/101147908459?pr=27173) is consistent with this ordering. In the job's **HAPI Test (Restart) Failure Artifacts**, under `build/hapi-test/hapiTestRestart/node0/output/`:

- `swirlds.log:399`: **2026-09-04 19:30:00.416 UTC**, platform enters FREEZING.
- `swirlds.log:414`: **2026-09-04 19:30:00.492 UTC**, the writer requests an async `PERIODIC_SNAPSHOT` for round **617**. It never logs completion, and the `FREEZE_STATE` save for round **618** never starts writing. `swirlds-vmap.log` ends with the preceding successful snapshot.
- `test-clients.log:134`: **2026-09-04 19:33:58.691 UTC**, the four-minute wait for FREEZE_COMPLETE fails.

Those original logs do not record nexus ownership. A local HAPI reproduction captured it directly: a completed signed state for round **188**, marked for a `PERIODIC_SNAPSHOT`, arrived after the nexus was cleared. The nexus retained its reservation, preventing the state's virtual-map copy from flushing. Its async snapshot remained pending and blocked the queued `FREEZE_STATE` save for round **189** until the test timed out. This occurred on all four nodes using one-second saves, one-round blocks, and an ordinary freeze deadline near the save boundary, without delaying state delivery. The failure was intermittent: with identical settings, one run completed successfully and another stalled when the periodic state arrived after the nexus was cleared.

### Change

Remember FREEZING in the nexus and release the existing reservation if present. Close later incoming reservations through both setter paths under the same synchronization, regardless of snapshot mode. Record freezing even when the nexus is initially empty. The change is confined to `DefaultLatestCompleteStateNexus`.

## Related issue(s):
Fixes https://github.com/hiero-ledger/hiero-consensus-node/issues/27227
Follow-up for https://github.com/hiero-ledger/hiero-consensus-node/pull/23455 and https://github.com/hiero-ledger/hiero-consensus-node/pull/23833

