### PR TITLE
feat: integrate HCPQ transaction signatures

### DIFF
--- a/gradle/modules.properties
+++ b/gradle/modules.properties
@@ -5,6 +5,7 @@
 #   https://github.com/gradlex-org/java-module-dependencies/blob/main/src/main/resources/org/gradlex/javamodule/dependencies/modules.properties
 # Consider contributing the missing entry back to the plugin by creating a PR for the 'modules.properties' linked above.
 com.hedera.cryptography.hints=com.hedera.cryptography:hedera-cryptography-hints
+com.hedera.cryptography.hcpq=com.hedera.cryptography:hedera-cryptography-hcpq
 com.hedera.cryptography.wraps=com.hedera.cryptography:hedera-cryptography-wraps
 com.hedera.cryptography.libsodium=com.hedera.cryptography:libsodium
 com.hedera.cryptography.libsecp256k1=com.hedera.cryptography:libsecp256k1

--- a/hapi/hedera-protobuf-java-api/src/main/proto/services/basic_types.proto
+++ b/hapi/hedera-protobuf-java-api/src/main/proto/services/basic_types.proto
@@ -999,10 +999,11 @@ enum TokenPauseStatus {
  * pairs and, optionally, the structure for how multiple signatures may be
  * composed to meet complex multiple-signature authorization requirements.
  *
- * A Key can be a public key from either the Ed25519 or ECDSA(secp256k1)
- * signature schemes. In the ECDSA(secp256k1) case we require the 33-byte
- * compressed form of the public key. For simplicity, we call these
- * cryptographic public keys `primitive` keys.<br/>
+ * A Key can be a public key from the Ed25519, ECDSA(secp256k1), or
+ * ML-DSA-44 signature schemes. In the ECDSA(secp256k1) case we require the
+ * 33-byte compressed form of the public key. In the ML-DSA-44 case we require
+ * the 1312-byte raw FIPS 204 public-key encoding. For simplicity, we call
+ * these cryptographic public keys `primitive` keys.<br/>
  * If an entity has a primitive key associated to it, then the corresponding
  * private key must sign any transaction to send tokens or perform other
  * actions requiring authorization.
@@ -1103,6 +1104,16 @@ message Key {
          * running another contract via a `delegatecall`.
          */
         ContractID delegatable_contract_id = 8;
+
+        /**
+         * A raw FIPS 204 ML-DSA-44 public key.<br/>
+         * This value MUST contain exactly 1312 bytes.
+         * <p>
+         * A transaction signature for this key MUST use the HCPQ v1
+         * ledger-bound transcript and the `ML_DSA_44` field in
+         * `SignaturePair`.
+         */
+        bytes ML_DSA_44 = 9;
     }
 }
 
@@ -1248,7 +1259,7 @@ message SignatureList {
 
 /**
  * A public key and signature pair.<br/>
- * Only Ed25519 and ECDSA(secp256k1) keys and signatures are currently supported
+ * Ed25519, ECDSA(secp256k1), and ML-DSA-44 keys and signatures are supported
  * as cryptographic (non-implied) signatures.
  */
 message SignaturePair {
@@ -1282,6 +1293,11 @@ message SignaturePair {
      * be required to sign a transaction, and ensure that the shortest prefix
      * that is sufficient to unambiguously identify the correct key is used.
      * </dd></dl>
+     * <p>
+     * For an ML-DSA-44 signature this field is not a variable public-key
+     * prefix. It MUST contain the complete 32-byte HCPQ v1 key identifier,
+     * computed as specified by the governing HIP. Shorter values MUST NOT be
+     * accepted for ML-DSA-44.
      */
     bytes pubKeyPrefix = 1;
 
@@ -1314,6 +1330,13 @@ message SignaturePair {
          * An ECDSA(secp256k1) signature.
          */
         bytes ECDSA_secp256k1 = 6;
+
+        /**
+         * A raw FIPS 204 ML-DSA-44 signature over the HCPQ v1 transaction
+         * transcript.<br/>
+         * This value MUST contain exactly 2420 bytes.
+         */
+        bytes ML_DSA_44 = 7;
     }
 }
 

--- a/hedera-node/hapi-fees/src/main/java/org/hiero/hapi/fees/FeeKeyUtils.java
+++ b/hedera-node/hapi-fees/src/main/java/org/hiero/hapi/fees/FeeKeyUtils.java
@@ -18,11 +18,11 @@ public final class FeeKeyUtils {
      * Useful for calculating KEYS extra fees per HIP-1261.
      *
      * @param key The key structure to count
-     * @return The total number of simple keys (ED25519, ECDSA_SECP256K1, ECDSA_384)
+     * @return The total number of simple cryptographic keys
      */
     public static long countKeys(@NonNull final Key key) {
         return switch (key.key().kind()) {
-            case ED25519, ECDSA_SECP256K1, ECDSA_384 -> 1L;
+            case ED25519, ECDSA_SECP256K1, ECDSA_384, ML_DSA_44 -> 1L;
             case THRESHOLD_KEY ->
                 key.thresholdKeyOrThrow().keys().keys().stream()
                         .mapToLong(FeeKeyUtils::countKeys)

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/KeyComparator.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/KeyComparator.java
@@ -42,9 +42,10 @@ public class KeyComparator implements Comparator<Key> {
                 case DELEGATABLE_CONTRACT_ID -> compareDelegateable(first, second);
                 case ED25519 -> compareEdwards(first, second);
                 case ECDSA_SECP256K1 -> compareSecp256k(first, second);
+                case ML_DSA_44 -> compareMlDsa44(first, second);
                 case THRESHOLD_KEY -> compareThreshold(first, second);
                 case KEY_LIST -> compareKeyList(first, second);
-                    // The next two are not currently supported key types.
+                // The next two are not currently supported key types.
                 case RSA_3072 -> compareRsa(first, second);
                 case ECDSA_384 -> compareEcdsa(first, second);
             };
@@ -106,6 +107,10 @@ public class KeyComparator implements Comparator<Key> {
         final Bytes lhs = first.ecdsaSecp256k1();
         final Bytes rhs = second.ecdsaSecp256k1();
         return compareBytes(lhs, rhs);
+    }
+
+    private int compareMlDsa44(final Key first, final Key second) {
+        return compareBytes(first.mlDsa44(), second.mlDsa44());
     }
 
     private int compareThreshold(final Key first, final Key second) {

--- a/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/KeyUtils.java
+++ b/hedera-node/hapi-utils/src/main/java/com/hedera/node/app/hapi/utils/keys/KeyUtils.java
@@ -51,6 +51,9 @@ import org.bouncycastle.util.io.pem.PemReader;
  * Utility class for working with algorithm-agnostic cryptographic keys
  */
 public final class KeyUtils {
+    /** The FIPS 204 ML-DSA-44 public-key length in bytes. */
+    public static final int ML_DSA_44_PUBLIC_KEY_LENGTH = 1312;
+
     public static final Key IMMUTABILITY_SENTINEL_KEY =
             Key.newBuilder().keyList(KeyList.DEFAULT).build();
     public static final String TEST_CLIENTS_PREFIX = "hedera-node" + File.separator + "test-clients" + File.separator;
@@ -260,6 +263,8 @@ public final class KeyUtils {
             return ((Bytes) key.value()).length() == 0;
         } else if (pbjKey.hasEcdsaSecp256k1()) {
             return ((Bytes) key.value()).length() == 0;
+        } else if (pbjKey.hasMlDsa44()) {
+            return ((Bytes) key.value()).length() == 0;
         } else if (pbjKey.hasDelegatableContractId() || pbjKey.hasContractID()) {
             return ((ContractID) key.value()).contractNumOrElse(0L) == 0
                     && ((ContractID) key.value()).evmAddressOrElse(Bytes.EMPTY).length() == 0L;
@@ -301,6 +306,8 @@ public final class KeyUtils {
             return isValidEd25519Key((Bytes) key.value());
         } else if (pbjKey.hasEcdsaSecp256k1()) {
             return isValidEcdsaSecp256k1Key((Bytes) key.value());
+        } else if (pbjKey.hasMlDsa44()) {
+            return ((Bytes) key.value()).length() == ML_DSA_44_PUBLIC_KEY_LENGTH;
         } else if (pbjKey.hasDelegatableContractId() || pbjKey.hasContractID()) {
             return isValidEvmAddress((ContractID) key.value());
         }

--- a/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/key/KeyUtilsTest.java
+++ b/hedera-node/hedera-app-spi/src/test/java/com/hedera/node/app/spi/key/KeyUtilsTest.java
@@ -2,6 +2,7 @@
 package com.hedera.node.app.spi.key;
 
 import static com.hedera.node.app.hapi.utils.keys.Secp256k1Utils.ECDSA_SECP256K1_COMPRESSED_KEY_LENGTH;
+import static com.hedera.node.app.hapi.utils.keys.KeyUtils.ML_DSA_44_PUBLIC_KEY_LENGTH;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -40,6 +41,7 @@ public class KeyUtilsTest {
                 .build()));
         assertTrue(KeyUtils.isEmpty(Key.newBuilder().ed25519(Bytes.EMPTY).build()));
         assertTrue(KeyUtils.isEmpty(Key.newBuilder().ecdsaSecp256k1(Bytes.EMPTY).build()));
+        assertTrue(KeyUtils.isEmpty(Key.newBuilder().mlDsa44(Bytes.EMPTY).build()));
         assertTrue(
                 KeyUtils.isEmpty(Key.newBuilder().contractID(ContractID.DEFAULT).build()));
         assertTrue(KeyUtils.isEmpty(
@@ -69,6 +71,7 @@ public class KeyUtilsTest {
         assertFalse(KeyUtils.isValid(Key.newBuilder().ed25519(Bytes.EMPTY).build()));
         assertFalse(
                 KeyUtils.isValid(Key.newBuilder().ecdsaSecp256k1(Bytes.EMPTY).build()));
+        assertFalse(KeyUtils.isValid(Key.newBuilder().mlDsa44(Bytes.EMPTY).build()));
         assertFalse(
                 KeyUtils.isValid(Key.newBuilder().contractID(ContractID.DEFAULT).build()));
         assertFalse(KeyUtils.isValid(
@@ -112,6 +115,8 @@ public class KeyUtilsTest {
                 Key.newBuilder().ed25519(Bytes.wrap("test".getBytes())).build()));
         assertFalse(KeyUtils.isValid(
                 Key.newBuilder().ecdsaSecp256k1(Bytes.wrap("0x02".getBytes())).build()));
+        assertFalse(KeyUtils.isValid(
+                Key.newBuilder().mlDsa44(Bytes.wrap(new byte[ML_DSA_44_PUBLIC_KEY_LENGTH - 1])).build()));
         assertFalse(KeyUtils.isValid(Key.newBuilder()
                 .contractID(ContractID.newBuilder().contractNum(-1).build())
                 .build()));
@@ -144,6 +149,9 @@ public class KeyUtilsTest {
                 .build()));
         assertTrue(KeyUtils.isValid(Key.newBuilder()
                 .ecdsaSecp256k1(Bytes.wrap(randomValidECDSASecp256K1Key()))
+                .build()));
+        assertTrue(KeyUtils.isValid(Key.newBuilder()
+                .mlDsa44(Bytes.wrap(new byte[ML_DSA_44_PUBLIC_KEY_LENGTH]))
                 .build()));
         assertTrue(KeyUtils.isValid(Key.newBuilder()
                 .contractID(ContractID.newBuilder().contractNum(1).build())

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ServicesConfigExtension.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/config/ServicesConfigExtension.java
@@ -42,6 +42,7 @@ import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.GovernanceTransactionsConfig;
 import com.hedera.node.config.data.GrpcConfig;
 import com.hedera.node.config.data.GrpcUsageTrackerConfig;
+import com.hedera.node.config.data.HcpqConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.HooksConfig;
 import com.hedera.node.config.data.JumboTransactionsConfig;
@@ -104,6 +105,7 @@ public class ServicesConfigExtension implements ConfigurationExtension {
                 FilesConfig.class,
                 GrpcConfig.class,
                 HederaConfig.class,
+                HcpqConfig.class,
                 LedgerConfig.class,
                 NettyConfig.class,
                 NetworkAdminConfig.class,

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/DefaultKeyVerifier.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/DefaultKeyVerifier.java
@@ -68,7 +68,7 @@ public class DefaultKeyVerifier implements AppKeyVerifier {
         requireNonNull(callback, "callback must not be null");
 
         return switch (key.key().kind()) {
-            case ED25519, ECDSA_SECP256K1 -> {
+            case ED25519, ECDSA_SECP256K1, ML_DSA_44 -> {
                 final var result = resolveFuture(keyVerifications.get(key), () -> failedVerification(key));
                 yield callback.test(key, result) ? passedVerification(key) : failedVerification(key);
             }
@@ -152,7 +152,7 @@ public class DefaultKeyVerifier implements AppKeyVerifier {
     @NonNull
     private Future<SignatureVerification> verificationFutureFor(@NonNull final Key key) {
         return switch (key.key().kind()) {
-            case ED25519, ECDSA_SECP256K1 -> {
+            case ED25519, ECDSA_SECP256K1, ML_DSA_44 -> {
                 final var result = keyVerifications.get(key);
                 yield result == null ? completedFuture(failedVerification(key)) : result;
             }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/ExpandedSignaturePair.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/ExpandedSignaturePair.java
@@ -14,13 +14,16 @@ import edu.umd.cs.findbugs.annotations.Nullable;
  * Represents a {@link SignaturePair} where the {@link SignaturePair#pubKeyPrefix()} has been fully "expanded" to a
  * full, uncompressed, public key.
  *
- * @param key The public key, compressed if ECDSA_SECP256K1, or the normal key for ED25519
- * @param keyBytes The key bytes, uncompressed if ECDSA_SECP256K1, or the normal key bytes for ED25519
+ * @param key The public key, compressed if ECDSA_SECP256K1, or the normal key for ED25519 and ML_DSA_44
+ * @param keyBytes The key bytes, uncompressed if ECDSA_SECP256K1, or the normal key bytes for ED25519 and ML_DSA_44
  * @param evmAlias An optional computed evm alias if the key was ECDSA_SECP256K1, and we decided to compute the alias
  * @param sigPair The original signature pair
  */
 public record ExpandedSignaturePair(
-        @NonNull Key key, @NonNull Bytes keyBytes, @Nullable Bytes evmAlias, @NonNull SignaturePair sigPair) {
+        @NonNull Key key,
+        @NonNull Bytes keyBytes,
+        @Nullable Bytes evmAlias,
+        @NonNull SignaturePair sigPair) {
     /**
      * Gets the {@link Bytes} representing the signature signed by the private key matching the fully expanded public
      * key.

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureExpander.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureExpander.java
@@ -11,8 +11,9 @@ import java.util.Set;
  * Expands {@link SignaturePair}s into {@link ExpandedSignaturePair}s.
  *
  * <p>A {@link SignaturePair} is a cryptographic signature and an optional public key prefix. The prefix can be anything
- * from 0 bytes all the way up to the bytes of a full cryptographic public key. Only ED25519 (32 bytes long) and
- * ECDSA_SECP256K1 <strong>compressed</strong> (33 bytes long) public keys are supported.
+ * from 0 bytes all the way up to the bytes of a full cryptographic public key. ED25519 (32 bytes long),
+ * ECDSA_SECP256K1 <strong>compressed</strong> (33 bytes long), and ML_DSA_44 keys are supported. ML_DSA_44 pairs use
+ * an exact 32-byte HCPQ key identifier rather than public-key prefix matching.
  *
  * <p>The job of the {@link SignatureExpander} is to "expand" the prefix of a {@link SignaturePair} to be a full,
  * uncompressed (in the case of ECDSA_SECP256K1), public key. There are two different scenarios it must deal with:
@@ -38,10 +39,10 @@ public interface SignatureExpander {
     void expand(@NonNull List<SignaturePair> sigPairs, @NonNull Set<ExpandedSignaturePair> expanded);
 
     /**
-     * Given a {@link Key}, traverses it looking for each cryptographic key (ED25519, ECDSA_SECP256K1). For each such
-     * cryptographic key, look for a corresponding matching prefix in the {@link SignaturePair}s. If one is found, then
-     * we are guaranteed that it is the only possible match, and a corresponding {@link ExpandedSignaturePair} will be
-     * created.
+     * Given a {@link Key}, traverses it looking for each supported cryptographic key. For each such key, look for a
+     * corresponding matching prefix, or exact HCPQ key identifier for ML_DSA_44, in the {@link SignaturePair}s. If one
+     * is found, then we are guaranteed that it is the only possible match, and a corresponding
+     * {@link ExpandedSignaturePair} will be created.
      *
      * @param key The {@link Key} to traverse looking for cryptographic keys, used to find matching
      *            {@link SignaturePair}s

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureVerifier.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/SignatureVerifier.java
@@ -30,6 +30,18 @@ public interface SignatureVerifier {
     }
 
     /**
+     * Verifies transaction signatures with the immutable ledger identifier required by HCPQ.
+     * Classical signatures retain their existing behavior.
+     */
+    @NonNull
+    default Map<Key, SignatureVerificationFuture> verify(
+            @NonNull final Bytes signedBytes,
+            @NonNull final Set<ExpandedSignaturePair> sigPairs,
+            @NonNull final Bytes ledgerId) {
+        return verify(signedBytes, sigPairs, RAW, ledgerId);
+    }
+
+    /**
      * Asynchronously verifies that the given {@code sigPairs} match the given {@code signedBytes}.
      *
      * @param signedBytes The signed bytes to verify
@@ -40,4 +52,17 @@ public interface SignatureVerifier {
     @NonNull
     Map<Key, SignatureVerificationFuture> verify(
             @NonNull Bytes signedBytes, @NonNull Set<ExpandedSignaturePair> sigPairs, @NonNull MessageType messageType);
+
+    /**
+     * Verifies signatures with a ledger domain. Implementations that do not support ledger-bound
+     * signatures may retain the legacy behavior.
+     */
+    @NonNull
+    default Map<Key, SignatureVerificationFuture> verify(
+            @NonNull final Bytes signedBytes,
+            @NonNull final Set<ExpandedSignaturePair> sigPairs,
+            @NonNull final MessageType messageType,
+            @NonNull final Bytes ledgerId) {
+        return verify(signedBytes, sigPairs, messageType);
+    }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/ImmediateSignatureVerificationFuture.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/ImmediateSignatureVerificationFuture.java
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.signature.impl;
+
+import static java.util.Objects.requireNonNull;
+
+import com.hedera.hapi.node.base.Key;
+import com.hedera.node.app.signature.SignatureVerificationFuture;
+import com.hedera.node.app.spi.signatures.SignatureVerification;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import edu.umd.cs.findbugs.annotations.NonNull;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.util.concurrent.TimeUnit;
+
+/** A completed signature-verification future for synchronous algorithms. */
+final class ImmediateSignatureVerificationFuture implements SignatureVerificationFuture {
+    private final Key key;
+    private final boolean passed;
+
+    ImmediateSignatureVerificationFuture(@NonNull final Key key, final boolean passed) {
+        this.key = requireNonNull(key);
+        this.passed = passed;
+    }
+
+    @Override
+    public @Nullable Bytes evmAlias() {
+        return null;
+    }
+
+    @Override
+    public @NonNull Key key() {
+        return key;
+    }
+
+    @Override
+    public boolean cancel(final boolean mayInterruptIfRunning) {
+        return false;
+    }
+
+    @Override
+    public boolean isCancelled() {
+        return false;
+    }
+
+    @Override
+    public boolean isDone() {
+        return true;
+    }
+
+    @Override
+    public @NonNull SignatureVerification get() {
+        return new SignatureVerificationImpl(key, null, passed);
+    }
+
+    @Override
+    public @NonNull SignatureVerification get(final long timeout, @NonNull final TimeUnit unit) {
+        requireNonNull(unit);
+        return get();
+    }
+}

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureExpanderImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureExpanderImpl.java
@@ -5,6 +5,7 @@ import static com.hedera.hapi.node.base.SignaturePair.SignatureOneOfType.ECDSA_S
 import static com.hedera.hapi.node.base.SignaturePair.SignatureOneOfType.ED25519;
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.cryptography.hcpq.Hcpq;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.hapi.node.base.Key.KeyOneOfType;
 import com.hedera.hapi.node.base.KeyList;
@@ -16,6 +17,7 @@ import com.hedera.node.app.signature.SignatureExpander;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
+import java.security.MessageDigest;
 import java.util.List;
 import java.util.Set;
 import javax.inject.Inject;
@@ -29,6 +31,8 @@ public final class SignatureExpanderImpl implements SignatureExpander {
     private static final int ED25519_KEY_LENGTH = 32;
     /** All ECDSA_SECP256K1 keys have a COMPRESSED length of 33 bytes */
     private static final int ECDSA_COMPRESSED_KEY_LENGTH = 33;
+    /** HCPQ identifiers are always the complete 32-byte digest. */
+    private static final int HCPQ_KEY_ID_LENGTH = Hcpq.KEY_ID_LENGTH;
 
     @Inject
     public SignatureExpanderImpl() {
@@ -96,16 +100,16 @@ public final class SignatureExpanderImpl implements SignatureExpander {
 
         // The key may be of some arbitrary depth and complexity, so we need to recursively expand it.
         switch (key.key().kind()) {
-                // If the key is an ED25519 cryptographic key, then we simply iterate through the list of signature
-                // pairs and find the one that matches the key.
+            // If the key is an ED25519 cryptographic key, then we simply iterate through the list of signature
+            // pairs and find the one that matches the key.
             case ED25519 -> {
                 final var match = findMatch(key, originals);
                 if (match != null) {
                     expanded.add(new ExpandedSignaturePair(key, key.ed25519OrThrow(), null, match));
                 }
             }
-                // If the key is an ECDSA_SECP256K1 cryptographic key, then we simply iterate through the list of
-                // signature pairs and find the one that matches the key, **and then decompress it**.
+            // If the key is an ECDSA_SECP256K1 cryptographic key, then we simply iterate through the list of
+            // signature pairs and find the one that matches the key, **and then decompress it**.
             case ECDSA_SECP256K1 -> {
                 final var match = findMatch(key, originals);
                 if (match != null) {
@@ -116,15 +120,22 @@ public final class SignatureExpanderImpl implements SignatureExpander {
                     }
                 }
             }
-                // If the key is a key list, then we need to recursively expand each key in the list.
+            case ML_DSA_44 -> {
+                final var match = findMatch(key, originals);
+                if (match != null) {
+                    expanded.add(new ExpandedSignaturePair(key, key.mlDsa44OrThrow(), null, match));
+                }
+            }
+            // If the key is a key list, then we need to recursively expand each key in the list.
             case KEY_LIST -> key.keyListOrElse(KeyList.DEFAULT).keys().forEach(k -> expand(k, originals, expanded));
-                // If the key is a threshold key, then we need to recursively expand each key in the threshold key's
-                // list. At this point in the process we don't care whether we have enough keys for the threshold or
-                // not, we just expand whatever we find.
-            case THRESHOLD_KEY -> key.thresholdKeyOrElse(ThresholdKey.DEFAULT)
-                    .keysOrElse(KeyList.DEFAULT)
-                    .keys()
-                    .forEach(k -> expand(k, originals, expanded));
+            // If the key is a threshold key, then we need to recursively expand each key in the threshold key's
+            // list. At this point in the process we don't care whether we have enough keys for the threshold or
+            // not, we just expand whatever we find.
+            case THRESHOLD_KEY ->
+                key.thresholdKeyOrElse(ThresholdKey.DEFAULT)
+                        .keysOrElse(KeyList.DEFAULT)
+                        .keys()
+                        .forEach(k -> expand(k, originals, expanded));
             case ECDSA_384, RSA_3072, CONTRACT_ID, DELEGATABLE_CONTRACT_ID, UNSET -> {
                 // We don't support these, so we won't expand them
             }
@@ -198,6 +209,17 @@ public final class SignatureExpanderImpl implements SignatureExpander {
                         return pair;
                     }
                 }
+                case ML_DSA_44 -> {
+                    final var matchingKeyType = key.key().kind() == KeyOneOfType.ML_DSA_44;
+                    if (matchingKeyType
+                            && key.mlDsa44OrThrow().length() == Hcpq.PUBLIC_KEY_LENGTH
+                            && prefix.length() == HCPQ_KEY_ID_LENGTH) {
+                        final var keyId = Hcpq.keyId(key.mlDsa44OrThrow().toByteArray());
+                        if (MessageDigest.isEqual(keyId, prefix.toByteArray())) {
+                            return pair;
+                        }
+                    }
+                }
                 case CONTRACT, ECDSA_384, RSA_3072, UNSET -> {
                     // Skip these signature types. They never match.
                 }
@@ -217,11 +239,11 @@ public final class SignatureExpanderImpl implements SignatureExpander {
     public static Key asKey(@NonNull final SignaturePair pair) {
         return switch (pair.signature().kind()) {
             case ED25519 -> Key.newBuilder().ed25519(pair.pubKeyPrefix()).build();
-            case ECDSA_SECP256K1 -> Key.newBuilder()
-                    .ecdsaSecp256k1(pair.pubKeyPrefix())
-                    .build();
-            case RSA_3072, ECDSA_384, CONTRACT, UNSET -> throw new IllegalArgumentException(
-                    "Unsupported cryptographic key: " + pair.signature().kind());
+            case ECDSA_SECP256K1 ->
+                Key.newBuilder().ecdsaSecp256k1(pair.pubKeyPrefix()).build();
+            case RSA_3072, ECDSA_384, ML_DSA_44, CONTRACT, UNSET ->
+                throw new IllegalArgumentException(
+                        "Unsupported cryptographic key: " + pair.signature().kind());
         };
     }
 }

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerifierImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/signature/impl/SignatureVerifierImpl.java
@@ -3,10 +3,12 @@ package com.hedera.node.app.signature.impl;
 
 import static com.hedera.hapi.node.base.SignaturePair.SignatureOneOfType.ECDSA_SECP256K1;
 import static com.hedera.hapi.node.base.SignaturePair.SignatureOneOfType.ED25519;
+import static com.hedera.hapi.node.base.SignaturePair.SignatureOneOfType.ML_DSA_44;
 import static com.hedera.node.app.spi.signatures.SignatureVerifier.MessageType.KECCAK_256_HASH;
 import static com.hedera.node.app.spi.signatures.SignatureVerifier.MessageType.RAW;
 import static java.util.Objects.requireNonNull;
 
+import com.hedera.cryptography.hcpq.Hcpq;
 import com.hedera.hapi.node.base.Key;
 import com.hedera.node.app.hapi.utils.MiscCryptoUtils;
 import com.hedera.node.app.signature.ExpandedSignaturePair;
@@ -52,9 +54,20 @@ public final class SignatureVerifierImpl implements SignatureVerifier {
             @NonNull final Bytes signedBytes,
             @NonNull final Set<ExpandedSignaturePair> sigs,
             @NonNull final MessageType messageType) {
+        return verify(signedBytes, sigs, messageType, Bytes.EMPTY);
+    }
+
+    @NonNull
+    @Override
+    public Map<Key, SignatureVerificationFuture> verify(
+            @NonNull final Bytes signedBytes,
+            @NonNull final Set<ExpandedSignaturePair> sigs,
+            @NonNull final MessageType messageType,
+            @NonNull final Bytes ledgerId) {
         requireNonNull(signedBytes);
         requireNonNull(sigs);
         requireNonNull(messageType);
+        requireNonNull(ledgerId);
         if (messageType == KECCAK_256_HASH && signedBytes.length() != 32) {
             throw new IllegalArgumentException(
                     "Message type " + KECCAK_256_HASH + " must be 32 bytes long, got '" + signedBytes.toHex() + "'");
@@ -63,8 +76,19 @@ public final class SignatureVerifierImpl implements SignatureVerifier {
         // Gather each TransactionSignature to send to the platform and the resulting SignatureVerificationFutures
         final var futures = HashMap.<Key, SignatureVerificationFuture>newHashMap(sigs.size());
         for (ExpandedSignaturePair sigPair : sigs) {
-            final TransactionSignature txSig;
             final var kind = sigPair.sigPair().signature().kind();
+            if (kind == ML_DSA_44) {
+                final var passed = Hcpq.verifyTransaction(
+                        ledgerId.toByteArray(),
+                        signedBytes.toByteArray(),
+                        sigPair.keyBytes().toByteArray(),
+                        sigPair.sigPair().pubKeyPrefix().toByteArray(),
+                        sigPair.signature().toByteArray());
+                futures.put(sigPair.key(), new ImmediateSignatureVerificationFuture(sigPair.key(), passed));
+                continue;
+            }
+
+            final TransactionSignature txSig;
             if (kind == ECDSA_SECP256K1) {
                 Bytes message = signedBytes;
                 if (messageType == RAW) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/TransactionChecker.java
@@ -6,12 +6,14 @@ import static com.hedera.hapi.node.base.HederaFunctionality.HINTS_PREPROCESSING_
 import static com.hedera.hapi.node.base.HederaFunctionality.HISTORY_PROOF_VOTE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SERIALIZED_TX_MESSAGE_HASH_ALGORITHM;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_DURATION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_START;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_PREFIX_MISMATCH;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PAYER_ACCOUNT_NOT_FOUND;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_EXPIRED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_HAS_UNKNOWN_FIELDS;
@@ -41,6 +43,7 @@ import com.hedera.node.app.spi.workflows.PreCheckException;
 import com.hedera.node.app.workflows.prehandle.DueDiligenceException;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.data.GovernanceTransactionsConfig;
+import com.hedera.node.config.data.HcpqConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.JumboTransactionsConfig;
 import com.hedera.pbj.runtime.Codec;
@@ -685,11 +688,13 @@ public class TransactionChecker {
             throws PreCheckException {
         validateTruePreCheck(signedTx.hasSigMap(), INVALID_TRANSACTION_BODY);
         final var signatureMap = signedTx.sigMapOrThrow();
+        checkHcpqPolicy(signatureMap.sigPair());
         final var txBody = parseStrict(
                 signedTx.bodyBytes().toReadableSequentialData(),
                 TransactionBody.PROTOBUF,
                 INVALID_TRANSACTION_BODY,
                 maxSize);
+        validateTruePreCheck(hasCanonicalHcpqBody(signedTx, txBody), INVALID_TRANSACTION_BODY);
         final HederaFunctionality functionality;
         try {
             functionality = HapiUtils.functionOf(txBody);
@@ -706,6 +711,41 @@ public class TransactionChecker {
         }
         return checkParsed(new TransactionInfo(
                 signedTx, txBody, signatureMap, signedTx.bodyBytes(), functionality, serializedSignedTx));
+    }
+
+    /**
+     * HCPQ signatures deliberately reject all alternate protobuf encodings. This rule is scoped
+     * to the new signature type so existing Ed25519/ECDSA transactions retain their historical
+     * wire compatibility.
+     */
+    @VisibleForTesting
+    static boolean hasCanonicalHcpqBody(
+            @NonNull final SignedTransaction signedTx, @NonNull final TransactionBody parsedBody) {
+        final var hasHcpqSignature =
+                signedTx.sigMapOrElse(com.hedera.hapi.node.base.SignatureMap.DEFAULT).sigPair().stream()
+                        .anyMatch(SignaturePair::hasMlDsa44);
+        return !hasHcpqSignature || signedTx.bodyBytes().equals(TransactionBody.PROTOBUF.toBytes(parsedBody));
+    }
+
+    /** Enforces the default-off activation gate and bounded pre-consensus verification work. */
+    @VisibleForTesting
+    void checkHcpqPolicy(@NonNull final List<SignaturePair> signaturePairs) throws PreCheckException {
+        final var hcpqPairs =
+                signaturePairs.stream().filter(SignaturePair::hasMlDsa44).toList();
+        if (hcpqPairs.isEmpty()) {
+            return;
+        }
+        final var config = configProvider.getConfiguration().getConfigData(HcpqConfig.class);
+        validateTruePreCheck(config.enabled(), NOT_SUPPORTED);
+        validateTruePreCheck(
+                config.maxSignaturesPerTransaction() > 0 && hcpqPairs.size() <= config.maxSignaturesPerTransaction(),
+                INVALID_SIGNATURE);
+        for (final var pair : hcpqPairs) {
+            validateTruePreCheck(
+                    pair.pubKeyPrefix().length() == com.hedera.cryptography.hcpq.Hcpq.KEY_ID_LENGTH
+                            && pair.mlDsa44OrThrow().length() == com.hedera.cryptography.hcpq.Hcpq.SIGNATURE_LENGTH,
+                    INVALID_SIGNATURE);
+        }
     }
 
     /**

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/AttributeValidatorImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/handle/validation/AttributeValidatorImpl.java
@@ -7,6 +7,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_EXPIRATION_TIME
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_RENEWAL_PERIOD;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MEMO_TOO_LONG;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.node.app.hapi.utils.keys.KeyUtils.isValid;
 import static com.hedera.node.app.spi.validation.ExpiryMeta.NA;
 import static com.hedera.node.app.spi.workflows.HandleException.validateTrue;
@@ -18,6 +19,7 @@ import com.hedera.node.app.spi.validation.AttributeValidator;
 import com.hedera.node.app.spi.workflows.HandleContext;
 import com.hedera.node.app.spi.workflows.HandleException;
 import com.hedera.node.config.data.EntitiesConfig;
+import com.hedera.node.config.data.HcpqConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.LedgerConfig;
 import edu.umd.cs.findbugs.annotations.NonNull;
@@ -126,6 +128,10 @@ public class AttributeValidatorImpl implements AttributeValidator {
     private void validateSimple(@NonNull final Key key) {
         if (key.key().kind() == Key.KeyOneOfType.UNSET) {
             throw new HandleException(BAD_ENCODING);
+        }
+        if (key.hasMlDsa44()
+                && !context.configuration().getConfigData(HcpqConfig.class).enabled()) {
+            throw new HandleException(NOT_SUPPORTED);
         }
     }
 

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/ingest/IngestChecker.java
@@ -73,6 +73,7 @@ import com.hedera.node.app.workflows.dispatcher.TransactionDispatcher;
 import com.hedera.node.app.workflows.purechecks.PureChecksContextImpl;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.HooksConfig;
+import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.node.config.data.NetworkAdminConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import com.swirlds.config.api.Configuration;
@@ -570,7 +571,8 @@ public final class IngestChecker {
         }
 
         // Verify the signatures
-        final var results = signatureVerifier.verify(txInfo.signedBytes(), expandedSigs);
+        final var ledgerId = configuration.getConfigData(LedgerConfig.class).id();
+        final var results = signatureVerifier.verify(txInfo.signedBytes(), expandedSigs, ledgerId);
         final var verifier = new DefaultKeyVerifier(hederaConfig, results);
         final SignatureVerification keyVerification;
         if (!isHollow(account)) {

--- a/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
+++ b/hedera-node/hedera-app/src/main/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImpl.java
@@ -39,6 +39,7 @@ import com.hedera.node.app.workflows.purechecks.PureChecksContextImpl;
 import com.hedera.node.config.ConfigProvider;
 import com.hedera.node.config.VersionedConfiguration;
 import com.hedera.node.config.data.HederaConfig;
+import com.hedera.node.config.data.LedgerConfig;
 import com.hedera.pbj.runtime.io.buffer.Bytes;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import edu.umd.cs.findbugs.annotations.Nullable;
@@ -411,7 +412,11 @@ public class PreHandleWorkflowImpl implements PreHandleWorkflow {
             signatureExpander.expand(context.requiredNonPayerKeys(), originals, expanded);
             signatureExpander.expand(context.optionalNonPayerKeys(), originals, expanded);
         }
-        return signatureVerifier.verify(txInfo.signedBytes(), expanded);
+        final var ledgerId = configProvider
+                .getConfiguration()
+                .getConfigData(LedgerConfig.class)
+                .id();
+        return signatureVerifier.verify(txInfo.signedBytes(), expanded, ledgerId);
     }
 
     private boolean wasComputedWithCurrentNodeConfiguration(@Nullable PreHandleResult previousResult) {

--- a/hedera-node/hedera-app/src/main/java/module-info.java
+++ b/hedera-node/hedera-app/src/main/java/module-info.java
@@ -108,6 +108,7 @@ module com.hedera.node.app {
     requires transitive org.apache.logging.log4j;
     requires transitive org.hyperledger.besu.datatypes;
     requires transitive org.hyperledger.besu.evm;
+    requires com.hedera.cryptography.hcpq;
     requires com.hedera.node.app.service.addressbook;
     requires com.hedera.node.app.service.consensus;
     requires com.hedera.node.app.service.contract;

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/HcpqSignatureIntegrationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/signature/impl/HcpqSignatureIntegrationTest.java
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.signature.impl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.hedera.cryptography.hcpq.Hcpq;
+import com.hedera.hapi.node.base.Key;
+import com.hedera.hapi.node.base.SignaturePair;
+import com.hedera.node.app.signature.DefaultKeyVerifier;
+import com.hedera.node.app.signature.ExpandedSignaturePair;
+import com.hedera.node.config.data.HederaConfig;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.security.SecureRandom;
+import java.util.HashSet;
+import java.util.List;
+import org.hiero.base.crypto.Cryptography;
+import org.junit.jupiter.api.Test;
+
+class HcpqSignatureIntegrationTest {
+    private static final Bytes LEDGER_ID = Bytes.wrap(new byte[] {0x00});
+    private static final Bytes BODY = Bytes.wrap(new byte[] {0x0a, 0x01, 0x01});
+
+    @Test
+    void expandsAndVerifiesAnHcpqSignature() throws Exception {
+        final var random = new SecureRandom();
+        final var keyPair = Hcpq.generateKeyPair(random);
+        final var publicKey = Hcpq.rawPublicKey(keyPair);
+        final var keyId = Hcpq.keyId(publicKey);
+        final var signature =
+                Hcpq.signTransaction(LEDGER_ID.toByteArray(), BODY.toByteArray(), keyPair.getPrivate(), random);
+        final var key = Key.newBuilder().mlDsa44(Bytes.wrap(publicKey)).build();
+        final var signaturePair = SignaturePair.newBuilder()
+                .pubKeyPrefix(Bytes.wrap(keyId))
+                .mlDsa44(Bytes.wrap(signature))
+                .build();
+
+        final var expanded = new HashSet<ExpandedSignaturePair>();
+        new SignatureExpanderImpl().expand(key, List.of(signaturePair), expanded);
+
+        assertThat(expanded).hasSize(1);
+        final var results = new SignatureVerifierImpl(mock(Cryptography.class)).verify(BODY, expanded, LEDGER_ID);
+        assertThat(results.get(key).get().passed()).isTrue();
+        assertThat(new DefaultKeyVerifier(mock(HederaConfig.class), results)
+                        .verificationFor(key)
+                        .passed())
+                .isTrue();
+        assertThat(new SignatureVerifierImpl(mock(Cryptography.class))
+                        .verify(BODY, expanded)
+                        .get(key)
+                        .get()
+                        .failed())
+                .isTrue();
+    }
+
+    @Test
+    void rejectsWrongLedgerAndShortKeyIdentifier() throws Exception {
+        final var random = new SecureRandom();
+        final var keyPair = Hcpq.generateKeyPair(random);
+        final var publicKey = Hcpq.rawPublicKey(keyPair);
+        final var keyId = Hcpq.keyId(publicKey);
+        final var signature =
+                Hcpq.signTransaction(LEDGER_ID.toByteArray(), BODY.toByteArray(), keyPair.getPrivate(), random);
+        final var key = Key.newBuilder().mlDsa44(Bytes.wrap(publicKey)).build();
+        final var validPair = SignaturePair.newBuilder()
+                .pubKeyPrefix(Bytes.wrap(keyId))
+                .mlDsa44(Bytes.wrap(signature))
+                .build();
+        final var expanded = new HashSet<ExpandedSignaturePair>();
+        new SignatureExpanderImpl().expand(key, List.of(validPair), expanded);
+
+        final var results = new SignatureVerifierImpl(mock(Cryptography.class))
+                .verify(BODY, expanded, Bytes.wrap(new byte[] {0x01}));
+        assertThat(results.get(key).get().failed()).isTrue();
+
+        final var shortIdPair = validPair
+                .copyBuilder()
+                .pubKeyPrefix(Bytes.wrap(java.util.Arrays.copyOf(keyId, keyId.length - 1)))
+                .build();
+        expanded.clear();
+        new SignatureExpanderImpl().expand(key, List.of(shortIdPair), expanded);
+        assertThat(expanded).isEmpty();
+
+        final var malformedKey =
+                Key.newBuilder().mlDsa44(Bytes.wrap(new byte[1311])).build();
+        new SignatureExpanderImpl().expand(malformedKey, List.of(validPair), expanded);
+        assertThat(expanded).isEmpty();
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/test/signatures/SignatureVerificationTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/test/signatures/SignatureVerificationTest.java
@@ -454,7 +454,7 @@ class SignatureVerificationTest implements Scenarios {
                                     .collect(Collectors.joining(", "))
                             + ")";
                 }
-                case CONTRACT_ID, DELEGATABLE_CONTRACT_ID, ECDSA_384, RSA_3072, UNSET ->
+                case CONTRACT_ID, DELEGATABLE_CONTRACT_ID, ECDSA_384, RSA_3072, ML_DSA_44, UNSET ->
                     throw new IllegalArgumentException(
                             "Unsupported key type: " + key.key().kind());
             };

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/HcpqCanonicalTransactionTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/HcpqCanonicalTransactionTest.java
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.app.workflows;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.hedera.hapi.node.base.SignatureMap;
+import com.hedera.hapi.node.base.SignaturePair;
+import com.hedera.hapi.node.transaction.SignedTransaction;
+import com.hedera.hapi.node.transaction.TransactionBody;
+import com.hedera.pbj.runtime.io.buffer.Bytes;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+
+class HcpqCanonicalTransactionTest {
+    private static final SignaturePair HCPQ_SIGNATURE = SignaturePair.newBuilder()
+            .pubKeyPrefix(Bytes.wrap(new byte[32]))
+            .mlDsa44(Bytes.wrap(new byte[2420]))
+            .build();
+
+    @Test
+    void requiresExactPbjEncodingOnlyForHcpq() {
+        final var body = TransactionBody.DEFAULT;
+        final var canonical = TransactionBody.PROTOBUF.toBytes(body);
+        final var canonicalSigned = new SignedTransaction(
+                canonical, SignatureMap.newBuilder().sigPair(HCPQ_SIGNATURE).build(), false);
+        assertThat(TransactionChecker.hasCanonicalHcpqBody(canonicalSigned, body))
+                .isTrue();
+
+        final var alternate = Arrays.copyOf(canonical.toByteArray(), Math.toIntExact(canonical.length()) + 2);
+        // An explicitly encoded empty memo is semantically the default but not canonical PBJ output.
+        alternate[alternate.length - 2] = 0x32;
+        alternate[alternate.length - 1] = 0x00;
+        final var alternateHcpq =
+                canonicalSigned.copyBuilder().bodyBytes(Bytes.wrap(alternate)).build();
+        assertThat(TransactionChecker.hasCanonicalHcpqBody(alternateHcpq, body)).isFalse();
+
+        final var classical = alternateHcpq
+                .copyBuilder()
+                .sigMap(SignatureMap.newBuilder()
+                        .sigPair(SignaturePair.newBuilder()
+                                .pubKeyPrefix(Bytes.EMPTY)
+                                .ed25519(Bytes.wrap(new byte[64]))
+                                .build())
+                        .build())
+                .build();
+        assertThat(TransactionChecker.hasCanonicalHcpqBody(classical, body)).isTrue();
+    }
+}

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/TransactionCheckerTest.java
@@ -4,12 +4,14 @@ package com.hedera.node.app.workflows;
 import static com.hedera.hapi.node.base.HederaFunctionality.CONSENSUS_CREATE_TOPIC;
 import static com.hedera.hapi.node.base.HederaFunctionality.CRYPTO_TRANSFER;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INSUFFICIENT_TX_FEE;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_SIGNATURE;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_BODY;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_DURATION;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_ID;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_TRANSACTION_START;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.KEY_PREFIX_MISMATCH;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.PAYER_ACCOUNT_NOT_FOUND;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_EXPIRED;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.TRANSACTION_HAS_UNKNOWN_FIELDS;
@@ -174,6 +176,50 @@ final class TransactionCheckerTest extends AppTestBase {
 
         // And create the checker itself
         checker = new TransactionChecker(props, metrics);
+    }
+
+    @Test
+    void hcpqIsDisabledByDefault() {
+        assertThatThrownBy(() -> checker.checkHcpqPolicy(List.of(hcpqPair(32, 2420))))
+                .isInstanceOf(PreCheckException.class)
+                .has(responseCode(NOT_SUPPORTED));
+    }
+
+    @Test
+    void hcpqRejectsMalformedWireSizesAndExcessSignatures() {
+        enableHcpq(1);
+        assertThatThrownBy(() -> checker.checkHcpqPolicy(List.of(hcpqPair(31, 2420))))
+                .isInstanceOf(PreCheckException.class)
+                .has(responseCode(INVALID_SIGNATURE));
+        assertThatThrownBy(() -> checker.checkHcpqPolicy(List.of(hcpqPair(32, 2419))))
+                .isInstanceOf(PreCheckException.class)
+                .has(responseCode(INVALID_SIGNATURE));
+        assertThatThrownBy(() -> checker.checkHcpqPolicy(List.of(hcpqPair(32, 2420), hcpqPair(32, 2420))))
+                .isInstanceOf(PreCheckException.class)
+                .has(responseCode(INVALID_SIGNATURE));
+    }
+
+    @Test
+    void hcpqAcceptsOneWellFormedSignatureWhenEnabled() {
+        enableHcpq(1);
+        assertThatNoException().isThrownBy(() -> checker.checkHcpqPolicy(List.of(hcpqPair(32, 2420))));
+    }
+
+    private void enableHcpq(final int maxSignatures) {
+        props = () -> new VersionedConfigImpl(
+                HederaTestConfigBuilder.create()
+                        .withValue("hcpq.enabled", true)
+                        .withValue("hcpq.maxSignaturesPerTransaction", maxSignatures)
+                        .getOrCreateConfig(),
+                1);
+        checker = new TransactionChecker(props, metrics);
+    }
+
+    private static SignaturePair hcpqPair(final int keyIdLength, final int signatureLength) {
+        return SignaturePair.newBuilder()
+                .pubKeyPrefix(Bytes.wrap(new byte[keyIdLength]))
+                .mlDsa44(Bytes.wrap(new byte[signatureLength]))
+                .build();
     }
 
     @Nested

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/AttributeValidatorImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/handle/validation/AttributeValidatorImplTest.java
@@ -6,6 +6,7 @@ import static com.hedera.hapi.node.base.ResponseCodeEnum.BAD_ENCODING;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_EXPIRATION_TIME;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.INVALID_ZERO_BYTE_IN_STRING;
 import static com.hedera.hapi.node.base.ResponseCodeEnum.MEMO_TOO_LONG;
+import static com.hedera.hapi.node.base.ResponseCodeEnum.NOT_SUPPORTED;
 import static com.hedera.node.app.spi.fixtures.workflows.ExceptionConditions.responseCode;
 import static com.hedera.node.app.spi.validation.AttributeValidator.MAX_NESTED_KEY_LEVELS;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -135,6 +136,30 @@ class AttributeValidatorImplTest {
         assertThatThrownBy(() -> subject.validateKey(Key.DEFAULT))
                 .isInstanceOf(HandleException.class)
                 .has(responseCode(BAD_ENCODING));
+    }
+
+    @Test
+    void rejectsHcpqKeysAtAnyDepthWhileDisabled() {
+        final var hcpq = Key.newBuilder().mlDsa44(Bytes.wrap(new byte[1312])).build();
+        final var nested =
+                Key.newBuilder().keyList(KeyList.newBuilder().keys(hcpq)).build();
+
+        assertThatThrownBy(() -> subject.validateKey(hcpq))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(NOT_SUPPORTED));
+        assertThatThrownBy(() -> subject.validateKey(nested))
+                .isInstanceOf(HandleException.class)
+                .has(responseCode(NOT_SUPPORTED));
+    }
+
+    @Test
+    void acceptsHcpqKeyWhenEnabled() {
+        final var config =
+                HederaTestConfigBuilder.create().withValue("hcpq.enabled", true).getOrCreateConfig();
+        given(context.configuration()).willReturn(config);
+        final var hcpq = Key.newBuilder().mlDsa44(Bytes.wrap(new byte[1312])).build();
+
+        assertThatCode(() -> subject.validateKey(hcpq)).doesNotThrowAnyException();
     }
 
     private static Key.Builder nestKeys(final Key.Builder builder, final int additionalLevels) {

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/ingest/IngestCheckerTest.java
@@ -303,7 +303,7 @@ class IngestCheckerTest extends AppTestBase {
         final var verificationResult = mock(SignatureVerification.class);
         when(verificationResult.failed()).thenReturn(false);
         when(verificationResultFuture.get(anyLong(), any())).thenReturn(verificationResult);
-        when(signatureVerifier.verify(any(), any()))
+        when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                 .thenReturn(Map.of(ALICE.account().keyOrThrow(), verificationResultFuture));
 
         // when
@@ -563,7 +563,7 @@ class IngestCheckerTest extends AppTestBase {
             final var verificationResult = mock(SignatureVerification.class);
             when(verificationResult.failed()).thenReturn(false);
             when(verificationResultFuture.get(anyLong(), any())).thenReturn(verificationResult);
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(ALICE.account().keyOrThrow(), verificationResultFuture));
 
             // When the transaction is checked with the feature enabled, it should pass
@@ -694,7 +694,7 @@ class IngestCheckerTest extends AppTestBase {
             final var verificationResult = mock(SignatureVerification.class);
             when(verificationResult.failed()).thenReturn(false);
             when(verificationResultFuture.get(anyLong(), any())).thenReturn(verificationResult);
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(ALICE.account().keyOrThrow(), verificationResultFuture));
         }
     }
@@ -708,7 +708,7 @@ class IngestCheckerTest extends AppTestBase {
         void noPayerSignature() {
             // If the signature verifier's returned map doesn't contain an entry for ALICE, it means she didn't have a
             // signature in the signature map to begin with.
-            when(signatureVerifier.verify(any(), any())).thenReturn(Map.of());
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class))).thenReturn(Map.of());
 
             // When the transaction is submitted, then the exception is thrown
             assertThatThrownBy(
@@ -725,7 +725,7 @@ class IngestCheckerTest extends AppTestBase {
             final var verificationResult = mock(SignatureVerification.class);
             when(verificationResult.failed()).thenReturn(true);
             when(verificationResultFuture.get(anyLong(), any())).thenReturn(verificationResult);
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(ALICE.account().keyOrThrow(), verificationResultFuture));
 
             assertThatThrownBy(
@@ -773,7 +773,7 @@ class IngestCheckerTest extends AppTestBase {
             final var verificationResultBob = mock(SignatureVerification.class);
             when(verificationResultBob.failed()).thenReturn(false);
             when(verificationResultFutureBob.get(anyLong(), any())).thenReturn(verificationResultBob);
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(
                             ALICE.account().keyOrThrow(), verificationResultFutureAlice,
                             BOB.account().keyOrThrow(), verificationResultFutureBob));
@@ -829,7 +829,7 @@ class IngestCheckerTest extends AppTestBase {
             final var verificationResultBob = mock(SignatureVerification.class);
             when(verificationResultBob.failed()).thenReturn(true);
             when(verificationResultFutureBob.get(anyLong(), any())).thenReturn(verificationResultBob);
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(
                             ALICE.account().keyOrThrow(), verificationResultFutureAlice,
                             BOB.account().keyOrThrow(), verificationResultFutureBob));
@@ -885,7 +885,7 @@ class IngestCheckerTest extends AppTestBase {
             final var verificationResultBob = mock(SignatureVerification.class);
             when(verificationResultBob.failed()).thenReturn(true);
             when(verificationResultFutureBob.get(anyLong(), any())).thenReturn(verificationResultBob);
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(
                             ALICE.account().keyOrThrow(), verificationResultFutureAlice,
                             BOB.account().keyOrThrow(), verificationResultFutureBob));
@@ -943,7 +943,7 @@ class IngestCheckerTest extends AppTestBase {
             final var verificationResultBob = mock(SignatureVerification.class);
             when(verificationResultBob.failed()).thenReturn(true);
             when(verificationResultFutureBob.get(anyLong(), any())).thenReturn(verificationResultBob);
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(
                             ALICE.account().keyOrThrow(), verificationResultFutureAlice,
                             BOB.account().keyOrThrow(), verificationResultFutureBob));
@@ -964,7 +964,7 @@ class IngestCheckerTest extends AppTestBase {
             doThrow(new RuntimeException("checkPayerSignature exception"))
                     .when(verificationResultFuture)
                     .get(anyLong(), any());
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(ALICE.account().keyOrThrow(), verificationResultFuture));
 
             // When the transaction is submitted, then the exception is bubbled up

--- a/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
+++ b/hedera-node/hedera-app/src/test/java/com/hedera/node/app/workflows/prehandle/PreHandleWorkflowImplTest.java
@@ -348,7 +348,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             final var key = ALICE.keyInfo().publicKey();
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenReturn(txInfo);
-            when(signatureVerifier.verify(any(), any())).thenReturn(Map.of(key, sigFuture));
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class))).thenReturn(Map.of(key, sigFuture));
             when(sigFuture.get(anyLong(), any())).thenReturn(new SignatureVerificationImpl(key, null, false));
 
             // When we pre-handle the transaction
@@ -522,7 +522,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenReturn(batchTxInfo)
                     .thenReturn(innerTxInfo);
-            when(signatureVerifier.verify(any(), any())).thenReturn(Map.of());
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class))).thenReturn(Map.of());
             doNothing()
                     .doThrow(new PreCheckException(INVALID_ACCOUNT_AMOUNTS))
                     .when(dispatcher)
@@ -570,7 +570,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             final var key = ALICE.keyInfo().publicKey();
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenReturn(txInfo);
-            when(signatureVerifier.verify(any(), any())).thenReturn(Map.of(key, sigFuture));
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class))).thenReturn(Map.of(key, sigFuture));
             doThrow(new PreCheckException(INVALID_ACCOUNT_AMOUNTS))
                     .when(dispatcher)
                     .dispatchPreHandle(any());
@@ -632,7 +632,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             when(badFuture.get(anyLong(), any())).thenReturn(new SignatureVerificationImpl(badKey, null, false));
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenReturn(txInfo);
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(
                             payerKey, goodFuture, // Payer check passes
                             badKey, badFuture)); // Sig checks fail
@@ -700,7 +700,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             when(sigFuture.get(anyLong(), any())).thenReturn(new SignatureVerificationImpl(payerKey, null, true));
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenReturn(txInfo);
-            when(signatureVerifier.verify(any(), any())).thenReturn(Map.of(payerKey, sigFuture));
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class))).thenReturn(Map.of(payerKey, sigFuture));
 
             // When we pre-handle the transaction
             workflow.preHandle(storeFactory, NODE_1.asInfo(), Stream.of(platformTx), (txns, bytes) -> {});
@@ -734,7 +734,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             when(sigFuture.get(anyLong(), any())).thenReturn(new SignatureVerificationImpl(payerKey, null, true));
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenReturn(txInfo);
-            when(signatureVerifier.verify(any(), any())).thenReturn(Map.of(payerKey, sigFuture));
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class))).thenReturn(Map.of(payerKey, sigFuture));
             final var previousResult = new PreHandleResult(
                     payerAccount,
                     payerKey,
@@ -786,7 +786,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenReturn(batchTxInfo)
                     .thenReturn(innerTxInfo);
-            when(signatureVerifier.verify(any(), any())).thenReturn(Map.of(payerKey, sigFuture));
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class))).thenReturn(Map.of(payerKey, sigFuture));
             final var previousResult = new PreHandleResult(
                     payerAccount,
                     payerKey,
@@ -888,7 +888,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             final Transaction platformTx = createAppPayloadWrapper(txBytes);
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenReturn(txInfo);
-            when(signatureVerifier.verify(any(), any())).thenReturn(Map.of(finalizedKey, sigFuture));
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class))).thenReturn(Map.of(finalizedKey, sigFuture));
             when(sigFuture.evmAlias()).thenReturn(hollowAccountAlias);
             when(sigFuture.get(anyLong(), any()))
                     .thenReturn(new SignatureVerificationImpl(finalizedKey, hollowAccountAlias, true));
@@ -930,7 +930,7 @@ final class PreHandleWorkflowImplTest extends AppTestBase implements Scenarios {
             final Transaction platformTx = createAppPayloadWrapper(txBytes);
             when(transactionChecker.parseSignedAndCheck(any(Bytes.class), anyInt()))
                     .thenReturn(txInfo);
-            when(signatureVerifier.verify(any(), any()))
+            when(signatureVerifier.verify(any(), any(), any(Bytes.class)))
                     .thenReturn(Map.of(payerKey, payerSigFuture, finalizedKey, nonPayerSigFuture));
             when(payerSigFuture.get(anyLong(), any())).thenReturn(new SignatureVerificationImpl(payerKey, null, true));
             when(nonPayerSigFuture.get(anyLong(), any()))

--- a/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HcpqConfig.java
+++ b/hedera-node/hedera-config/src/main/java/com/hedera/node/config/data/HcpqConfig.java
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+package com.hedera.node.config.data;
+
+import com.hedera.node.config.NetworkProperty;
+import com.swirlds.config.api.ConfigData;
+import com.swirlds.config.api.ConfigProperty;
+
+/** Network-controlled activation and resource limits for HCPQ signatures. */
+@ConfigData("hcpq")
+public record HcpqConfig(
+        @ConfigProperty(defaultValue = "false") @NetworkProperty
+        boolean enabled,
+
+        @ConfigProperty(defaultValue = "1") @NetworkProperty int maxSignaturesPerTransaction) {}

--- a/hedera-node/hedera-config/src/testFixtures/java/com/hedera/node/config/testfixtures/HederaTestConfigBuilder.java
+++ b/hedera-node/hedera-config/src/testFixtures/java/com/hedera/node/config/testfixtures/HederaTestConfigBuilder.java
@@ -44,6 +44,7 @@ import com.hedera.node.config.data.FilesConfig;
 import com.hedera.node.config.data.GovernanceTransactionsConfig;
 import com.hedera.node.config.data.GrpcConfig;
 import com.hedera.node.config.data.GrpcUsageTrackerConfig;
+import com.hedera.node.config.data.HcpqConfig;
 import com.hedera.node.config.data.HederaConfig;
 import com.hedera.node.config.data.HooksConfig;
 import com.hedera.node.config.data.JumboTransactionsConfig;
@@ -155,6 +156,7 @@ public final class HederaTestConfigBuilder {
                 .withConfigDataType(FilesConfig.class)
                 .withConfigDataType(GrpcConfig.class)
                 .withConfigDataType(HederaConfig.class)
+                .withConfigDataType(HcpqConfig.class)
                 .withConfigDataType(LedgerConfig.class)
                 .withConfigDataType(NettyConfig.class)
                 .withConfigDataType(NetworkAdminConfig.class)

--- a/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
+++ b/hedera-node/hedera-consensus-service-impl/src/main/java/com/hedera/node/app/service/consensus/impl/handlers/ConsensusSubmitMessageHandler.java
@@ -366,14 +366,14 @@ public class ConsensusSubmitMessageHandler implements TransactionHandler {
         final Set<Key> cryptoSigs = new HashSet<>();
         signatories.forEach(k -> {
             switch (k.key().kind()) {
-                case ED25519, ECDSA_SECP256K1 -> cryptoSigs.add(k);
+                case ED25519, ECDSA_SECP256K1, ML_DSA_44 -> cryptoSigs.add(k);
                 default -> {
                     // No other key type can be a signatory
                 }
             }
         });
         return key -> switch (key.key().kind()) {
-            case ED25519, ECDSA_SECP256K1 -> cryptoSigs.contains(key);
+            case ED25519, ECDSA_SECP256K1, ML_DSA_44 -> cryptoSigs.contains(key);
             default -> false;
         };
     }

--- a/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
+++ b/hedera-node/hedera-schedule-service-impl/src/main/java/com/hedera/node/app/service/schedule/impl/handlers/AbstractScheduleHandler.java
@@ -299,7 +299,7 @@ public abstract class AbstractScheduleHandler {
         final Set<ContractID> delegatableContractIdSigs = new HashSet<>();
         signatories.forEach(k -> {
             switch (k.key().kind()) {
-                case ED25519, ECDSA_SECP256K1 -> cryptoSigs.add(k);
+                case ED25519, ECDSA_SECP256K1, ML_DSA_44 -> cryptoSigs.add(k);
                 case CONTRACT_ID -> contractIdSigs.add(k.contractIDOrThrow());
                 case DELEGATABLE_CONTRACT_ID -> delegatableContractIdSigs.add(k.delegatableContractIdOrThrow());
                 default -> {
@@ -308,12 +308,13 @@ public abstract class AbstractScheduleHandler {
             }
         });
         return key -> switch (key.key().kind()) {
-            case ED25519, ECDSA_SECP256K1 -> cryptoSigs.contains(key);
-                // A contract id key is only activated by direct authorization
+            case ED25519, ECDSA_SECP256K1, ML_DSA_44 -> cryptoSigs.contains(key);
+            // A contract id key is only activated by direct authorization
             case CONTRACT_ID -> isAuthorized(key.contractIDOrThrow(), accountStore, contractIdSigs, emptySet());
-                // The more permissive "delegatable" key is activated by either type of authorization
-            case DELEGATABLE_CONTRACT_ID -> isAuthorized(
-                    key.delegatableContractIdOrThrow(), accountStore, delegatableContractIdSigs, contractIdSigs);
+            // The more permissive "delegatable" key is activated by either type of authorization
+            case DELEGATABLE_CONTRACT_ID ->
+                isAuthorized(
+                        key.delegatableContractIdOrThrow(), accountStore, delegatableContractIdSigs, contractIdSigs);
             default -> false;
         };
     }
@@ -372,18 +373,18 @@ public abstract class AbstractScheduleHandler {
     private static void accumulateNewSignatories(
             @NonNull final Set<Key> signatories, @NonNull final Set<Key> signingCryptoKeys, @NonNull final Key key) {
         switch (key.key().kind()) {
-            case ED25519, ECDSA_SECP256K1 -> {
+            case ED25519, ECDSA_SECP256K1, ML_DSA_44 -> {
                 if (signingCryptoKeys.contains(key)) {
                     signatories.add(key);
                 }
             }
-            case KEY_LIST -> key.keyListOrThrow()
-                    .keys()
-                    .forEach(k -> accumulateNewSignatories(signatories, signingCryptoKeys, k));
-            case THRESHOLD_KEY -> key.thresholdKeyOrThrow()
-                    .keysOrThrow()
-                    .keys()
-                    .forEach(k -> accumulateNewSignatories(signatories, signingCryptoKeys, k));
+            case KEY_LIST ->
+                key.keyListOrThrow().keys().forEach(k -> accumulateNewSignatories(signatories, signingCryptoKeys, k));
+            case THRESHOLD_KEY ->
+                key.thresholdKeyOrThrow()
+                        .keysOrThrow()
+                        .keys()
+                        .forEach(k -> accumulateNewSignatories(signatories, signingCryptoKeys, k));
         }
     }
 

--- a/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
+++ b/hedera-node/hedera-token-service-impl/src/main/java/com/hedera/node/app/service/token/impl/handlers/TokenAirdropHandler.java
@@ -254,7 +254,7 @@ public class TokenAirdropHandler extends TransferExecutor implements Transaction
     private static boolean canClaimAirdrop(@NonNull final Key key) {
         return switch (key.key().kind()) {
             case UNSET -> throw new IllegalStateException("Key kind cannot be UNSET");
-            case CONTRACT_ID, ED25519, ECDSA_SECP256K1 -> true;
+            case CONTRACT_ID, ED25519, ECDSA_SECP256K1, ML_DSA_44 -> true;
             case RSA_3072, ECDSA_384, DELEGATABLE_CONTRACT_ID -> false;
             case THRESHOLD_KEY ->
                 key.thresholdKeyOrThrow().keysOrThrow().keys().stream()

--- a/hiero-dependency-versions/build.gradle.kts
+++ b/hiero-dependency-versions/build.gradle.kts
@@ -128,6 +128,9 @@ dependencies.constraints {
     api("com.hedera.cryptography:hedera-cryptography-hints:$hederaCryptography") {
         because("com.hedera.cryptography.hints")
     }
+    api("com.hedera.cryptography:hedera-cryptography-hcpq:$hederaCryptography") {
+        because("com.hedera.cryptography.hcpq")
+    }
     api("com.hedera.cryptography:libsodium:$hederaCryptography") {
         because("com.hedera.cryptography.libsodium")
     }


### PR DESCRIPTION
**Description**:

Integrate the experimental HCPQ v1 ML-DSA-44 transaction profile into the Hiero consensus node.

- Add ML-DSA-44 key and signature wire fields with exact size rules
- Expand signatures by the complete 32-byte HCPQ key identifier
- Bind verification to the node's trusted ledger ID
- Require deterministic canonical TransactionBody bytes when an HCPQ signature is present
- Keep classical transaction parsing behavior unchanged
- Add default-off network configuration and a per-transaction HCPQ signature limit
- Update key traversal, fee, scheduling, consensus, and token paths
- Add real signing, negative-path, canonicalization, activation, and integration tests

**Dependency**:

This draft depends on https://github.com/hiero-ledger/hiero-cryptography/pull/693 and on a subsequent release containing the hedera-cryptography-hcpq artifact. CI dependency resolution may remain blocked until that artifact is published.

**Notes for reviewer**:

The feature is disabled by default (hcpq.enabled=false), and the default maximum is one HCPQ signature per transaction. Ledgerless verification fails closed.

Local validation passed:

- 11,085 tests across the affected node modules, with 8 pre-existing pending tests
- 850 focused post-audit integration tests
- Full compile of the affected project tree

This is reference integration, not a production activation recommendation or evidence of 10,000 TPS. Independent security review, SDK/mirror/hardware-wallet support, fees and throttles, cross-language vectors, and representative multi-node performance testing remain required.

**Checklist**

- [x] Documented (Code comments, configuration, HIP draft)
- [x] Tested (unit and integration)
